### PR TITLE
Improve workspace management (#14)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -175,16 +175,16 @@ v1은 Built-in only. 플러그인 시스템은 추후 고려.
 
 ### 규칙
 
-- SyncGroup은 **이름 문자열** 하나로 식별
-- 기본값: 소속 Workspace의 이름 (자동 설정)
+- SyncGroup은 **문자열** 하나로 식별
+- 기본값: 소속 Workspace의 **ID** (자동 설정, rename에 안정적)
 - 같은 syncGroup 값을 가진 모든 TerminalView가 동기화 대상
-- Workspace를 넘나드는 그룹도 가능 (같은 이름이면 자동 연결)
+- 크로스 워크스페이스 동기화: 명시적 커스텀 syncGroup 문자열을 지정하면 Workspace를 넘나드는 동기화 가능
 - 독립 터미널: 빈 문자열로 설정
 
 ```jsonc
-{ "syncGroup": "프로젝트A" }  // Workspace 이름 = 기본값 (자동)
-{ "syncGroup": "prod-db"   }  // 커스텀 그룹 (Workspace 무관)
-{ "syncGroup": ""          }  // 독립 — 동기화 받지 않음
+{ "syncGroup": ""            }  // 기본값 = Workspace ID (자동)
+{ "syncGroup": "shared-dev"  }  // 커스텀 그룹 (Workspace 무관, 크로스 WS 동기화)
+{ "syncGroup": ""            }  // 독립 — 동기화 받지 않음
 ```
 
 ### 무한루프 방지

--- a/ui/src/components/layout/GridEditToolbar.tsx
+++ b/ui/src/components/layout/GridEditToolbar.tsx
@@ -26,6 +26,19 @@ export function GridEditToolbar() {
   const toggleLayoutMode = useDockStore((s) => s.toggleLayoutMode);
 
   const [maximized, setMaximized] = useState(false);
+  const [saveFlash, setSaveFlash] = useState<string | null>(null);
+
+  const flash = (key: string) => {
+    setSaveFlash(key);
+    setTimeout(() => setSaveFlash(null), 1500);
+  };
+
+  const handleSave = () => { saveWorkspace(); flash("save"); };
+  const handleSaveAll = () => { saveAndPropagate(); flash("save-all"); };
+  const handleSaveAs = () => {
+    const name = window.prompt("New layout name:");
+    if (name?.trim()) { saveAsNewLayout(name.trim()); flash("save-as"); }
+  };
 
   useEffect(() => {
     getWindow().then((w) => w.isMaximized().then(setMaximized)).catch(() => {});
@@ -130,36 +143,33 @@ export function GridEditToolbar() {
 
             <button
               data-testid="save-btn"
-              onClick={saveWorkspace}
+              onClick={handleSave}
               className={btnBase}
-              style={btnStyle}
-              onMouseEnter={hoverIn}
-              onMouseLeave={hoverOut}
+              style={saveFlash === "save" ? { ...btnH, border: "1px solid var(--green)", color: "var(--bg-base)", background: "var(--green)", borderRadius: 2 } : btnStyle}
+              onMouseEnter={saveFlash === "save" ? undefined : hoverIn}
+              onMouseLeave={saveFlash === "save" ? undefined : hoverOut}
             >
-              Save
+              {saveFlash === "save" ? "Saved!" : "Save"}
             </button>
             <button
               data-testid="save-propagate-btn"
-              onClick={saveAndPropagate}
+              onClick={handleSaveAll}
               className={btnBase}
-              style={btnStyle}
-              onMouseEnter={hoverIn}
-              onMouseLeave={hoverOut}
+              style={saveFlash === "save-all" ? { ...btnH, border: "1px solid var(--green)", color: "var(--bg-base)", background: "var(--green)", borderRadius: 2 } : btnStyle}
+              onMouseEnter={saveFlash === "save-all" ? undefined : hoverIn}
+              onMouseLeave={saveFlash === "save-all" ? undefined : hoverOut}
             >
-              Save All
+              {saveFlash === "save-all" ? "Saved!" : "Save All"}
             </button>
             <button
               data-testid="save-as-btn"
-              onClick={() => {
-                const name = window.prompt("New layout name:");
-                if (name?.trim()) saveAsNewLayout(name.trim());
-              }}
+              onClick={handleSaveAs}
               className={btnBase}
-              style={btnStyle}
-              onMouseEnter={hoverIn}
-              onMouseLeave={hoverOut}
+              style={saveFlash === "save-as" ? { ...btnH, border: "1px solid var(--green)", color: "var(--bg-base)", background: "var(--green)", borderRadius: 2 } : btnStyle}
+              onMouseEnter={saveFlash === "save-as" ? undefined : hoverIn}
+              onMouseLeave={saveFlash === "save-as" ? undefined : hoverOut}
             >
-              Save As
+              {saveFlash === "save-as" ? "Saved!" : "Save As"}
             </button>
             <button
               data-testid="revert-btn"

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -40,9 +40,9 @@ function resolveWorkspaceId(terminalId: string): string {
   const inst = useTerminalStore.getState().instances.find((i) => i.id === terminalId);
   const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState();
   if (inst?.workspaceId) return inst.workspaceId;
-  // Fall back: find workspace by syncGroup name match
+  // Fall back: find workspace by syncGroup ID match
   if (inst?.syncGroup) {
-    const ws = workspaces.find((w) => w.name === inst.syncGroup);
+    const ws = workspaces.find((w) => w.id === inst.syncGroup);
     if (ws) return ws.id;
   }
   return activeWorkspaceId;

--- a/ui/src/components/views/ViewRenderer.test.tsx
+++ b/ui/src/components/views/ViewRenderer.test.tsx
@@ -62,26 +62,28 @@ describe("ViewRenderer", () => {
     expect(terminalViewProps.at(-1)?.syncGroup).toBe("MyGroup");
   });
 
-  it("defaults syncGroup to workspaceName when syncGroup is empty", () => {
+  it("defaults syncGroup to workspaceId when syncGroup is empty", () => {
     render(
       <ViewRenderer
         viewType="TerminalView"
         viewConfig={{ type: "TerminalView", syncGroup: "" }}
         workspaceName="ProjectA"
+        workspaceId="ws-abc123"
       />,
     );
-    expect(terminalViewProps.at(-1)?.syncGroup).toBe("ProjectA");
+    expect(terminalViewProps.at(-1)?.syncGroup).toBe("ws-abc123");
   });
 
-  it("defaults syncGroup to workspaceName when syncGroup is not specified", () => {
+  it("defaults syncGroup to workspaceId when syncGroup is not specified", () => {
     render(
       <ViewRenderer
         viewType="TerminalView"
         viewConfig={{ type: "TerminalView" }}
         workspaceName="ProjectB"
+        workspaceId="ws-def456"
       />,
     );
-    expect(terminalViewProps.at(-1)?.syncGroup).toBe("ProjectB");
+    expect(terminalViewProps.at(-1)?.syncGroup).toBe("ws-def456");
   });
 
   it("passes profile from viewConfig to TerminalView", () => {

--- a/ui/src/components/views/ViewRenderer.tsx
+++ b/ui/src/components/views/ViewRenderer.tsx
@@ -39,7 +39,7 @@ export function ViewRenderer({ viewType, viewConfig, onSelectView, workspaceName
       );
     case "TerminalView": {
       const configSyncGroup = (viewConfig?.syncGroup as string) ?? "";
-      const effectiveSyncGroup = configSyncGroup || workspaceName || "";
+      const effectiveSyncGroup = configSyncGroup || workspaceId || "";
       const instanceId = paneId ? `terminal-${paneId}` : `terminal-${fallbackIdRef.current}`;
       return (
         <div data-testid="view-terminal" className="h-full">

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useWorkspaceStore } from "@/stores/workspace-store";
+import { useWorkspaceStore, isWorkspaceDirty } from "@/stores/workspace-store";
 import { useGridStore } from "@/stores/grid-store";
 import { useNotificationStore } from "@/stores/notification-store";
 import { useTerminalStore } from "@/stores/terminal-store";
@@ -42,6 +42,8 @@ function WorkspaceItem({
   panes,
   canClose,
   pathEllipsis,
+  layoutName,
+  isDirty,
   onSelect,
   onClose,
   onDuplicate,
@@ -54,6 +56,8 @@ function WorkspaceItem({
   panes: WorkspacePane[];
   canClose: boolean;
   pathEllipsis: "start" | "end";
+  layoutName: string;
+  isDirty: boolean;
   onSelect: () => void;
   onClose: () => void;
   onDuplicate: () => void;
@@ -108,6 +112,23 @@ function WorkspaceItem({
             onDoubleClick={(e) => { e.stopPropagation(); onRename(); }}
           >
             {ws.name}
+          </span>
+          {isDirty && (
+            <span
+              data-testid={`workspace-dirty-${ws.id}`}
+              className="shrink-0"
+              style={{ color: "var(--yellow)", fontSize: 9, lineHeight: 1 }}
+              title="Layout has unsaved changes"
+            >
+              *
+            </span>
+          )}
+          <span
+            data-testid={`workspace-layout-${ws.id}`}
+            className="shrink-0 truncate text-[9px]"
+            style={{ color: "var(--text-secondary)", opacity: 0.4 }}
+          >
+            {layoutName}
           </span>
           {summary.terminalCount > 0 && (
             <span
@@ -586,6 +607,7 @@ export function WorkspaceSelectorView() {
         {workspaces.map((ws, idx) => {
           const isActive = ws.id === activeWorkspaceId;
           const summary = computeWorkspaceSummary(ws.id, terminalInstances, terminalPorts, notifications, ws.name);
+          const wsLayout = layouts.find((l) => l.id === ws.layoutId);
           return (
             <WorkspaceItem
               key={ws.id}
@@ -596,6 +618,8 @@ export function WorkspaceSelectorView() {
               panes={ws.panes}
               canClose={workspaces.length > 1}
               pathEllipsis={pathEllipsis}
+              layoutName={wsLayout?.name ?? "Unknown"}
+              isDirty={wsLayout ? isWorkspaceDirty(ws, wsLayout) : false}
               onSelect={() => handleSelectWorkspace(ws.id)}
               onClose={() => removeWorkspace(ws.id)}
               onDuplicate={() => {

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -72,7 +72,7 @@ export function useSyncEvents() {
         const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState();
         let targetWsId = activeWorkspaceId;
         if (instance?.syncGroup) {
-          const ownerWs = workspaces.find((ws) => ws.name === instance.syncGroup);
+          const ownerWs = workspaces.find((ws) => ws.id === instance.syncGroup);
           if (ownerWs) {
             targetWsId = ownerWs.id;
           }

--- a/ui/src/stores/workspace-store.test.ts
+++ b/ui/src/stores/workspace-store.test.ts
@@ -352,6 +352,73 @@ describe("WorkspaceStore", () => {
     });
   });
 
+  describe("isWorkspaceDirty", () => {
+    it("returns false for freshly created workspace", () => {
+      const { isActiveWorkspaceDirty } = useWorkspaceStore.getState();
+      expect(isActiveWorkspaceDirty()).toBe(false);
+    });
+
+    it("returns true after splitPane", () => {
+      useWorkspaceStore.getState().splitPane(0, "horizontal");
+      expect(useWorkspaceStore.getState().isActiveWorkspaceDirty()).toBe(true);
+    });
+
+    it("returns true after removePane (split then remove one)", () => {
+      useWorkspaceStore.getState().splitPane(0, "vertical");
+      useWorkspaceStore.getState().saveWorkspace(); // save so layout has 2 panes
+      useWorkspaceStore.getState().removePane(1);
+      expect(useWorkspaceStore.getState().isActiveWorkspaceDirty()).toBe(true);
+    });
+
+    it("returns true after resizePane", () => {
+      useWorkspaceStore.getState().splitPane(0, "vertical");
+      useWorkspaceStore.getState().saveWorkspace();
+      useWorkspaceStore.getState().resizePane(0, { w: 0.7 });
+      expect(useWorkspaceStore.getState().isActiveWorkspaceDirty()).toBe(true);
+    });
+
+    it("returns true after setPaneView changes viewType", () => {
+      useWorkspaceStore.getState().setPaneView(0, { type: "TerminalView" });
+      expect(useWorkspaceStore.getState().isActiveWorkspaceDirty()).toBe(true);
+    });
+
+    it("returns false after setPaneView changes only profile (same viewType)", () => {
+      // Default layout has EmptyView. Set to EmptyView with extra config.
+      useWorkspaceStore.getState().setPaneView(0, { type: "EmptyView", someConfig: "x" });
+      expect(useWorkspaceStore.getState().isActiveWorkspaceDirty()).toBe(false);
+    });
+
+    it("returns false after saveWorkspace", () => {
+      useWorkspaceStore.getState().splitPane(0, "vertical");
+      expect(useWorkspaceStore.getState().isActiveWorkspaceDirty()).toBe(true);
+      useWorkspaceStore.getState().saveWorkspace();
+      expect(useWorkspaceStore.getState().isActiveWorkspaceDirty()).toBe(false);
+    });
+
+    it("returns false after revertWorkspace", () => {
+      useWorkspaceStore.getState().splitPane(0, "horizontal");
+      expect(useWorkspaceStore.getState().isActiveWorkspaceDirty()).toBe(true);
+      useWorkspaceStore.getState().revertWorkspace();
+      expect(useWorkspaceStore.getState().isActiveWorkspaceDirty()).toBe(false);
+    });
+
+    it("handles floating point comparison with epsilon", () => {
+      // Split creates panes with exact 0.5 values. Tiny float drift shouldn't be dirty.
+      useWorkspaceStore.getState().splitPane(0, "vertical");
+      useWorkspaceStore.getState().saveWorkspace();
+      // Simulate tiny float drift
+      useWorkspaceStore.getState().resizePane(0, { w: 0.5 + 0.0005 });
+      expect(useWorkspaceStore.getState().isActiveWorkspaceDirty()).toBe(false);
+    });
+
+    it("detects dirty when float difference exceeds epsilon", () => {
+      useWorkspaceStore.getState().splitPane(0, "vertical");
+      useWorkspaceStore.getState().saveWorkspace();
+      useWorkspaceStore.getState().resizePane(0, { w: 0.502 });
+      expect(useWorkspaceStore.getState().isActiveWorkspaceDirty()).toBe(true);
+    });
+  });
+
   describe("Pane ID stability", () => {
     it("default workspace panes have an id", () => {
       const ws = useWorkspaceStore.getState().getActiveWorkspace()!;

--- a/ui/src/stores/workspace-store.ts
+++ b/ui/src/stores/workspace-store.ts
@@ -16,6 +16,27 @@ function ensureUniqueName(name: string, existing: { name: string }[]): string {
   return `${name} (${n})`;
 }
 
+const EPSILON = 0.001;
+
+/** Compare workspace panes against its layout template to detect divergence. */
+export function isWorkspaceDirty(workspace: Workspace, layout: Layout): boolean {
+  if (workspace.panes.length !== layout.panes.length) return true;
+  for (let i = 0; i < workspace.panes.length; i++) {
+    const wp = workspace.panes[i];
+    const lp = layout.panes[i];
+    if (
+      Math.abs(wp.x - lp.x) > EPSILON ||
+      Math.abs(wp.y - lp.y) > EPSILON ||
+      Math.abs(wp.w - lp.w) > EPSILON ||
+      Math.abs(wp.h - lp.h) > EPSILON ||
+      wp.view.type !== lp.viewType
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 const defaultLayout: Layout = {
   id: "default-layout",
   name: "Default",
@@ -44,6 +65,7 @@ interface WorkspaceState {
   activeWorkspaceId: string;
 
   getActiveWorkspace: () => Workspace | undefined;
+  isActiveWorkspaceDirty: () => boolean;
   setActiveWorkspace: (id: string) => void;
   addWorkspace: (name: string, layoutId: string) => void;
   duplicateWorkspace: (id: string) => void;
@@ -77,6 +99,15 @@ export const useWorkspaceStore = create<WorkspaceState>()((set, get) => ({
   getActiveWorkspace: () => {
     const { workspaces, activeWorkspaceId } = get();
     return workspaces.find((ws) => ws.id === activeWorkspaceId);
+  },
+
+  isActiveWorkspaceDirty: () => {
+    const { workspaces, activeWorkspaceId, layouts } = get();
+    const ws = workspaces.find((w) => w.id === activeWorkspaceId);
+    if (!ws) return false;
+    const layout = layouts.find((l) => l.id === ws.layoutId);
+    if (!layout) return false;
+    return isWorkspaceDirty(ws, layout);
   },
 
   setActiveWorkspace: (id) => {


### PR DESCRIPTION
## Summary
- **Dirty state 감지**: `isWorkspaceDirty()` 순수 함수로 workspace가 layout 대비 변경되었는지 감지 (pane 수, geometry, viewType 비교)
- **Layout 출처 표시**: WorkspaceSelectorView에 각 workspace의 base layout 이름을 작은 뱃지로 표시
- **Dirty 표시자**: layout 대비 변경된 workspace에 `*` 표시
- **Save 피드백**: Save/Save All/Save As 버튼 클릭 시 1.5초간 녹색 "Saved!" 피드백
- **SyncGroup UUID화**: 기본 syncGroup을 workspace name → workspace ID로 변경하여 rename 시 안정성 확보

Closes #14

## Test plan
- [x] `isWorkspaceDirty` 단위 테스트 10개 추가 (TDD)
- [x] ViewRenderer syncGroup 테스트 업데이트 (workspace ID 기반)
- [x] 전체 테스트 992/993 통과 (1개 기존 실패: AppLayout dock visibility — 이전 커밋 CSS hide 전환 관련)
- [x] 스크린샷 검증: layout 이름 표시, dirty `*` 표시, save 후 `*` 해제 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)