### PR TITLE
Fix scrollbar style setting not applying to existing terminals

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -40,12 +40,14 @@ vi.mock("@xterm/xterm", () => ({
     loadAddon = vi.fn();
     cols = 80;
     rows = 24;
+    options: Record<string, unknown> = {};
   },
 }));
 
+const mockFit = vi.fn();
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: class MockFitAddon {
-    fit = vi.fn();
+    fit = mockFit;
     dispose = vi.fn();
   },
 }));
@@ -594,6 +596,63 @@ describe("TerminalView", () => {
     const container = screen.getByTestId("terminal-view-t-sb2");
     expect(container.classList.contains("scrollbar-separate")).toBe(true);
     expect(container.classList.contains("scrollbar-overlay")).toBe(false);
+  });
+
+  it("updates xterm overviewRuler and re-fits when scrollbarStyle changes dynamically", async () => {
+    render(
+      <TerminalView instanceId="t-sb-dyn" profile="PowerShell" syncGroup="" />,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockCreateTerminalSession).toHaveBeenCalled();
+    });
+
+    mockFit.mockClear();
+
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      convenience: { ...useSettingsStore.getState().convenience, scrollbarStyle: "separate" as const },
+    });
+
+    await vi.waitFor(() => {
+      const container = screen.getByTestId("terminal-view-t-sb-dyn");
+      expect(container.classList.contains("scrollbar-separate")).toBe(true);
+    });
+
+    await vi.waitFor(() => {
+      expect(mockFit).toHaveBeenCalled();
+    });
+  });
+
+  it("updates xterm overviewRuler when scrollbarStyle changes from separate to overlay", async () => {
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      convenience: { ...useSettingsStore.getState().convenience, scrollbarStyle: "separate" as const },
+    });
+
+    render(
+      <TerminalView instanceId="t-sb-rev" profile="PowerShell" syncGroup="" />,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockCreateTerminalSession).toHaveBeenCalled();
+    });
+
+    mockFit.mockClear();
+
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      convenience: { ...useSettingsStore.getState().convenience, scrollbarStyle: "overlay" as const },
+    });
+
+    await vi.waitFor(() => {
+      const container = screen.getByTestId("terminal-view-t-sb-rev");
+      expect(container.classList.contains("scrollbar-overlay")).toBe(true);
+    });
+
+    await vi.waitFor(() => {
+      expect(mockFit).toHaveBeenCalled();
+    });
   });
 
   it("clamps font size to maximum 72", async () => {

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -72,6 +72,7 @@ export function TerminalView({
 }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
   const openedRef = useRef(false);
   const isFocusedRef = useRef(isFocused);
   const onKeyboardActivityRef = useRef(onKeyboardActivity);
@@ -132,6 +133,7 @@ export function TerminalView({
     });
 
     const fitAddon = new FitAddon();
+    fitAddonRef.current = fitAddon;
     const webLinksAddon = new WebLinksAddon((_event, uri) => {
       openExternal(uri).catch(() => {});
     });
@@ -538,6 +540,20 @@ export function TerminalView({
       term.options.fontFamily = `'${font.face}', 'Cascadia Mono', 'Consolas', monospace`;
     } catch { /* xterm mock may not support options setter */ }
   }, [currentSchemeName, colorSchemes, font]);
+
+  // Reactively update xterm overviewRuler width when scrollbarStyle changes
+  const scrollbarStyleForEffect = useSettingsStore(
+    (s) => s.convenience.scrollbarStyle ?? "overlay",
+  );
+  useEffect(() => {
+    const term = terminalRef.current;
+    if (!term?.options) return;
+    try {
+      const newWidth = scrollbarStyleForEffect === "overlay" ? 0 : 14;
+      term.options.overviewRuler = { width: newWidth };
+      fitAddonRef.current?.fit();
+    } catch { /* xterm mock may not support options setter */ }
+  }, [scrollbarStyleForEffect]);
 
   // Resolve terminal background for padding area
   const termBg = (() => {


### PR DESCRIPTION
## Summary
- scrollbarStyle 변경 시 xterm.js `overviewRuler.width`를 동적으로 업데이트하고 `fitAddon.fit()` 호출
- `fitAddonRef`를 추가하여 생성 후에도 fit 호출 가능하게 함
- 동적 변경 테스트 2건 추가

## Test plan
- [x] `npx vitest run` — TerminalView 테스트 38개 통과
- [ ] Settings에서 Scrollbar Style 변경 시 기존 터미널에 즉시 반영되는지 확인

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)