### PR TITLE
Fix: URL 링크 클릭 시 브라우저 열리지 않는 문제

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -50,8 +50,12 @@ vi.mock("@xterm/addon-fit", () => ({
   },
 }));
 
+let capturedLinkHandler: ((event: MouseEvent, uri: string) => void) | null = null;
 vi.mock("@xterm/addon-web-links", () => ({
   WebLinksAddon: class MockWebLinksAddon {
+    constructor(handler?: (event: MouseEvent, uri: string) => void) {
+      if (handler) capturedLinkHandler = handler;
+    }
     dispose = vi.fn();
   },
 }));
@@ -69,6 +73,7 @@ const mockOnTerminalOutput = vi.fn().mockResolvedValue(vi.fn());
 const mockSmartPaste = vi.fn().mockResolvedValue({ pasteType: "none", content: "" });
 const mockClipboardWriteText = vi.fn().mockResolvedValue(undefined);
 const mockSetTerminalCwdReceive = vi.fn().mockResolvedValue(undefined);
+const mockOpenExternal = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("@/lib/tauri-api", () => ({
   createTerminalSession: (...args: unknown[]) => mockCreateTerminalSession(...args),
@@ -80,6 +85,7 @@ vi.mock("@/lib/tauri-api", () => ({
   clipboardWriteText: (...args: unknown[]) => mockClipboardWriteText(...args),
   setTerminalCwdReceive: (...args: unknown[]) => mockSetTerminalCwdReceive(...args),
   updateTerminalSyncGroup: vi.fn().mockResolvedValue(undefined),
+  openExternal: (...args: unknown[]) => mockOpenExternal(...args),
 }));
 
 describe("TerminalView", () => {
@@ -87,6 +93,7 @@ describe("TerminalView", () => {
     useTerminalStore.setState(useTerminalStore.getInitialState());
     useSettingsStore.setState(useSettingsStore.getInitialState());
     capturedKeyHandler = null;
+    capturedLinkHandler = null;
     vi.clearAllMocks();
   });
 
@@ -605,6 +612,45 @@ describe("TerminalView", () => {
     container.dispatchEvent(event);
 
     expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  // -- URL link click (issue #29) --
+
+  describe("URL link click", () => {
+    it("passes a custom handler to WebLinksAddon that calls openExternal", async () => {
+      render(
+        <TerminalView instanceId="t-link1" profile="PowerShell" syncGroup="" />,
+      );
+
+      // WebLinksAddon should have been constructed with a handler
+      expect(capturedLinkHandler).not.toBeNull();
+
+      // Simulate clicking a link
+      const fakeEvent = new MouseEvent("click");
+      capturedLinkHandler!(fakeEvent, "https://example.com");
+
+      await vi.waitFor(() => {
+        expect(mockOpenExternal).toHaveBeenCalledWith("https://example.com");
+      });
+    });
+
+    it("handles openExternal failure gracefully (does not throw)", async () => {
+      mockOpenExternal.mockRejectedValueOnce(new Error("shell open failed"));
+
+      render(
+        <TerminalView instanceId="t-link2" profile="PowerShell" syncGroup="" />,
+      );
+
+      expect(capturedLinkHandler).not.toBeNull();
+
+      // Should not throw even when openExternal fails
+      const fakeEvent = new MouseEvent("click");
+      expect(() => capturedLinkHandler!(fakeEvent, "https://example.com")).not.toThrow();
+
+      await vi.waitFor(() => {
+        expect(mockOpenExternal).toHaveBeenCalledWith("https://example.com");
+      });
+    });
   });
 
   // -- cwdReceive sync (issue #24) --

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -16,6 +16,7 @@ import {
   clipboardWriteText,
   setTerminalCwdReceive,
   updateTerminalSyncGroup,
+  openExternal,
 } from "@/lib/tauri-api";
 import {
   colorSchemeToXtermTheme,
@@ -124,7 +125,9 @@ export function TerminalView({
     });
 
     const fitAddon = new FitAddon();
-    const webLinksAddon = new WebLinksAddon();
+    const webLinksAddon = new WebLinksAddon((_event, uri) => {
+      openExternal(uri).catch(() => {});
+    });
 
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(webLinksAddon);

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -225,6 +225,17 @@ export async function updateTerminalSyncGroup(terminalId: string, newGroup: stri
   return invoke("update_terminal_sync_group", { terminalId, newGroup });
 }
 
+/** Open a URL in the user's default browser via Tauri shell plugin. */
+export async function openExternal(url: string): Promise<void> {
+  try {
+    const { open } = await import("@tauri-apps/plugin-shell");
+    await open(url);
+  } catch (e) {
+    console.warn("shell.open failed, falling back to window.open:", e);
+    window.open(url, "_blank");
+  }
+}
+
 /** Listen for terminal output events from the backend. */
 export function onTerminalOutput(
   terminalId: string,


### PR DESCRIPTION
## Summary
- `WebLinksAddon`에 커스텀 핸들러를 추가하여 Tauri `shell.open()`으로 외부 브라우저를 여는 방식으로 수정
- 실패 시 `window.open()` 폴백 처리
- `openExternal` 유틸리티 함수를 `tauri-api.ts`에 추가

## Test plan
- [x] WebLinksAddon에 커스텀 핸들러 전달 검증
- [x] openExternal 실패 시 예외 미발생 검증
- [x] 전체 871개 테스트 통과

Fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)