### PR TITLE
Fix EmptyView not receiving focus on Alt+Arrow navigation

### DIFF
--- a/ui/src/components/views/EmptyView.test.tsx
+++ b/ui/src/components/views/EmptyView.test.tsx
@@ -92,8 +92,8 @@ describe("EmptyView", () => {
   });
 
   it("grabs DOM focus when isFocused becomes true", () => {
-    const { container } = render(<EmptyView isFocused={true} />);
-    const wrapper = container.querySelector("[data-testid='empty-view']")!;
+    render(<EmptyView isFocused={true} />);
+    const wrapper = screen.getByTestId("empty-view");
     expect(document.activeElement).toBe(wrapper);
   });
 

--- a/ui/src/components/views/EmptyView.test.tsx
+++ b/ui/src/components/views/EmptyView.test.tsx
@@ -91,6 +91,12 @@ describe("EmptyView", () => {
     );
   });
 
+  it("grabs DOM focus when isFocused becomes true", () => {
+    const { container } = render(<EmptyView isFocused={true} />);
+    const wrapper = container.querySelector("[data-testid='empty-view']")!;
+    expect(document.activeElement).toBe(wrapper);
+  });
+
   it("shows all views including dock views in any context", () => {
     render(<EmptyView context="pane" />);
     expect(screen.getByTestId("empty-view-workspace-selector")).toBeInTheDocument();

--- a/ui/src/components/views/EmptyView.tsx
+++ b/ui/src/components/views/EmptyView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useCallback, useRef, useState } from "react";
 import type { ViewInstanceConfig } from "@/stores/types";
 import { useSettingsStore } from "@/stores/settings-store";
 
@@ -170,11 +170,19 @@ function applyOrder(options: ViewOption[], order: string[]): ViewOption[] {
 }
 
 export function EmptyView({ onSelectView, context: _context = "pane", isFocused }: EmptyViewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
   const profiles = useSettingsStore((s) => s.profiles);
   const visibleProfiles = profiles.filter((p) => !p.hidden);
   const viewOrder = useSettingsStore((s) => s.viewOrder) ?? [];
   const setViewOrder = useSettingsStore((s) => s.setViewOrder);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+
+  // Grab DOM focus when this pane becomes focused (e.g. via Alt+Arrow navigation)
+  useEffect(() => {
+    if (isFocused) {
+      containerRef.current?.focus();
+    }
+  }, [isFocused]);
 
   const rawOptions = buildOptions(visibleProfiles);
   const options = applyOrder(rawOptions, viewOrder);
@@ -237,8 +245,10 @@ export function EmptyView({ onSelectView, context: _context = "pane", isFocused 
 
   return (
     <div
+      ref={containerRef}
+      tabIndex={-1}
       data-testid="empty-view"
-      className="flex h-full flex-col items-center justify-center gap-3 p-6"
+      className="flex h-full flex-col items-center justify-center gap-3 p-6 outline-none"
       style={{ color: "var(--text-secondary)" }}
     >
       {/* Header */}

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -201,6 +201,24 @@ describe("TerminalView", () => {
     });
   });
 
+  it("calls terminal.blur() when isFocused becomes false", async () => {
+    const { rerender } = render(
+      <TerminalView instanceId="t-blur" profile="PowerShell" syncGroup="" isFocused={true} />,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockCreateTerminalSession).toHaveBeenCalled();
+    });
+
+    mockBlur.mockClear();
+
+    rerender(
+      <TerminalView instanceId="t-blur" profile="PowerShell" syncGroup="" isFocused={false} />,
+    );
+
+    expect(mockBlur).toHaveBeenCalled();
+  });
+
   it("does not call terminal.focus() when isFocused is false", async () => {
     render(
       <TerminalView instanceId="t10" profile="PowerShell" syncGroup="" isFocused={false} />,

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -475,10 +475,14 @@ export function TerminalView({
     setTerminalCwdReceive(instanceId, cwdReceive).catch(() => {});
   }, [instanceId, cwdReceive]);
 
-  // Focus terminal when pane focus state changes (only if terminal is opened)
+  // Focus/blur terminal when pane focus state changes (only if terminal is opened)
   useEffect(() => {
-    if (isFocused && openedRef.current) {
-      terminalRef.current?.focus();
+    if (openedRef.current) {
+      if (isFocused) {
+        terminalRef.current?.focus();
+      } else {
+        terminalRef.current?.blur();
+      }
     }
   }, [isFocused]);
 


### PR DESCRIPTION
## Summary
- **TerminalView**: `terminal.blur()` 호출 추가 — 포커스를 잃을 때 xterm.js가 키보드 입력을 놓아줌
- **EmptyView**: `containerRef` + `tabIndex={-1}` 추가 — 포커스를 받을 때 DOM focus를 가져와서 숫자키 선택이 동작함

Closes #10

## Test plan
- [x] TerminalView: `isFocused` false로 변경 시 `terminal.blur()` 호출 확인 (새 테스트)
- [x] EmptyView: `isFocused=true` 시 DOM focus 획득 확인 (새 테스트)
- [x] 기존 826개 테스트 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)