### PR TITLE
Allow Alt+Arrow navigation into/out of dock areas

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -350,6 +350,9 @@ pub struct ConvenienceSettings {
     /// Terminal scrollbar style: "overlay" (default) or "separate".
     #[serde(default = "default_scrollbar_style")]
     pub scrollbar_style: String,
+    /// Allow Alt+Arrow to navigate into/out of dock areas.
+    #[serde(default = "default_true")]
+    pub dock_arrow_nav: bool,
 }
 
 impl Default for ConvenienceSettings {
@@ -360,6 +363,7 @@ impl Default for ConvenienceSettings {
             copy_on_select: true,
             path_ellipsis: PathEllipsisMode::default(),
             scrollbar_style: "overlay".to_string(),
+            dock_arrow_nav: true,
         }
     }
 }

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1096,6 +1096,29 @@ function ConvenienceSection() {
             </FocusSelect>
           </div>
         </div>
+
+        {/* Dock Arrow Nav toggle */}
+        <div className="mt-3 flex items-start gap-3 py-1">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>Dock Arrow Nav</span>
+            <p className="mt-0.5 text-[11px] leading-tight" style={{ color: "var(--text-secondary)", opacity: 0.65 }}>
+              Alt+Arrow로 Dock 영역 진입/이탈 허용
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                data-testid="dock-arrow-nav-toggle"
+                type="checkbox"
+                checked={convenience.dockArrowNav}
+                onChange={(e) => updateConvenience({ dockArrowNav: e.target.checked })}
+              />
+              <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+                {convenience.dockArrowNav ? "Enabled" : "Disabled"}
+              </span>
+            </label>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -6,6 +6,13 @@ import { useDockStore } from "@/stores/dock-store";
 import { useNotificationStore } from "@/stores/notification-store";
 import { useGridStore } from "@/stores/grid-store";
 import { useUiStore } from "@/stores/ui-store";
+import { useSettingsStore } from "@/stores/settings-store";
+
+vi.mock("@/lib/tauri-api", () => ({
+  loadMemo: vi.fn().mockResolvedValue(""),
+  saveMemo: vi.fn().mockResolvedValue(undefined),
+  saveSettings: vi.fn().mockResolvedValue(undefined),
+}));
 
 function fireKey(
   key: string,
@@ -23,6 +30,7 @@ describe("useKeyboardShortcuts", () => {
     useNotificationStore.setState(useNotificationStore.getInitialState());
     useGridStore.setState(useGridStore.getInitialState());
     useUiStore.setState(useUiStore.getInitialState());
+    useSettingsStore.setState(useSettingsStore.getInitialState());
   });
 
   // --- Ctrl+Alt+1~9: workspace switch ---
@@ -332,7 +340,70 @@ describe("useKeyboardShortcuts", () => {
     expect(useGridStore.getState().focusedPaneIndex).toBe(1);
   });
 
-  it("Alt+Arrow does nothing when no pane in that direction", () => {
+  // --- Alt+Arrow: dock navigation ---
+  it("Alt+Arrow enters visible dock when no workspace pane in that direction", () => {
+    // Left dock is visible by default — single pane workspace, pressing left enters dock
+    useGridStore.setState({ focusedPaneIndex: 0 });
+    renderHook(() => useKeyboardShortcuts());
+
+    fireKey("ArrowLeft", { altKey: true });
+
+    expect(useDockStore.getState().focusedDock).toBe("left");
+    expect(useGridStore.getState().focusedPaneIndex).toBeNull();
+  });
+
+  it("Alt+Arrow does not enter hidden dock", () => {
+    // Hide the left dock first (it's visible by default)
+    useDockStore.getState().toggleDockVisible("left");
+    useGridStore.setState({ focusedPaneIndex: 0 });
+    renderHook(() => useKeyboardShortcuts());
+
+    fireKey("ArrowLeft", { altKey: true });
+
+    expect(useDockStore.getState().focusedDock).toBeNull();
+    expect(useGridStore.getState().focusedPaneIndex).toBe(0);
+  });
+
+  it("Alt+Arrow exits dock back to workspace", () => {
+    // Focus left dock, then press right to exit
+    useDockStore.getState().setFocusedDock("left");
+    useGridStore.setState({ focusedPaneIndex: null });
+    renderHook(() => useKeyboardShortcuts());
+
+    fireKey("ArrowRight", { altKey: true }); // right exits left dock
+
+    expect(useDockStore.getState().focusedDock).toBeNull();
+    expect(useGridStore.getState().focusedPaneIndex).toBe(0);
+  });
+
+  it("Alt+Arrow navigates between docks", () => {
+    // Both left and top docks are visible by default
+    useDockStore.getState().setFocusedDock("left");
+    renderHook(() => useKeyboardShortcuts());
+
+    fireKey("ArrowUp", { altKey: true }); // from left dock → top dock
+
+    expect(useDockStore.getState().focusedDock).toBe("top");
+  });
+
+  it("Alt+Arrow dock nav disabled when dockArrowNav is false", () => {
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      convenience: { ...useSettingsStore.getState().convenience, dockArrowNav: false },
+    });
+    // Hide left dock to ensure dock nav doesn't interfere
+    useDockStore.getState().toggleDockVisible("left");
+    useGridStore.setState({ focusedPaneIndex: 0 });
+    renderHook(() => useKeyboardShortcuts());
+
+    fireKey("ArrowLeft", { altKey: true });
+
+    // Should NOT enter dock
+    expect(useDockStore.getState().focusedDock).toBeNull();
+    expect(useGridStore.getState().focusedPaneIndex).toBe(0);
+  });
+
+  it("Alt+Arrow does nothing when no pane and no dock in that direction", () => {
     useWorkspaceStore.setState({
       ...useWorkspaceStore.getState(),
       workspaces: [
@@ -348,6 +419,8 @@ describe("useKeyboardShortcuts", () => {
       ],
     });
 
+    // Hide left dock so pressing left at p1 has nowhere to go
+    useDockStore.getState().toggleDockVisible("left");
     useGridStore.setState({ focusedPaneIndex: 0 });
     renderHook(() => useKeyboardShortcuts());
 

--- a/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -377,7 +377,8 @@ describe("useKeyboardShortcuts", () => {
   });
 
   it("Alt+Arrow navigates between docks", () => {
-    // Both left and top docks are visible by default
+    // Top dock is visible but has no panes by default — add a view so it's navigable
+    useDockStore.getState().setDockActiveView("top", "SettingsView");
     useDockStore.getState().setFocusedDock("left");
     renderHook(() => useKeyboardShortcuts());
 
@@ -452,6 +453,86 @@ describe("useKeyboardShortcuts", () => {
     fireKey("ArrowRight", { altKey: true });
 
     expect(useGridStore.getState().focusedPaneIndex).toBe(1);
+  });
+
+  it("Alt+Arrow does not enter dock with no panes (empty dock)", () => {
+    // Top dock is visible but has no panes by default
+    useGridStore.setState({ focusedPaneIndex: 0 });
+    renderHook(() => useKeyboardShortcuts());
+
+    fireKey("ArrowUp", { altKey: true });
+
+    // Should NOT enter empty dock
+    expect(useDockStore.getState().focusedDock).toBeNull();
+    expect(useGridStore.getState().focusedPaneIndex).toBe(0);
+  });
+
+  it("Alt+Arrow does not navigate to empty dock from another dock", () => {
+    // Top dock is visible but has no panes by default
+    useDockStore.getState().setFocusedDock("left");
+    renderHook(() => useKeyboardShortcuts());
+
+    fireKey("ArrowUp", { altKey: true });
+
+    // Should stay on left dock — top dock has no panes
+    expect(useDockStore.getState().focusedDock).toBe("left");
+  });
+
+  it("Alt+Arrow same direction as dock position is a no-op", () => {
+    // Left Dock → ArrowLeft should do nothing (intentional)
+    useDockStore.getState().setFocusedDock("left");
+    renderHook(() => useKeyboardShortcuts());
+
+    fireKey("ArrowLeft", { altKey: true });
+
+    expect(useDockStore.getState().focusedDock).toBe("left");
+  });
+
+  it("Alt+Arrow in dock when all other docks are hidden stays put", () => {
+    // Hide all docks except left
+    useDockStore.getState().toggleDockVisible("top");
+    useDockStore.getState().toggleDockVisible("bottom");
+    useDockStore.getState().toggleDockVisible("right");
+    useDockStore.getState().setFocusedDock("left");
+    renderHook(() => useKeyboardShortcuts());
+
+    fireKey("ArrowUp", { altKey: true });
+    expect(useDockStore.getState().focusedDock).toBe("left");
+
+    fireKey("ArrowDown", { altKey: true });
+    expect(useDockStore.getState().focusedDock).toBe("left");
+  });
+
+  it("Alt+Arrow exit dock restores pane 0 when focusedPaneIndex was non-null before", () => {
+    // Set focusedPaneIndex to 2, then enter dock (clears it), then exit
+    useWorkspaceStore.setState({
+      ...useWorkspaceStore.getState(),
+      workspaces: [
+        {
+          id: "ws-default",
+          name: "Default",
+          layoutId: "default-layout",
+          panes: [
+            { id: "p1", x: 0, y: 0, w: 0.33, h: 1, view: { type: "TerminalView" } },
+            { id: "p2", x: 0.33, y: 0, w: 0.34, h: 1, view: { type: "TerminalView" } },
+            { id: "p3", x: 0.67, y: 0, w: 0.33, h: 1, view: { type: "TerminalView" } },
+          ],
+        },
+      ],
+    });
+    useGridStore.setState({ focusedPaneIndex: 2 });
+    renderHook(() => useKeyboardShortcuts());
+
+    // Enter left dock from pane 0 (leftmost)
+    useGridStore.setState({ focusedPaneIndex: 0 });
+    fireKey("ArrowLeft", { altKey: true });
+    expect(useDockStore.getState().focusedDock).toBe("left");
+    expect(useGridStore.getState().focusedPaneIndex).toBeNull();
+
+    // Exit back — currently restores to 0 (known limitation, see PR #66 review comment #2)
+    fireKey("ArrowRight", { altKey: true });
+    expect(useDockStore.getState().focusedDock).toBeNull();
+    expect(useGridStore.getState().focusedPaneIndex).toBe(0);
   });
 
   // --- Ctrl+Alt+ArrowLeft/Right: notification-based pane navigation ---

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -83,11 +83,13 @@ export function useKeyboardShortcuts() {
               if (focusedPaneIndex === null) setFocusedPane(0);
               return;
             }
-            // Other directions while in dock: try to navigate to another dock
+            // Other directions while in dock: try to navigate to another dock.
+            // Note: pressing the same direction as the dock's own side (e.g., ArrowLeft
+            // in Left Dock) is intentionally a no-op — there's nothing further in that direction.
             if (dockArrowNav) {
               const targetDock = getDockForDirection(direction);
               const targetState = dockStore.getDock(targetDock);
-              if (targetState?.visible && targetDock !== focusedDock) {
+              if (targetState?.visible && targetState.panes.length > 0 && targetDock !== focusedDock) {
                 dockStore.setFocusedDock(targetDock);
                 return;
               }
@@ -108,7 +110,7 @@ export function useKeyboardShortcuts() {
             // No pane in that direction → try to enter a dock
             const targetDock = getDockForDirection(direction);
             const targetState = dockStore.getDock(targetDock);
-            if (targetState?.visible) {
+            if (targetState?.visible && targetState.panes.length > 0) {
               dockStore.setFocusedDock(targetDock);
               useGridStore.getState().setFocusedPane(null);
             }

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -4,8 +4,10 @@ import { useDockStore } from "@/stores/dock-store";
 import { useGridStore } from "@/stores/grid-store";
 import { useNotificationStore } from "@/stores/notification-store";
 import { useUiStore } from "@/stores/ui-store";
+import { useSettingsStore } from "@/stores/settings-store";
 import { findPaneInDirection, type Direction } from "@/lib/pane-navigation";
 import { findNotificationNavTarget } from "@/lib/notification-navigation";
+import { getDockForDirection, getDockExitDirection } from "@/lib/dock-navigation";
 
 const ARROW_TO_DIRECTION: Record<string, Direction> = {
   ArrowLeft: "left",
@@ -62,11 +64,38 @@ export function useKeyboardShortcuts() {
         return;
       }
 
-      // Alt+Arrow: pane navigation
+      // Alt+Arrow: pane navigation (workspace + dock)
       if (e.altKey && !e.ctrlKey && !e.shiftKey) {
         const direction = ARROW_TO_DIRECTION[e.key];
         if (direction) {
           e.preventDefault();
+          const dockStore = useDockStore.getState();
+          const { focusedDock } = dockStore;
+          const dockArrowNav = useSettingsStore.getState().convenience.dockArrowNav;
+
+          // If currently focused on a dock, try to exit it
+          if (focusedDock !== null) {
+            const exitDir = getDockExitDirection(focusedDock);
+            if (direction === exitDir) {
+              // Exit dock → go back to workspace
+              dockStore.setFocusedDock(null);
+              const { focusedPaneIndex, setFocusedPane } = useGridStore.getState();
+              if (focusedPaneIndex === null) setFocusedPane(0);
+              return;
+            }
+            // Other directions while in dock: try to navigate to another dock
+            if (dockArrowNav) {
+              const targetDock = getDockForDirection(direction);
+              const targetState = dockStore.getDock(targetDock);
+              if (targetState?.visible && targetDock !== focusedDock) {
+                dockStore.setFocusedDock(targetDock);
+                return;
+              }
+            }
+            return;
+          }
+
+          // Currently in workspace: try pane navigation first
           const ws = useWorkspaceStore.getState().getActiveWorkspace();
           if (!ws) return;
           const { focusedPaneIndex, setFocusedPane } = useGridStore.getState();
@@ -74,7 +103,15 @@ export function useKeyboardShortcuts() {
           const next = findPaneInDirection(ws.panes, current, direction);
           if (next !== null) {
             setFocusedPane(next);
-            useDockStore.getState().setFocusedDock(null);
+            dockStore.setFocusedDock(null);
+          } else if (dockArrowNav) {
+            // No pane in that direction → try to enter a dock
+            const targetDock = getDockForDirection(direction);
+            const targetState = dockStore.getDock(targetDock);
+            if (targetState?.visible) {
+              dockStore.setFocusedDock(targetDock);
+              useGridStore.getState().setFocusedPane(null);
+            }
           }
           return;
         }

--- a/ui/src/lib/dock-navigation.test.ts
+++ b/ui/src/lib/dock-navigation.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { getDockForDirection, getDockExitDirection } from "./dock-navigation";
+
+describe("dock-navigation", () => {
+  describe("getDockForDirection", () => {
+    it("maps left → left dock", () => {
+      expect(getDockForDirection("left")).toBe("left");
+    });
+    it("maps right → right dock", () => {
+      expect(getDockForDirection("right")).toBe("right");
+    });
+    it("maps up → top dock", () => {
+      expect(getDockForDirection("up")).toBe("top");
+    });
+    it("maps down → bottom dock", () => {
+      expect(getDockForDirection("down")).toBe("bottom");
+    });
+  });
+
+  describe("getDockExitDirection", () => {
+    it("left dock exits via right", () => {
+      expect(getDockExitDirection("left")).toBe("right");
+    });
+    it("right dock exits via left", () => {
+      expect(getDockExitDirection("right")).toBe("left");
+    });
+    it("top dock exits via down", () => {
+      expect(getDockExitDirection("top")).toBe("down");
+    });
+    it("bottom dock exits via up", () => {
+      expect(getDockExitDirection("bottom")).toBe("up");
+    });
+  });
+});

--- a/ui/src/lib/dock-navigation.ts
+++ b/ui/src/lib/dock-navigation.ts
@@ -1,0 +1,40 @@
+import type { Direction } from "./pane-navigation";
+import type { DockPosition } from "@/stores/types";
+
+/**
+ * Maps a navigation direction to the dock position it leads to.
+ * E.g., pressing "left" at the left edge → LeftDock.
+ */
+const DIRECTION_TO_DOCK: Record<Direction, DockPosition> = {
+  left: "left",
+  right: "right",
+  up: "top",
+  down: "bottom",
+};
+
+/**
+ * Maps a dock position to the direction that would exit the dock
+ * back into the workspace area. E.g., LeftDock → "right".
+ */
+const DOCK_EXIT_DIRECTION: Record<DockPosition, Direction> = {
+  left: "right",
+  right: "left",
+  top: "down",
+  bottom: "up",
+};
+
+/**
+ * Given a direction, return the dock position that would be reached
+ * if navigating from the workspace edge.
+ */
+export function getDockForDirection(direction: Direction): DockPosition {
+  return DIRECTION_TO_DOCK[direction];
+}
+
+/**
+ * Given a dock position, return the direction that exits the dock
+ * back into the workspace area.
+ */
+export function getDockExitDirection(dock: DockPosition): Direction {
+  return DOCK_EXIT_DIRECTION[dock];
+}

--- a/ui/src/lib/dock-navigation.ts
+++ b/ui/src/lib/dock-navigation.ts
@@ -1,10 +1,6 @@
 import type { Direction } from "./pane-navigation";
 import type { DockPosition } from "@/stores/types";
 
-/**
- * Maps a navigation direction to the dock position it leads to.
- * E.g., pressing "left" at the left edge → LeftDock.
- */
 const DIRECTION_TO_DOCK: Record<Direction, DockPosition> = {
   left: "left",
   right: "right",
@@ -12,10 +8,6 @@ const DIRECTION_TO_DOCK: Record<Direction, DockPosition> = {
   down: "bottom",
 };
 
-/**
- * Maps a dock position to the direction that would exit the dock
- * back into the workspace area. E.g., LeftDock → "right".
- */
 const DOCK_EXIT_DIRECTION: Record<DockPosition, Direction> = {
   left: "right",
   right: "left",
@@ -23,18 +15,10 @@ const DOCK_EXIT_DIRECTION: Record<DockPosition, Direction> = {
   bottom: "up",
 };
 
-/**
- * Given a direction, return the dock position that would be reached
- * if navigating from the workspace edge.
- */
 export function getDockForDirection(direction: Direction): DockPosition {
   return DIRECTION_TO_DOCK[direction];
 }
 
-/**
- * Given a dock position, return the direction that exits the dock
- * back into the workspace area.
- */
 export function getDockExitDirection(dock: DockPosition): Direction {
   return DOCK_EXIT_DIRECTION[dock];
 }

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -60,6 +60,8 @@ export interface ConvenienceSettings {
   pathEllipsis: PathEllipsisMode;
   /** Terminal scrollbar style: "overlay" renders on top of content, "separate" reserves space. */
   scrollbarStyle: ScrollbarStyle;
+  /** Allow Alt+Arrow to navigate into/out of dock areas. */
+  dockArrowNav: boolean;
 }
 
 
@@ -389,7 +391,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   keybindings: [],
   viewOrder: [],
   appThemeId: "catppuccin-mocha",
-  convenience: { smartPaste: true, pasteImageDir: "", hoverIdleSeconds: 2, notificationDismiss: "workspace" as const, copyOnSelect: true, pathEllipsis: "start" as const, scrollbarStyle: "overlay" as const },
+  convenience: { smartPaste: true, pasteImageDir: "", hoverIdleSeconds: 2, notificationDismiss: "workspace" as const, copyOnSelect: true, pathEllipsis: "start" as const, scrollbarStyle: "overlay" as const, dockArrowNav: true },
   claude: { syncCwd: "skip" as ClaudeSyncCwdMode },
 
   setAppTheme: (appThemeId) => set({ appThemeId }),
@@ -507,7 +509,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     })() : undefined;
     // Ensure convenience settings have all fields (backwards compat)
     const convenience = data.convenience
-      ? { smartPaste: true, pasteImageDir: "", hoverIdleSeconds: 2, notificationDismiss: "workspace" as const, copyOnSelect: true, pathEllipsis: "start" as const, scrollbarStyle: "overlay" as const, ...(data.convenience as Partial<ConvenienceSettings>) }
+      ? { smartPaste: true, pasteImageDir: "", hoverIdleSeconds: 2, notificationDismiss: "workspace" as const, copyOnSelect: true, pathEllipsis: "start" as const, scrollbarStyle: "overlay" as const, dockArrowNav: true, ...(data.convenience as Partial<ConvenienceSettings>) }
       : undefined;
     // Ensure claude settings have all fields (backwards compat)
     const claude = data.claude


### PR DESCRIPTION
## Summary
- Alt+Arrow로 WorkspaceArea에서 Dock으로, Dock에서 WorkspaceArea로, Dock 간 포커스 이동 가능
- `dock-navigation.ts` 유틸리티 모듈 추가 (방향↔Dock 매핑)
- Convenience settings에 `dockArrowNav` 토글 추가 (기본: 활성화)

## Test plan
- [x] `npx vitest run` — useKeyboardShortcuts 48개, dock-navigation 8개 통과
- [x] `cargo test --lib settings` — Rust 49개 통과
- [ ] Alt+Left로 Left Dock 진입, Alt+Right로 복귀 확인
- [ ] Settings에서 Dock Arrow Nav 비활성화 시 Dock 진입 불가 확인

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)