### PR TITLE
Fix Report Issue dialog bugs

### DIFF
--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { IssueReporterView } from "./IssueReporterView";
+
+// Mock fetch for screenshot capture
+const mockFetch = vi.fn().mockResolvedValue({
+  json: () => Promise.resolve({ path: "/tmp/screenshot.png", dataUrl: "data:image/png;base64,abc" }),
+});
+global.fetch = mockFetch;
+
+// Mock @tauri-apps/api/core
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+describe("IssueReporterView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ path: "/tmp/screenshot.png", dataUrl: "data:image/png;base64,abc" }),
+    });
+  });
+
+  it("renders the form", () => {
+    render(<IssueReporterView />);
+    expect(screen.getByTestId("issue-reporter-view")).toBeInTheDocument();
+    expect(screen.getByTestId("issue-title")).toBeInTheDocument();
+    expect(screen.getByTestId("issue-body")).toBeInTheDocument();
+    expect(screen.getByTestId("issue-submit")).toBeInTheDocument();
+  });
+
+  it("disables submit button after successful submission", async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockResolvedValue("https://github.com/repo/issues/1");
+
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Test issue");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-submit")).toBeDisabled();
+    });
+  });
+
+  it("shows 'New Report' button after successful submission", async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockResolvedValue("https://github.com/repo/issues/1");
+
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Test issue");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-new-report")).toBeInTheDocument();
+    });
+  });
+
+  it("resets form when 'New Report' is clicked", async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockResolvedValue("https://github.com/repo/issues/1");
+
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Test issue");
+    await user.type(screen.getByTestId("issue-body"), "Some body");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-new-report")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("issue-new-report"));
+
+    expect(screen.getByTestId("issue-title")).toHaveValue("");
+    expect(screen.getByTestId("issue-body")).toHaveValue("");
+    // Button text should be back to "Submit Issue" (not "Submitted!")
+    expect(screen.getByText("Submit Issue")).toBeInTheDocument();
+    // "New Report" button should be gone
+    expect(screen.queryByTestId("issue-new-report")).not.toBeInTheDocument();
+  });
+
+  it("does not open external window for issue URL", async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockResolvedValue("https://github.com/repo/issues/1");
+
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Test issue");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Submitted!")).toBeInTheDocument();
+    });
+
+    // URL should be displayed as text, not as a link with target="_blank"
+    const links = screen.queryAllByRole("link");
+    const externalLinks = links.filter((l) => l.getAttribute("target") === "_blank");
+    expect(externalLinks).toHaveLength(0);
+  });
+
+  it("disables submit button during submission", async () => {
+    const user = userEvent.setup();
+    // Make invoke hang to test the submitting state
+    mockInvoke.mockImplementation(() => new Promise(() => {}));
+
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Test issue");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    expect(screen.getByTestId("issue-submit")).toBeDisabled();
+    expect(screen.getByText("Submitting...")).toBeInTheDocument();
+  });
+
+  it("disables submit button after error and allows retry", async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockRejectedValueOnce(new Error("Network error"));
+
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Test issue");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      // After error, submit button should be re-enabled for retry
+      expect(screen.getByTestId("issue-submit")).not.toBeDisabled();
+    });
+  });
+});

--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -96,10 +96,10 @@ describe("IssueReporterView", () => {
       expect(screen.getByText("Submitted!")).toBeInTheDocument();
     });
 
-    // URL should be displayed as text, not as a link with target="_blank"
-    const links = screen.queryAllByRole("link");
-    const externalLinks = links.filter((l) => l.getAttribute("target") === "_blank");
-    expect(externalLinks).toHaveLength(0);
+    // URL should be displayed as a link but without target="_blank"
+    const link = screen.getByTestId("issue-link");
+    expect(link).toBeInTheDocument();
+    expect(link).not.toHaveAttribute("target", "_blank");
   });
 
   it("disables submit button during submission", async () => {

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -28,7 +28,7 @@ export function IssueReporterView() {
   };
 
   const handleSubmit = async () => {
-    if (!title.trim()) return;
+    if (!title.trim() || state === "submitting" || state === "success") return;
     setState("submitting");
     setResultMsg("");
     try {
@@ -44,6 +44,13 @@ export function IssueReporterView() {
       setState("error");
       setResultMsg(String(e));
     }
+  };
+
+  const handleNewReport = () => {
+    setTitle("");
+    setBody("");
+    setResultMsg("");
+    setState("idle");
   };
 
   const fieldStyle: React.CSSProperties = {
@@ -162,30 +169,44 @@ export function IssueReporterView() {
         <button
           data-testid="issue-submit"
           onClick={handleSubmit}
-          disabled={!title.trim() || state === "submitting"}
+          disabled={!title.trim() || state === "submitting" || state === "success"}
           className="cursor-pointer px-5 py-1.5 text-xs font-medium"
           style={{
             background: state === "success" ? "var(--green)" : "var(--accent)",
             color: "var(--bg-base)",
             border: "none",
             borderRadius: 3,
-            opacity: !title.trim() || state === "submitting" ? 0.4 : 1,
+            opacity: !title.trim() || state === "submitting" || state === "success" ? 0.4 : 1,
             transition: "opacity 0.15s",
           }}
         >
           {state === "submitting" ? "Submitting..." : state === "success" ? "Submitted!" : "Submit Issue"}
         </button>
 
+        {state === "success" && (
+          <button
+            data-testid="issue-new-report"
+            onClick={handleNewReport}
+            className="cursor-pointer px-4 py-1.5 text-xs font-medium"
+            style={{
+              background: "transparent",
+              color: "var(--accent)",
+              border: "1px solid rgba(137,180,250,0.2)",
+              borderRadius: 3,
+            }}
+          >
+            New Report
+          </button>
+        )}
+
         {state === "success" && resultMsg && (
-          <a
-            href={resultMsg}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="truncate text-[11px] underline"
-            style={{ color: "var(--accent)" }}
+          <span
+            className="truncate text-[11px]"
+            style={{ color: "var(--green)" }}
+            title={resultMsg}
           >
             {resultMsg}
-          </a>
+          </span>
         )}
         {state === "error" && (
           <span className="truncate text-[11px]" style={{ color: "var(--red)" }}>

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -200,13 +200,7 @@ export function IssueReporterView() {
         )}
 
         {state === "success" && resultMsg && (
-          <span
-            className="truncate text-[11px]"
-            style={{ color: "var(--green)" }}
-            title={resultMsg}
-          >
-            {resultMsg}
-          </span>
+          <span className="truncate text-[11px]" style={{ color: "var(--green)" }}>✓</span>
         )}
         {state === "error" && (
           <span className="truncate text-[11px]" style={{ color: "var(--red)" }}>
@@ -214,6 +208,20 @@ export function IssueReporterView() {
           </span>
         )}
       </div>
+
+      {/* Issue link */}
+      {state === "success" && resultMsg && (
+        <a
+          data-testid="issue-link"
+          href={resultMsg}
+          onClick={(e) => e.preventDefault()}
+          className="mt-2 truncate text-[11px] underline"
+          style={{ color: "var(--accent)", cursor: "text", userSelect: "all" }}
+          title={resultMsg}
+        >
+          {resultMsg}
+        </a>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Prevent double-submit**: Disable submit button after successful submission so users can't create duplicate issues
- **Add "New Report" button**: After submission, users can reset the form to file another issue
- **Remove external window popup**: Issue URL is now displayed as inline text instead of opening in a new browser window via `target="_blank"`

Closes #9

## Test plan
- [x] Added 7 tests for IssueReporterView covering all bug scenarios
- [x] All 831 existing tests pass
- [ ] Manual: Submit an issue → verify button is disabled after success
- [ ] Manual: Click "New Report" → verify form resets
- [ ] Manual: Verify no external browser window opens on submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)