### PR TITLE
Add MemoView settings with per-direction padding

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -364,6 +364,35 @@ impl Default for ConvenienceSettings {
     }
 }
 
+fn default_memo_padding() -> u32 {
+    12
+}
+
+/// MemoView settings (padding, etc.).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoSettings {
+    #[serde(default = "default_memo_padding")]
+    pub padding_top: u32,
+    #[serde(default = "default_memo_padding")]
+    pub padding_right: u32,
+    #[serde(default = "default_memo_padding")]
+    pub padding_bottom: u32,
+    #[serde(default = "default_memo_padding")]
+    pub padding_left: u32,
+}
+
+impl Default for MemoSettings {
+    fn default() -> Self {
+        Self {
+            padding_top: 12,
+            padding_right: 12,
+            padding_bottom: 12,
+            padding_left: 12,
+        }
+    }
+}
+
 /// Dock pane definition (persisted view config with position).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -441,6 +470,8 @@ pub struct Settings {
     pub convenience: ConvenienceSettings,
     #[serde(default)]
     pub claude: ClaudeSettings,
+    #[serde(default)]
+    pub memo: MemoSettings,
 }
 
 fn default_app_theme_id() -> String {
@@ -511,6 +542,7 @@ impl Default for Settings {
             ],
             convenience: ConvenienceSettings::default(),
             claude: ClaudeSettings::default(),
+            memo: MemoSettings::default(),
         }
     }
 }

--- a/ui/src/components/views/MemoView.test.tsx
+++ b/ui/src/components/views/MemoView.test.tsx
@@ -2,10 +2,12 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoView } from "./MemoView";
 import { loadMemo, saveMemo } from "@/lib/tauri-api";
+import { useSettingsStore } from "@/stores/settings-store";
 
 vi.mock("@/lib/tauri-api", () => ({
   loadMemo: vi.fn().mockResolvedValue(""),
   saveMemo: vi.fn().mockResolvedValue(undefined),
+  saveSettings: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("MemoView", () => {
@@ -13,6 +15,7 @@ describe("MemoView", () => {
     vi.useFakeTimers();
     vi.mocked(loadMemo).mockClear().mockResolvedValue("");
     vi.mocked(saveMemo).mockClear().mockResolvedValue(undefined);
+    useSettingsStore.setState(useSettingsStore.getInitialState());
   });
   afterEach(() => {
     vi.useRealTimers();
@@ -83,6 +86,23 @@ describe("MemoView", () => {
     unmount();
 
     expect(saveMemo).toHaveBeenCalledWith("pane-3", "pending");
+  });
+
+  it("applies memo padding from settings", () => {
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      memo: { paddingTop: 20, paddingRight: 10, paddingBottom: 5, paddingLeft: 15 },
+    });
+
+    render(<MemoView memoKey="pane-pad" />);
+    const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
+    expect(textarea.style.padding).toBe("20px 10px 5px 15px");
+  });
+
+  it("uses default padding (12px) when no memo settings customized", () => {
+    render(<MemoView memoKey="pane-default-pad" />);
+    const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
+    expect(textarea.style.padding).toBe("12px");
   });
 
   it("renders empty when loadMemo fails", async () => {

--- a/ui/src/components/views/MemoView.tsx
+++ b/ui/src/components/views/MemoView.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { loadMemo, saveMemo } from "@/lib/tauri-api";
+import { useSettingsStore } from "@/stores/settings-store";
 
 const DEBOUNCE_MS = 300;
 
@@ -60,6 +61,8 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
     }, DEBOUNCE_MS);
   };
 
+  const memo = useSettingsStore((s) => s.memo);
+
   return (
     <div data-testid="memo-view" className="flex h-full w-full flex-col">
       <textarea
@@ -67,13 +70,14 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
         data-testid="memo-textarea"
         value={text}
         onChange={handleChange}
-        className="h-full w-full flex-1 resize-none border-none p-3 outline-none"
+        className="h-full w-full flex-1 resize-none border-none outline-none"
         style={{
           background: "var(--bg-base)",
           color: "var(--text-primary)",
           fontFamily: "inherit",
           fontSize: "13px",
           lineHeight: "1.6",
+          padding: `${memo.paddingTop}px ${memo.paddingRight}px ${memo.paddingBottom}px ${memo.paddingLeft}px`,
         }}
         spellCheck={false}
       />

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1139,6 +1139,55 @@ function ClaudeSection() {
   );
 }
 
+// -- Section: Memo --
+
+function MemoSection() {
+  const storeMemo = useSettingsStore((s) => s.memo);
+  const setMemo = useSettingsStore((s) => s.setMemo);
+  const [memo, setDraftMemo] = useDraft("memo", storeMemo, (v) => setMemo(v));
+  const updateMemo = (partial: Partial<typeof memo>) => setDraftMemo(prev => ({ ...prev, ...partial }));
+
+  return (
+    <div>
+      <SectionTitle>Memo</SectionTitle>
+
+      <div style={cardStyle} className="p-4">
+        {/* Padding */}
+        <div className="flex items-start gap-3 py-1.5">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>Padding</span>
+            <p className="mt-0.5 text-[11px] leading-tight" style={{ color: "var(--text-secondary)", opacity: 0.65 }}>
+              메모 영역의 안쪽 여백 (px)
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="grid grid-cols-2 gap-2">
+              {(["Top", "Right", "Bottom", "Left"] as const).map((dir) => {
+                const key = `padding${dir}` as keyof typeof memo;
+                return (
+                  <label key={dir} className="flex items-center gap-1.5">
+                    <span className="w-12 text-[11px]" style={{ color: "var(--text-secondary)" }}>{dir}</span>
+                    <input
+                      data-testid={`memo-padding-${dir.toLowerCase()}`}
+                      type="number"
+                      min={0}
+                      max={64}
+                      className={inputCls}
+                      style={{ width: 60 }}
+                      value={memo[key]}
+                      onChange={(e) => updateMemo({ [key]: Math.max(0, Math.min(64, Number(e.target.value) || 0)) })}
+                    />
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // -- Section: Keybindings --
 
 interface KeybindingDef {
@@ -1660,6 +1709,16 @@ export function SettingsView() {
         >
           Claude Code
         </button>
+        <button
+          data-testid="nav-memo"
+          className="w-full px-4 py-2 text-left text-[13px]"
+          style={navBtnStyle("memo")}
+          onClick={() => setActiveNav("memo")}
+          onMouseEnter={() => setNavHover("memo")}
+          onMouseLeave={() => setNavHover(null)}
+        >
+          Memo
+        </button>
 
         {/* Profiles group */}
         <div className="mt-3 flex items-center justify-between px-3 pb-1">
@@ -1731,6 +1790,7 @@ export function SettingsView() {
           {activeNav === "keybindings" && <KeybindingsSection />}
           {activeNav === "convenience" && <ConvenienceSection />}
           {activeNav === "claude" && <ClaudeSection />}
+          {activeNav === "memo" && <MemoSection />}
         </div>
 
         {/* Sticky save bar — always visible at bottom */}

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -92,6 +92,7 @@ export async function persistSession(): Promise<void> {
     })),
     convenience: { ...settingsState.convenience },
     claude: { ...settingsState.claude },
+    memo: { ...settingsState.memo },
     docks: dockState.docks.map((d) => ({
       position: d.position,
       activeView: d.activeView,

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -95,6 +95,13 @@ export interface ClaudeSettings {
   syncCwd: ClaudeSyncCwdMode;
 }
 
+export interface MemoSettings {
+  paddingTop: number;
+  paddingRight: number;
+  paddingBottom: number;
+  paddingLeft: number;
+}
+
 export interface ProfileDefaults {
   colorScheme?: string;
   cursorShape?: string;
@@ -123,6 +130,7 @@ export interface Settings {
   docks: DockSetting[];
   convenience: ConvenienceSettings;
   claude: ClaudeSettings;
+  memo: MemoSettings;
 }
 
 export interface ColorScheme {

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { ClaudeSyncCwdMode, ClaudeSettings } from "../lib/tauri-api";
+import type { ClaudeSyncCwdMode, ClaudeSettings, MemoSettings } from "../lib/tauri-api";
 
 export interface FontSettings {
   face: string;
@@ -63,12 +63,7 @@ export interface ConvenienceSettings {
 }
 
 
-export interface MemoSettings {
-  paddingTop: number;
-  paddingRight: number;
-  paddingBottom: number;
-  paddingLeft: number;
-}
+export type { MemoSettings } from "../lib/tauri-api";
 
 export type CursorShape = "bar" | "underscore" | "filledBox" | "emptyBox" | "doubleUnderscore" | "vintage";
 export type BellStyle = "audible" | "none" | "window" | "taskbar" | "all";
@@ -204,6 +199,8 @@ interface SettingsState {
 }
 
 const defaultPadding: PaddingSettings = { top: 8, right: 8, bottom: 8, left: 8 };
+
+const DEFAULT_MEMO_PADDING: MemoSettings = { paddingTop: 12, paddingRight: 12, paddingBottom: 12, paddingLeft: 12 };
 
 export const DEFAULT_FONT: FontSettings = { face: "Cascadia Mono", size: 14, weight: "normal" };
 
@@ -400,7 +397,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   appThemeId: "catppuccin-mocha",
   convenience: { smartPaste: true, pasteImageDir: "", hoverIdleSeconds: 2, notificationDismiss: "workspace" as const, copyOnSelect: true, pathEllipsis: "start" as const, scrollbarStyle: "overlay" as const },
   claude: { syncCwd: "skip" as ClaudeSyncCwdMode },
-  memo: { paddingTop: 12, paddingRight: 12, paddingBottom: 12, paddingLeft: 12 },
+  memo: { ...DEFAULT_MEMO_PADDING },
 
   setAppTheme: (appThemeId) => set({ appThemeId }),
 
@@ -530,7 +527,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       : undefined;
     // Ensure memo settings have all fields (backwards compat)
     const memo = data.memo
-      ? { paddingTop: 12, paddingRight: 12, paddingBottom: 12, paddingLeft: 12, ...(data.memo as Partial<MemoSettings>) }
+      ? { ...DEFAULT_MEMO_PADDING, ...(data.memo as Partial<MemoSettings>) }
       : undefined;
 
     // Strip legacy font field before spreading into state

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -63,6 +63,13 @@ export interface ConvenienceSettings {
 }
 
 
+export interface MemoSettings {
+  paddingTop: number;
+  paddingRight: number;
+  paddingBottom: number;
+  paddingLeft: number;
+}
+
 export type CursorShape = "bar" | "underscore" | "filledBox" | "emptyBox" | "doubleUnderscore" | "vintage";
 export type BellStyle = "audible" | "none" | "window" | "taskbar" | "all";
 export type CloseOnExit = "automatic" | "graceful" | "always" | "never";
@@ -173,12 +180,14 @@ interface SettingsState {
   appThemeId: string;
   convenience: ConvenienceSettings;
   claude: ClaudeSettings;
+  memo: MemoSettings;
 
   setDefaultProfile: (profile: string) => void;
   setViewOrder: (order: string[]) => void;
   setAppTheme: (themeId: string) => void;
   setConvenience: (data: Partial<ConvenienceSettings>) => void;
   setClaude: (data: Partial<ClaudeSettings>) => void;
+  setMemo: (data: Partial<MemoSettings>) => void;
   setProfileDefaults: (data: Partial<ProfileDefaults>) => void;
   addProfile: (profile: Profile) => void;
   removeProfile: (index: number) => void;
@@ -191,7 +200,7 @@ interface SettingsState {
   updateKeybinding: (index: number, data: Partial<Keybinding>) => void;
   /** Resolve effective font for a profile: profile.font -> profileDefaults.font -> hardcoded default. */
   resolveFont: (profileName: string) => FontSettings;
-  loadFromSettings: (data: Partial<Pick<SettingsState, "defaultProfile" | "profileDefaults" | "profiles" | "colorSchemes" | "keybindings" | "viewOrder" | "appThemeId" | "convenience" | "claude">> & { font?: FontSettings }) => void;
+  loadFromSettings: (data: Partial<Pick<SettingsState, "defaultProfile" | "profileDefaults" | "profiles" | "colorSchemes" | "keybindings" | "viewOrder" | "appThemeId" | "convenience" | "claude" | "memo">> & { font?: FontSettings }) => void;
 }
 
 const defaultPadding: PaddingSettings = { top: 8, right: 8, bottom: 8, left: 8 };
@@ -391,6 +400,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   appThemeId: "catppuccin-mocha",
   convenience: { smartPaste: true, pasteImageDir: "", hoverIdleSeconds: 2, notificationDismiss: "workspace" as const, copyOnSelect: true, pathEllipsis: "start" as const, scrollbarStyle: "overlay" as const },
   claude: { syncCwd: "skip" as ClaudeSyncCwdMode },
+  memo: { paddingTop: 12, paddingRight: 12, paddingBottom: 12, paddingLeft: 12 },
 
   setAppTheme: (appThemeId) => set({ appThemeId }),
 
@@ -402,6 +412,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setClaude: (data) =>
     set((state) => ({
       claude: { ...state.claude, ...data },
+    })),
+
+  setMemo: (data) =>
+    set((state) => ({
+      memo: { ...state.memo, ...data },
     })),
 
   setDefaultProfile: (defaultProfile) => set({ defaultProfile }),
@@ -513,6 +528,10 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     const claude = data.claude
       ? { syncCwd: "skip" as ClaudeSyncCwdMode, ...(data.claude as Partial<ClaudeSettings>) }
       : undefined;
+    // Ensure memo settings have all fields (backwards compat)
+    const memo = data.memo
+      ? { paddingTop: 12, paddingRight: 12, paddingBottom: 12, paddingLeft: 12, ...(data.memo as Partial<MemoSettings>) }
+      : undefined;
 
     // Strip legacy font field before spreading into state
     const { font: _legacyFont, ...rest } = data;
@@ -524,6 +543,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       ...(mergedSchemes ? { colorSchemes: mergedSchemes } : {}),
       ...(convenience ? { convenience } : {}),
       ...(claude ? { claude } : {}),
+      ...(memo ? { memo } : {}),
     }));
   },
 }));


### PR DESCRIPTION
## Summary
- Settings UI에 Memo 섹션 추가 (padding top/right/bottom/left 개별 설정)
- Rust `MemoSettings` 구조체 + 프론트엔드 `MemoSettings` 인터페이스 추가
- MemoView textarea에서 설정된 padding 반영

## Test plan
- [x] `npx vitest run` — MemoView 테스트 9개, SettingsView 테스트 74개 통과
- [x] `cargo test --lib settings` — Rust 49개 통과
- [ ] Settings Memo 섹션에서 padding 변경 시 MemoView에 즉시 반영되는지 확인

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)