### PR TITLE
Fix IssueReporter: double submit, error clear, link open

### DIFF
--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -139,4 +139,68 @@ describe("IssueReporterView", () => {
       expect(screen.getByTestId("issue-submit")).not.toBeDisabled();
     });
   });
+
+  it("shows 'New Report' button after error for clearing form", async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockRejectedValueOnce(new Error("Network error"));
+
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Test issue");
+    await user.type(screen.getByTestId("issue-body"), "Some body");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-new-report")).toBeInTheDocument();
+    });
+
+    // Clicking New Report should clear form
+    await user.click(screen.getByTestId("issue-new-report"));
+    expect(screen.getByTestId("issue-title")).toHaveValue("");
+    expect(screen.getByTestId("issue-body")).toHaveValue("");
+    expect(screen.getByText("Submit Issue")).toBeInTheDocument();
+  });
+
+  it("prevents double submission with rapid clicks", async () => {
+    const user = userEvent.setup();
+    let resolveSubmit: (value: string) => void;
+    mockInvoke.mockImplementation(
+      () => new Promise<string>((resolve) => { resolveSubmit = resolve; }),
+    );
+
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Test issue");
+
+    // Rapid double-click
+    const btn = screen.getByTestId("issue-submit");
+    await user.click(btn);
+    await user.click(btn);
+
+    // Should only invoke once despite two clicks
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+
+    // Resolve to clean up
+    resolveSubmit!("https://github.com/repo/issues/1");
+  });
+
+  it("awaits shell open and handles errors gracefully", async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockResolvedValue("https://github.com/repo/issues/1");
+    mockShellOpen.mockRejectedValueOnce(new Error("shell open failed"));
+
+    render(<IssueReporterView />);
+
+    await user.type(screen.getByTestId("issue-title"), "Test issue");
+    await user.click(screen.getByTestId("issue-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("issue-link")).toBeInTheDocument();
+    });
+
+    // Click the link — should not throw even if shell open fails
+    await user.click(screen.getByTestId("issue-link"));
+
+    expect(mockShellOpen).toHaveBeenCalledWith("https://github.com/repo/issues/1");
+  });
 });

--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -198,9 +198,20 @@ describe("IssueReporterView", () => {
       expect(screen.getByTestId("issue-link")).toBeInTheDocument();
     });
 
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
     // Click the link — should not throw even if shell open fails
     await user.click(screen.getByTestId("issue-link"));
 
     expect(mockShellOpen).toHaveBeenCalledWith("https://github.com/repo/issues/1");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("shell.open failed"),
+      expect.any(Error),
+    );
+    expect(windowOpenSpy).toHaveBeenCalledWith("https://github.com/repo/issues/1", "_blank");
+
+    warnSpy.mockRestore();
+    windowOpenSpy.mockRestore();
   });
 });

--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { IssueReporterView } from "./IssueReporterView";
@@ -180,8 +180,10 @@ describe("IssueReporterView", () => {
     // Should only invoke once despite two clicks
     expect(mockInvoke).toHaveBeenCalledTimes(1);
 
-    // Resolve to clean up
-    resolveSubmit!("https://github.com/repo/issues/1");
+    // Resolve to clean up pending promise
+    await act(async () => {
+      resolveSubmit!("https://github.com/repo/issues/1");
+    });
   });
 
   it("awaits shell open and handles errors gracefully", async () => {

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -223,7 +223,8 @@ export function IssueReporterView() {
             try {
               const { open } = await import("@tauri-apps/plugin-shell");
               await open(resultMsg);
-            } catch {
+            } catch (e) {
+              console.warn("shell.open failed, falling back to window.open:", e);
               window.open(resultMsg, "_blank");
             }
           }}

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -11,6 +11,7 @@ export function IssueReporterView() {
   const [resultMsg, setResultMsg] = useState("");
   const [showPreview, setShowPreview] = useState(true);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const submittingRef = useRef(false);
 
   useEffect(() => {
     captureScreenshot();
@@ -28,7 +29,8 @@ export function IssueReporterView() {
   };
 
   const handleSubmit = async () => {
-    if (!title.trim() || state === "submitting" || state === "success") return;
+    if (!title.trim() || submittingRef.current || state === "success") return;
+    submittingRef.current = true;
     setState("submitting");
     setResultMsg("");
     try {
@@ -43,6 +45,8 @@ export function IssueReporterView() {
     } catch (e) {
       setState("error");
       setResultMsg(String(e));
+    } finally {
+      submittingRef.current = false;
     }
   };
 
@@ -183,7 +187,7 @@ export function IssueReporterView() {
           {state === "submitting" ? "Submitting..." : state === "success" ? "Submitted!" : "Submit Issue"}
         </button>
 
-        {state === "success" && (
+        {(state === "success" || state === "error") && (
           <button
             data-testid="issue-new-report"
             onClick={handleNewReport}
@@ -216,11 +220,15 @@ export function IssueReporterView() {
           href={resultMsg}
           onClick={async (e) => {
             e.preventDefault();
-            const { open } = await import("@tauri-apps/plugin-shell");
-            open(resultMsg);
+            try {
+              const { open } = await import("@tauri-apps/plugin-shell");
+              await open(resultMsg);
+            } catch {
+              window.open(resultMsg, "_blank");
+            }
           }}
           className="mt-2 truncate text-[11px] underline"
-          style={{ color: "var(--accent)", cursor: "pointer", userSelect: "all" }}
+          style={{ color: "var(--accent)", cursor: "pointer" }}
           title={resultMsg}
         >
           {resultMsg}


### PR DESCRIPTION
## Summary
- **#8**: `submittingRef`로 race-condition 이중 제출 방지, error 상태에서도 "New Report" 버튼 표시하여 폼 초기화 가능
- **#35**: `shell.open()` await + try-catch + `window.open` fallback 추가, 클릭 간섭하던 `userSelect:"all"` 제거

Closes #8
Closes #35

## Test plan
- [x] 기존 7개 테스트 통과
- [x] 신규 3개 테스트 추가 (error 시 New Report, 이중클릭 방지, shell open 에러 핸들링)
- [x] 전체 869개 테스트 통과 (regression 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)