### PR TITLE
Fix Report Issue submit bugs (#9)

### DIFF
--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -1,0 +1,228 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock @tauri-apps/api/core — must be before component import
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+// Mock global fetch for screenshot capture
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+import { IssueReporterView } from "./IssueReporterView";
+
+describe("IssueReporterView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: screenshot capture returns no data
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({}),
+    });
+    // Default: submit succeeds
+    mockInvoke.mockResolvedValue("https://github.com/user/repo/issues/42");
+  });
+
+  it("renders the issue reporter form", () => {
+    render(<IssueReporterView />);
+    expect(screen.getByTestId("issue-reporter-view")).toBeInTheDocument();
+    expect(screen.getByTestId("issue-title")).toBeInTheDocument();
+    expect(screen.getByTestId("issue-body")).toBeInTheDocument();
+    expect(screen.getByTestId("issue-submit")).toBeInTheDocument();
+  });
+
+  it("submit button is disabled when title is empty", () => {
+    render(<IssueReporterView />);
+    const submitBtn = screen.getByTestId("issue-submit");
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it("submit button is enabled when title has content", async () => {
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    expect(screen.getByTestId("issue-submit")).toBeEnabled();
+  });
+
+  it("disables submit button after successful submission", async () => {
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-submit")).toBeDisabled();
+    });
+  });
+
+  it("shows 'Submitted!' text after successful submission", async () => {
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-submit")).toHaveTextContent("Submitted!");
+    });
+  });
+
+  it("shows 'New Report' button after successful submission", async () => {
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-new-report")).toBeInTheDocument();
+    });
+  });
+
+  it("'New Report' button resets the form", async () => {
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    await user.type(screen.getByTestId("issue-body"), "Some description");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-new-report")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("issue-new-report"));
+
+    // Form should be reset
+    expect((screen.getByTestId("issue-title") as HTMLInputElement).value).toBe("");
+    expect((screen.getByTestId("issue-body") as HTMLTextAreaElement).value).toBe("");
+    // Submit button should show "Submit Issue" and be disabled (empty title)
+    expect(screen.getByTestId("issue-submit")).toHaveTextContent("Submit Issue");
+    expect(screen.getByTestId("issue-submit")).toBeDisabled();
+    // "New Report" button should be gone
+    expect(screen.queryByTestId("issue-new-report")).not.toBeInTheDocument();
+  });
+
+  it("disables submit button while submitting", async () => {
+    // Make invoke hang to test the submitting state
+    mockInvoke.mockReturnValue(new Promise(() => {}));
+
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-submit")).toBeDisabled();
+      expect(screen.getByTestId("issue-submit")).toHaveTextContent("Submitting...");
+    });
+  });
+
+  it("shows error message on submission failure", async () => {
+    mockInvoke.mockRejectedValue("gh CLI not found");
+
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByText("gh CLI not found")).toBeInTheDocument();
+    });
+  });
+
+  it("submit button is re-enabled after error so user can retry", async () => {
+    mockInvoke.mockRejectedValue("Network error");
+
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-submit")).toBeEnabled();
+      expect(screen.getByTestId("issue-submit")).toHaveTextContent("Submit Issue");
+    });
+  });
+
+  it("submits using Tauri invoke, not window.open", async () => {
+    const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-submit")).toHaveTextContent("Submitted!");
+    });
+
+    // Verify invoke was called with the right command
+    expect(mockInvoke).toHaveBeenCalledWith("submit_github_issue", {
+      title: "Bug report",
+      body: "",
+      screenshotPath: null,
+    });
+
+    // Verify window.open was NOT called
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+    windowOpenSpy.mockRestore();
+  });
+
+  it("does not show 'New Report' button before submission", () => {
+    render(<IssueReporterView />);
+    expect(screen.queryByTestId("issue-new-report")).not.toBeInTheDocument();
+  });
+
+  it("does not show 'New Report' button during submission", async () => {
+    mockInvoke.mockReturnValue(new Promise(() => {}));
+
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-submit")).toHaveTextContent("Submitting...");
+    });
+
+    expect(screen.queryByTestId("issue-new-report")).not.toBeInTheDocument();
+  });
+
+  it("shows issue URL link after successful submission", async () => {
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      const link = screen.getByTestId("issue-result-link");
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveTextContent("https://github.com/user/repo/issues/42");
+    });
+  });
+
+  it("title and body inputs are disabled after successful submission", async () => {
+    const user = userEvent.setup();
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Bug report");
+    await user.type(screen.getByTestId("issue-body"), "Description");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-title")).toBeDisabled();
+      expect(screen.getByTestId("issue-body")).toBeDisabled();
+    });
+  });
+});

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -46,6 +46,15 @@ export function IssueReporterView() {
     }
   };
 
+  const handleReset = () => {
+    setTitle("");
+    setBody("");
+    setScreenshotPath(null);
+    setScreenshotDataUrl(null);
+    setState("idle");
+    setResultMsg("");
+  };
+
   const fieldStyle: React.CSSProperties = {
     background: "var(--bg-base)",
     color: "var(--text-primary)",
@@ -139,6 +148,7 @@ export function IssueReporterView() {
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         placeholder="Issue title"
+        disabled={state === "success"}
         className="mb-3 w-full rounded px-3 py-2 text-xs"
         style={fieldStyle}
       />
@@ -150,6 +160,7 @@ export function IssueReporterView() {
         value={body}
         onChange={(e) => setBody(e.target.value)}
         placeholder="Describe the issue..."
+        disabled={state === "success"}
         className="mb-4 min-h-0 w-full flex-1 resize-none rounded px-3 py-2 text-xs leading-relaxed"
         style={{ ...fieldStyle, minHeight: 80 }}
       />
@@ -162,22 +173,41 @@ export function IssueReporterView() {
         <button
           data-testid="issue-submit"
           onClick={handleSubmit}
-          disabled={!title.trim() || state === "submitting"}
+          disabled={!title.trim() || state === "submitting" || state === "success"}
           className="cursor-pointer px-5 py-1.5 text-xs font-medium"
           style={{
             background: state === "success" ? "var(--green)" : "var(--accent)",
             color: "var(--bg-base)",
             border: "none",
             borderRadius: 3,
-            opacity: !title.trim() || state === "submitting" ? 0.4 : 1,
+            opacity: !title.trim() || state === "submitting" || state === "success" ? 0.4 : 1,
             transition: "opacity 0.15s",
           }}
         >
           {state === "submitting" ? "Submitting..." : state === "success" ? "Submitted!" : "Submit Issue"}
         </button>
 
+        {state === "success" && (
+          <button
+            data-testid="issue-new-report"
+            onClick={handleReset}
+            className="cursor-pointer rounded px-4 py-1.5 text-xs font-medium"
+            style={{
+              background: "transparent",
+              color: "var(--accent)",
+              border: "1px solid rgba(137,180,250,0.3)",
+              borderRadius: 3,
+            }}
+            onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "rgba(137,180,250,0.08)"; }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
+          >
+            New Report
+          </button>
+        )}
+
         {state === "success" && resultMsg && (
           <a
+            data-testid="issue-result-link"
             href={resultMsg}
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- Submit 버튼이 성공 후 비활성화되어 중복 제출 방지
- 성공 후 "New Report" 버튼 추가로 폼 초기화 가능
- 성공 후 입력 필드도 비활성화하여 혼란 방지

Closes #9

## Test plan
- [x] 15개 새 테스트 추가 (IssueReporterView.test.tsx)
- [x] Submit 버튼 비활성화 상태 검증
- [x] New Report 버튼 표시/동작 검증
- [x] 에러 시 재시도 가능 검증
- [x] 전체 839개 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)