### PR TITLE
Show Claude Code detailed status in WorkspaceSelectorView

### DIFF
--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -188,7 +188,7 @@ function WorkspaceItem({
                 const tCmdColor = ts.lastCommand
                   ? ts.lastExitCode === undefined ? "var(--yellow)" : ts.lastExitCode === 0 ? "var(--green)" : "var(--red)"
                   : undefined;
-                const actInfo = formatActivity(ts.activity);
+                const actInfo = formatActivity(ts.activity, ts.title);
                 return (
                   <div key={pane.id} className="flex items-center gap-1.5 truncate text-[11px]" style={{ paddingLeft: showMinimap ? 2 : 18 }}>
                     {showMinimap && (

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { detectActivityFromTitle, detectActivityFromCommand, detectClaudeTaskTransition, extractClaudeTaskDesc, isGenericClaudeTitle, getClaudeCompletionMessage } from "./activity-detection";
+import { detectActivityFromTitle, detectActivityFromCommand, detectClaudeTaskTransition, extractClaudeTaskDesc, isGenericClaudeTitle, getClaudeCompletionMessage, parseClaudeMode, isRalphActive } from "./activity-detection";
 
 describe("detectActivityFromTitle", () => {
   it("detects vim from title", () => {
@@ -255,5 +255,48 @@ describe("Claude completion notification wiring (bug repro)", () => {
     const message = getClaudeCompletionMessage("✻ Fix the bug", "✳ Claude Code");
     expect(message).toBe("Fix the bug");
     expect(isGenericClaudeTitle(message)).toBe(false);
+  });
+});
+
+describe("parseClaudeMode", () => {
+  const claudeActivity = { type: "interactiveApp" as const, name: "Claude" };
+
+  it("returns undefined for non-Claude terminals", () => {
+    expect(parseClaudeMode("some title", { type: "shell" })).toBeUndefined();
+    expect(parseClaudeMode("some title", { type: "interactiveApp", name: "vim" })).toBeUndefined();
+    expect(parseClaudeMode("some title", undefined)).toBeUndefined();
+  });
+
+  it("returns idle for ✳ prefix title", () => {
+    expect(parseClaudeMode("✳ Claude Code", claudeActivity)).toBe("idle");
+  });
+
+  it("returns working for spinner prefix title", () => {
+    expect(parseClaudeMode("✶ Writing code...", claudeActivity)).toBe("working");
+  });
+
+  it("returns plan when title contains 'plan'", () => {
+    expect(parseClaudeMode("✶ Plan mode", claudeActivity)).toBe("plan");
+    expect(parseClaudeMode("✳ Plan: approach for fix", claudeActivity)).toBe("plan");
+  });
+
+  it("returns danger when title contains 'danger'", () => {
+    expect(parseClaudeMode("✳ Danger mode active", claudeActivity)).toBe("danger");
+  });
+
+  it("returns idle when title is undefined", () => {
+    expect(parseClaudeMode(undefined, claudeActivity)).toBe("idle");
+  });
+});
+
+describe("isRalphActive", () => {
+  it("returns true when title contains 'ralph'", () => {
+    expect(isRalphActive("✶ Ralph: fixing bugs")).toBe(true);
+    expect(isRalphActive("✳ Ralph loop active")).toBe(true);
+  });
+
+  it("returns false for normal Claude titles", () => {
+    expect(isRalphActive("✳ Claude Code")).toBe(false);
+    expect(isRalphActive(undefined)).toBe(false);
   });
 });

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -54,6 +54,44 @@ export function detectActivityFromCommand(command: string): TerminalActivityInfo
   return undefined;
 }
 
+export type ClaudeMode = "idle" | "working" | "plan" | "danger";
+
+/**
+ * Parse Claude Code mode from terminal title.
+ *
+ * Claude Code embeds status in its terminal title:
+ * - ✳ prefix = idle (accept edits)
+ * - spinner prefix = working
+ * - Title may contain mode keywords: "Plan mode", "Danger", etc.
+ *
+ * Returns undefined if not a Claude terminal.
+ */
+export function parseClaudeMode(
+  title: string | undefined,
+  activity: TerminalActivityInfo | undefined,
+): ClaudeMode | undefined {
+  if (activity?.type !== "interactiveApp" || activity.name !== "Claude") return undefined;
+  if (!title) return "idle";
+
+  // Check for plan mode indicator (case-insensitive)
+  if (/\bplan\b/i.test(title)) return "plan";
+  // Check for danger mode indicator
+  if (/\bdanger\b/i.test(title)) return "danger";
+
+  // Idle vs working based on prefix character
+  if (isClaudeIdle(title)) return "idle";
+  return "working";
+}
+
+/**
+ * Check if the title indicates Ralph (autonomous loop) is active.
+ * Ralph typically sets a distinctive title pattern.
+ */
+export function isRalphActive(title: string | undefined): boolean {
+  if (!title) return false;
+  return /\bralph\b/i.test(title);
+}
+
 export type ClaudeTaskTransition = "started" | "completed";
 
 /** Claude Code idle prefix: ✳ (U+2733) */

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -73,9 +73,10 @@ export function parseClaudeMode(
   if (activity?.type !== "interactiveApp" || activity.name !== "Claude") return undefined;
   if (!title) return "idle";
 
-  // Check for plan mode indicator (case-insensitive)
+  // Priority: plan > danger > idle/working.
+  // Claude Code title may contain both mode keywords and idle/working prefix.
+  // We check mode keywords first so "✳ Plan: approach" returns "plan", not "idle".
   if (/\bplan\b/i.test(title)) return "plan";
-  // Check for danger mode indicator
   if (/\bdanger\b/i.test(title)) return "danger";
 
   // Idle vs working based on prefix character
@@ -85,11 +86,12 @@ export function parseClaudeMode(
 
 /**
  * Check if the title indicates Ralph (autonomous loop) is active.
- * Ralph typically sets a distinctive title pattern.
+ * Ralph loop sets titles like "✶ Ralph: fixing bugs" or "✳ Ralph loop active".
+ * We match "Ralph:" or "Ralph loop" to avoid false positives from file/variable names.
  */
 export function isRalphActive(title: string | undefined): boolean {
   if (!title) return false;
-  return /\bralph\b/i.test(title);
+  return /\bRalph[:\s]+(loop\b|[^)]*)/i.test(title);
 }
 
 export type ClaudeTaskTransition = "started" | "completed";

--- a/ui/src/lib/workspace-summary.test.ts
+++ b/ui/src/lib/workspace-summary.test.ts
@@ -417,8 +417,28 @@ describe("formatActivity", () => {
 
   it("returns Claude brand color (#D97757) for Claude app", () => {
     const result = formatActivity({ type: "interactiveApp", name: "Claude" });
-    expect(result.label).toBe("Claude");
+    expect(result.label).toContain("Claude");
     expect(result.color).toBe("#D97757");
+  });
+
+  it("shows Claude mode from title", () => {
+    const result = formatActivity({ type: "interactiveApp", name: "Claude" }, "✶ Plan: approach");
+    expect(result.label).toContain("Plan");
+    expect(result.claudeMode).toBe("plan");
+    expect(result.color).toBe("var(--yellow)");
+  });
+
+  it("shows Claude danger mode from title", () => {
+    const result = formatActivity({ type: "interactiveApp", name: "Claude" }, "✳ Danger mode");
+    expect(result.label).toContain("Danger");
+    expect(result.claudeMode).toBe("danger");
+    expect(result.color).toBe("var(--red)");
+  });
+
+  it("shows Ralph indicator from title", () => {
+    const result = formatActivity({ type: "interactiveApp", name: "Claude" }, "✶ Ralph: fixing");
+    expect(result.ralph).toBe(true);
+    expect(result.label).toContain("®");
   });
 });
 

--- a/ui/src/lib/workspace-summary.ts
+++ b/ui/src/lib/workspace-summary.ts
@@ -1,6 +1,6 @@
 import type { TerminalInstance, TerminalActivityInfo } from "@/stores/terminal-store";
 import type { Notification } from "@/stores/notification-store";
-import { parseClaudeMode, isRalphActive, type ClaudeMode } from "@/lib/activity-detection";
+import { parseClaudeMode, isRalphActive, type ClaudeMode } from "./activity-detection";
 
 export interface LastCommandInfo {
   command: string;
@@ -204,7 +204,7 @@ export function formatPorts(ports: number[], maxDisplay = 5): string {
 
 const CLAUDE_MODE_LABELS: Record<ClaudeMode, { suffix: string; icon: string }> = {
   idle: { suffix: "", icon: "✳" },
-  working: { suffix: "", icon: "⟳" },
+  working: { suffix: "", icon: "✶" },
   plan: { suffix: " Plan", icon: "📋" },
   danger: { suffix: " Danger", icon: "⚠" },
 };

--- a/ui/src/lib/workspace-summary.ts
+++ b/ui/src/lib/workspace-summary.ts
@@ -1,5 +1,6 @@
 import type { TerminalInstance, TerminalActivityInfo } from "@/stores/terminal-store";
 import type { Notification } from "@/stores/notification-store";
+import { parseClaudeMode, isRalphActive, type ClaudeMode } from "@/lib/activity-detection";
 
 export interface LastCommandInfo {
   command: string;
@@ -13,6 +14,7 @@ export interface TerminalSummaryInfo {
   profile: string;
   cwd: string | null;
   branch: string | null;
+  title: string | undefined;
   lastCommand: string | undefined;
   lastExitCode: number | undefined;
   lastCommandAt: number | undefined;
@@ -124,6 +126,7 @@ export function computeWorkspaceSummary(
       profile: t.profile,
       cwd: t.cwd ?? null,
       branch: t.branch ?? null,
+      title: t.title,
       lastCommand: t.lastCommand,
       lastExitCode: t.lastExitCode,
       lastCommandAt: t.lastCommandAt,
@@ -199,10 +202,19 @@ export function formatPorts(ports: number[], maxDisplay = 5): string {
   return `${shown}  +${ports.length - maxDisplay}`;
 }
 
+const CLAUDE_MODE_LABELS: Record<ClaudeMode, { suffix: string; icon: string }> = {
+  idle: { suffix: "", icon: "✳" },
+  working: { suffix: "", icon: "⟳" },
+  plan: { suffix: " Plan", icon: "📋" },
+  danger: { suffix: " Danger", icon: "⚠" },
+};
+
 /** Get a display label for terminal activity state. */
-export function formatActivity(activity: TerminalActivityInfo | undefined): {
+export function formatActivity(activity: TerminalActivityInfo | undefined, title?: string): {
   label: string;
   color: string;
+  claudeMode?: ClaudeMode;
+  ralph?: boolean;
 } {
   if (!activity) return { label: "shell", color: "var(--text-secondary)" };
   switch (activity.type) {
@@ -210,11 +222,17 @@ export function formatActivity(activity: TerminalActivityInfo | undefined): {
       return { label: "shell", color: "var(--text-secondary)" };
     case "running":
       return { label: "running", color: "var(--yellow)" };
-    case "interactiveApp":
+    case "interactiveApp": {
       if (activity.name === "Claude") {
-        return { label: activity.name, color: "#D97757" };
+        const mode = parseClaudeMode(title, activity);
+        const ralph = isRalphActive(title);
+        const modeInfo = mode ? CLAUDE_MODE_LABELS[mode] : { suffix: "", icon: "" };
+        const label = `${modeInfo.icon} Claude${modeInfo.suffix}${ralph ? " ®" : ""}`.trim();
+        const color = mode === "danger" ? "var(--red)" : mode === "plan" ? "var(--yellow)" : "#D97757";
+        return { label, color, claudeMode: mode, ralph };
       }
       return { label: activity.name ?? "app", color: "var(--accent)" };
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Claude Code 터미널 타이틀에서 mode(idle/working/plan/danger) 파싱
- Ralph 루프 활성 여부 감지 (® 표시)
- WorkspaceSelectorView에 모드별 아이콘+색상 표시 (plan=노랑, danger=빨강)

## Test plan
- [x] `npx vitest run` — activity-detection 60개, workspace-summary 59개 통과
- [ ] Claude Code 실행 중 Plan 모드 진입 시 "📋 Claude Plan" 표시 확인
- [ ] 일반 idle 상태에서 "✳ Claude" 표시 확인

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)