### PR TITLE
Fix Claude task completion not triggering notification

### DIFF
--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -26,7 +26,7 @@ import { getPresetHooks } from "@/lib/osc-presets";
 import type { OscHook } from "@/lib/osc-parser";
 import { isLxShortcut } from "@/lib/lx-shortcuts";
 
-import { detectActivityFromTitle, detectActivityFromCommand, detectClaudeTaskTransition, extractClaudeTaskDesc, isGenericClaudeTitle } from "@/lib/activity-detection";
+import { detectActivityFromTitle, detectActivityFromCommand, detectClaudeTaskTransition, extractClaudeTaskDesc, getClaudeCompletionMessage } from "@/lib/activity-detection";
 import { useNotificationStore } from "@/stores/notification-store";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { OutputIdleDetector } from "@/lib/output-idle-detector";
@@ -213,7 +213,8 @@ export function TerminalView({
       const currentActivity = detected ?? instance?.activity;
 
       // Claude task transition (handles garbled encoding from xterm.js)
-      const transition = detectClaudeTaskTransition(previousClaudeTitle ?? instance?.title, title, currentActivity);
+      const prevTitle = previousClaudeTitle ?? instance?.title;
+      const transition = detectClaudeTaskTransition(prevTitle, title, currentActivity);
       previousClaudeTitle = title;
 
       updateInstanceInfo(instanceId, {
@@ -223,14 +224,11 @@ export function TerminalView({
 
       if (transition === "completed") {
         updateInstanceInfo(instanceId, { lastExitCode: 0, lastCommandAt: Date.now() });
-        const taskDesc = extractClaudeTaskDesc(title);
-        // Skip notification for generic idle titles (e.g., startup "Claude Code")
-        if (!isGenericClaudeTitle(taskDesc)) {
-          const wsId = resolveWorkspaceId(instanceId);
-          useNotificationStore.getState().addNotification({
-            terminalId: instanceId, workspaceId: wsId, message: taskDesc || "Claude task completed", level: "success",
-          });
-        }
+        const message = getClaudeCompletionMessage(prevTitle, title);
+        const wsId = resolveWorkspaceId(instanceId);
+        useNotificationStore.getState().addNotification({
+          terminalId: instanceId, workspaceId: wsId, message, level: "success",
+        });
       } else if (transition === "started") {
         const taskDesc = extractClaudeTaskDesc(title);
         updateInstanceInfo(instanceId, {
@@ -302,7 +300,8 @@ export function TerminalView({
           const rawTitle = titleMatch[1];
           const inst0 = useTerminalStore.getState().instances.find((i) => i.id === instanceId);
           const currentActivity = inst0?.activity;
-          const transition = detectClaudeTaskTransition(previousClaudeTitle, rawTitle, currentActivity);
+          const prevTitle = previousClaudeTitle;
+          const transition = detectClaudeTaskTransition(prevTitle, rawTitle, currentActivity);
           previousClaudeTitle = rawTitle;
 
           if (transition === "completed") {
@@ -310,16 +309,14 @@ export function TerminalView({
               lastExitCode: 0,
               lastCommandAt: Date.now(),
             });
-            const taskDesc = extractClaudeTaskDesc(rawTitle);
-            if (!isGenericClaudeTitle(taskDesc)) {
-              const wsId = resolveWorkspaceId(instanceId);
-              useNotificationStore.getState().addNotification({
-                terminalId: instanceId,
-                workspaceId: wsId,
-                message: taskDesc || "Claude task completed",
-                level: "success",
-              });
-            }
+            const message = getClaudeCompletionMessage(prevTitle, rawTitle);
+            const wsId = resolveWorkspaceId(instanceId);
+            useNotificationStore.getState().addNotification({
+              terminalId: instanceId,
+              workspaceId: wsId,
+              message,
+              level: "success",
+            });
           } else if (transition === "started") {
             const taskDesc = extractClaudeTaskDesc(rawTitle);
             useTerminalStore.getState().updateInstanceInfo(instanceId, {

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { detectActivityFromTitle, detectActivityFromCommand, detectClaudeTaskTransition, extractClaudeTaskDesc, isGenericClaudeTitle } from "./activity-detection";
+import { detectActivityFromTitle, detectActivityFromCommand, detectClaudeTaskTransition, extractClaudeTaskDesc, isGenericClaudeTitle, getClaudeCompletionMessage } from "./activity-detection";
 
 describe("detectActivityFromTitle", () => {
   it("detects vim from title", () => {
@@ -198,5 +198,62 @@ describe("isGenericClaudeTitle", () => {
   it("returns false for actual task description", () => {
     expect(isGenericClaudeTitle("Build project")).toBe(false);
     expect(isGenericClaudeTitle("Basic arithmetic")).toBe(false);
+  });
+});
+
+describe("getClaudeCompletionMessage", () => {
+  it("extracts task description from previous (spinner) title when new title is generic idle", () => {
+    expect(getClaudeCompletionMessage("✻ Fix the bug", "✳ Claude Code")).toBe("Fix the bug");
+  });
+
+  it("works with various spinner characters", () => {
+    expect(getClaudeCompletionMessage("✶ Build project", "✳ Claude Code")).toBe("Build project");
+    expect(getClaudeCompletionMessage("✽ Running tests", "✳ Claude Code")).toBe("Running tests");
+    expect(getClaudeCompletionMessage("· Thinking about solution", "✳ Claude Code")).toBe("Thinking about solution");
+  });
+
+  it("prefers previous title description over new title description", () => {
+    expect(getClaudeCompletionMessage("✻ Fix the bug", "✳ Review results")).toBe("Fix the bug");
+  });
+
+  it("falls back to new title when previous title is generic", () => {
+    expect(getClaudeCompletionMessage("✻ Claude Code", "✳ Some specific task")).toBe("Some specific task");
+  });
+
+  it("falls back to default message when both titles are generic", () => {
+    expect(getClaudeCompletionMessage("✻ Claude Code", "✳ Claude Code")).toBe("Claude task completed");
+  });
+
+  it("falls back to default message when both titles extract to empty", () => {
+    expect(getClaudeCompletionMessage("✻", "✳")).toBe("Claude task completed");
+  });
+
+  it("handles undefined previous title", () => {
+    expect(getClaudeCompletionMessage(undefined, "✳ Claude Code")).toBe("Claude task completed");
+  });
+
+  it("handles garbled encoding — still creates non-generic message", () => {
+    // Garbled spinner prefix may not be fully stripped, but result is still non-generic
+    const message = getClaudeCompletionMessage("\udce2\uc7fc Build project", "\udce2\uc454 Claude Code");
+    expect(isGenericClaudeTitle(message)).toBe(false);
+    expect(message).toContain("Build project");
+  });
+
+  it("handles lowercase generic 'claude' in previous title", () => {
+    expect(getClaudeCompletionMessage("✻ claude", "✳ Claude Code")).toBe("Claude task completed");
+  });
+});
+
+describe("Claude completion notification wiring (bug repro)", () => {
+  it("old code skips notification when title transitions to idle", () => {
+    // OLD buggy flow: extracts from newTitle → "Claude Code" → generic → SKIP
+    const oldTaskDesc = extractClaudeTaskDesc("✳ Claude Code");
+    expect(isGenericClaudeTitle(oldTaskDesc)).toBe(true);
+  });
+
+  it("new code extracts task from previous title", () => {
+    const message = getClaudeCompletionMessage("✻ Fix the bug", "✳ Claude Code");
+    expect(message).toBe("Fix the bug");
+    expect(isGenericClaudeTitle(message)).toBe(false);
   });
 });

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -87,6 +87,25 @@ export function isGenericClaudeTitle(taskDesc: string): boolean {
 }
 
 /**
+ * Extract a meaningful notification message for Claude task completion.
+ *
+ * Tries the previous title first (contains the actual task description from the spinner),
+ * falls back to the new title, then to a default message.
+ */
+export function getClaudeCompletionMessage(
+  previousTitle: string | undefined,
+  newTitle: string,
+): string {
+  if (previousTitle) {
+    const prevDesc = extractClaudeTaskDesc(previousTitle);
+    if (!isGenericClaudeTitle(prevDesc)) return prevDesc;
+  }
+  const newDesc = extractClaudeTaskDesc(newTitle);
+  if (!isGenericClaudeTitle(newDesc)) return newDesc;
+  return "Claude task completed";
+}
+
+/**
  * Detect Claude Code task state transitions from title changes.
  *
  * Claude Code uses spinner characters (✶✻✽✢*·) while working and ✳ when idle.


### PR DESCRIPTION
## Summary
- Claude 작업 완료 시 notification이 생성되지 않아 unread 배지와 알림 네비게이션(Ctrl+Alt+Left/Right)이 동작하지 않던 버그 수정
- 원인: newTitle(`"✳ Claude Code"`)에서 task description을 추출하면 항상 generic으로 판정되어 notification이 skip됨
- 수정: `getClaudeCompletionMessage(prevTitle, newTitle)` 함수를 추가하여 previousTitle(spinner 상태)에서 실제 task description을 추출

Closes #11

## Test plan
- [x] `getClaudeCompletionMessage` 단위 테스트 추가 (10개 케이스)
- [x] 기존 버그 재현 테스트 추가
- [x] 전체 테스트 856개 통과 확인
- [ ] dev 인스턴스에서 Claude 실행 → 작업 완료 → unread 배지 표시 확인
- [ ] Ctrl+Alt+Left/Right로 해당 터미널 네비게이션 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)