### PR TITLE
Fix focus not leaving terminal on Alt+Arrow to EmptyView (#10)

### DIFF
--- a/ui/src/components/views/EmptyView.test.tsx
+++ b/ui/src/components/views/EmptyView.test.tsx
@@ -121,6 +121,18 @@ describe("EmptyView", () => {
     expect(handles.length).toBeGreaterThan(0);
   });
 
+  it("focuses container element when isFocused becomes true", () => {
+    const { container } = render(<EmptyView isFocused={true} />);
+    const focusable = container.querySelector("[data-testid='empty-view']") as HTMLElement;
+    expect(focusable).toBe(document.activeElement);
+  });
+
+  it("does not steal focus when isFocused is false", () => {
+    const { container } = render(<EmptyView isFocused={false} />);
+    const focusable = container.querySelector("[data-testid='empty-view']") as HTMLElement;
+    expect(focusable).not.toBe(document.activeElement);
+  });
+
   it("respects stored viewOrder", () => {
     // Set custom order: browser first
     useSettingsStore.setState({ viewOrder: ["browser", "settings", "ws-selector"] });

--- a/ui/src/components/views/EmptyView.tsx
+++ b/ui/src/components/views/EmptyView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useCallback, useState, useRef } from "react";
 import type { ViewInstanceConfig } from "@/stores/types";
 import { useSettingsStore } from "@/stores/settings-store";
 
@@ -170,11 +170,19 @@ function applyOrder(options: ViewOption[], order: string[]): ViewOption[] {
 }
 
 export function EmptyView({ onSelectView, context: _context = "pane", isFocused }: EmptyViewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
   const profiles = useSettingsStore((s) => s.profiles);
   const visibleProfiles = profiles.filter((p) => !p.hidden);
   const viewOrder = useSettingsStore((s) => s.viewOrder) ?? [];
   const setViewOrder = useSettingsStore((s) => s.setViewOrder);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+
+  // Grab DOM focus when this pane becomes focused (e.g. via Alt+Arrow navigation)
+  useEffect(() => {
+    if (isFocused) {
+      containerRef.current?.focus();
+    }
+  }, [isFocused]);
 
   const rawOptions = buildOptions(visibleProfiles);
   const options = applyOrder(rawOptions, viewOrder);
@@ -237,8 +245,10 @@ export function EmptyView({ onSelectView, context: _context = "pane", isFocused 
 
   return (
     <div
+      ref={containerRef}
+      tabIndex={-1}
       data-testid="empty-view"
-      className="flex h-full flex-col items-center justify-center gap-3 p-6"
+      className="flex h-full flex-col items-center justify-center gap-3 p-6 outline-none"
       style={{ color: "var(--text-secondary)" }}
     >
       {/* Header */}

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -217,6 +217,26 @@ describe("TerminalView", () => {
     expect(mockFocus).not.toHaveBeenCalled();
   });
 
+  it("calls terminal.blur() when isFocused transitions from true to false", async () => {
+    const { rerender } = render(
+      <TerminalView instanceId="t-blur1" profile="PowerShell" syncGroup="" isFocused={true} />,
+    );
+
+    // Wait for terminal to open
+    await vi.waitFor(() => {
+      expect(mockCreateTerminalSession).toHaveBeenCalled();
+    });
+
+    mockBlur.mockClear();
+
+    // Transition isFocused from true to false (simulates Alt+Arrow away)
+    rerender(
+      <TerminalView instanceId="t-blur1" profile="PowerShell" syncGroup="" isFocused={false} />,
+    );
+
+    expect(mockBlur).toHaveBeenCalled();
+  });
+
   // -- syncGroup change (workspace rename) should NOT recreate terminal --
 
   it("does not destroy and recreate terminal when syncGroup changes", async () => {

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -475,10 +475,14 @@ export function TerminalView({
     setTerminalCwdReceive(instanceId, cwdReceive).catch(() => {});
   }, [instanceId, cwdReceive]);
 
-  // Focus terminal when pane focus state changes (only if terminal is opened)
+  // Focus/blur terminal when pane focus state changes (only if terminal is opened)
   useEffect(() => {
-    if (isFocused && openedRef.current) {
-      terminalRef.current?.focus();
+    if (openedRef.current) {
+      if (isFocused) {
+        terminalRef.current?.focus();
+      } else {
+        terminalRef.current?.blur();
+      }
     }
   }, [isFocused]);
 


### PR DESCRIPTION
## Summary
- TerminalView가 `isFocused=false`일 때 `terminal.blur()`를 호출하여 xterm.js 키보드 캡처 해제
- EmptyView에 `tabIndex={-1}` 추가하고, `isFocused=true`일 때 컨테이너에 DOM focus 부여
- EmptyView에서 숫자키로 View 선택이 정상 동작하도록 수정

Closes #10

## Test plan
- [x] TerminalView: `isFocused` false 전환 시 `terminal.blur()` 호출 테스트
- [x] EmptyView: `isFocused` true일 때 컨테이너 포커스 테스트
- [x] EmptyView: `isFocused` false일 때 포커스 미획득 테스트
- [x] 전체 827개 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)