### PR TITLE
Strengthen test assertions and type layouts_export handler

### DIFF
--- a/src-tauri/src/automation_server.rs
+++ b/src-tauri/src/automation_server.rs
@@ -73,6 +73,14 @@ pub struct RenameWorkspaceBody {
 }
 
 #[derive(Deserialize)]
+pub struct ExportLayoutBody {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default, rename = "layoutId")]
+    pub layout_id: Option<String>,
+}
+
+#[derive(Deserialize)]
 pub struct EditModeBody {
     pub enabled: bool,
 }
@@ -764,10 +772,10 @@ async fn workspaces_delete(
 
 async fn layouts_export(
     AxumState(state): AxumState<ServerState>,
-    Json(body): Json<serde_json::Value>,
+    Json(body): Json<ExportLayoutBody>,
 ) -> impl IntoResponse {
-    let name = body.get("name").and_then(|v| v.as_str()).unwrap_or("");
-    let layout_id = body.get("layoutId").and_then(|v| v.as_str()).unwrap_or("");
+    let name = body.name.as_deref().unwrap_or("");
+    let layout_id = body.layout_id.as_deref().unwrap_or("");
     if layout_id.is_empty() && name.is_empty() {
         return (
             StatusCode::BAD_REQUEST,

--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -202,7 +202,8 @@ describe("WorkspaceSelectorView", () => {
 
     expect(useWorkspaceStore.getState().workspaces).toHaveLength(2);
     const newWs = useWorkspaceStore.getState().workspaces[1];
-
+    const exportedLayout = useWorkspaceStore.getState().layouts[1];
+    expect(newWs.panes).toHaveLength(exportedLayout.panes.length);
   });
 
   it("auto-switches to newly created workspace", async () => {
@@ -323,7 +324,6 @@ describe("WorkspaceSelectorView", () => {
       workspaces: [{
         id: "ws-default",
         name: "Default",
-       
         panes: [
           { id: "pane-left", x: 0, y: 0, w: 0.5, h: 1, view: { type: "TerminalView", profile: "WSL" } },
           { id: "pane-right", x: 0.5, y: 0, w: 0.5, h: 1, view: { type: "TerminalView", profile: "PowerShell" } },
@@ -367,7 +367,6 @@ describe("WorkspaceSelectorView", () => {
       workspaces: [{
         id: "ws-default",
         name: "Default",
-       
         panes: [
           { id: "pane-top", x: 0, y: 0, w: 1, h: 0.6, view: { type: "TerminalView", profile: "WSL" } },
           { id: "pane-bl", x: 0, y: 0.6, w: 0.5, h: 0.4, view: { type: "TerminalView", profile: "PowerShell" } },
@@ -703,7 +702,6 @@ describe("WorkspaceSelectorView", () => {
       workspaces: [{
         id: "ws-default",
         name: "Test",
-       
         panes: [
           { id: "p1", x: 0, y: 0, w: 0.5, h: 1, view: { type: "TerminalView", profile: "PowerShell" } },
           { id: "p2", x: 0.5, y: 0, w: 0.5, h: 1, view: { type: "TerminalView", profile: "WSL" } },
@@ -728,7 +726,6 @@ describe("WorkspaceSelectorView", () => {
       workspaces: [{
         id: "ws-default",
         name: "Test",
-       
         panes: [{ id: "p1", x: 0, y: 0, w: 1, h: 1, view: { type: "TerminalView", profile: "PowerShell" } }],
       }],
       activeWorkspaceId: "ws-default",

--- a/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -832,7 +832,8 @@ describe("useKeyboardShortcuts", () => {
     fireKey("N", { ctrlKey: true, altKey: true });
 
     const newWs = useWorkspaceStore.getState().workspaces[1];
-
+    expect(newWs.panes).toHaveLength(1);
+    expect(newWs.panes[0].view.type).toBe("EmptyView");
   });
 
   // --- Lowercase Ctrl+Alt letter keys (case-insensitive) ---


### PR DESCRIPTION
## Summary
- PR #77 리뷰에서 발견된 두 가지 개선사항 적용
- `layoutId` assertion 제거 후 빈 줄로 남았던 테스트에 pane 구조 검증 assertion 보충
- `layouts_export` Rust 핸들러를 `serde_json::Value` 대신 typed `ExportLayoutBody` struct로 변경하여 다른 핸들러와 패턴 일치
- 테스트 파일 trailing whitespace 정리 (4곳)

## Test plan
- [x] 프론트엔드 테스트 1010/1010 통과
- [ ] Rust 빌드: WSL fontconfig 부재로 로컬 검증 불가 — CI에서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)