### PR TITLE
Add terminal scrollbar overlay/separate mode setting

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -262,6 +262,22 @@ impl Default for ClaudeSettings {
     }
 }
 
+/// Terminal scrollbar display mode.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ScrollbarMode {
+    /// Scrollbar overlaps terminal content (default, saves space).
+    Overlay,
+    /// Scrollbar has its own dedicated space.
+    Separate,
+}
+
+impl Default for ScrollbarMode {
+    fn default() -> Self {
+        Self::Overlay
+    }
+}
+
 /// Convenience feature settings (smart paste, etc.).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -273,6 +289,9 @@ pub struct ConvenienceSettings {
     /// Automatically copy text to clipboard when selected in terminal.
     #[serde(default = "default_true")]
     pub copy_on_select: bool,
+    /// Terminal scrollbar display mode: overlay (default) or separate.
+    #[serde(default)]
+    pub scrollbar_mode: ScrollbarMode,
 }
 
 impl Default for ConvenienceSettings {
@@ -281,6 +300,7 @@ impl Default for ConvenienceSettings {
             smart_paste: true,
             paste_image_dir: String::new(),
             copy_on_select: true,
+            scrollbar_mode: ScrollbarMode::default(),
         }
     }
 }
@@ -696,6 +716,47 @@ mod tests {
         let settings: Settings = serde_json::from_str(json).unwrap();
         assert!(settings.convenience.smart_paste);
         assert_eq!(settings.convenience.paste_image_dir, "");
+    }
+
+    #[test]
+    fn scrollbar_mode_default_is_overlay() {
+        let settings = Settings::default();
+        assert_eq!(settings.convenience.scrollbar_mode, ScrollbarMode::Overlay);
+    }
+
+    #[test]
+    fn scrollbar_mode_deserialize_overlay() {
+        let json = r#"{"convenience": {"scrollbarMode": "overlay"}}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.convenience.scrollbar_mode, ScrollbarMode::Overlay);
+    }
+
+    #[test]
+    fn scrollbar_mode_deserialize_separate() {
+        let json = r#"{"convenience": {"scrollbarMode": "separate"}}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.convenience.scrollbar_mode, ScrollbarMode::Separate);
+    }
+
+    #[test]
+    fn scrollbar_mode_defaults_to_overlay_when_missing() {
+        let json = r#"{"convenience": {"smartPaste": true}}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.convenience.scrollbar_mode, ScrollbarMode::Overlay);
+    }
+
+    #[test]
+    fn scrollbar_mode_round_trip() {
+        let settings = Settings {
+            convenience: ConvenienceSettings {
+                scrollbar_mode: ScrollbarMode::Separate,
+                ..ConvenienceSettings::default()
+            },
+            ..Settings::default()
+        };
+        let json = serde_json::to_string_pretty(&settings).unwrap();
+        let parsed: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.convenience.scrollbar_mode, ScrollbarMode::Separate);
     }
 
     #[test]

--- a/ui/src/components/views/SettingsView.test.tsx
+++ b/ui/src/components/views/SettingsView.test.tsx
@@ -397,4 +397,30 @@ describe("SettingsView", () => {
     await user.selectOptions(select, "command");
     expect(useSettingsStore.getState().claude.syncCwd).toBe("command");
   });
+
+  // -- Scrollbar mode setting --
+
+  it("shows scrollbar mode select in Convenience section", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+    await user.click(screen.getByTestId("nav-convenience"));
+    expect(screen.getByTestId("scrollbar-mode-select")).toBeInTheDocument();
+  });
+
+  it("scrollbar mode defaults to overlay", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+    await user.click(screen.getByTestId("nav-convenience"));
+    const select = screen.getByTestId("scrollbar-mode-select") as HTMLSelectElement;
+    expect(select.value).toBe("overlay");
+  });
+
+  it("changing scrollbar mode updates store", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+    await user.click(screen.getByTestId("nav-convenience"));
+    const select = screen.getByTestId("scrollbar-mode-select");
+    await user.selectOptions(select, "separate");
+    expect(useSettingsStore.getState().convenience.scrollbarMode).toBe("separate");
+  });
 });

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -990,6 +990,27 @@ function ConvenienceSection() {
             </FocusSelect>
           </div>
         </div>
+
+        {/* Scrollbar mode */}
+        <div className="flex items-start gap-3 py-1.5">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>Scrollbar Mode</span>
+            <p className="mt-0.5 text-[11px] leading-tight" style={{ color: "var(--text-secondary)", opacity: 0.65 }}>
+              터미널 스크롤바 표시 방식
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <FocusSelect
+              data-testid="scrollbar-mode-select"
+              className={inputCls}
+              value={convenience.scrollbarMode ?? "overlay"}
+              onChange={(e) => setConvenience({ scrollbarMode: e.target.value as "overlay" | "separate" })}
+            >
+              <option value="overlay">겹쳐서 위에 보여주기 (Overlay)</option>
+              <option value="separate">별도 공간 할당 (Separate)</option>
+            </FocusSelect>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -740,4 +740,51 @@ describe("TerminalView", () => {
       });
     });
   });
+
+  // -- Scrollbar overlay mode --
+
+  describe("scrollbar mode", () => {
+    it("applies scrollbar-overlay class by default", () => {
+      render(
+        <TerminalView instanceId="t-sb1" profile="PowerShell" syncGroup="" />,
+      );
+      const container = screen.getByTestId("terminal-view-t-sb1");
+      expect(container.classList.contains("scrollbar-overlay")).toBe(true);
+      expect(container.classList.contains("scrollbar-separate")).toBe(false);
+    });
+
+    it("applies scrollbar-separate class when setting is separate", () => {
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        convenience: { ...useSettingsStore.getState().convenience, scrollbarMode: "separate" as const },
+      });
+
+      render(
+        <TerminalView instanceId="t-sb2" profile="PowerShell" syncGroup="" />,
+      );
+      const container = screen.getByTestId("terminal-view-t-sb2");
+      expect(container.classList.contains("scrollbar-separate")).toBe(true);
+      expect(container.classList.contains("scrollbar-overlay")).toBe(false);
+    });
+
+    it("reactively switches scrollbar class when setting changes", () => {
+      const { rerender } = render(
+        <TerminalView instanceId="t-sb3" profile="PowerShell" syncGroup="" />,
+      );
+      const container = screen.getByTestId("terminal-view-t-sb3");
+      expect(container.classList.contains("scrollbar-overlay")).toBe(true);
+
+      // Change setting to separate
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        convenience: { ...useSettingsStore.getState().convenience, scrollbarMode: "separate" as const },
+      });
+
+      rerender(
+        <TerminalView instanceId="t-sb3" profile="PowerShell" syncGroup="" />,
+      );
+      expect(container.classList.contains("scrollbar-separate")).toBe(true);
+      expect(container.classList.contains("scrollbar-overlay")).toBe(false);
+    });
+  });
 });

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -527,6 +527,9 @@ export function TerminalView({
     return scheme?.background || "#1e1e2e";
   })();
 
+  // Read scrollbar mode from convenience settings
+  const scrollbarMode = useSettingsStore((s) => s.convenience.scrollbarMode ?? "overlay");
+
   // Read padding from profile settings
   const padding = useSettingsStore(
     (s) => s.profiles.find((p) => p.name === profile)?.padding,
@@ -536,10 +539,12 @@ export function TerminalView({
   const pb = padding?.bottom ?? 8;
   const pl = padding?.left ?? 8;
 
+  const scrollbarCls = scrollbarMode === "separate" ? "scrollbar-separate" : "scrollbar-overlay";
+
   return (
     <div
       data-testid={`terminal-view-${instanceId}`}
-      className="h-full w-full"
+      className={`h-full w-full ${scrollbarCls}`}
       style={{
         background: termBg,
         padding: `${pt}px ${pr}px ${pb}px ${pl}px`,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -54,6 +54,7 @@ body {
  */
 .scrollbar-overlay .xterm-viewport {
   overflow-y: auto !important;
+  right: 0; /* overlap screen area so scrollbar doesn't eat space */
 }
 .scrollbar-overlay .xterm-viewport::-webkit-scrollbar {
   width: 8px;
@@ -69,11 +70,7 @@ body {
 .scrollbar-overlay .xterm-viewport::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.35);
 }
-/* Position viewport to overlap screen area so scrollbar doesn't eat space */
-.scrollbar-overlay .xterm .xterm-viewport {
-  right: 0;
-}
-.scrollbar-overlay .xterm .xterm-screen {
+.scrollbar-overlay .xterm-screen {
   width: 100% !important;
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -46,5 +46,58 @@ body {
   height: 0;
 }
 
+/* ── Terminal Scrollbar Modes ── */
+
+/*
+ * Overlay mode (default): scrollbar floats over terminal content,
+ * transparent by default and visible on hover. No extra space consumed.
+ */
+.scrollbar-overlay .xterm-viewport {
+  overflow-y: auto !important;
+}
+.scrollbar-overlay .xterm-viewport::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+.scrollbar-overlay .xterm-viewport::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollbar-overlay .xterm-viewport::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+}
+.scrollbar-overlay .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+/* Position viewport to overlap screen area so scrollbar doesn't eat space */
+.scrollbar-overlay .xterm .xterm-viewport {
+  right: 0;
+}
+.scrollbar-overlay .xterm .xterm-screen {
+  width: 100% !important;
+}
+
+/*
+ * Separate mode: scrollbar has its own dedicated space (standard browser behavior).
+ * The terminal viewport's native scrollbar is fully visible.
+ */
+.scrollbar-separate .xterm-viewport {
+  overflow-y: scroll !important;
+}
+.scrollbar-separate .xterm-viewport::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.scrollbar-separate .xterm-viewport::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.2);
+}
+.scrollbar-separate .xterm-viewport::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 5px;
+}
+.scrollbar-separate .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.45);
+}
+
 
 

--- a/ui/src/stores/settings-store.test.ts
+++ b/ui/src/stores/settings-store.test.ts
@@ -280,4 +280,51 @@ describe("settings-store", () => {
     const { claude } = useSettingsStore.getState();
     expect(claude.syncCwd).toBe("skip");
   });
+
+  // -- Scrollbar mode settings --
+
+  it("has default scrollbarMode of overlay in convenience settings", () => {
+    const { convenience } = useSettingsStore.getState();
+    expect(convenience.scrollbarMode).toBe("overlay");
+  });
+
+  it("setConvenience updates scrollbarMode to separate", () => {
+    useSettingsStore.getState().setConvenience({ scrollbarMode: "separate" });
+    expect(useSettingsStore.getState().convenience.scrollbarMode).toBe("separate");
+  });
+
+  it("setConvenience updates scrollbarMode to overlay", () => {
+    useSettingsStore.getState().setConvenience({ scrollbarMode: "separate" });
+    useSettingsStore.getState().setConvenience({ scrollbarMode: "overlay" });
+    expect(useSettingsStore.getState().convenience.scrollbarMode).toBe("overlay");
+  });
+
+  it("setConvenience scrollbarMode does not affect other convenience fields", () => {
+    useSettingsStore.getState().setConvenience({ scrollbarMode: "separate" });
+    const { convenience } = useSettingsStore.getState();
+    expect(convenience.smartPaste).toBe(true);
+    expect(convenience.copyOnSelect).toBe(true);
+    expect(convenience.scrollbarMode).toBe("separate");
+  });
+
+  it("loadFromSettings loads scrollbarMode from convenience", () => {
+    useSettingsStore.getState().loadFromSettings({
+      convenience: { smartPaste: true, pasteImageDir: "", hoverIdleSeconds: 2, notificationDismiss: "workspace" as const, copyOnSelect: true, scrollbarMode: "separate" as const },
+    });
+    expect(useSettingsStore.getState().convenience.scrollbarMode).toBe("separate");
+  });
+
+  it("loadFromSettings fills missing scrollbarMode with overlay default", () => {
+    useSettingsStore.getState().loadFromSettings({
+      convenience: { smartPaste: false } as any,
+    });
+    expect(useSettingsStore.getState().convenience.scrollbarMode).toBe("overlay");
+  });
+
+  it("loadFromSettings without convenience preserves scrollbarMode default", () => {
+    useSettingsStore.getState().loadFromSettings({
+      font: { face: "Fira Code", size: 16, weight: "normal" },
+    });
+    expect(useSettingsStore.getState().convenience.scrollbarMode).toBe("overlay");
+  });
 });

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -41,6 +41,9 @@ export interface ColorScheme {
 
 export type NotificationDismissMode = "workspace" | "paneFocus" | "manual";
 
+/** Terminal scrollbar display mode. */
+export type ScrollbarMode = "overlay" | "separate";
+
 export interface ConvenienceSettings {
   smartPaste: boolean;
   pasteImageDir: string;
@@ -50,6 +53,8 @@ export interface ConvenienceSettings {
   notificationDismiss: NotificationDismissMode;
   /** Automatically copy text to clipboard when selected in terminal. */
   copyOnSelect: boolean;
+  /** Terminal scrollbar display mode: "overlay" (overlaps content, default) or "separate" (own space). */
+  scrollbarMode: ScrollbarMode;
 }
 
 
@@ -371,7 +376,7 @@ export const useSettingsStore = create<SettingsState>()((set, _get) => ({
   keybindings: [],
   viewOrder: [],
   appThemeId: "catppuccin-mocha",
-  convenience: { smartPaste: true, pasteImageDir: "", hoverIdleSeconds: 2, notificationDismiss: "workspace" as const, copyOnSelect: true },
+  convenience: { smartPaste: true, pasteImageDir: "", hoverIdleSeconds: 2, notificationDismiss: "workspace" as const, copyOnSelect: true, scrollbarMode: "overlay" as ScrollbarMode },
   claude: { syncCwd: "skip" as ClaudeSyncCwdMode },
 
   setFont: (font) => set({ font }),
@@ -468,7 +473,7 @@ export const useSettingsStore = create<SettingsState>()((set, _get) => ({
     })() : undefined;
     // Ensure convenience settings have all fields (backwards compat)
     const convenience = data.convenience
-      ? { smartPaste: true, pasteImageDir: "", hoverIdleSeconds: 2, notificationDismiss: "workspace" as const, copyOnSelect: true, ...(data.convenience as Partial<ConvenienceSettings>) }
+      ? { smartPaste: true, pasteImageDir: "", hoverIdleSeconds: 2, notificationDismiss: "workspace" as const, copyOnSelect: true, scrollbarMode: "overlay" as ScrollbarMode, ...(data.convenience as Partial<ConvenienceSettings>) }
       : undefined;
     // Ensure claude settings have all fields (backwards compat)
     const claude = data.claude


### PR DESCRIPTION
## Summary
- 터미널 스크롤바 표시 모드 설정 추가: overlay(기본, 콘텐츠 위에 겹침) / separate(별도 공간 차지)
- Settings > Convenience 섹션에 UI 추가
- Rust 백엔드에 `ScrollbarMode` enum 및 직렬화 지원

## Test plan
- [x] Rust 단위 테스트: 기본값, 직렬화/역직렬화, round-trip
- [x] settings-store 테스트: 기본값, 로드, 업데이트
- [x] SettingsView 테스트: UI 표시, 기본값, 변경 반영
- [x] TerminalView 테스트: CSS 클래스 적용, 설정 변경 시 반응

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)