### PR TITLE
Fix workspace selector showing dock terminal data

### DIFF
--- a/ui/src/components/layout/WorkspaceArea.tsx
+++ b/ui/src/components/layout/WorkspaceArea.tsx
@@ -120,6 +120,7 @@ export function WorkspaceArea() {
                   viewConfig={pane.view}
                   onSelectView={isActive ? (config) => setPaneView(i, config) : undefined}
                   workspaceName={ws.name}
+                  workspaceId={ws.id}
                   paneId={pane.id}
                   isFocused={isFocused}
                   onKeyboardActivity={() => {

--- a/ui/src/components/views/ViewRenderer.tsx
+++ b/ui/src/components/views/ViewRenderer.tsx
@@ -12,13 +12,14 @@ interface ViewRendererProps {
   viewConfig?: ViewInstanceConfig;
   onSelectView?: (config: ViewInstanceConfig) => void;
   workspaceName?: string;
+  workspaceId?: string;
   paneId?: string;
   emptyViewContext?: EmptyViewContext;
   isFocused?: boolean;
   onKeyboardActivity?: () => void;
 }
 
-export function ViewRenderer({ viewType, viewConfig, onSelectView, workspaceName, paneId, emptyViewContext, isFocused, onKeyboardActivity }: ViewRendererProps) {
+export function ViewRenderer({ viewType, viewConfig, onSelectView, workspaceName, workspaceId, paneId, emptyViewContext, isFocused, onKeyboardActivity }: ViewRendererProps) {
   const defaultProfile = useSettingsStore((s) => s.defaultProfile);
   switch (viewType) {
     case "WorkspaceSelectorView":
@@ -45,6 +46,7 @@ export function ViewRenderer({ viewType, viewConfig, onSelectView, workspaceName
             syncGroup={effectiveSyncGroup}
             cwdSend={(viewConfig?.cwdSend as boolean) ?? true}
             cwdReceive={(viewConfig?.cwdReceive as boolean) ?? true}
+            workspaceId={workspaceId}
             isFocused={isFocused}
             onKeyboardActivity={onKeyboardActivity}
           />

--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -447,6 +447,36 @@ describe("WorkspaceSelectorView", () => {
     expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("ws-default");
   });
 
+  it("does not show dock terminal last command in active workspace summary", () => {
+    useWorkspaceStore.setState({
+      workspaces: [{
+        id: "ws-default", name: "Default", layoutId: "default-layout",
+        panes: [{ id: "p1", x: 0, y: 0, w: 1, h: 1, view: { type: "TerminalView", profile: "PowerShell" } }],
+      }],
+      activeWorkspaceId: "ws-default",
+    });
+    // Workspace terminal with old command
+    useTerminalStore.getState().registerInstance({
+      id: "terminal-p1", profile: "PowerShell", syncGroup: "Default", workspaceId: "ws-default",
+    });
+    useTerminalStore.getState().updateInstanceInfo("terminal-p1", {
+      lastCommand: "npm test", lastExitCode: 0, lastCommandAt: Date.now() - 60000,
+    });
+    // Dock terminal with newer command (should NOT appear in workspace summary)
+    useTerminalStore.getState().registerInstance({
+      id: "terminal-dock-bottom", profile: "WSL", syncGroup: "Default", workspaceId: "",
+    });
+    useTerminalStore.getState().updateInstanceInfo("terminal-dock-bottom", {
+      lastCommand: "cargo build", lastExitCode: 1, lastCommandAt: Date.now(),
+    });
+
+    render(<WorkspaceSelectorView />);
+    // Should show workspace terminal's command, not dock's
+    expect(screen.getByText(/npm test/)).toBeInTheDocument();
+    expect(screen.queryByText(/cargo build/)).not.toBeInTheDocument();
+    expect(screen.getByTestId("cmd-status-ws-default")).toHaveTextContent("✓");
+  });
+
   it("workspace items always render 3 rows even without data", () => {
     render(<WorkspaceSelectorView />);
     const item = screen.getByTestId("workspace-item-ws-default");

--- a/ui/src/lib/workspace-summary.test.ts
+++ b/ui/src/lib/workspace-summary.test.ts
@@ -213,14 +213,27 @@ describe("computeWorkspaceSummary - terminal summaries", () => {
     expect(summary.terminalSummaries).toHaveLength(0);
   });
 
-  it("includes syncGroup-matched terminals in count", () => {
+  it("excludes dock terminals (empty workspaceId) from summary", () => {
     const terminals = [
       makeTerminal({ id: "t1", workspaceId: "ws-1", profile: "WSL", label: "WSL" }),
       makeTerminal({ id: "t2", workspaceId: "", syncGroup: "MyWS", profile: "PS", label: "PS" }),
     ];
     const summary = computeWorkspaceSummary("ws-1", terminals, new Map(), [], "MyWS");
-    expect(summary.terminalCount).toBe(2);
-    expect(summary.terminalSummaries).toHaveLength(2);
+    // Dock terminal (workspaceId="") should NOT be included even if syncGroup matches
+    expect(summary.terminalCount).toBe(1);
+    expect(summary.terminalSummaries).toHaveLength(1);
+    expect(summary.terminalSummaries[0].id).toBe("t1");
+  });
+
+  it("does not show dock terminal last command in workspace summary", () => {
+    const terminals = [
+      makeTerminal({ id: "t1", workspaceId: "ws-1", lastCommand: "npm test", lastExitCode: 0, lastCommandAt: 100 }),
+      makeTerminal({ id: "dock-t", workspaceId: "", syncGroup: "MyWS", lastCommand: "cargo build", lastExitCode: 1, lastCommandAt: 200 }),
+    ];
+    const summary = computeWorkspaceSummary("ws-1", terminals, new Map(), [], "MyWS");
+    // Should show workspace terminal's command, not dock terminal's more recent command
+    expect(summary.lastCommand?.command).toBe("npm test");
+    expect(summary.lastCommand?.exitCode).toBe(0);
   });
 });
 

--- a/ui/src/lib/workspace-summary.ts
+++ b/ui/src/lib/workspace-summary.ts
@@ -95,9 +95,7 @@ export function computeWorkspaceSummary(
   workspaceName?: string,
 ): WorkspaceSummary {
   const wsTerminals = terminals.filter(
-    (t) =>
-      t.workspaceId === workspaceId ||
-      (workspaceName && t.syncGroup === workspaceName),
+    (t) => t.workspaceId === workspaceId,
   );
   const wsNotifications = notifications.filter(
     (n) => n.workspaceId === workspaceId,


### PR DESCRIPTION
## Summary
- **원인**: `computeWorkspaceSummary`가 `syncGroup` 이름 매칭으로 터미널을 필터링하여, Dock 터미널(활성 워크스페이스 이름을 syncGroup으로 받음)이 워크스페이스 요약에 포함됨
- **수정**: `workspaceId`를 WorkspaceArea → ViewRenderer → TerminalView 체인으로 전달하고, `computeWorkspaceSummary`에서 `workspaceId`만으로 필터링하도록 변경
- Dock 터미널은 `workspaceId=""`이므로 어떤 워크스페이스 요약에도 포함되지 않음

Closes #53

## Test plan
- [x] `workspace-summary.test.ts` - Dock 터미널(workspaceId="") 제외 테스트 추가 및 통과 (47/47)
- [x] `WorkspaceSelectorView.test.tsx` - Dock 터미널 last command 미표시 테스트 추가
- [ ] 수동 검증: 워크스페이스 전환 시 Row 3에 Dock 터미널 명령이 표시되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)