### PR TITLE
Add double-click rename on workspace name

### DIFF
--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -18,13 +18,13 @@ vi.mock("@/lib/tauri-api", () => ({
   resizeTerminal: vi.fn().mockResolvedValue(undefined),
   closeTerminalSession: vi.fn().mockResolvedValue(undefined),
   getSyncGroupTerminals: vi.fn().mockResolvedValue([]),
-  handleIdeMessage: vi.fn().mockResolvedValue({}),
+  handleLxMessage: vi.fn().mockResolvedValue({}),
   loadSettings: vi.fn().mockResolvedValue({}),
   saveSettings: vi.fn().mockResolvedValue(undefined),
   onTerminalOutput: vi.fn().mockResolvedValue(() => {}),
   onSyncCwd: vi.fn().mockResolvedValue(() => {}),
   onSyncBranch: vi.fn().mockResolvedValue(() => {}),
-  onIdeNotify: vi.fn().mockResolvedValue(() => {}),
+  onLxNotify: vi.fn().mockResolvedValue(() => {}),
   onSetTabTitle: vi.fn().mockResolvedValue(() => {}),
   getGitBranch: vi.fn().mockResolvedValue(null),
   sendOsNotification: vi.fn().mockResolvedValue(undefined),
@@ -491,6 +491,40 @@ describe("WorkspaceSelectorView", () => {
     const card = screen.getByTestId("layout-card-default-layout");
     await user.hover(card);
     expect(screen.getByTestId("layout-menu-default-layout")).toBeInTheDocument();
+  });
+
+  it("double-clicking workspace name triggers rename prompt", async () => {
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Renamed WS");
+    render(<WorkspaceSelectorView />);
+    const nameEl = screen.getByTestId("workspace-name-ws-default");
+    fireEvent.doubleClick(nameEl);
+    expect(promptSpy).toHaveBeenCalledWith("Rename workspace:", "Default");
+    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Renamed WS");
+    promptSpy.mockRestore();
+  });
+
+  it("double-clicking workspace name does not rename when prompt is cancelled", () => {
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue(null);
+    render(<WorkspaceSelectorView />);
+    const nameEl = screen.getByTestId("workspace-name-ws-default");
+    fireEvent.doubleClick(nameEl);
+    expect(promptSpy).toHaveBeenCalled();
+    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Default");
+    promptSpy.mockRestore();
+  });
+
+  it("double-clicking workspace name does not trigger workspace select", () => {
+    // Add a second workspace so we can check that double-clicking name on a non-active ws doesn't switch
+    useWorkspaceStore.getState().addWorkspace("Second", "default-layout");
+    const workspaces = useWorkspaceStore.getState().workspaces;
+    const ws2 = workspaces[workspaces.length - 1];
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue(null);
+    render(<WorkspaceSelectorView />);
+    const nameEl = screen.getByTestId(`workspace-name-${ws2.id}`);
+    fireEvent.doubleClick(nameEl);
+    // Active workspace should still be the first one
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("ws-default");
+    promptSpy.mockRestore();
   });
 
   it("renameLayout changes layout name in store", () => {

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -98,8 +98,10 @@ function WorkspaceItem({
             {index < 9 ? index + 1 : ""}
           </span>
           <span
+            data-testid={`workspace-name-${ws.id}`}
             className="truncate text-sm font-medium"
             style={{ color: isActive ? "var(--text-primary)" : "var(--text-secondary)" }}
+            onDoubleClick={(e) => { e.stopPropagation(); onRename(); }}
           >
             {ws.name}
           </span>


### PR DESCRIPTION
## Summary
- 워크스페이스 목록에서 워크스페이스 이름을 더블클릭하면 기존 rename prompt(`window.prompt`)가 열리도록 연결
- 더블클릭 시 `stopPropagation`으로 워크스페이스 선택(onClick)이 동시에 발생하지 않도록 처리
- TDD: 3개 테스트 추가 (rename 실행, 취소 시 무변경, 선택 미발생)

## Test plan
- [x] 더블클릭 시 rename prompt 호출 확인
- [x] prompt 취소 시 이름 변경 없음 확인
- [x] 더블클릭이 워크스페이스 전환을 트리거하지 않음 확인
- [x] 기존 42개 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)