### PR TITLE
Fix dock layout H/V toggle destroying terminal sessions

### DIFF
--- a/src-tauri/src/automation_server.rs
+++ b/src-tauri/src/automation_server.rs
@@ -252,6 +252,7 @@ pub const REGISTERED_ROUTES: &[(&str, &str)] = &[
     ("PUT",    "/api/v1/docks/{position}/size"),
     ("PUT",    "/api/v1/docks/{position}/views"),
     ("POST",   "/api/v1/docks/{position}/split"),
+    ("POST",   "/api/v1/docks/layout-mode/toggle"),
     ("DELETE","/api/v1/docks/{position}/panes/{paneId}"),
     ("GET",    "/api/v1/terminals"),
     ("POST",   "/api/v1/terminals/{id}/write"),
@@ -296,6 +297,7 @@ pub fn build_router(state: ServerState) -> Router {
         .route("/api/v1/docks/{position}/toggle", post(docks_toggle_visible))
         .route("/api/v1/docks/{position}/size", put(docks_set_size))
         .route("/api/v1/docks/{position}/views", put(docks_set_views))
+        .route("/api/v1/docks/layout-mode/toggle", post(docks_toggle_layout_mode))
         .route("/api/v1/docks/{position}/split", post(docks_split_pane))
         .route("/api/v1/docks/{position}/panes/{paneId}", delete(docks_remove_pane))
         .route("/api/v1/terminals", get(terminals_list))
@@ -415,6 +417,10 @@ async fn api_docs() -> impl IntoResponse {
                 "method": "PUT", "path": "/api/v1/docks/{position}/active-view",
                 "description": "Set the active view of a dock. position: top|bottom|left|right.",
                 "body": { "view": "\"WorkspaceSelectorView\" | \"SettingsView\"" }
+            },
+            {
+                "method": "POST", "path": "/api/v1/docks/layout-mode/toggle",
+                "description": "Toggle dock layout mode between horizontal and vertical."
             },
             {
                 "method": "POST", "path": "/api/v1/docks/{position}/toggle",
@@ -926,6 +932,23 @@ async fn docks_set_active_view(
         "docks",
         "setActiveView",
         serde_json::json!({ "position": position, "view": body.view }),
+    )
+    .await
+    {
+        Ok(data) => (StatusCode::OK, Json(data)),
+        Err(e) => e,
+    }
+}
+
+async fn docks_toggle_layout_mode(
+    AxumState(state): AxumState<ServerState>,
+) -> impl IntoResponse {
+    match bridge_request(
+        &state,
+        "action",
+        "docks",
+        "toggleLayoutMode",
+        serde_json::json!({}),
     )
     .await
     {

--- a/src-tauri/src/automation_server.rs
+++ b/src-tauri/src/automation_server.rs
@@ -247,12 +247,12 @@ pub const REGISTERED_ROUTES: &[(&str, &str)] = &[
     ("DELETE", "/api/v1/panes/{index}"),
     ("PUT",    "/api/v1/panes/{index}/view"),
     ("GET",    "/api/v1/docks"),
+    ("POST",   "/api/v1/docks/layout-mode/toggle"),
     ("PUT",    "/api/v1/docks/{position}/active-view"),
     ("POST",   "/api/v1/docks/{position}/toggle"),
     ("PUT",    "/api/v1/docks/{position}/size"),
     ("PUT",    "/api/v1/docks/{position}/views"),
     ("POST",   "/api/v1/docks/{position}/split"),
-    ("POST",   "/api/v1/docks/layout-mode/toggle"),
     ("DELETE","/api/v1/docks/{position}/panes/{paneId}"),
     ("GET",    "/api/v1/terminals"),
     ("POST",   "/api/v1/terminals/{id}/write"),
@@ -293,11 +293,11 @@ pub fn build_router(state: ServerState) -> Router {
         .route("/api/v1/panes/{index}", delete(panes_remove))
         .route("/api/v1/panes/{index}/view", put(panes_set_view))
         .route("/api/v1/docks", get(docks_list))
+        .route("/api/v1/docks/layout-mode/toggle", post(docks_toggle_layout_mode))
         .route("/api/v1/docks/{position}/active-view", put(docks_set_active_view))
         .route("/api/v1/docks/{position}/toggle", post(docks_toggle_visible))
         .route("/api/v1/docks/{position}/size", put(docks_set_size))
         .route("/api/v1/docks/{position}/views", put(docks_set_views))
-        .route("/api/v1/docks/layout-mode/toggle", post(docks_toggle_layout_mode))
         .route("/api/v1/docks/{position}/split", post(docks_split_pane))
         .route("/api/v1/docks/{position}/panes/{paneId}", delete(docks_remove_pane))
         .route("/api/v1/terminals", get(terminals_list))

--- a/ui/src/components/layout/AppLayout.test.tsx
+++ b/ui/src/components/layout/AppLayout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
@@ -102,6 +102,30 @@ describe("AppLayout", () => {
     await user.click(screen.getByTestId("notification-panel-close"));
 
     expect(useUiStore.getState().notificationPanelOpen).toBe(false);
+  });
+
+  // --- Layout Mode Toggle (Issue #6) ---
+
+  it("layout mode toggle does not remount dock components", () => {
+    const { rerender } = render(<AppLayout />);
+    const dockBefore = screen.getByTestId("dock-left");
+
+    act(() => { useDockStore.getState().toggleLayoutMode(); });
+    rerender(<AppLayout />);
+
+    const dockAfter = screen.getByTestId("dock-left");
+    expect(dockAfter).toBe(dockBefore); // Same DOM node, not recreated
+  });
+
+  it("dock pane IDs remain stable after toggleLayoutMode", () => {
+    useDockStore.getState().setDockActiveView("bottom", "TerminalView");
+    const paneIdBefore = useDockStore.getState().getDock("bottom")?.panes[0]?.id;
+
+    render(<AppLayout />);
+    act(() => { useDockStore.getState().toggleLayoutMode(); });
+
+    const paneIdAfter = useDockStore.getState().getDock("bottom")?.panes[0]?.id;
+    expect(paneIdAfter).toBe(paneIdBefore);
   });
 
   it("notification panel overlay shows only active workspace notifications", () => {

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useEffect } from "react";
+import { useCallback, useMemo, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useDockStore } from "@/stores/dock-store";
 import { useGridStore } from "@/stores/grid-store";
@@ -118,24 +118,29 @@ export function AppLayout() {
   const left = docks.find((d) => d.position === "left");
   const right = docks.find((d) => d.position === "right");
 
-  const renderDock = (dock: typeof top, borderSide: string) => {
+  const gridStyles = useMemo((): React.CSSProperties => {
+    const topSize = top?.visible ? `${top.size}px` : "0px";
+    const bottomSize = bottom?.visible ? `${bottom.size}px` : "0px";
+    const leftSize = left?.visible ? `${left.size}px` : "0px";
+    const rightSize = right?.visible ? `${right.size}px` : "0px";
+
+    return {
+      display: "grid",
+      gridTemplateAreas:
+        layoutMode === "horizontal"
+          ? `"top top top" "left ws right" "bottom bottom bottom"`
+          : `"left top right" "left ws right" "left bottom right"`,
+      gridTemplateColumns: `${leftSize} 1fr ${rightSize}`,
+      gridTemplateRows: `${topSize} 1fr ${bottomSize}`,
+    };
+  }, [layoutMode, top?.visible, top?.size, bottom?.visible, bottom?.size,
+    left?.visible, left?.size, right?.visible, right?.size]);
+
+  const renderDockContent = (dock: typeof top, pos: DockPosition, borderSide: string) => {
     if (!dock?.visible) return null;
-    const pos = dock.position;
-    const isLR = pos === "left" || pos === "right";
     const isFocused = focusedDock === pos;
     return (
-      <div
-        className={`relative shrink-0 ${isLR ? "" : "w-full"}`}
-        style={{
-          [isLR ? "width" : "height"]: dock.size,
-          [`border${borderSide}`]: `1px solid var(--border)`,
-          background: "var(--bg-surface)",
-        }}
-        onMouseDown={() => {
-          setFocusedDock(pos);
-          useGridStore.getState().setFocusedPane(null);
-        }}
-      >
+      <>
         <Dock
           position={pos}
           activeView={dock.activeView}
@@ -154,48 +159,58 @@ export function AppLayout() {
             style={{ boxShadow: "inset 0 0 0 1px var(--accent)", zIndex: 20 }}
           />
         )}
-      </div>
+      </>
     );
   };
 
-  const topDock = renderDock(top, "Bottom");
-  const bottomDock = renderDock(bottom, "Top");
-  const leftDock = renderDock(left, "Right");
-  const rightDock = renderDock(right, "Left");
-
-  const workspace = (
-    <div className="min-w-0 flex-1">
-      <WorkspaceArea />
-    </div>
-  );
-
-  const content =
-    layoutMode === "horizontal" ? (
-      <>
-        {topDock}
-        <div className="flex min-h-0 flex-1">
-          {leftDock}
-          {workspace}
-          {rightDock}
-        </div>
-        {bottomDock}
-      </>
-    ) : (
-      <div className="flex min-h-0 flex-1">
-        {leftDock}
-        <div className="flex min-w-0 flex-1 flex-col">
-          {topDock}
-          {workspace}
-          {bottomDock}
-        </div>
-        {rightDock}
-      </div>
-    );
+  const dockAreaStyle = (pos: DockPosition, borderSide: string, dock: typeof top): React.CSSProperties => {
+    const areaMap = { top: "top", bottom: "bottom", left: "left", right: "right" } as const;
+    if (!dock?.visible) return { gridArea: areaMap[pos], overflow: "hidden" };
+    return {
+      gridArea: areaMap[pos],
+      position: "relative",
+      overflow: "hidden",
+      [`border${borderSide}`]: "1px solid var(--border)",
+      background: "var(--bg-surface)",
+    };
+  };
 
   return (
     <div className="flex h-full flex-col">
       <GridEditToolbar />
-      {content}
+      <div className="min-h-0 flex-1" style={gridStyles}>
+        <div
+          key="dock-top"
+          style={dockAreaStyle("top", "Bottom", top)}
+          onMouseDown={top?.visible ? () => { setFocusedDock("top"); useGridStore.getState().setFocusedPane(null); } : undefined}
+        >
+          {renderDockContent(top, "top", "Bottom")}
+        </div>
+        <div
+          key="dock-left"
+          style={dockAreaStyle("left", "Right", left)}
+          onMouseDown={left?.visible ? () => { setFocusedDock("left"); useGridStore.getState().setFocusedPane(null); } : undefined}
+        >
+          {renderDockContent(left, "left", "Right")}
+        </div>
+        <div key="dock-ws" style={{ gridArea: "ws", minWidth: 0, minHeight: 0, overflow: "hidden" }}>
+          <WorkspaceArea />
+        </div>
+        <div
+          key="dock-right"
+          style={dockAreaStyle("right", "Left", right)}
+          onMouseDown={right?.visible ? () => { setFocusedDock("right"); useGridStore.getState().setFocusedPane(null); } : undefined}
+        >
+          {renderDockContent(right, "right", "Left")}
+        </div>
+        <div
+          key="dock-bottom"
+          style={dockAreaStyle("bottom", "Top", bottom)}
+          onMouseDown={bottom?.visible ? () => { setFocusedDock("bottom"); useGridStore.getState().setFocusedPane(null); } : undefined}
+        >
+          {renderDockContent(bottom, "bottom", "Top")}
+        </div>
+      </div>
 
       {/* Notification Panel Overlay */}
       {notificationPanelOpen && createPortal(

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -163,6 +163,11 @@ const handlers: HandlerMap = {
       );
       return ok({ viewSet: true });
     },
+    toggleLayoutMode: () => {
+      useDockStore.getState().toggleLayoutMode();
+      const { layoutMode } = useDockStore.getState();
+      return ok({ layoutMode });
+    },
   },
 
   settings: {


### PR DESCRIPTION
## Summary
- **Fixes #6**: Dock horizontal ↔ vertical 레이아웃 전환 시 터미널 등 모든 dock 콘텐츠가 파괴되는 버그 수정
- `AppLayout`의 조건부 JSX 분기를 단일 CSS Grid 컨테이너로 교체하여 React 트리를 안정화
- Automation API에 `toggleLayoutMode` 엔드포인트 추가 (`POST /api/v1/docks/layout-mode/toggle`)

## Root Cause
`layoutMode` 전환 시 완전히 다른 JSX 트리를 렌더링(Fragment vs div)하여 React가 모든 Dock 컴포넌트를 unmount/remount → `TerminalView` cleanup(`closeTerminalSession`, `terminal.dispose()`) 실행 → 세션 소멸

## Solution
5개 영역(4 dock + workspace)을 항상 같은 부모의 같은 순서 형제 노드로 CSS Grid에 배치. `grid-template-areas`만 변경하여 레이아웃 전환. React 트리가 안정되므로 컴포넌트가 unmount되지 않음.

## Test plan
- [x] 975 기존 테스트 전부 통과
- [x] DOM 안정성 테스트 추가: 레이아웃 토글 후 dock DOM 노드가 동일 인스턴스인지 확인
- [x] Pane ID 안정성 테스트 추가: `toggleLayoutMode` 후 pane ID 불변 확인
- [x] Dev 인스턴스에서 H/V 전환 스크린샷 검증 — 레이아웃 변경되고 dock 내용 유지됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)