### PR TITLE
feat: session persistence — restore terminal output & CWD on restart

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -575,3 +575,84 @@ Claude Code가 터미널에서 실행 중일 때 sync-cwd 전파를 제어한다
 - `127.0.0.1` only 바인딩 (외부 접근 불가)
 - v1: 인증 없음 (로컬 전용)
 - 추후: 디스커버리 파일에 bearer token 포함 가능
+
+---
+
+## 13. Session Persistence & Cache
+
+### 13.1 개요
+
+앱 재시작 시 터미널의 이전 출력과 CWD를 복원한다. 프로파일 단위로 제어한다.
+
+### 13.2 캐시 디렉터리
+
+```
+~/.config/laymux/          (Linux)
+%APPDATA%/laymux/          (Windows)
+├── settings.json
+├── memo.json
+└── cache/
+    └── terminal-output/
+        ├── pane-abc12345.dat    ← xterm.js SerializeAddon 출력
+        └── pane-def67890.dat
+```
+
+`cache/` 디렉터리는 향후 다른 캐시 데이터(메모 등)도 수용할 수 있도록 확장 가능한 구조.
+
+### 13.3 프로파일 설정
+
+```jsonc
+{
+  "profileDefaults": {
+    "restoreCwd": true,       // 기본값: 마지막 CWD 복원
+    "restoreOutput": true     // 기본값: 이전 출력 복원
+  },
+  "profiles": [
+    {
+      "name": "PowerShell",
+      "restoreOutput": false   // 프로파일별 오버라이드 (Option — 없으면 defaults 상속)
+    }
+  ]
+}
+```
+
+### 13.4 종료 시퀀스
+
+```
+[Window close-requested event]
+    │  App.tsx onCloseRequested 핸들러
+    ▼
+[saveBeforeClose()]
+    ├─ 1. 모든 TerminalView의 SerializeAddon.serialize()
+    │     → cache/terminal-output/{paneId}.dat 저장
+    ├─ 2. persistSession()
+    │     → settings.json (lastCwd 포함)
+    └─ 3. cleanTerminalOutputCache(activePaneIds)
+          → 고아 캐시 파일 정리
+    ▼
+[appWindow.destroy()]
+```
+
+### 13.5 시작 시퀀스
+
+```
+[useSessionPersistence 로드]
+    │  settings.json → stores 적용
+    │  workspace pane ID 복원 (안정 ID)
+    │  orphan 캐시 정리
+    ▼
+[TerminalView 마운트]
+    │  profile restoreOutput 확인
+    │  lastCwd 존재 = 복원 대상 pane
+    ├─ loadTerminalOutputCache(paneId)
+    │     → terminal.write(cached)
+    │     → "--- session restored ---" 구분선
+    └─ createTerminalSession(cwd: lastCwd)
+          → PTY가 마지막 CWD에서 시작
+```
+
+### 13.6 Workspace Pane ID
+
+- Pane ID는 `pane-{uuid8}` 형식으로 생성되며 settings.json에 저장
+- 세션 간 안정적 — 캐시 파일 키로 사용
+- 기존 ID 없는 설정은 마이그레이션 시 자동 생성

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1748,6 +1748,9 @@ fn sanitize_filename(s: &str) -> String {
 /// Save terminal output to the cache directory.
 #[tauri::command]
 pub fn save_terminal_output_cache(pane_id: String, data: Vec<u8>) -> Result<(), String> {
+    if pane_id.is_empty() {
+        return Err("Empty pane ID".into());
+    }
     let cache_dir = crate::settings::cache_dir_path()
         .ok_or("Cannot determine cache directory")?
         .join("terminal-output");
@@ -1759,6 +1762,9 @@ pub fn save_terminal_output_cache(pane_id: String, data: Vec<u8>) -> Result<(), 
 /// Load terminal output from the cache directory.
 #[tauri::command]
 pub fn load_terminal_output_cache(pane_id: String) -> Result<Vec<u8>, String> {
+    if pane_id.is_empty() {
+        return Err("Empty pane ID".into());
+    }
     let cache_dir = crate::settings::cache_dir_path()
         .ok_or("Cannot determine cache directory")?
         .join("terminal-output");

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1795,7 +1795,7 @@ fn clean_terminal_output_cache_in(
     for entry in std::fs::read_dir(&dir).map_err(|e| format!("Read dir: {e}"))? {
         let entry = entry.map_err(|e| format!("Dir entry: {e}"))?;
         let name = entry.file_name().to_string_lossy().to_string();
-        if !active_set.contains(&name) {
+        if name.ends_with(".dat") && !active_set.contains(&name) {
             if std::fs::remove_file(entry.path()).is_ok() {
                 removed += 1;
             }
@@ -1890,6 +1890,20 @@ mod tests {
         // Verify via load
         assert!(load_terminal_output_cache_from(dir.path(), "pane-keep").is_ok());
         assert!(load_terminal_output_cache_from(dir.path(), "pane-orphan").is_err());
+    }
+
+    #[test]
+    fn clean_cache_skips_non_dat_files() {
+        let dir = tempfile::tempdir().unwrap();
+        save_terminal_output_cache_to(dir.path(), "pane-keep", "data").unwrap();
+        // Create a non-.dat file in the terminal-output directory
+        let non_dat = dir.path().join("terminal-output").join("readme.txt");
+        std::fs::write(&non_dat, "do not delete").unwrap();
+
+        let removed = clean_terminal_output_cache_in(dir.path(), &["pane-keep".into()]).unwrap();
+        assert_eq!(removed, 0);
+        // Non-.dat file should still exist
+        assert!(non_dat.exists());
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1773,7 +1773,10 @@ fn load_terminal_output_cache_from(
     }
     let dir = cache_dir.join("terminal-output");
     let path = dir.join(format!("{}.dat", sanitize_filename(pane_id)));
-    let bytes = std::fs::read(&path).map_err(|e| format!("Failed to read cache: {e}"))?;
+    let bytes = std::fs::read(&path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => format!("Cache not found: {}", path.display()),
+        _ => format!("Failed to read cache: {e}"),
+    })?;
     String::from_utf8(bytes).map_err(|e| format!("Invalid UTF-8 in cache: {e}"))
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1734,7 +1734,8 @@ fn clipboard_write_text_platform(_text: &str) -> Result<(), String> {
 }
 
 fn sanitize_filename(s: &str) -> String {
-    s.chars()
+    let sanitized: String = s
+        .chars()
         .map(|c| {
             if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' {
                 c
@@ -1742,7 +1743,9 @@ fn sanitize_filename(s: &str) -> String {
                 '_'
             }
         })
-        .collect()
+        .collect();
+    // Prevent path traversal via ".." components
+    sanitized.replace("..", "_")
 }
 
 /// Inner implementation for saving terminal output cache, testable with arbitrary path.
@@ -1842,8 +1845,14 @@ mod tests {
 
     #[test]
     fn sanitize_filename_special_chars_replaced() {
-        assert_eq!(sanitize_filename("pane/../../etc"), "pane_.._.._etc");
+        assert_eq!(sanitize_filename("pane/../../etc"), "pane_____etc");
         assert_eq!(sanitize_filename("a b.c"), "a_b.c");
+    }
+
+    #[test]
+    fn sanitize_filename_rejects_dot_dot_traversal() {
+        assert_eq!(sanitize_filename(".."), "_");
+        assert_eq!(sanitize_filename("foo..bar"), "foo_bar");
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1745,43 +1745,42 @@ fn sanitize_filename(s: &str) -> String {
         .collect()
 }
 
-/// Save terminal output to the cache directory.
-/// Accepts a string (xterm.js SerializeAddon output) and writes as UTF-8 bytes.
-#[tauri::command]
-pub fn save_terminal_output_cache(pane_id: String, data: String) -> Result<(), String> {
+/// Inner implementation for saving terminal output cache, testable with arbitrary path.
+fn save_terminal_output_cache_to(
+    cache_dir: &std::path::Path,
+    pane_id: &str,
+    data: &str,
+) -> Result<(), String> {
     if pane_id.is_empty() {
         return Err("Empty pane ID".into());
     }
-    let cache_dir = crate::settings::cache_dir_path()
-        .ok_or("Cannot determine cache directory")?
-        .join("terminal-output");
-    std::fs::create_dir_all(&cache_dir).map_err(|e| format!("Failed to create cache dir: {e}"))?;
-    let path = cache_dir.join(format!("{}.dat", sanitize_filename(&pane_id)));
+    let dir = cache_dir.join("terminal-output");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create cache dir: {e}"))?;
+    let path = dir.join(format!("{}.dat", sanitize_filename(pane_id)));
     std::fs::write(&path, data.as_bytes()).map_err(|e| format!("Failed to write cache: {e}"))
 }
 
-/// Load terminal output from the cache directory.
-/// Returns a string (to be written back via terminal.write()).
-#[tauri::command]
-pub fn load_terminal_output_cache(pane_id: String) -> Result<String, String> {
+/// Inner implementation for loading terminal output cache, testable with arbitrary path.
+fn load_terminal_output_cache_from(
+    cache_dir: &std::path::Path,
+    pane_id: &str,
+) -> Result<String, String> {
     if pane_id.is_empty() {
         return Err("Empty pane ID".into());
     }
-    let cache_dir = crate::settings::cache_dir_path()
-        .ok_or("Cannot determine cache directory")?
-        .join("terminal-output");
-    let path = cache_dir.join(format!("{}.dat", sanitize_filename(&pane_id)));
+    let dir = cache_dir.join("terminal-output");
+    let path = dir.join(format!("{}.dat", sanitize_filename(pane_id)));
     let bytes = std::fs::read(&path).map_err(|e| format!("Failed to read cache: {e}"))?;
     String::from_utf8(bytes).map_err(|e| format!("Invalid UTF-8 in cache: {e}"))
 }
 
-/// Remove orphaned cache files that don't correspond to any active pane.
-#[tauri::command]
-pub fn clean_terminal_output_cache(active_pane_ids: Vec<String>) -> Result<u32, String> {
-    let cache_dir = crate::settings::cache_dir_path()
-        .ok_or("Cannot determine cache directory")?
-        .join("terminal-output");
-    if !cache_dir.exists() {
+/// Inner implementation for cleaning orphaned cache files, testable with arbitrary path.
+fn clean_terminal_output_cache_in(
+    cache_dir: &std::path::Path,
+    active_pane_ids: &[String],
+) -> Result<u32, String> {
+    let dir = cache_dir.join("terminal-output");
+    if !dir.exists() {
         return Ok(0);
     }
     let active_set: std::collections::HashSet<String> = active_pane_ids
@@ -1790,7 +1789,7 @@ pub fn clean_terminal_output_cache(active_pane_ids: Vec<String>) -> Result<u32, 
         .map(|id| format!("{}.dat", sanitize_filename(id)))
         .collect();
     let mut removed = 0u32;
-    for entry in std::fs::read_dir(&cache_dir).map_err(|e| format!("Read dir: {e}"))? {
+    for entry in std::fs::read_dir(&dir).map_err(|e| format!("Read dir: {e}"))? {
         let entry = entry.map_err(|e| format!("Dir entry: {e}"))?;
         let name = entry.file_name().to_string_lossy().to_string();
         if !active_set.contains(&name) {
@@ -1799,6 +1798,29 @@ pub fn clean_terminal_output_cache(active_pane_ids: Vec<String>) -> Result<u32, 
         }
     }
     Ok(removed)
+}
+
+/// Save terminal output to the cache directory.
+/// Accepts a string (xterm.js SerializeAddon output) and writes as UTF-8 bytes.
+#[tauri::command]
+pub fn save_terminal_output_cache(pane_id: String, data: String) -> Result<(), String> {
+    let cache_dir = crate::settings::cache_dir_path().ok_or("Cannot determine cache directory")?;
+    save_terminal_output_cache_to(&cache_dir, &pane_id, &data)
+}
+
+/// Load terminal output from the cache directory.
+/// Returns a string (to be written back via terminal.write()).
+#[tauri::command]
+pub fn load_terminal_output_cache(pane_id: String) -> Result<String, String> {
+    let cache_dir = crate::settings::cache_dir_path().ok_or("Cannot determine cache directory")?;
+    load_terminal_output_cache_from(&cache_dir, &pane_id)
+}
+
+/// Remove orphaned cache files that don't correspond to any active pane.
+#[tauri::command]
+pub fn clean_terminal_output_cache(active_pane_ids: Vec<String>) -> Result<u32, String> {
+    let cache_dir = crate::settings::cache_dir_path().ok_or("Cannot determine cache directory")?;
+    clean_terminal_output_cache_in(&cache_dir, &active_pane_ids)
 }
 
 #[cfg(test)]
@@ -1826,44 +1848,48 @@ mod tests {
     #[test]
     fn terminal_output_cache_round_trip() {
         let dir = tempfile::tempdir().unwrap();
-        let cache_dir = dir.path().join("cache").join("terminal-output");
-        std::fs::create_dir_all(&cache_dir).unwrap();
-
         let data = "Hello terminal output \x1b[32mgreen\x1b[0m";
-        let pane_id = "pane-test123";
-        let path = cache_dir.join(format!("{}.dat", sanitize_filename(pane_id)));
-        std::fs::write(&path, data.as_bytes()).unwrap();
+        save_terminal_output_cache_to(dir.path(), "pane-test123", data).unwrap();
+        let loaded = load_terminal_output_cache_from(dir.path(), "pane-test123").unwrap();
+        assert_eq!(loaded, data);
+    }
 
-        let loaded = std::fs::read(&path).unwrap();
-        assert_eq!(String::from_utf8(loaded).unwrap(), data);
+    #[test]
+    fn save_cache_rejects_empty_pane_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = save_terminal_output_cache_to(dir.path(), "", "data");
+        assert_eq!(result.unwrap_err(), "Empty pane ID");
+    }
+
+    #[test]
+    fn load_cache_rejects_empty_pane_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = load_terminal_output_cache_from(dir.path(), "");
+        assert_eq!(result.unwrap_err(), "Empty pane ID");
     }
 
     #[test]
     fn clean_terminal_output_cache_removes_orphans() {
         let dir = tempfile::tempdir().unwrap();
-        let cache_dir = dir.path().join("terminal-output");
-        std::fs::create_dir_all(&cache_dir).unwrap();
+        save_terminal_output_cache_to(dir.path(), "pane-keep", "data").unwrap();
+        save_terminal_output_cache_to(dir.path(), "pane-orphan", "data").unwrap();
+        save_terminal_output_cache_to(dir.path(), "pane-also-orphan", "data").unwrap();
 
-        // Create some cache files
-        std::fs::write(cache_dir.join("pane-keep.dat"), b"data").unwrap();
-        std::fs::write(cache_dir.join("pane-orphan.dat"), b"data").unwrap();
-        std::fs::write(cache_dir.join("pane-also-orphan.dat"), b"data").unwrap();
-
-        let active_set: std::collections::HashSet<String> =
-            vec!["pane-keep.dat".to_string()].into_iter().collect();
-
-        let mut removed = 0u32;
-        for entry in std::fs::read_dir(&cache_dir).unwrap() {
-            let entry = entry.unwrap();
-            let name = entry.file_name().to_string_lossy().to_string();
-            if !active_set.contains(&name) {
-                let _ = std::fs::remove_file(entry.path());
-                removed += 1;
-            }
-        }
+        let removed = clean_terminal_output_cache_in(dir.path(), &["pane-keep".into()]).unwrap();
         assert_eq!(removed, 2);
-        assert!(cache_dir.join("pane-keep.dat").exists());
-        assert!(!cache_dir.join("pane-orphan.dat").exists());
+        // Verify via load
+        assert!(load_terminal_output_cache_from(dir.path(), "pane-keep").is_ok());
+        assert!(load_terminal_output_cache_from(dir.path(), "pane-orphan").is_err());
+    }
+
+    #[test]
+    fn clean_cache_filters_empty_pane_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        save_terminal_output_cache_to(dir.path(), "pane-a", "data").unwrap();
+        // Empty string in active list should not match everything
+        let removed =
+            clean_terminal_output_cache_in(dir.path(), &["".into(), "pane-a".into()]).unwrap();
+        assert_eq!(removed, 0);
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1744,8 +1744,8 @@ fn sanitize_filename(s: &str) -> String {
             }
         })
         .collect();
-    // Prevent path traversal via ".." components
-    sanitized.replace("..", "_")
+    // Prevent path traversal via ".." components (use "__" to preserve length and avoid collisions)
+    sanitized.replace("..", "__")
 }
 
 /// Inner implementation for saving terminal output cache, testable with arbitrary path.
@@ -1845,14 +1845,14 @@ mod tests {
 
     #[test]
     fn sanitize_filename_special_chars_replaced() {
-        assert_eq!(sanitize_filename("pane/../../etc"), "pane_____etc");
+        assert_eq!(sanitize_filename("pane/../../etc"), "pane_______etc");
         assert_eq!(sanitize_filename("a b.c"), "a_b.c");
     }
 
     #[test]
     fn sanitize_filename_rejects_dot_dot_traversal() {
-        assert_eq!(sanitize_filename(".."), "_");
-        assert_eq!(sanitize_filename("foo..bar"), "foo_bar");
+        assert_eq!(sanitize_filename(".."), "__");
+        assert_eq!(sanitize_filename("foo..bar"), "foo__bar");
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1746,8 +1746,9 @@ fn sanitize_filename(s: &str) -> String {
 }
 
 /// Save terminal output to the cache directory.
+/// Accepts a string (xterm.js SerializeAddon output) and writes as UTF-8 bytes.
 #[tauri::command]
-pub fn save_terminal_output_cache(pane_id: String, data: Vec<u8>) -> Result<(), String> {
+pub fn save_terminal_output_cache(pane_id: String, data: String) -> Result<(), String> {
     if pane_id.is_empty() {
         return Err("Empty pane ID".into());
     }
@@ -1756,12 +1757,13 @@ pub fn save_terminal_output_cache(pane_id: String, data: Vec<u8>) -> Result<(), 
         .join("terminal-output");
     std::fs::create_dir_all(&cache_dir).map_err(|e| format!("Failed to create cache dir: {e}"))?;
     let path = cache_dir.join(format!("{}.dat", sanitize_filename(&pane_id)));
-    std::fs::write(&path, &data).map_err(|e| format!("Failed to write cache: {e}"))
+    std::fs::write(&path, data.as_bytes()).map_err(|e| format!("Failed to write cache: {e}"))
 }
 
 /// Load terminal output from the cache directory.
+/// Returns a string (to be written back via terminal.write()).
 #[tauri::command]
-pub fn load_terminal_output_cache(pane_id: String) -> Result<Vec<u8>, String> {
+pub fn load_terminal_output_cache(pane_id: String) -> Result<String, String> {
     if pane_id.is_empty() {
         return Err("Empty pane ID".into());
     }
@@ -1769,7 +1771,8 @@ pub fn load_terminal_output_cache(pane_id: String) -> Result<Vec<u8>, String> {
         .ok_or("Cannot determine cache directory")?
         .join("terminal-output");
     let path = cache_dir.join(format!("{}.dat", sanitize_filename(&pane_id)));
-    std::fs::read(&path).map_err(|e| format!("Failed to read cache: {e}"))
+    let bytes = std::fs::read(&path).map_err(|e| format!("Failed to read cache: {e}"))?;
+    String::from_utf8(bytes).map_err(|e| format!("Invalid UTF-8 in cache: {e}"))
 }
 
 /// Remove orphaned cache files that don't correspond to any active pane.
@@ -1783,6 +1786,7 @@ pub fn clean_terminal_output_cache(active_pane_ids: Vec<String>) -> Result<u32, 
     }
     let active_set: std::collections::HashSet<String> = active_pane_ids
         .iter()
+        .filter(|id| !id.is_empty())
         .map(|id| format!("{}.dat", sanitize_filename(id)))
         .collect();
     let mut removed = 0u32;
@@ -1825,13 +1829,13 @@ mod tests {
         let cache_dir = dir.path().join("cache").join("terminal-output");
         std::fs::create_dir_all(&cache_dir).unwrap();
 
-        let data = b"Hello terminal output \x1b[32mgreen\x1b[0m".to_vec();
+        let data = "Hello terminal output \x1b[32mgreen\x1b[0m";
         let pane_id = "pane-test123";
         let path = cache_dir.join(format!("{}.dat", sanitize_filename(pane_id)));
-        std::fs::write(&path, &data).unwrap();
+        std::fs::write(&path, data.as_bytes()).unwrap();
 
         let loaded = std::fs::read(&path).unwrap();
-        assert_eq!(loaded, data);
+        assert_eq!(String::from_utf8(loaded).unwrap(), data);
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -30,6 +30,7 @@ pub fn create_terminal_session(
     rows: u16,
     sync_group: String,
     cwd_receive: Option<bool>,
+    cwd: Option<String>,
     state: State<Arc<AppState>>,
     app: AppHandle,
 ) -> Result<TerminalSession, String> {
@@ -55,9 +56,11 @@ pub fn create_terminal_session(
     let startup_command = matched_profile
         .map(|p| p.startup_command.clone())
         .unwrap_or_default();
-    let starting_directory = matched_profile
-        .map(|p| p.starting_directory.clone())
-        .unwrap_or_default();
+    let starting_directory = cwd.filter(|c| !c.is_empty()).unwrap_or_else(|| {
+        matched_profile
+            .map(|p| p.starting_directory.clone())
+            .unwrap_or_default()
+    });
 
     let config = TerminalConfig {
         profile,
@@ -1730,6 +1733,64 @@ fn clipboard_write_text_platform(_text: &str) -> Result<(), String> {
     Err("Clipboard write not implemented on this platform".into())
 }
 
+fn sanitize_filename(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Save terminal output to the cache directory.
+#[tauri::command]
+pub fn save_terminal_output_cache(pane_id: String, data: Vec<u8>) -> Result<(), String> {
+    let cache_dir = crate::settings::cache_dir_path()
+        .ok_or("Cannot determine cache directory")?
+        .join("terminal-output");
+    std::fs::create_dir_all(&cache_dir).map_err(|e| format!("Failed to create cache dir: {e}"))?;
+    let path = cache_dir.join(format!("{}.dat", sanitize_filename(&pane_id)));
+    std::fs::write(&path, &data).map_err(|e| format!("Failed to write cache: {e}"))
+}
+
+/// Load terminal output from the cache directory.
+#[tauri::command]
+pub fn load_terminal_output_cache(pane_id: String) -> Result<Vec<u8>, String> {
+    let cache_dir = crate::settings::cache_dir_path()
+        .ok_or("Cannot determine cache directory")?
+        .join("terminal-output");
+    let path = cache_dir.join(format!("{}.dat", sanitize_filename(&pane_id)));
+    std::fs::read(&path).map_err(|e| format!("Failed to read cache: {e}"))
+}
+
+/// Remove orphaned cache files that don't correspond to any active pane.
+#[tauri::command]
+pub fn clean_terminal_output_cache(active_pane_ids: Vec<String>) -> Result<u32, String> {
+    let cache_dir = crate::settings::cache_dir_path()
+        .ok_or("Cannot determine cache directory")?
+        .join("terminal-output");
+    if !cache_dir.exists() {
+        return Ok(0);
+    }
+    let active_set: std::collections::HashSet<String> = active_pane_ids
+        .iter()
+        .map(|id| format!("{}.dat", sanitize_filename(id)))
+        .collect();
+    let mut removed = 0u32;
+    for entry in std::fs::read_dir(&cache_dir).map_err(|e| format!("Read dir: {e}"))? {
+        let entry = entry.map_err(|e| format!("Dir entry: {e}"))?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !active_set.contains(&name) {
+            let _ = std::fs::remove_file(entry.path());
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1738,6 +1799,61 @@ mod tests {
     fn greet_returns_message() {
         let result = greet("Laymux");
         assert_eq!(result, "Hello, Laymux! Welcome to Laymux.");
+    }
+
+    #[test]
+    fn sanitize_filename_alphanumeric_preserved() {
+        assert_eq!(sanitize_filename("pane-abc123"), "pane-abc123");
+        assert_eq!(sanitize_filename("dp_test_1"), "dp_test_1");
+    }
+
+    #[test]
+    fn sanitize_filename_special_chars_replaced() {
+        assert_eq!(sanitize_filename("pane/../../etc"), "pane_______etc");
+        assert_eq!(sanitize_filename("a b.c"), "a_b_c");
+    }
+
+    #[test]
+    fn terminal_output_cache_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_dir = dir.path().join("cache").join("terminal-output");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        let data = b"Hello terminal output \x1b[32mgreen\x1b[0m".to_vec();
+        let pane_id = "pane-test123";
+        let path = cache_dir.join(format!("{}.dat", sanitize_filename(pane_id)));
+        std::fs::write(&path, &data).unwrap();
+
+        let loaded = std::fs::read(&path).unwrap();
+        assert_eq!(loaded, data);
+    }
+
+    #[test]
+    fn clean_terminal_output_cache_removes_orphans() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_dir = dir.path().join("terminal-output");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        // Create some cache files
+        std::fs::write(cache_dir.join("pane-keep.dat"), b"data").unwrap();
+        std::fs::write(cache_dir.join("pane-orphan.dat"), b"data").unwrap();
+        std::fs::write(cache_dir.join("pane-also-orphan.dat"), b"data").unwrap();
+
+        let active_set: std::collections::HashSet<String> =
+            vec!["pane-keep.dat".to_string()].into_iter().collect();
+
+        let mut removed = 0u32;
+        for entry in std::fs::read_dir(&cache_dir).unwrap() {
+            let entry = entry.unwrap();
+            let name = entry.file_name().to_string_lossy().to_string();
+            if !active_set.contains(&name) {
+                let _ = std::fs::remove_file(entry.path());
+                removed += 1;
+            }
+        }
+        assert_eq!(removed, 2);
+        assert!(cache_dir.join("pane-keep.dat").exists());
+        assert!(!cache_dir.join("pane-orphan.dat").exists());
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1736,7 +1736,7 @@ fn clipboard_write_text_platform(_text: &str) -> Result<(), String> {
 fn sanitize_filename(s: &str) -> String {
     s.chars()
         .map(|c| {
-            if c.is_alphanumeric() || c == '-' || c == '_' {
+            if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' {
                 c
             } else {
                 '_'
@@ -1793,8 +1793,9 @@ fn clean_terminal_output_cache_in(
         let entry = entry.map_err(|e| format!("Dir entry: {e}"))?;
         let name = entry.file_name().to_string_lossy().to_string();
         if !active_set.contains(&name) {
-            let _ = std::fs::remove_file(entry.path());
-            removed += 1;
+            if std::fs::remove_file(entry.path()).is_ok() {
+                removed += 1;
+            }
         }
     }
     Ok(removed)
@@ -1841,8 +1842,8 @@ mod tests {
 
     #[test]
     fn sanitize_filename_special_chars_replaced() {
-        assert_eq!(sanitize_filename("pane/../../etc"), "pane_______etc");
-        assert_eq!(sanitize_filename("a b.c"), "a_b_c");
+        assert_eq!(sanitize_filename("pane/../../etc"), "pane_.._.._etc");
+        assert_eq!(sanitize_filename("a b.c"), "a_b.c");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -108,6 +108,9 @@ pub fn run() {
             commands::clipboard_write_text,
             commands::set_terminal_cwd_receive,
             commands::update_terminal_sync_group,
+            commands::save_terminal_output_cache,
+            commands::load_terminal_output_cache,
+            commands::clean_terminal_output_cache,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -660,6 +660,15 @@ fn migrate_settings(settings: &mut Settings) {
         }
     }
 
+    // Assign stable IDs to dock panes that don't have one
+    for dock in &mut settings.docks {
+        for pane in &mut dock.panes {
+            if pane.id.is_empty() {
+                pane.id = format!("pane-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+            }
+        }
+    }
+
     // Deduplicate workspace names
     let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
     for ws in &mut settings.workspaces {
@@ -1360,6 +1369,40 @@ mod tests {
         assert_eq!(settings.workspaces[0].panes[0].id.len(), 13); // "pane-" + 8 chars
                                                                   // Existing ID is preserved
         assert_eq!(settings.workspaces[0].panes[1].id, "existing-id");
+    }
+
+    #[test]
+    fn migrate_assigns_pane_ids_to_dock_panes() {
+        let mut settings = Settings::default();
+        settings.docks = vec![DockSetting {
+            position: "left".into(),
+            active_view: None,
+            views: vec![],
+            visible: true,
+            size: 240.0,
+            panes: vec![
+                DockPaneSetting {
+                    id: "".into(),
+                    view: serde_json::json!({"type": "TerminalView"}),
+                    x: 0.0,
+                    y: 0.0,
+                    w: 1.0,
+                    h: 1.0,
+                },
+                DockPaneSetting {
+                    id: "dock-existing".into(),
+                    view: serde_json::json!({"type": "EmptyView"}),
+                    x: 0.0,
+                    y: 0.0,
+                    w: 1.0,
+                    h: 1.0,
+                },
+            ],
+        }];
+        migrate_settings(&mut settings);
+        assert!(settings.docks[0].panes[0].id.starts_with("pane-"));
+        assert_eq!(settings.docks[0].panes[0].id.len(), 13);
+        assert_eq!(settings.docks[0].panes[1].id, "dock-existing");
     }
 
     // --- Phase 1: restore_cwd / restore_output tests ---

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -119,6 +119,12 @@ pub struct Profile {
     /// Per-profile font override. When None, inherits from profileDefaults / global default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font: Option<FontSettings>,
+    /// Whether to restore the last CWD on restart. When None, inherits from profileDefaults.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restore_cwd: Option<bool>,
+    /// Whether to restore terminal output on restart. When None, inherits from profileDefaults.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restore_output: Option<bool>,
 }
 
 impl Default for Profile {
@@ -141,6 +147,8 @@ impl Default for Profile {
             suppress_application_title: false,
             snap_on_input: true,
             font: None,
+            restore_cwd: None,
+            restore_output: None,
         }
     }
 }
@@ -230,6 +238,12 @@ pub struct ProfileDefaults {
     pub snap_on_input: bool,
     #[serde(default)]
     pub font: FontSettings,
+    /// Whether to restore the last CWD on restart.
+    #[serde(default = "default_true")]
+    pub restore_cwd: bool,
+    /// Whether to restore terminal output on restart.
+    #[serde(default = "default_true")]
+    pub restore_output: bool,
 }
 
 impl Default for ProfileDefaults {
@@ -246,6 +260,8 @@ impl Default for ProfileDefaults {
             suppress_application_title: false,
             snap_on_input: true,
             font: FontSettings::default(),
+            restore_cwd: true,
+            restore_output: true,
         }
     }
 }
@@ -281,6 +297,9 @@ pub struct WorkspacePaneView {
 /// Workspace pane definition.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WorkspacePane {
+    /// Stable pane identifier, persisted across restarts. Empty string means unassigned (migrated).
+    #[serde(default)]
+    pub id: String,
     pub x: f64,
     pub y: f64,
     #[serde(default)]
@@ -547,6 +566,7 @@ impl Default for Settings {
                 name: "Default".into(),
                 layout_id: None,
                 panes: vec![WorkspacePane {
+                    id: format!("pane-{}", &uuid::Uuid::new_v4().to_string()[..8]),
                     x: 0.0,
                     y: 0.0,
                     w: 1.0,
@@ -631,6 +651,15 @@ fn migrate_settings(settings: &mut Settings) {
         .profiles
         .retain(|p| !p.name.eq_ignore_ascii_case("cmd"));
 
+    // Assign stable IDs to workspace panes that don't have one
+    for ws in &mut settings.workspaces {
+        for pane in &mut ws.panes {
+            if pane.id.is_empty() {
+                pane.id = format!("pane-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+            }
+        }
+    }
+
     // Deduplicate workspace names
     let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
     for ws in &mut settings.workspaces {
@@ -648,6 +677,13 @@ fn migrate_settings(settings: &mut Settings) {
             }
         }
     }
+}
+
+/// Get the cache directory path.
+/// Windows: %APPDATA%/laymux/cache/
+/// Linux: ~/.config/laymux/cache/
+pub fn cache_dir_path() -> Option<PathBuf> {
+    dirs_config_path().map(|p| p.join("cache"))
 }
 
 /// Get the memo file path (sibling of settings.json).
@@ -1066,6 +1102,7 @@ mod tests {
             name: "Test".into(),
             layout_id: None,
             panes: vec![WorkspacePane {
+                id: "pane-test1".into(),
                 x: 0.0,
                 y: 0.0,
                 w: 1.0,
@@ -1264,6 +1301,140 @@ mod tests {
         let font = parsed.font.unwrap();
         assert_eq!(font.face, "Mono");
         assert_eq!(font.size, 12);
+    }
+
+    // --- Phase 0: Workspace Pane ID tests ---
+
+    #[test]
+    fn workspace_pane_id_round_trip() {
+        let pane = WorkspacePane {
+            id: "pane-abc12345".into(),
+            x: 0.0,
+            y: 0.0,
+            w: 1.0,
+            h: 1.0,
+            view: serde_json::from_value(serde_json::json!({"type": "TerminalView"})).unwrap(),
+        };
+        let json = serde_json::to_string(&pane).unwrap();
+        let parsed: WorkspacePane = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, "pane-abc12345");
+    }
+
+    #[test]
+    fn workspace_pane_id_defaults_empty_when_missing() {
+        let json = r#"{"x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0, "view": {"type": "EmptyView"}}"#;
+        let pane: WorkspacePane = serde_json::from_str(json).unwrap();
+        assert_eq!(pane.id, "");
+    }
+
+    #[test]
+    fn migrate_assigns_pane_ids_to_empty() {
+        let mut settings = Settings::default();
+        settings.workspaces = vec![Workspace {
+            id: "ws-1".into(),
+            name: "Test".into(),
+            layout_id: None,
+            panes: vec![
+                WorkspacePane {
+                    id: "".into(),
+                    x: 0.0,
+                    y: 0.0,
+                    w: 0.5,
+                    h: 1.0,
+                    view: serde_json::from_value(serde_json::json!({"type": "TerminalView"}))
+                        .unwrap(),
+                },
+                WorkspacePane {
+                    id: "existing-id".into(),
+                    x: 0.5,
+                    y: 0.0,
+                    w: 0.5,
+                    h: 1.0,
+                    view: serde_json::from_value(serde_json::json!({"type": "EmptyView"})).unwrap(),
+                },
+            ],
+        }];
+        migrate_settings(&mut settings);
+        // Empty ID gets assigned a pane-{uuid} format
+        assert!(settings.workspaces[0].panes[0].id.starts_with("pane-"));
+        assert_eq!(settings.workspaces[0].panes[0].id.len(), 13); // "pane-" + 8 chars
+                                                                  // Existing ID is preserved
+        assert_eq!(settings.workspaces[0].panes[1].id, "existing-id");
+    }
+
+    // --- Phase 1: restore_cwd / restore_output tests ---
+
+    #[test]
+    fn profile_defaults_restore_fields_default_true() {
+        let defaults = ProfileDefaults::default();
+        assert!(defaults.restore_cwd);
+        assert!(defaults.restore_output);
+    }
+
+    #[test]
+    fn profile_defaults_restore_fields_round_trip() {
+        let json = r#"{
+            "profileDefaults": {
+                "restoreCwd": false,
+                "restoreOutput": false
+            }
+        }"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert!(!settings.profile_defaults.restore_cwd);
+        assert!(!settings.profile_defaults.restore_output);
+
+        let serialized = serde_json::to_string_pretty(&settings).unwrap();
+        let reparsed: Settings = serde_json::from_str(&serialized).unwrap();
+        assert!(!reparsed.profile_defaults.restore_cwd);
+        assert!(!reparsed.profile_defaults.restore_output);
+    }
+
+    #[test]
+    fn profile_defaults_restore_fields_default_when_missing() {
+        let json = r#"{}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert!(settings.profile_defaults.restore_cwd);
+        assert!(settings.profile_defaults.restore_output);
+    }
+
+    #[test]
+    fn profile_restore_fields_optional() {
+        let profile = Profile::default();
+        assert!(profile.restore_cwd.is_none());
+        assert!(profile.restore_output.is_none());
+    }
+
+    #[test]
+    fn profile_restore_fields_round_trip() {
+        let json = r#"{"name": "Test", "commandLine": "bash", "restoreCwd": false, "restoreOutput": true}"#;
+        let profile: Profile = serde_json::from_str(json).unwrap();
+        assert_eq!(profile.restore_cwd, Some(false));
+        assert_eq!(profile.restore_output, Some(true));
+
+        let serialized = serde_json::to_string(&profile).unwrap();
+        let reparsed: Profile = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.restore_cwd, Some(false));
+        assert_eq!(reparsed.restore_output, Some(true));
+    }
+
+    #[test]
+    fn profile_restore_fields_not_serialized_when_none() {
+        let profile = Profile::default();
+        let json = serde_json::to_string(&profile).unwrap();
+        assert!(!json.contains("restoreCwd"));
+        assert!(!json.contains("restoreOutput"));
+    }
+
+    // --- Phase 2: cache_dir_path tests ---
+
+    #[test]
+    fn cache_dir_path_is_under_config() {
+        if let Some(cache) = cache_dir_path() {
+            if let Some(config) = dirs_config_path() {
+                assert_eq!(cache.parent(), Some(config.as_path()));
+                assert_eq!(cache.file_name().unwrap(), "cache");
+            }
+        }
     }
 
     // --- Memo file tests ---

--- a/src-tauri/tests/e2e_test.rs
+++ b/src-tauri/tests/e2e_test.rs
@@ -107,6 +107,7 @@ fn settings_round_trip_with_full_config() {
             layout_id: None,
             panes: vec![
                 WorkspacePane {
+                    id: "pane-e2e-1".into(),
                     x: 0.0,
                     y: 0.0,
                     w: 1.0,
@@ -117,6 +118,7 @@ fn settings_round_trip_with_full_config() {
                     },
                 },
                 WorkspacePane {
+                    id: "pane-e2e-2".into(),
                     x: 0.0,
                     y: 0.5,
                     w: 0.5,
@@ -127,6 +129,7 @@ fn settings_round_trip_with_full_config() {
                     },
                 },
                 WorkspacePane {
+                    id: "pane-e2e-3".into(),
                     x: 0.5,
                     y: 0.5,
                     w: 0.5,
@@ -348,6 +351,7 @@ fn settings_multiple_layouts_multiple_workspaces() {
                 name: "WS1".into(),
                 layout_id: None,
                 panes: vec![WorkspacePane {
+                    id: "pane-ws1".into(),
                     x: 0.0,
                     y: 0.0,
                     w: 1.0,
@@ -420,6 +424,7 @@ fn settings_pane_boundary_values() {
 #[test]
 fn settings_workspace_pane_view_extra_data_preserved() {
     let pane = WorkspacePane {
+        id: "pane-extra-test".into(),
         x: 0.0,
         y: 0.0,
         w: 1.0,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,6 +11,7 @@
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-shell": "^2.3.5",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-serialize": "^0.14.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
@@ -2233,6 +2234,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-serialize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0.tgz",
+      "integrity": "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,6 +19,7 @@
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-serialize": "^0.14.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -16,29 +16,40 @@ export function App() {
   const cleanupRef = useRef<(() => void) | null>(null);
   useEffect(() => {
     let cancelled = false;
-    import("@tauri-apps/api/window").then(({ getCurrentWindow }) => {
-      if (cancelled) return;
-      const appWindow = getCurrentWindow();
-      const CLOSE_TIMEOUT_MS = 5000;
-      appWindow
-        .onCloseRequested(async (event) => {
-          event.preventDefault();
-          try {
-            await Promise.race([
-              saveBeforeClose(),
-              new Promise<void>((resolve) => setTimeout(resolve, CLOSE_TIMEOUT_MS)),
-            ]);
-          } catch {
-            // Save failed — close anyway
-          }
-          await appWindow.destroy();
-        })
-        .then((unlisten) => {
-          if (cancelled) unlisten();
-          else cleanupRef.current = unlisten;
-        })
-        .catch(() => {});
-    });
+    import("@tauri-apps/api/window")
+      .then(({ getCurrentWindow }) => {
+        if (cancelled) return;
+        const appWindow = getCurrentWindow();
+        const CLOSE_TIMEOUT_MS = 5000;
+        appWindow
+          .onCloseRequested(async (event) => {
+            event.preventDefault();
+            try {
+              const result = await Promise.race([
+                saveBeforeClose().then(() => "saved" as const),
+                new Promise<"timeout">((resolve) =>
+                  setTimeout(() => resolve("timeout"), CLOSE_TIMEOUT_MS),
+                ),
+              ]);
+              if (result === "timeout") {
+                console.warn("[App] saveBeforeClose timed out after", CLOSE_TIMEOUT_MS, "ms");
+              }
+            } catch (err) {
+              console.error("[App] saveBeforeClose failed:", err);
+            }
+            await appWindow.destroy();
+          })
+          .then((unlisten) => {
+            if (cancelled) unlisten();
+            else cleanupRef.current = unlisten;
+          })
+          .catch((err) => {
+            console.error("[App] Failed to register onCloseRequested handler:", err);
+          });
+      })
+      .catch((err) => {
+        console.error("[App] Failed to import @tauri-apps/api/window:", err);
+      });
     return () => {
       cancelled = true;
       cleanupRef.current?.();

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,11 +19,15 @@ export function App() {
     import("@tauri-apps/api/window").then(({ getCurrentWindow }) => {
       if (cancelled) return;
       const appWindow = getCurrentWindow();
+      const CLOSE_TIMEOUT_MS = 5000;
       appWindow
         .onCloseRequested(async (event) => {
           event.preventDefault();
           try {
-            await saveBeforeClose();
+            await Promise.race([
+              saveBeforeClose(),
+              new Promise<void>((resolve) => setTimeout(resolve, CLOSE_TIMEOUT_MS)),
+            ]);
           } catch {
             // Save failed — close anyway
           }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,14 +1,45 @@
+import { useEffect, useRef } from "react";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useSyncEvents } from "@/hooks/useSyncEvents";
 import { useSessionPersistence } from "@/hooks/useSessionPersistence";
 import { useAutomationBridge } from "@/hooks/useAutomationBridge";
+import { saveBeforeClose } from "@/lib/persist-session";
 
 export function App() {
   useKeyboardShortcuts();
   useSyncEvents();
   useSessionPersistence();
   useAutomationBridge();
+
+  // Save terminal state before window close (Alt+F4, OS close, etc.)
+  const cleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    import("@tauri-apps/api/window").then(({ getCurrentWindow }) => {
+      if (cancelled) return;
+      const appWindow = getCurrentWindow();
+      appWindow
+        .onCloseRequested(async (event) => {
+          event.preventDefault();
+          try {
+            await saveBeforeClose();
+          } catch {
+            // Save failed — close anyway
+          }
+          await appWindow.destroy();
+        })
+        .then((unlisten) => {
+          if (cancelled) unlisten();
+          else cleanupRef.current = unlisten;
+        })
+        .catch(() => {});
+    });
+    return () => {
+      cancelled = true;
+      cleanupRef.current?.();
+    };
+  }, []);
 
   return (
     <div className="h-screen" data-testid="app-root">

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -101,7 +101,7 @@ const mockSetTerminalCwdReceive = vi.fn().mockResolvedValue(undefined);
 const mockOpenExternal = vi.fn().mockResolvedValue(undefined);
 const mockLoadTerminalOutputCache = vi
   .fn()
-  .mockRejectedValue(new Error("Failed to read cache: not found"));
+  .mockRejectedValue(new Error("Cache not found: /fake/path.dat"));
 
 vi.mock("@/lib/tauri-api", () => ({
   createTerminalSession: (...args: unknown[]) => mockCreateTerminalSession(...args),
@@ -819,7 +819,9 @@ describe("TerminalView", () => {
     });
 
     it("still creates session when cache load fails", async () => {
-      mockLoadTerminalOutputCache.mockRejectedValueOnce(new Error("Failed to read cache: missing"));
+      mockLoadTerminalOutputCache.mockRejectedValueOnce(
+        new Error("Cache not found: /fake/path.dat"),
+      );
 
       render(
         <TerminalView

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -62,6 +62,21 @@ vi.mock("@xterm/addon-web-links", () => ({
   },
 }));
 
+const mockSerialize = vi.fn().mockReturnValue("serialized-data");
+vi.mock("@xterm/addon-serialize", () => ({
+  SerializeAddon: class MockSerializeAddon {
+    serialize = mockSerialize;
+    dispose = vi.fn();
+  },
+}));
+
+const mockRegisterTerminalSerializer = vi.fn();
+const mockUnregisterTerminalSerializer = vi.fn();
+vi.mock("@/lib/terminal-serialize-registry", () => ({
+  registerTerminalSerializer: (...args: unknown[]) => mockRegisterTerminalSerializer(...args),
+  unregisterTerminalSerializer: (...args: unknown[]) => mockUnregisterTerminalSerializer(...args),
+}));
+
 // Mock IME handler
 const mockSetupImeHandler = vi.fn().mockReturnValue(true);
 const mockDisposeImeHandler = vi.fn();
@@ -84,6 +99,9 @@ const mockSmartPaste = vi.fn().mockResolvedValue({ pasteType: "none", content: "
 const mockClipboardWriteText = vi.fn().mockResolvedValue(undefined);
 const mockSetTerminalCwdReceive = vi.fn().mockResolvedValue(undefined);
 const mockOpenExternal = vi.fn().mockResolvedValue(undefined);
+const mockLoadTerminalOutputCache = vi
+  .fn()
+  .mockRejectedValue(new Error("Failed to read cache: not found"));
 
 vi.mock("@/lib/tauri-api", () => ({
   createTerminalSession: (...args: unknown[]) => mockCreateTerminalSession(...args),
@@ -96,6 +114,7 @@ vi.mock("@/lib/tauri-api", () => ({
   setTerminalCwdReceive: (...args: unknown[]) => mockSetTerminalCwdReceive(...args),
   updateTerminalSyncGroup: vi.fn().mockResolvedValue(undefined),
   openExternal: (...args: unknown[]) => mockOpenExternal(...args),
+  loadTerminalOutputCache: (...args: unknown[]) => mockLoadTerminalOutputCache(...args),
 }));
 
 describe("TerminalView", () => {
@@ -699,6 +718,150 @@ describe("TerminalView", () => {
       await vi.waitFor(() => {
         expect(mockOpenExternal).toHaveBeenCalledWith("https://example.com");
       });
+    });
+  });
+
+  // -- session restore --
+
+  describe("session restore", () => {
+    it("restores cached output when paneId is provided and restoreOutput is true", async () => {
+      mockLoadTerminalOutputCache.mockResolvedValueOnce("cached-terminal-output");
+
+      render(
+        <TerminalView
+          instanceId="t-restore1"
+          paneId="pane-abc"
+          profile="PowerShell"
+          syncGroup="default"
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(mockLoadTerminalOutputCache).toHaveBeenCalledWith("pane-abc");
+      });
+    });
+
+    it("does not load cache when paneId is not provided", async () => {
+      render(<TerminalView instanceId="t-restore2" profile="PowerShell" syncGroup="default" />);
+
+      await vi.waitFor(() => {
+        expect(mockCreateTerminalSession).toHaveBeenCalled();
+      });
+      expect(mockLoadTerminalOutputCache).not.toHaveBeenCalled();
+    });
+
+    it("does not load cache when restoreOutput is false in profile", async () => {
+      useSettingsStore.getState().updateProfile(0, { restoreOutput: false });
+
+      render(
+        <TerminalView
+          instanceId="t-restore3"
+          paneId="pane-noout"
+          profile="PowerShell"
+          syncGroup="default"
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(mockCreateTerminalSession).toHaveBeenCalled();
+      });
+      expect(mockLoadTerminalOutputCache).not.toHaveBeenCalled();
+    });
+
+    it("passes lastCwd to createTerminalSession when restoreCwd is true", async () => {
+      render(
+        <TerminalView
+          instanceId="t-restore4"
+          paneId="pane-cwd"
+          profile="PowerShell"
+          syncGroup="default"
+          lastCwd="/home/user/project"
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(mockCreateTerminalSession).toHaveBeenCalledWith(
+          "t-restore4",
+          "PowerShell",
+          80,
+          24,
+          "default",
+          true,
+          "/home/user/project",
+        );
+      });
+    });
+
+    it("does not pass lastCwd when restoreCwd is false in profile", async () => {
+      useSettingsStore.getState().updateProfile(0, { restoreCwd: false });
+
+      render(
+        <TerminalView
+          instanceId="t-restore5"
+          paneId="pane-nocwd"
+          profile="PowerShell"
+          syncGroup="default"
+          lastCwd="/home/user/project"
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(mockCreateTerminalSession).toHaveBeenCalledWith(
+          "t-restore5",
+          "PowerShell",
+          80,
+          24,
+          "default",
+          true,
+          undefined,
+        );
+      });
+    });
+
+    it("still creates session when cache load fails", async () => {
+      mockLoadTerminalOutputCache.mockRejectedValueOnce(new Error("Failed to read cache: missing"));
+
+      render(
+        <TerminalView
+          instanceId="t-restore6"
+          paneId="pane-fail"
+          profile="PowerShell"
+          syncGroup="default"
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(mockCreateTerminalSession).toHaveBeenCalledWith(
+          "t-restore6",
+          "PowerShell",
+          80,
+          24,
+          "default",
+          true,
+          undefined,
+        );
+      });
+    });
+
+    it("registers serializer on mount and unregisters on unmount", async () => {
+      const { unmount } = render(
+        <TerminalView
+          instanceId="t-ser1"
+          paneId="pane-ser"
+          profile="PowerShell"
+          syncGroup="default"
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(mockRegisterTerminalSerializer).toHaveBeenCalledWith(
+          "pane-ser",
+          expect.any(Function),
+        );
+      });
+
+      unmount();
+      expect(mockUnregisterTerminalSerializer).toHaveBeenCalledWith("pane-ser");
     });
   });
 

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -141,6 +141,7 @@ describe("TerminalView", () => {
         24,
         "grp",
         true,
+        undefined,
       );
     });
   });
@@ -723,6 +724,7 @@ describe("TerminalView", () => {
           24,
           "default",
           false,
+          undefined,
         );
       });
     });
@@ -745,6 +747,7 @@ describe("TerminalView", () => {
           24,
           "default",
           true,
+          undefined,
         );
       });
     });

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -487,10 +487,7 @@ export function TerminalView({
 
         // Register serializer for shutdown save
         if (paneId) {
-          registerTerminalSerializer(paneId, () => {
-            const serialized = serializeAddon.serialize();
-            return new TextEncoder().encode(serialized);
-          });
+          registerTerminalSerializer(paneId, () => serializeAddon.serialize());
         }
 
         fitAddon.fit();
@@ -512,10 +509,9 @@ export function TerminalView({
           if (shouldRestoreOutput && paneId) {
             try {
               const cached = await loadTerminalOutputCache(paneId);
+              if (cancelled) return;
               if (cached && cached.length > 0) {
-                const bytes = new Uint8Array(cached);
-                const text = new TextDecoder().decode(bytes);
-                terminal.write(text);
+                terminal.write(cached);
                 terminal.write("\r\n\x1b[90m--- session restored ---\x1b[0m\r\n");
               }
             } catch {

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -35,6 +35,12 @@ import {
 import { useNotificationStore } from "@/stores/notification-store";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { OutputIdleDetector } from "@/lib/output-idle-detector";
+import { SerializeAddon } from "@xterm/addon-serialize";
+import { loadTerminalOutputCache } from "@/lib/tauri-api";
+import {
+  registerTerminalSerializer,
+  unregisterTerminalSerializer,
+} from "@/lib/terminal-serialize-registry";
 
 /** Default silence timeout for output idle detection (ms). */
 const OUTPUT_IDLE_TIMEOUT_MS = 5000;
@@ -54,6 +60,7 @@ function resolveWorkspaceId(terminalId: string): string {
 
 interface TerminalViewProps {
   instanceId: string;
+  paneId?: string;
   profile: string;
   syncGroup: string;
   cwdSend?: boolean;
@@ -62,10 +69,13 @@ interface TerminalViewProps {
   isFocused?: boolean;
   /** Called when user starts typing — parent can hide control bar / hover state. */
   onKeyboardActivity?: () => void;
+  /** Last CWD from previous session, used for restore on startup. */
+  lastCwd?: string;
 }
 
 export function TerminalView({
   instanceId,
+  paneId,
   profile,
   syncGroup,
   cwdSend = true,
@@ -73,6 +83,7 @@ export function TerminalView({
   workspaceId = "",
   isFocused = false,
   onKeyboardActivity,
+  lastCwd,
 }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
@@ -470,19 +481,59 @@ export function TerminalView({
         } catch {
           // WebGL not available — fall back to default renderer
         }
+        // Load SerializeAddon for session persistence
+        const serializeAddon = new SerializeAddon();
+        terminal.loadAddon(serializeAddon);
+
+        // Register serializer for shutdown save
+        if (paneId) {
+          registerTerminalSerializer(paneId, () => {
+            const serialized = serializeAddon.serialize();
+            return new TextEncoder().encode(serialized);
+          });
+        }
+
         fitAddon.fit();
         openedRef.current = true;
         if (isFocusedRef.current) {
           terminal.focus();
         }
-        createTerminalSession(
-          instanceId,
-          profile,
-          terminal.cols,
-          terminal.rows,
-          syncGroup,
-          cwdReceiveRef.current,
-        ).catch(() => {});
+
+        // Resolve profile restore settings and create session (async)
+        const profileConfig = settingsState.profiles.find((p) => p.name === profile);
+        const shouldRestoreCwd =
+          profileConfig?.restoreCwd ?? settingsState.profileDefaults.restoreCwd;
+        const shouldRestoreOutput =
+          profileConfig?.restoreOutput ?? settingsState.profileDefaults.restoreOutput;
+
+        (async () => {
+          if (cancelled) return;
+          // Restore cached terminal output from previous session
+          if (shouldRestoreOutput && lastCwd && paneId) {
+            try {
+              const cached = await loadTerminalOutputCache(paneId);
+              if (cached && cached.length > 0) {
+                const bytes = new Uint8Array(cached);
+                const text = new TextDecoder().decode(bytes);
+                terminal.write(text);
+                terminal.write("\r\n\x1b[90m--- session restored ---\x1b[0m\r\n");
+              }
+            } catch {
+              // No cache — fresh start
+            }
+          }
+
+          if (cancelled) return;
+          createTerminalSession(
+            instanceId,
+            profile,
+            terminal.cols,
+            terminal.rows,
+            syncGroup,
+            cwdReceiveRef.current,
+            shouldRestoreCwd ? lastCwd : undefined,
+          ).catch(() => {});
+        })();
       } else if (sessionCreated && width > 0 && height > 0) {
         fitAddon.fit();
       }
@@ -503,6 +554,9 @@ export function TerminalView({
       if (imeContainerRef.current) {
         disposeImeHandler(imeContainerRef.current);
         imeContainerRef.current = null;
+      }
+      if (paneId) {
+        unregisterTerminalSerializer(paneId);
       }
       unlistenOutput?.();
       closeTerminalSession(instanceId).catch(() => {});

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -515,9 +515,9 @@ export function TerminalView({
                 terminal.write("\r\n\x1b[90m--- session restored ---\x1b[0m\r\n");
               }
             } catch (err) {
-              // File-not-found is expected for new panes — log anything else
+              // "Cache not found" is expected for new panes — log anything else
               const msg = err instanceof Error ? err.message : String(err);
-              if (!msg.includes("Failed to read cache")) {
+              if (!msg.startsWith("Cache not found:")) {
                 console.warn(`[TerminalView] Unexpected error restoring cache for ${paneId}:`, err);
               }
             }

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -514,8 +514,12 @@ export function TerminalView({
                 terminal.write(cached);
                 terminal.write("\r\n\x1b[90m--- session restored ---\x1b[0m\r\n");
               }
-            } catch {
-              // No cache — fresh start
+            } catch (err) {
+              // File-not-found is expected for new panes — log anything else
+              const msg = err instanceof Error ? err.message : String(err);
+              if (!msg.includes("Failed to read cache")) {
+                console.warn(`[TerminalView] Unexpected error restoring cache for ${paneId}:`, err);
+              }
             }
           }
 
@@ -528,7 +532,10 @@ export function TerminalView({
             syncGroup,
             cwdReceiveRef.current,
             shouldRestoreCwd ? lastCwd : undefined,
-          ).catch(() => {});
+          ).catch((err) => {
+            console.error(`[TerminalView] Failed to create session ${instanceId}:`, err);
+            terminal.write(`\r\n\x1b[31mFailed to create terminal session: ${err}\x1b[0m\r\n`);
+          });
         })();
       } else if (sessionCreated && width > 0 && height > 0) {
         fitAddon.fit();
@@ -561,6 +568,7 @@ export function TerminalView({
     };
     // syncGroup intentionally excluded: changes (e.g. workspace rename) must NOT
     // destroy/recreate the terminal session. syncGroupRef is used at runtime instead.
+    // paneId, lastCwd: mount-time only for session restore, must NOT trigger re-creation.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [instanceId, profile, registerInstance, unregisterInstance]);
 

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -509,7 +509,7 @@ export function TerminalView({
         (async () => {
           if (cancelled) return;
           // Restore cached terminal output from previous session
-          if (shouldRestoreOutput && lastCwd && paneId) {
+          if (shouldRestoreOutput && paneId) {
             try {
               const cached = await loadTerminalOutputCache(paneId);
               if (cached && cached.length > 0) {

--- a/ui/src/components/views/ViewRenderer.tsx
+++ b/ui/src/components/views/ViewRenderer.tsx
@@ -50,10 +50,12 @@ export function ViewRenderer({
       const configSyncGroup = (viewConfig?.syncGroup as string) ?? "";
       const effectiveSyncGroup = configSyncGroup || workspaceId || "";
       const instanceId = paneId ? `terminal-${paneId}` : `terminal-${fallbackId}`;
+      const lastCwd = (viewConfig?.lastCwd as string) ?? undefined;
       return (
         <div data-testid="view-terminal" className="h-full">
           <TerminalView
             instanceId={instanceId}
+            paneId={paneId}
             profile={(viewConfig?.profile as string) || defaultProfile || "PowerShell"}
             syncGroup={effectiveSyncGroup}
             cwdSend={(viewConfig?.cwdSend as boolean) ?? true}
@@ -61,6 +63,7 @@ export function ViewRenderer({
             workspaceId={workspaceId}
             isFocused={isFocused}
             onKeyboardActivity={onKeyboardActivity}
+            lastCwd={lastCwd}
           />
         </div>
       );

--- a/ui/src/hooks/useSessionPersistence.ts
+++ b/ui/src/hooks/useSessionPersistence.ts
@@ -190,7 +190,9 @@ export function useSessionPersistence() {
             []),
         ];
         if (allPaneIds.length > 0) {
-          cleanTerminalOutputCache(allPaneIds).catch(() => {});
+          cleanTerminalOutputCache(allPaneIds).catch((err) => {
+            console.warn("[useSessionPersistence] Failed to clean orphaned cache:", err);
+          });
         }
 
         setLoaded(true);

--- a/ui/src/hooks/useSessionPersistence.ts
+++ b/ui/src/hooks/useSessionPersistence.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { loadSettings } from "@/lib/tauri-api";
+import { loadSettings, cleanTerminalOutputCache } from "@/lib/tauri-api";
 import { persistSession } from "@/lib/persist-session";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useSettingsStore, makeDefaultColorScheme } from "@/stores/settings-store";
@@ -65,6 +65,8 @@ export function useSessionPersistence() {
                     },
                   }
                 : {}),
+              ...(p.restoreCwd !== undefined ? { restoreCwd: p.restoreCwd } : {}),
+              ...(p.restoreOutput !== undefined ? { restoreOutput: p.restoreOutput } : {}),
             })) ?? [],
           colorSchemes:
             sColorSchemes?.map((cs) => {
@@ -109,7 +111,7 @@ export function useSessionPersistence() {
             id: ws.id,
             name: ws.name,
             panes: ws.panes.map((p) => ({
-              id: `loaded-pane-${++paneCounter}`,
+              id: p.id || `loaded-pane-${++paneCounter}`,
               x: p.x,
               y: p.y,
               w: p.w || 1,
@@ -178,6 +180,21 @@ export function useSessionPersistence() {
             };
           });
           useDockStore.setState({ docks: updatedDocks });
+        }
+
+        // Clean orphaned terminal output cache files
+        const allPaneIds: string[] = [
+          ...(rawSettings.workspaces?.flatMap((ws) => ws.panes.map((p) => p.id).filter(Boolean)) ??
+            []),
+          ...(rawSettings.docks?.flatMap(
+            (d) =>
+              (d as unknown as { panes?: { id: string }[] }).panes
+                ?.map((p) => p.id)
+                .filter(Boolean) ?? [],
+          ) ?? []),
+        ];
+        if (allPaneIds.length > 0) {
+          cleanTerminalOutputCache(allPaneIds).catch(() => {});
         }
 
         setLoaded(true);

--- a/ui/src/hooks/useSessionPersistence.ts
+++ b/ui/src/hooks/useSessionPersistence.ts
@@ -186,12 +186,8 @@ export function useSessionPersistence() {
         const allPaneIds: string[] = [
           ...(rawSettings.workspaces?.flatMap((ws) => ws.panes.map((p) => p.id).filter(Boolean)) ??
             []),
-          ...(rawSettings.docks?.flatMap(
-            (d) =>
-              (d as unknown as { panes?: { id: string }[] }).panes
-                ?.map((p) => p.id)
-                .filter(Boolean) ?? [],
-          ) ?? []),
+          ...(rawSettings.docks?.flatMap((d) => d.panes?.map((p) => p.id).filter(Boolean) ?? []) ??
+            []),
         ];
         if (allPaneIds.length > 0) {
           cleanTerminalOutputCache(allPaneIds).catch(() => {});

--- a/ui/src/lib/persist-session.test.ts
+++ b/ui/src/lib/persist-session.test.ts
@@ -482,6 +482,21 @@ describe("saveBeforeClose", () => {
     expect(saveTerminalOutputCache).toHaveBeenCalledTimes(1);
   });
 
+  it("skips serializations exceeding 2MB size limit", async () => {
+    const largeData = "x".repeat(2 * 1024 * 1024 + 1); // Just over 2MB
+    const smallData = "small-output";
+    const mockMap = new Map([
+      ["pane-large", () => largeData],
+      ["pane-small", () => smallData],
+    ]);
+    vi.mocked(getTerminalSerializeMap).mockReturnValue(mockMap);
+
+    await saveBeforeClose();
+
+    expect(saveTerminalOutputCache).toHaveBeenCalledTimes(1);
+    expect(saveTerminalOutputCache).toHaveBeenCalledWith("pane-small", smallData);
+  });
+
   it("filters empty pane IDs from activePaneIds before cleaning cache", async () => {
     vi.mocked(getTerminalSerializeMap).mockReturnValue(new Map());
 

--- a/ui/src/lib/persist-session.test.ts
+++ b/ui/src/lib/persist-session.test.ts
@@ -487,6 +487,38 @@ describe("saveBeforeClose", () => {
     expect(saveTerminalOutputCache).toHaveBeenCalledTimes(1);
   });
 
+  it("completes other saves when one saveTerminalOutputCache rejects (allSettled)", async () => {
+    let callCount = 0;
+    vi.mocked(saveTerminalOutputCache).mockImplementation(async (paneId: string) => {
+      callCount++;
+      if (paneId === "pane-fail") throw new Error("disk full");
+    });
+    const mockMap = new Map([
+      ["pane-fail", () => "data-fail"],
+      ["pane-ok", () => "data-ok"],
+    ]);
+    vi.mocked(getTerminalSerializeMap).mockReturnValue(mockMap);
+
+    await saveBeforeClose();
+
+    // Both saves were attempted despite one failing
+    expect(callCount).toBe(2);
+    // persistSession (saveSettings) was still called
+    expect(saveSettings).toHaveBeenCalledTimes(1);
+    // cleanup was still called
+    expect(cleanTerminalOutputCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("still completes when cleanTerminalOutputCache rejects", async () => {
+    vi.mocked(getTerminalSerializeMap).mockReturnValue(new Map());
+    vi.mocked(cleanTerminalOutputCache).mockRejectedValueOnce(new Error("permission denied"));
+
+    // Should not throw
+    await saveBeforeClose();
+
+    expect(saveSettings).toHaveBeenCalledTimes(1);
+  });
+
   it("truncates serializations exceeding 2MB keeping recent lines", async () => {
     // Build data: many lines, total > 2MB
     const line = "x".repeat(1000) + "\n";

--- a/ui/src/lib/persist-session.test.ts
+++ b/ui/src/lib/persist-session.test.ts
@@ -17,19 +17,30 @@ vi.mock("@/lib/tauri-api", () => ({
   getListeningPorts: vi.fn().mockResolvedValue([]),
   getGitBranch: vi.fn().mockResolvedValue(null),
   sendOsNotification: vi.fn().mockResolvedValue(undefined),
+  saveTerminalOutputCache: vi.fn().mockResolvedValue(undefined),
+  cleanTerminalOutputCache: vi.fn().mockResolvedValue(0),
 }));
 
-import { persistSession } from "./persist-session";
-import { saveSettings } from "@/lib/tauri-api";
+vi.mock("@/lib/terminal-serialize-registry", () => ({
+  getTerminalSerializeMap: vi.fn().mockReturnValue(new Map()),
+  registerTerminalSerializer: vi.fn(),
+  unregisterTerminalSerializer: vi.fn(),
+}));
+
+import { persistSession, saveBeforeClose } from "./persist-session";
+import { saveSettings, saveTerminalOutputCache, cleanTerminalOutputCache } from "@/lib/tauri-api";
+import { getTerminalSerializeMap } from "@/lib/terminal-serialize-registry";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useDockStore } from "@/stores/dock-store";
+import { useTerminalStore } from "@/stores/terminal-store";
 
 describe("persistSession", () => {
   beforeEach(() => {
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
     useSettingsStore.setState(useSettingsStore.getInitialState());
     useDockStore.setState(useDockStore.getInitialState());
+    useTerminalStore.setState({ instances: [] });
     vi.clearAllMocks();
   });
 
@@ -252,5 +263,210 @@ describe("persistSession", () => {
     expect(leftDock.panes[0].y).toBe(0);
     expect(leftDock.panes[0].w).toBe(1);
     expect(leftDock.panes[0].h).toBe(1);
+  });
+
+  // -- restoreCwd / restoreOutput profile field tests --
+
+  it("preserves restoreCwd and restoreOutput in profiles", async () => {
+    useSettingsStore.getState().updateProfile(0, {
+      restoreCwd: false,
+      restoreOutput: false,
+    });
+
+    await persistSession();
+
+    const savedArg = (saveSettings as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(savedArg.profiles[0].restoreCwd).toBe(false);
+    expect(savedArg.profiles[0].restoreOutput).toBe(false);
+  });
+
+  it("includes default restoreCwd/restoreOutput values (true) from profile defaults", async () => {
+    // makeProfile spreads defaultProfileDefaults, so restoreCwd/restoreOutput
+    // are true by default (not undefined).
+    await persistSession();
+
+    const savedArg = (saveSettings as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(savedArg.profiles[0].restoreCwd).toBe(true);
+    expect(savedArg.profiles[0].restoreOutput).toBe(true);
+  });
+
+  it("preserves restoreCwd/restoreOutput in profileDefaults", async () => {
+    useSettingsStore.getState().setProfileDefaults({
+      restoreCwd: false,
+      restoreOutput: false,
+    });
+
+    await persistSession();
+
+    const savedArg = (saveSettings as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(savedArg.profileDefaults.restoreCwd).toBe(false);
+    expect(savedArg.profileDefaults.restoreOutput).toBe(false);
+  });
+
+  it("restoreCwd/restoreOutput profile fields survive round-trip", async () => {
+    useSettingsStore.getState().updateProfile(0, {
+      restoreCwd: false,
+      restoreOutput: true,
+    });
+
+    await persistSession();
+
+    const saved = (saveSettings as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    useSettingsStore.setState(useSettingsStore.getInitialState());
+    useSettingsStore.getState().loadFromSettings(saved);
+
+    const profile = useSettingsStore.getState().profiles[0];
+    expect(profile.restoreCwd).toBe(false);
+    expect(profile.restoreOutput).toBe(true);
+  });
+
+  // -- lastCwd injection tests --
+
+  it("injects lastCwd into workspace TerminalView panes from terminal store", async () => {
+    const wsState = useWorkspaceStore.getState();
+    const paneId = wsState.workspaces[0].panes[0].id;
+    wsState.setPaneView(0, { type: "TerminalView", profile: "WSL" });
+
+    // Register a terminal instance with CWD
+    useTerminalStore.getState().registerInstance({
+      id: `terminal-${paneId}`,
+      profile: "WSL",
+      syncGroup: "default",
+      workspaceId: wsState.workspaces[0].id,
+    });
+    useTerminalStore.getState().updateInstanceInfo(`terminal-${paneId}`, {
+      cwd: "/home/user/project",
+    });
+
+    await persistSession();
+
+    const savedArg = (saveSettings as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(savedArg.workspaces[0].panes[0].view.lastCwd).toBe("/home/user/project");
+  });
+
+  it("injects lastCwd into dock TerminalView panes from terminal store", async () => {
+    const dockState = useDockStore.getState();
+    const dockPaneId = dockState.getDock("left")!.panes[0].id;
+    dockState.setDockPaneView("left", dockPaneId, {
+      type: "TerminalView",
+      profile: "WSL",
+    });
+
+    useTerminalStore.getState().registerInstance({
+      id: `terminal-${dockPaneId}`,
+      profile: "WSL",
+      syncGroup: "default",
+      workspaceId: "",
+    });
+    useTerminalStore.getState().updateInstanceInfo(`terminal-${dockPaneId}`, {
+      cwd: "/tmp/dock-cwd",
+    });
+
+    await persistSession();
+
+    const savedArg = (saveSettings as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const leftDock = savedArg.docks.find((d: { position: string }) => d.position === "left");
+    expect(leftDock.panes[0].view.lastCwd).toBe("/tmp/dock-cwd");
+  });
+
+  it("does not inject lastCwd for non-TerminalView panes", async () => {
+    useWorkspaceStore.getState().setPaneView(0, { type: "MemoView" });
+
+    await persistSession();
+
+    const savedArg = (saveSettings as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(savedArg.workspaces[0].panes[0].view.lastCwd).toBeUndefined();
+  });
+
+  it("includes stable pane id in saved workspace panes", async () => {
+    await persistSession();
+
+    const savedArg = (saveSettings as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(savedArg.workspaces[0].panes[0].id).toBeDefined();
+    expect(savedArg.workspaces[0].panes[0].id).not.toBe("");
+  });
+});
+
+// -- saveBeforeClose tests --
+
+describe("saveBeforeClose", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
+    useSettingsStore.setState(useSettingsStore.getInitialState());
+    useDockStore.setState(useDockStore.getInitialState());
+    useTerminalStore.setState({ instances: [] });
+    vi.clearAllMocks();
+  });
+
+  it("serializes terminal outputs and saves to cache", async () => {
+    const mockSerialize = vi.fn().mockReturnValue("serialized-output");
+    const mockMap = new Map([["pane-abc", mockSerialize]]);
+    vi.mocked(getTerminalSerializeMap).mockReturnValue(mockMap);
+
+    await saveBeforeClose();
+
+    expect(mockSerialize).toHaveBeenCalledTimes(1);
+    expect(saveTerminalOutputCache).toHaveBeenCalledWith("pane-abc", "serialized-output");
+  });
+
+  it("skips empty serializations", async () => {
+    const mockMap = new Map([["pane-abc", () => ""]]);
+    vi.mocked(getTerminalSerializeMap).mockReturnValue(mockMap);
+
+    await saveBeforeClose();
+
+    expect(saveTerminalOutputCache).not.toHaveBeenCalled();
+  });
+
+  it("calls persistSession (saveSettings) during close", async () => {
+    vi.mocked(getTerminalSerializeMap).mockReturnValue(new Map());
+
+    await saveBeforeClose();
+
+    expect(saveSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans orphaned cache files after save completes", async () => {
+    vi.mocked(getTerminalSerializeMap).mockReturnValue(new Map());
+
+    await saveBeforeClose();
+
+    expect(cleanTerminalOutputCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("awaits saves before cleaning orphans (ordering)", async () => {
+    const callOrder: string[] = [];
+    vi.mocked(saveSettings).mockImplementation(async () => {
+      callOrder.push("saveSettings");
+    });
+    vi.mocked(cleanTerminalOutputCache).mockImplementation(async () => {
+      callOrder.push("cleanCache");
+      return 0;
+    });
+    vi.mocked(getTerminalSerializeMap).mockReturnValue(new Map());
+
+    await saveBeforeClose();
+
+    const saveIdx = callOrder.indexOf("saveSettings");
+    const cleanIdx = callOrder.indexOf("cleanCache");
+    expect(saveIdx).toBeLessThan(cleanIdx);
+  });
+
+  it("handles serialization errors gracefully", async () => {
+    const mockMap = new Map<string, () => string>([
+      [
+        "pane-err",
+        () => {
+          throw new Error("serialize failed");
+        },
+      ],
+      ["pane-ok", () => "good-data"],
+    ]);
+    vi.mocked(getTerminalSerializeMap).mockReturnValue(mockMap);
+
+    await saveBeforeClose();
+
+    expect(saveTerminalOutputCache).toHaveBeenCalledWith("pane-ok", "good-data");
+    expect(saveTerminalOutputCache).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/lib/persist-session.test.ts
+++ b/ui/src/lib/persist-session.test.ts
@@ -469,4 +469,17 @@ describe("saveBeforeClose", () => {
     expect(saveTerminalOutputCache).toHaveBeenCalledWith("pane-ok", "good-data");
     expect(saveTerminalOutputCache).toHaveBeenCalledTimes(1);
   });
+
+  it("filters empty pane IDs from activePaneIds before cleaning cache", async () => {
+    vi.mocked(getTerminalSerializeMap).mockReturnValue(new Map());
+
+    // Set up workspace with a pane that has an empty ID
+    const wsState = useWorkspaceStore.getState();
+    wsState.workspaces[0].panes[0].id = "";
+
+    await saveBeforeClose();
+
+    const cleanArgs = (cleanTerminalOutputCache as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(cleanArgs.every((id: string) => id !== "")).toBe(true);
+  });
 });

--- a/ui/src/lib/persist-session.test.ts
+++ b/ui/src/lib/persist-session.test.ts
@@ -27,7 +27,7 @@ vi.mock("@/lib/terminal-serialize-registry", () => ({
   unregisterTerminalSerializer: vi.fn(),
 }));
 
-import { persistSession, saveBeforeClose } from "./persist-session";
+import { persistSession, saveBeforeClose, _resetClosingDown } from "./persist-session";
 import { saveSettings, saveTerminalOutputCache, cleanTerminalOutputCache } from "@/lib/tauri-api";
 import { getTerminalSerializeMap } from "@/lib/terminal-serialize-registry";
 import { useWorkspaceStore } from "@/stores/workspace-store";
@@ -37,6 +37,7 @@ import { useTerminalStore } from "@/stores/terminal-store";
 
 describe("persistSession", () => {
   beforeEach(() => {
+    _resetClosingDown();
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
     useSettingsStore.setState(useSettingsStore.getInitialState());
     useDockStore.setState(useDockStore.getInitialState());
@@ -378,6 +379,16 @@ describe("persistSession", () => {
     expect(savedArg.workspaces[0].panes[0].view.lastCwd).toBeUndefined();
   });
 
+  it("is no-op after saveBeforeClose sets closingDown flag", async () => {
+    vi.mocked(getTerminalSerializeMap).mockReturnValue(new Map());
+    await saveBeforeClose();
+    vi.mocked(saveSettings).mockClear();
+
+    await persistSession();
+
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+
   it("includes stable pane id in saved workspace panes", async () => {
     await persistSession();
 
@@ -391,6 +402,7 @@ describe("persistSession", () => {
 
 describe("saveBeforeClose", () => {
   beforeEach(() => {
+    _resetClosingDown();
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
     useSettingsStore.setState(useSettingsStore.getInitialState());
     useDockStore.setState(useDockStore.getInitialState());

--- a/ui/src/lib/persist-session.test.ts
+++ b/ui/src/lib/persist-session.test.ts
@@ -27,7 +27,12 @@ vi.mock("@/lib/terminal-serialize-registry", () => ({
   unregisterTerminalSerializer: vi.fn(),
 }));
 
-import { persistSession, saveBeforeClose, _resetClosingDown } from "./persist-session";
+import {
+  persistSession,
+  saveBeforeClose,
+  _resetClosingDown,
+  truncateFromEnd,
+} from "./persist-session";
 import { saveSettings, saveTerminalOutputCache, cleanTerminalOutputCache } from "@/lib/tauri-api";
 import { getTerminalSerializeMap } from "@/lib/terminal-serialize-registry";
 import { useWorkspaceStore } from "@/stores/workspace-store";
@@ -482,19 +487,20 @@ describe("saveBeforeClose", () => {
     expect(saveTerminalOutputCache).toHaveBeenCalledTimes(1);
   });
 
-  it("skips serializations exceeding 2MB size limit", async () => {
-    const largeData = "x".repeat(2 * 1024 * 1024 + 1); // Just over 2MB
-    const smallData = "small-output";
-    const mockMap = new Map([
-      ["pane-large", () => largeData],
-      ["pane-small", () => smallData],
-    ]);
+  it("truncates serializations exceeding 2MB keeping recent lines", async () => {
+    // Build data: many lines, total > 2MB
+    const line = "x".repeat(1000) + "\n";
+    const lineCount = Math.ceil((2 * 1024 * 1024 + 100) / line.length);
+    const largeData = line.repeat(lineCount);
+    const mockMap = new Map([["pane-large", () => largeData]]);
     vi.mocked(getTerminalSerializeMap).mockReturnValue(mockMap);
 
     await saveBeforeClose();
 
     expect(saveTerminalOutputCache).toHaveBeenCalledTimes(1);
-    expect(saveTerminalOutputCache).toHaveBeenCalledWith("pane-small", smallData);
+    const savedData = vi.mocked(saveTerminalOutputCache).mock.calls[0][1];
+    expect(savedData.length).toBeLessThanOrEqual(2 * 1024 * 1024);
+    expect(savedData.length).toBeGreaterThan(0);
   });
 
   it("filters empty pane IDs from activePaneIds before cleaning cache", async () => {
@@ -508,5 +514,39 @@ describe("saveBeforeClose", () => {
 
     const cleanArgs = (cleanTerminalOutputCache as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(cleanArgs.every((id: string) => id !== "")).toBe(true);
+  });
+});
+
+// -- truncateFromEnd tests --
+
+describe("truncateFromEnd", () => {
+  it("returns data unchanged when under limit", () => {
+    const data = "line1\nline2\nline3";
+    expect(truncateFromEnd(data, 1000)).toBe(data);
+  });
+
+  it("keeps most recent lines when over limit", () => {
+    const data = "oldest\nmiddle\nnewest";
+    // limit to 13 chars — "middle\nnewest" = 13
+    expect(truncateFromEnd(data, 13)).toBe("middle\nnewest");
+  });
+
+  it("returns empty string when single line exceeds limit", () => {
+    const data = "x".repeat(100);
+    expect(truncateFromEnd(data, 50)).toBe("");
+  });
+
+  it("handles exact boundary correctly", () => {
+    const data = "aaa\nbbb\nccc";
+    // "aaa\nbbb\nccc" = 11 chars
+    expect(truncateFromEnd(data, 11)).toBe(data);
+  });
+
+  it("preserves escape sequences in kept lines", () => {
+    const lines = ["\x1b[31mold-red\x1b[0m", "\x1b[32mnew-green\x1b[0m"];
+    const data = lines.join("\n");
+    // Limit to only fit the last line
+    const lastLine = lines[1];
+    expect(truncateFromEnd(data, lastLine.length)).toBe(lastLine);
   });
 });

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -151,14 +151,12 @@ export async function saveBeforeClose(): Promise<void> {
 
   // 1. Serialize and cache terminal outputs
   const serializeMap = getTerminalSerializeMap();
-  // TODO: Array.from(Uint8Array) → JSON number[] is 3-4x larger than raw bytes.
-  // Consider base64 encoding or Tauri binary IPC to reduce overhead.
   const cachePromises: Promise<void>[] = [];
   for (const [paneId, serializeFn] of serializeMap.entries()) {
     try {
       const data = serializeFn();
       if (data && data.length > 0) {
-        cachePromises.push(saveTerminalOutputCache(paneId, Array.from(data)));
+        cachePromises.push(saveTerminalOutputCache(paneId, data));
       }
     } catch {
       // skip failed serializations

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -10,8 +10,24 @@ import { useDockStore } from "@/stores/dock-store";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { getTerminalSerializeMap } from "@/lib/terminal-serialize-registry";
 
-/** Maximum serialized terminal output size to cache (2MB). Larger outputs are skipped. */
+/** Maximum serialized terminal output size to cache (2MB). Outputs exceeding this are truncated from the front, keeping recent lines. */
 const MAX_CACHE_BYTES = 2 * 1024 * 1024;
+
+/** Truncate serialized output by dropping oldest lines until it fits within maxBytes. */
+export function truncateFromEnd(data: string, maxBytes: number): string {
+  if (data.length <= maxBytes) return data;
+  const lines = data.split("\n");
+  let total = 0;
+  let startIdx = lines.length;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const lineLen = lines[i].length + (i < lines.length - 1 ? 1 : 0);
+    if (total + lineLen > maxBytes) break;
+    total += lineLen;
+    startIdx = i;
+  }
+  if (startIdx >= lines.length) return "";
+  return lines.slice(startIdx).join("\n");
+}
 
 /** True once saveBeforeClose() starts — prevents duplicate persistSession() calls during teardown. */
 let closingDown = false;
@@ -177,8 +193,12 @@ export async function saveBeforeClose(): Promise<void> {
   const cachePromises: Promise<void>[] = [];
   for (const [paneId, serializeFn] of serializeMap.entries()) {
     try {
-      const data = serializeFn();
-      if (data && data.length > 0 && data.length <= MAX_CACHE_BYTES) {
+      let data = serializeFn();
+      if (!data || data.length === 0) continue;
+      if (data.length > MAX_CACHE_BYTES) {
+        data = truncateFromEnd(data, MAX_CACHE_BYTES);
+      }
+      if (data.length > 0) {
         cachePromises.push(saveTerminalOutputCache(paneId, data));
       }
     } catch {

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -13,15 +13,15 @@ import { getTerminalSerializeMap } from "@/lib/terminal-serialize-registry";
 /** Maximum serialized terminal output size to cache (2M chars). Outputs exceeding this are truncated from the front, keeping recent lines. */
 const MAX_CACHE_CHARS = 2 * 1024 * 1024;
 
-/** Truncate serialized output by dropping oldest lines until it fits within maxBytes. */
-export function truncateFromEnd(data: string, maxBytes: number): string {
-  if (data.length <= maxBytes) return data;
+/** Truncate serialized output by dropping oldest lines until it fits within maxChars. */
+export function truncateFromEnd(data: string, maxChars: number): string {
+  if (data.length <= maxChars) return data;
   const lines = data.split("\n");
   let total = 0;
   let startIdx = lines.length;
   for (let i = lines.length - 1; i >= 0; i--) {
     const lineLen = lines[i].length + (i < lines.length - 1 ? 1 : 0);
-    if (total + lineLen > maxBytes) break;
+    if (total + lineLen > maxChars) break;
     total += lineLen;
     startIdx = i;
   }

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -1,7 +1,14 @@
-import { saveSettings, type Settings } from "@/lib/tauri-api";
+import {
+  saveSettings,
+  saveTerminalOutputCache,
+  cleanTerminalOutputCache,
+  type Settings,
+} from "@/lib/tauri-api";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useDockStore } from "@/stores/dock-store";
+import { useTerminalStore } from "@/stores/terminal-store";
+import { getTerminalSerializeMap } from "@/lib/terminal-serialize-registry";
 
 /**
  * Gathers state from all stores and persists to settings.json via Tauri backend.
@@ -11,11 +18,14 @@ export async function persistSession(): Promise<void> {
   const settingsState = useSettingsStore.getState();
   const wsState = useWorkspaceStore.getState();
   const dockState = useDockStore.getState();
+  const terminalInstances = useTerminalStore.getState().instances;
 
   // Build the base settings object (matches the Tauri Settings type).
   const base: Settings = {
     defaultProfile: settingsState.defaultProfile,
-    profileDefaults: { ...settingsState.profileDefaults },
+    profileDefaults: {
+      ...settingsState.profileDefaults,
+    },
     viewOrder: settingsState.viewOrder ?? [],
     appThemeId: settingsState.appThemeId ?? "catppuccin-mocha",
     // WARNING: Profile 필드를 추가할 때 여기에도 반드시 포함할 것.
@@ -39,6 +49,8 @@ export async function persistSession(): Promise<void> {
       suppressApplicationTitle: p.suppressApplicationTitle,
       snapOnInput: p.snapOnInput,
       ...(p.font ? { font: p.font } : {}),
+      ...(p.restoreCwd !== undefined ? { restoreCwd: p.restoreCwd } : {}),
+      ...(p.restoreOutput !== undefined ? { restoreOutput: p.restoreOutput } : {}),
     })),
     colorSchemes: settingsState.colorSchemes.map((cs) => ({
       name: cs.name,
@@ -81,13 +93,22 @@ export async function persistSession(): Promise<void> {
     workspaces: wsState.workspaces.map((ws) => ({
       id: ws.id,
       name: ws.name,
-      panes: ws.panes.map((p) => ({
-        x: p.x,
-        y: p.y,
-        w: p.w,
-        h: p.h,
-        view: p.view as { type: string; [key: string]: unknown },
-      })),
+      panes: ws.panes.map((p) => {
+        const viewExtra: Record<string, unknown> = {};
+        if (p.view.type === "TerminalView") {
+          const termId = `terminal-${p.id}`;
+          const inst = terminalInstances.find((i) => i.id === termId);
+          if (inst?.cwd) viewExtra.lastCwd = inst.cwd;
+        }
+        return {
+          id: p.id,
+          x: p.x,
+          y: p.y,
+          w: p.w,
+          h: p.h,
+          view: { ...p.view, ...viewExtra } as { type: string; [key: string]: unknown },
+        };
+      }),
     })),
     convenience: { ...settingsState.convenience },
     workspaceDisplay: { ...settingsState.workspaceDisplay },
@@ -99,16 +120,61 @@ export async function persistSession(): Promise<void> {
       views: d.views,
       visible: d.visible,
       size: d.size,
-      panes: d.panes.map((p) => ({
-        id: p.id,
-        view: p.view,
-        x: p.x,
-        y: p.y,
-        w: p.w,
-        h: p.h,
-      })),
+      panes: d.panes.map((p) => {
+        const dockViewExtra: Record<string, unknown> = {};
+        if (p.view.type === "TerminalView") {
+          const termId = `terminal-${p.id}`;
+          const inst = terminalInstances.find((i) => i.id === termId);
+          if (inst?.cwd) dockViewExtra.lastCwd = inst.cwd;
+        }
+        return {
+          id: p.id,
+          view: Object.keys(dockViewExtra).length > 0 ? { ...p.view, ...dockViewExtra } : p.view,
+          x: p.x,
+          y: p.y,
+          w: p.w,
+          h: p.h,
+        };
+      }),
     })),
   };
 
   await saveSettings(base);
+}
+
+/**
+ * Serialize all terminal outputs and persist session state before window close.
+ */
+export async function saveBeforeClose(): Promise<void> {
+  const wsState = useWorkspaceStore.getState();
+  const dockState = useDockStore.getState();
+
+  // 1. Serialize and cache terminal outputs
+  const serializeMap = getTerminalSerializeMap();
+  const cachePromises: Promise<void>[] = [];
+  for (const [paneId, serializeFn] of serializeMap.entries()) {
+    try {
+      const data = serializeFn();
+      if (data && data.length > 0) {
+        cachePromises.push(saveTerminalOutputCache(paneId, Array.from(data)));
+      }
+    } catch {
+      // skip failed serializations
+    }
+  }
+
+  // 2. Persist session (includes lastCwd in view configs)
+  cachePromises.push(persistSession());
+
+  // 3. Clean orphaned cache files
+  const activePaneIds: string[] = [];
+  for (const ws of wsState.workspaces) {
+    for (const p of ws.panes) activePaneIds.push(p.id);
+  }
+  for (const d of dockState.docks) {
+    for (const p of d.panes) activePaneIds.push(p.id);
+  }
+  cachePromises.push(cleanTerminalOutputCache(activePaneIds).then(() => {}));
+
+  await Promise.all(cachePromises);
 }

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -173,10 +173,10 @@ export async function saveBeforeClose(): Promise<void> {
   // 3. Clean orphaned cache files (safe now that saves have completed)
   const activePaneIds: string[] = [];
   for (const ws of wsState.workspaces) {
-    for (const p of ws.panes) activePaneIds.push(p.id);
+    for (const p of ws.panes) if (p.id) activePaneIds.push(p.id);
   }
   for (const d of dockState.docks) {
-    for (const p of d.panes) activePaneIds.push(p.id);
+    for (const p of d.panes) if (p.id) activePaneIds.push(p.id);
   }
   await cleanTerminalOutputCache(activePaneIds);
 }

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -10,8 +10,8 @@ import { useDockStore } from "@/stores/dock-store";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { getTerminalSerializeMap } from "@/lib/terminal-serialize-registry";
 
-/** Maximum serialized terminal output size to cache (2MB). Outputs exceeding this are truncated from the front, keeping recent lines. */
-const MAX_CACHE_BYTES = 2 * 1024 * 1024;
+/** Maximum serialized terminal output size to cache (2M chars). Outputs exceeding this are truncated from the front, keeping recent lines. */
+const MAX_CACHE_CHARS = 2 * 1024 * 1024;
 
 /** Truncate serialized output by dropping oldest lines until it fits within maxBytes. */
 export function truncateFromEnd(data: string, maxBytes: number): string {
@@ -195,8 +195,8 @@ export async function saveBeforeClose(): Promise<void> {
     try {
       let data = serializeFn();
       if (!data || data.length === 0) continue;
-      if (data.length > MAX_CACHE_BYTES) {
-        data = truncateFromEnd(data, MAX_CACHE_BYTES);
+      if (data.length > MAX_CACHE_CHARS) {
+        data = truncateFromEnd(data, MAX_CACHE_CHARS);
       }
       if (data.length > 0) {
         cachePromises.push(saveTerminalOutputCache(paneId, data));
@@ -211,7 +211,7 @@ export async function saveBeforeClose(): Promise<void> {
 
   // Wait for save + persist before cleaning — otherwise clean may race and
   // delete files that are still being written.
-  await Promise.all(cachePromises);
+  await Promise.allSettled(cachePromises);
 
   // 3. Clean orphaned cache files (safe now that saves have completed)
   const activePaneIds: string[] = [];

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -151,6 +151,8 @@ export async function saveBeforeClose(): Promise<void> {
 
   // 1. Serialize and cache terminal outputs
   const serializeMap = getTerminalSerializeMap();
+  // TODO: Array.from(Uint8Array) → JSON number[] is 3-4x larger than raw bytes.
+  // Consider base64 encoding or Tauri binary IPC to reduce overhead.
   const cachePromises: Promise<void>[] = [];
   for (const [paneId, serializeFn] of serializeMap.entries()) {
     try {
@@ -166,7 +168,11 @@ export async function saveBeforeClose(): Promise<void> {
   // 2. Persist session (includes lastCwd in view configs)
   cachePromises.push(persistSession());
 
-  // 3. Clean orphaned cache files
+  // Wait for save + persist before cleaning — otherwise clean may race and
+  // delete files that are still being written.
+  await Promise.all(cachePromises);
+
+  // 3. Clean orphaned cache files (safe now that saves have completed)
   const activePaneIds: string[] = [];
   for (const ws of wsState.workspaces) {
     for (const p of ws.panes) activePaneIds.push(p.id);
@@ -174,7 +180,5 @@ export async function saveBeforeClose(): Promise<void> {
   for (const d of dockState.docks) {
     for (const p of d.panes) activePaneIds.push(p.id);
   }
-  cachePromises.push(cleanTerminalOutputCache(activePaneIds).then(() => {}));
-
-  await Promise.all(cachePromises);
+  await cleanTerminalOutputCache(activePaneIds);
 }

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -10,6 +10,9 @@ import { useDockStore } from "@/stores/dock-store";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { getTerminalSerializeMap } from "@/lib/terminal-serialize-registry";
 
+/** Maximum serialized terminal output size to cache (2MB). Larger outputs are skipped. */
+const MAX_CACHE_BYTES = 2 * 1024 * 1024;
+
 /** True once saveBeforeClose() starts — prevents duplicate persistSession() calls during teardown. */
 let closingDown = false;
 
@@ -136,7 +139,7 @@ async function persistSessionCore(): Promise<void> {
         }
         return {
           id: p.id,
-          view: Object.keys(dockViewExtra).length > 0 ? { ...p.view, ...dockViewExtra } : p.view,
+          view: { ...p.view, ...dockViewExtra },
           x: p.x,
           y: p.y,
           w: p.w,
@@ -175,7 +178,7 @@ export async function saveBeforeClose(): Promise<void> {
   for (const [paneId, serializeFn] of serializeMap.entries()) {
     try {
       const data = serializeFn();
-      if (data && data.length > 0) {
+      if (data && data.length > 0 && data.length <= MAX_CACHE_BYTES) {
         cachePromises.push(saveTerminalOutputCache(paneId, data));
       }
     } catch {

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -10,11 +10,18 @@ import { useDockStore } from "@/stores/dock-store";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { getTerminalSerializeMap } from "@/lib/terminal-serialize-registry";
 
+/** True once saveBeforeClose() starts — prevents duplicate persistSession() calls during teardown. */
+let closingDown = false;
+
+/** Reset closingDown flag (for tests only). */
+export function _resetClosingDown(): void {
+  closingDown = false;
+}
+
 /**
- * Gathers state from all stores and persists to settings.json via Tauri backend.
- * Called by workspace store save actions and other persistence triggers.
+ * Core implementation: gathers state from all stores and saves to settings.json.
  */
-export async function persistSession(): Promise<void> {
+async function persistSessionCore(): Promise<void> {
   const settingsState = useSettingsStore.getState();
   const wsState = useWorkspaceStore.getState();
   const dockState = useDockStore.getState();
@@ -143,9 +150,22 @@ export async function persistSession(): Promise<void> {
 }
 
 /**
+ * Gathers state from all stores and persists to settings.json via Tauri backend.
+ * Called by workspace store save actions and other persistence triggers.
+ * No-op if saveBeforeClose() is already in progress (prevents duplicate saves during teardown).
+ */
+export async function persistSession(): Promise<void> {
+  if (closingDown) return;
+  await persistSessionCore();
+}
+
+/**
  * Serialize all terminal outputs and persist session state before window close.
+ * Sets closingDown flag to suppress any concurrent persistSession() calls
+ * that store actions might trigger during teardown.
  */
 export async function saveBeforeClose(): Promise<void> {
+  closingDown = true;
   const wsState = useWorkspaceStore.getState();
   const dockState = useDockStore.getState();
 
@@ -163,8 +183,8 @@ export async function saveBeforeClose(): Promise<void> {
     }
   }
 
-  // 2. Persist session (includes lastCwd in view configs)
-  cachePromises.push(persistSession());
+  // 2. Persist session directly (bypasses closingDown guard)
+  cachePromises.push(persistSessionCore());
 
   // Wait for save + persist before cleaning — otherwise clean may race and
   // delete files that are still being written.

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -201,8 +201,8 @@ export async function saveBeforeClose(): Promise<void> {
       if (data.length > 0) {
         cachePromises.push(saveTerminalOutputCache(paneId, data));
       }
-    } catch {
-      // skip failed serializations
+    } catch (err) {
+      console.warn(`[saveBeforeClose] Failed to serialize pane ${paneId}:`, err);
     }
   }
 
@@ -221,5 +221,9 @@ export async function saveBeforeClose(): Promise<void> {
   for (const d of dockState.docks) {
     for (const p of d.panes) if (p.id) activePaneIds.push(p.id);
   }
-  await cleanTerminalOutputCache(activePaneIds);
+  try {
+    await cleanTerminalOutputCache(activePaneIds);
+  } catch (err) {
+    console.warn("[saveBeforeClose] Failed to clean orphaned cache:", err);
+  }
 }

--- a/ui/src/lib/tauri-api.test.ts
+++ b/ui/src/lib/tauri-api.test.ts
@@ -56,6 +56,7 @@ describe("tauri-api", () => {
         rows: 24,
         syncGroup: "default",
         cwdReceive: true,
+        cwd: null,
       });
       expect(result).toEqual(mockResult);
     });
@@ -74,6 +75,7 @@ describe("tauri-api", () => {
         rows: 24,
         syncGroup: "",
         cwdReceive: false,
+        cwd: null,
       });
     });
   });

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -75,11 +75,11 @@ export async function saveMemo(key: string, content: string): Promise<void> {
   return invoke("save_memo", { key, content });
 }
 
-export async function saveTerminalOutputCache(paneId: string, data: number[]): Promise<void> {
+export async function saveTerminalOutputCache(paneId: string, data: string): Promise<void> {
   return invoke("save_terminal_output_cache", { paneId, data });
 }
 
-export async function loadTerminalOutputCache(paneId: string): Promise<number[]> {
+export async function loadTerminalOutputCache(paneId: string): Promise<string> {
   return invoke("load_terminal_output_cache", { paneId });
 }
 

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -20,6 +20,7 @@ export async function createTerminalSession(
   rows: number,
   syncGroup: string,
   cwdReceive: boolean = true,
+  cwd?: string,
 ): Promise<TerminalSessionResult> {
   return invoke("create_terminal_session", {
     id,
@@ -28,6 +29,7 @@ export async function createTerminalSession(
     rows,
     syncGroup,
     cwdReceive,
+    cwd: cwd ?? null,
   });
 }
 
@@ -73,6 +75,18 @@ export async function saveMemo(key: string, content: string): Promise<void> {
   return invoke("save_memo", { key, content });
 }
 
+export async function saveTerminalOutputCache(paneId: string, data: number[]): Promise<void> {
+  return invoke("save_terminal_output_cache", { paneId, data });
+}
+
+export async function loadTerminalOutputCache(paneId: string): Promise<number[]> {
+  return invoke("load_terminal_output_cache", { paneId });
+}
+
+export async function cleanTerminalOutputCache(activePaneIds: string[]): Promise<number> {
+  return invoke("clean_terminal_output_cache", { activePaneIds });
+}
+
 export interface ConvenienceSettings {
   smartPaste: boolean;
   pasteImageDir: string;
@@ -111,6 +125,8 @@ export interface ProfileDefaults {
   suppressApplicationTitle?: boolean;
   snapOnInput?: boolean;
   font?: FontSettings;
+  restoreCwd?: boolean;
+  restoreOutput?: boolean;
 }
 
 export interface Settings {
@@ -181,6 +197,8 @@ export interface Profile {
   suppressApplicationTitle?: boolean;
   snapOnInput?: boolean;
   font?: FontSettings;
+  restoreCwd?: boolean;
+  restoreOutput?: boolean;
 }
 
 export interface Keybinding {
@@ -205,6 +223,7 @@ export interface SettingsWorkspace {
   name: string;
   layoutId?: string; // deprecated — kept for backward compat with old settings.json
   panes: {
+    id?: string;
     x: number;
     y: number;
     w: number;

--- a/ui/src/lib/terminal-serialize-registry.test.ts
+++ b/ui/src/lib/terminal-serialize-registry.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  registerTerminalSerializer,
+  unregisterTerminalSerializer,
+  getTerminalSerializeMap,
+} from "./terminal-serialize-registry";
+
+describe("terminal-serialize-registry", () => {
+  beforeEach(() => {
+    // Clean up all registered serializers
+    const map = getTerminalSerializeMap();
+    for (const key of map.keys()) {
+      unregisterTerminalSerializer(key);
+    }
+  });
+
+  it("registers and retrieves a serializer", () => {
+    const fn = () => "data";
+    registerTerminalSerializer("pane-1", fn);
+
+    const map = getTerminalSerializeMap();
+    expect(map.size).toBe(1);
+    expect(map.get("pane-1")!()).toBe("data");
+  });
+
+  it("unregisters a serializer", () => {
+    registerTerminalSerializer("pane-2", () => "data");
+    unregisterTerminalSerializer("pane-2");
+
+    const map = getTerminalSerializeMap();
+    expect(map.size).toBe(0);
+    expect(map.has("pane-2")).toBe(false);
+  });
+
+  it("returns a copy, not the live registry", () => {
+    registerTerminalSerializer("pane-3", () => "data");
+    const map1 = getTerminalSerializeMap();
+
+    registerTerminalSerializer("pane-4", () => "more");
+    const map2 = getTerminalSerializeMap();
+
+    // map1 should still have only 1 entry (it's a snapshot)
+    expect(map1.size).toBe(1);
+    expect(map2.size).toBe(2);
+  });
+
+  it("overwrites existing serializer for same paneId", () => {
+    registerTerminalSerializer("pane-5", () => "old");
+    registerTerminalSerializer("pane-5", () => "new");
+
+    const map = getTerminalSerializeMap();
+    expect(map.size).toBe(1);
+    expect(map.get("pane-5")!()).toBe("new");
+  });
+});

--- a/ui/src/lib/terminal-serialize-registry.ts
+++ b/ui/src/lib/terminal-serialize-registry.ts
@@ -1,0 +1,15 @@
+type SerializeFn = () => Uint8Array;
+
+const registry = new Map<string, SerializeFn>();
+
+export function registerTerminalSerializer(paneId: string, fn: SerializeFn): void {
+  registry.set(paneId, fn);
+}
+
+export function unregisterTerminalSerializer(paneId: string): void {
+  registry.delete(paneId);
+}
+
+export function getTerminalSerializeMap(): Map<string, SerializeFn> {
+  return registry;
+}

--- a/ui/src/lib/terminal-serialize-registry.ts
+++ b/ui/src/lib/terminal-serialize-registry.ts
@@ -1,4 +1,4 @@
-type SerializeFn = () => Uint8Array;
+type SerializeFn = () => string;
 
 const registry = new Map<string, SerializeFn>();
 
@@ -10,6 +10,6 @@ export function unregisterTerminalSerializer(paneId: string): void {
   registry.delete(paneId);
 }
 
-export function getTerminalSerializeMap(): Map<string, SerializeFn> {
-  return registry;
+export function getTerminalSerializeMap(): ReadonlyMap<string, SerializeFn> {
+  return new Map(registry);
 }

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -101,6 +101,8 @@ export interface ProfileDefaults {
   suppressApplicationTitle: boolean;
   snapOnInput: boolean;
   font: FontSettings;
+  restoreCwd: boolean;
+  restoreOutput: boolean;
 }
 
 export interface Profile {
@@ -122,6 +124,10 @@ export interface Profile {
   snapOnInput: boolean;
   /** Per-profile font override. When undefined, inherits from profileDefaults. */
   font?: FontSettings;
+  /** Whether to restore CWD on restart. When undefined, inherits from profileDefaults. */
+  restoreCwd?: boolean;
+  /** Whether to restore terminal output on restart. When undefined, inherits from profileDefaults. */
+  restoreOutput?: boolean;
 }
 
 export interface Keybinding {
@@ -142,6 +148,8 @@ export const INHERITABLE_KEYS: (keyof ProfileDefaults)[] = [
   "suppressApplicationTitle",
   "snapOnInput",
   "font",
+  "restoreCwd",
+  "restoreOutput",
 ];
 
 /** App UI theme — separate from terminal color schemes. */
@@ -296,6 +304,8 @@ const defaultProfileDefaults: ProfileDefaults = {
   suppressApplicationTitle: false,
   snapOnInput: true,
   font: { ...DEFAULT_FONT },
+  restoreCwd: true,
+  restoreOutput: true,
 };
 
 function makeProfile(name: string, commandLine: string, overrides?: Partial<Profile>): Profile {


### PR DESCRIPTION
## Summary
- 재시작 시 터미널 출력 내용과 CWD를 복원하는 세션 보존 기능 (#78)
- 프로파일 단위로 `restoreCwd`/`restoreOutput` 제어 (기본: true)
- `cache/terminal-output/` 디렉터리에 xterm.js SerializeAddon으로 캡처한 출력 저장
- Workspace pane ID를 UUID 기반으로 안정화하여 세션 간 캐시 키로 활용

## Test plan
- [x] Rust 전체 테스트 통과 (12개 신규 포함)
- [x] Frontend 전체 테스트 통과 (1043개)
- [ ] dev 빌드에서 터미널 작업 → 앱 종료 → 재시작 → 이전 출력/CWD 확인
- [ ] `restoreOutput: false` 프로파일에서 출력 미복원 확인
- [ ] 새 워크스페이스 생성 시 pane ID가 UUID 형식인지 확인

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)