### PR TITLE
fix: push restored terminal content into scrollback before shell init

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 pub mod cli;
 
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -259,7 +259,7 @@ fn parse_dib_to_rgba(data: &[u8]) -> Option<(u32, u32, Vec<u8>)> {
     let w = width as u32;
     let h = abs_height;
     let bytes_per_pixel = (bit_count / 8) as usize;
-    let row_stride = ((w as usize * bytes_per_pixel + 3) / 4) * 4; // 4-byte aligned
+    let row_stride = (w as usize * bytes_per_pixel).div_ceil(4) * 4; // 4-byte aligned
 
     // Pixel data starts after the header (and optional color masks for BI_BITFIELDS)
     let pixel_offset = if compression == 3 && header_size <= 40 {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -983,7 +983,10 @@ fn gh_command(shell_prefix: &str) -> std::process::Command {
 
 /// Upload a screenshot to the GitHub repo via the contents API.
 /// Returns the raw download URL of the uploaded image.
-fn upload_screenshot_to_github(path: &std::path::Path, shell_prefix: &str) -> Result<String, String> {
+fn upload_screenshot_to_github(
+    path: &std::path::Path,
+    shell_prefix: &str,
+) -> Result<String, String> {
     let bytes = std::fs::read(path).map_err(|e| format!("Failed to read screenshot: {e}"))?;
     let b64 = base64_encode(&bytes);
 
@@ -1979,7 +1982,10 @@ mod tests {
     #[test]
     fn split_shell_prefix_unclosed_quote() {
         // Unclosed quote: rest of string is one token
-        assert_eq!(split_shell_prefix(r#"cmd "unclosed arg"#), vec!["cmd", "unclosed arg"]);
+        assert_eq!(
+            split_shell_prefix(r#"cmd "unclosed arg"#),
+            vec!["cmd", "unclosed arg"]
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -971,6 +971,7 @@ fn build_gh_command(shell_prefix: &str) -> std::process::Command {
 
 /// Build a `gh` CLI command that runs without a visible console window on Windows.
 fn gh_command(shell_prefix: &str) -> std::process::Command {
+    #[allow(unused_mut)]
     let mut cmd = build_gh_command(shell_prefix);
 
     #[cfg(target_os = "windows")]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub fn greet(name: &str) -> String {
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub fn create_terminal_session(
     id: String,
     profile: String,
@@ -369,10 +370,10 @@ fn handle_lx_message_dispatch(
             all,
             target_group,
         } => {
-            cleanup_stale_propagations(&state);
+            cleanup_stale_propagations(state);
 
             // Check if this is an echo from a propagated command — suppress to prevent loop
-            if is_propagated(&state, &terminal_id)? {
+            if is_propagated(state, &terminal_id)? {
                 return Ok(LxResponse::ok(Some(format!(
                     "sync-cwd {} suppressed (propagated)",
                     path
@@ -383,7 +384,7 @@ fn handle_lx_message_dispatch(
             let normalized_path = normalize_wsl_path(&path);
 
             // Skip if CWD hasn't actually changed for this terminal
-            if should_skip_sync_cwd(&state, &terminal_id, &normalized_path) {
+            if should_skip_sync_cwd(state, &terminal_id, &normalized_path) {
                 return Ok(LxResponse::ok(Some(format!(
                     "sync-cwd {} skipped (unchanged)",
                     normalized_path
@@ -391,10 +392,10 @@ fn handle_lx_message_dispatch(
             }
 
             // Update stored CWD for the source terminal
-            update_terminal_cwd(&state, &terminal_id, &normalized_path);
+            update_terminal_cwd(state, &terminal_id, &normalized_path);
 
             let all_targets = resolve_target_terminals(
-                &state,
+                state,
                 &terminal_id,
                 &group_id,
                 all,
@@ -402,21 +403,21 @@ fn handle_lx_message_dispatch(
             )?;
 
             // Skip targets that have cwd_receive disabled
-            let receiving_targets = filter_targets_cwd_receive(&state, &all_targets);
+            let receiving_targets = filter_targets_cwd_receive(state, &all_targets);
 
             // Skip targets that have a command running (e.g., interactive apps like Claude Code)
             let settings = crate::settings::load_settings();
             let (idle_targets, claude_ids) =
-                filter_targets_not_busy(&state, &receiving_targets, &settings.claude.sync_cwd);
+                filter_targets_not_busy(state, &receiving_targets, &settings.claude.sync_cwd);
 
             // Skip targets that are already at the same CWD
             let target_terminals =
-                filter_targets_needing_cd(&state, &idle_targets, &normalized_path);
+                filter_targets_needing_cd(state, &idle_targets, &normalized_path);
 
             // Write cd command to target terminals (with propagation flag + path conversion)
             if !target_terminals.is_empty() {
                 write_cd_to_group_terminals(
-                    &state,
+                    state,
                     &target_terminals,
                     &terminal_id,
                     &normalized_path,
@@ -426,12 +427,12 @@ fn handle_lx_message_dispatch(
 
             // Mark targets so their OSC echo won't re-propagate
             if !target_terminals.is_empty() {
-                mark_propagated(&state, &target_terminals)?;
+                mark_propagated(state, &target_terminals)?;
             }
 
             // Update stored CWD for receiving targets only (respect cwd_receive filter)
             for tid in &receiving_targets {
-                update_terminal_cwd(&state, tid, &normalized_path);
+                update_terminal_cwd(state, tid, &normalized_path);
             }
 
             // Emit sync-cwd event to frontend — only receiving targets, not all
@@ -551,7 +552,7 @@ fn handle_lx_message_dispatch(
                 .unwrap_or_default();
             drop(groups);
 
-            write_to_group_terminals(&state, &target_ids, "", &format!("{command}\n"))?;
+            write_to_group_terminals(state, &target_ids, "", &format!("{command}\n"))?;
 
             Ok(LxResponse::ok(Some(format!(
                 "sent '{}' to {} terminals in group '{}'",
@@ -840,7 +841,7 @@ pub fn list_system_monospace_fonts() -> Result<Vec<String>, String> {
         })
         .collect();
 
-    result.sort_unstable_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    result.sort_unstable_by_key(|a| a.to_lowercase());
     result.dedup();
     Ok(result)
 }
@@ -888,7 +889,7 @@ pub fn open_settings_file() -> Result<(), String> {
 /// Simple base64 encoder (no external crate needed).
 fn base64_encode(input: &[u8]) -> String {
     const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut result = String::with_capacity((input.len() + 2) / 3 * 4);
+    let mut result = String::with_capacity(input.len().div_ceil(3) * 4);
     for chunk in input.chunks(3) {
         let b0 = chunk[0] as u32;
         let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
@@ -1198,12 +1199,13 @@ fn should_skip_sync_cwd(state: &AppState, terminal_id: &str, normalized_path: &s
 /// Checks the terminal output buffer for the last OSC 133 marker:
 /// - OSC 133;C (preexec) = command is running → exclude
 /// - OSC 133;D (exit code) = at shell prompt → include
+///
 /// Filter out terminals that have cwd_receive disabled.
 fn filter_targets_cwd_receive(state: &AppState, targets: &[String]) -> Vec<String> {
     if let Ok(terminals) = state.terminals.lock() {
         targets
             .iter()
-            .filter(|id| terminals.get(id.as_str()).map_or(true, |s| s.cwd_receive))
+            .filter(|id| terminals.get(id.as_str()).is_none_or(|s| s.cwd_receive))
             .cloned()
             .collect()
     } else {
@@ -1473,7 +1475,7 @@ fn extract_last_terminal_title(data: &[u8]) -> Option<String> {
                 .position(|w| w == needle)
             {
                 let abs_pos = start + found;
-                if best_pos.map_or(true, |bp| abs_pos > bp) {
+                if best_pos.is_none_or(|bp| abs_pos > bp) {
                     best_pos = Some(abs_pos);
                     best_code = needle[2]; // '0' or '2'
                 }
@@ -1557,7 +1559,7 @@ fn filter_targets_needing_cd(
         targets
             .iter()
             .filter(|id| {
-                terminals.get(id.as_str()).map_or(true, |session| {
+                terminals.get(id.as_str()).is_none_or(|session| {
                     session.cwd.as_deref() != Some(normalized_path)
                 })
             })
@@ -1874,11 +1876,10 @@ fn clean_terminal_output_cache_in(
     for entry in std::fs::read_dir(&dir).map_err(|e| format!("Read dir: {e}"))? {
         let entry = entry.map_err(|e| format!("Dir entry: {e}"))?;
         let name = entry.file_name().to_string_lossy().to_string();
-        if name.ends_with(".dat") && !active_set.contains(&name) {
-            if std::fs::remove_file(entry.path()).is_ok() {
+        if name.ends_with(".dat") && !active_set.contains(&name)
+            && std::fs::remove_file(entry.path()).is_ok() {
                 removed += 1;
             }
-        }
     }
     Ok(removed)
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1559,9 +1559,9 @@ fn filter_targets_needing_cd(
         targets
             .iter()
             .filter(|id| {
-                terminals.get(id.as_str()).is_none_or(|session| {
-                    session.cwd.as_deref() != Some(normalized_path)
-                })
+                terminals
+                    .get(id.as_str())
+                    .is_none_or(|session| session.cwd.as_deref() != Some(normalized_path))
             })
             .cloned()
             .collect()
@@ -1876,10 +1876,12 @@ fn clean_terminal_output_cache_in(
     for entry in std::fs::read_dir(&dir).map_err(|e| format!("Read dir: {e}"))? {
         let entry = entry.map_err(|e| format!("Dir entry: {e}"))?;
         let name = entry.file_name().to_string_lossy().to_string();
-        if name.ends_with(".dat") && !active_set.contains(&name)
-            && std::fs::remove_file(entry.path()).is_ok() {
-                removed += 1;
-            }
+        if name.ends_with(".dat")
+            && !active_set.contains(&name)
+            && std::fs::remove_file(entry.path()).is_ok()
+        {
+            removed += 1;
+        }
     }
     Ok(removed)
 }

--- a/src-tauri/src/ipc_server.rs
+++ b/src-tauri/src/ipc_server.rs
@@ -134,7 +134,7 @@ where
             drop(path_clone);
         });
 
-        return Ok(path);
+        Ok(path)
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -341,7 +341,6 @@ pub enum ClaudeSyncCwdMode {
     Command,
 }
 
-
 /// Claude Code integration settings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -350,7 +349,6 @@ pub struct ClaudeSettings {
     #[serde(default)]
     pub sync_cwd: ClaudeSyncCwdMode,
 }
-
 
 /// Path ellipsis direction: "start" truncates the beginning, "end" truncates the end.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -361,7 +359,6 @@ pub enum PathEllipsisMode {
     Start,
     End,
 }
-
 
 fn default_scrollbar_style() -> String {
     "overlay".to_string()
@@ -422,7 +419,6 @@ pub struct IssueReporterSettings {
     #[serde(default)]
     pub shell: String,
 }
-
 
 /// MemoView settings (padding, etc.).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -332,48 +332,36 @@ pub struct Workspace {
 /// Claude Code sync-cwd propagation mode.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum ClaudeSyncCwdMode {
     /// Don't propagate cd when Claude Code is detected (default).
+    #[default]
     Skip,
     /// When Claude Code is idle, send `! cd /path` format.
     Command,
 }
 
-impl Default for ClaudeSyncCwdMode {
-    fn default() -> Self {
-        Self::Skip
-    }
-}
 
 /// Claude Code integration settings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct ClaudeSettings {
     #[serde(default)]
     pub sync_cwd: ClaudeSyncCwdMode,
 }
 
-impl Default for ClaudeSettings {
-    fn default() -> Self {
-        Self {
-            sync_cwd: ClaudeSyncCwdMode::default(),
-        }
-    }
-}
 
 /// Path ellipsis direction: "start" truncates the beginning, "end" truncates the end.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum PathEllipsisMode {
+    #[default]
     Start,
     End,
 }
 
-impl Default for PathEllipsisMode {
-    fn default() -> Self {
-        Self::Start
-    }
-}
 
 fn default_scrollbar_style() -> String {
     "overlay".to_string()
@@ -425,6 +413,7 @@ fn default_memo_padding() -> u32 {
 /// Issue reporter settings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct IssueReporterSettings {
     /// Shell prefix for running gh commands.
     /// When set, gh is invoked as: `{shell_parts...} gh {args...}`
@@ -434,13 +423,6 @@ pub struct IssueReporterSettings {
     pub shell: String,
 }
 
-impl Default for IssueReporterSettings {
-    fn default() -> Self {
-        Self {
-            shell: String::new(),
-        }
-    }
-}
 
 /// MemoView settings (padding, etc.).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -178,7 +178,7 @@ impl TerminalSession {
             ShellType::PowerShell => {
                 let mut init = shell_integration_powershell();
                 if !startup_command.is_empty() {
-                    init.push_str("\n");
+                    init.push('\n');
                     init.push_str(startup_command);
                 }
                 (
@@ -244,8 +244,8 @@ impl SyncGroup {
 /// Overrides `prompt` to emit:
 /// - OSC 133;D (command exit code) — enables notify-on-fail
 /// - OSC 7 (current working directory) — enables sync-cwd
-/// Uses single quotes and concatenation to avoid double-quote escaping issues
-/// with PowerShell's -Command parameter.
+///   Uses single quotes and concatenation to avoid double-quote escaping issues
+///   with PowerShell's -Command parameter.
 fn shell_integration_powershell() -> String {
     // PowerShell 5.1 doesn't support `e escape — use [char]27 instead.
     // OSC sequences are embedded directly in the prompt return string.

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -20,10 +20,11 @@ let capturedKeyHandler: ((e: KeyboardEvent) => boolean) | null = null;
 const mockAttachCustomKeyEventHandler = vi.fn((handler: (e: KeyboardEvent) => boolean) => {
   capturedKeyHandler = handler;
 });
+const mockWrite = vi.fn();
 vi.mock("@xterm/xterm", () => ({
   Terminal: class MockTerminal {
     open = vi.fn();
-    write = vi.fn();
+    write = mockWrite;
     onData = mockOnData;
     onResize = mockOnResize;
     onTitleChange = mockOnTitleChange;
@@ -834,6 +835,30 @@ describe("TerminalView", () => {
           true,
           undefined,
         );
+      });
+    });
+
+    it("pushes restored content into scrollback with padding newlines", async () => {
+      mockLoadTerminalOutputCache.mockResolvedValueOnce("cached-terminal-output");
+
+      render(
+        <TerminalView
+          instanceId="t-restore-scroll"
+          paneId="pane-scroll"
+          profile="PowerShell"
+          syncGroup="default"
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(mockLoadTerminalOutputCache).toHaveBeenCalledWith("pane-scroll");
+      });
+
+      // Should write: cached content, separator, then padding newlines (rows=24)
+      await vi.waitFor(() => {
+        const calls = mockWrite.mock.calls.map((c: unknown[]) => c[0]);
+        expect(calls).toContain("cached-terminal-output");
+        expect(calls).toContain("\r\n".repeat(24));
       });
     });
 

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -499,6 +499,9 @@ export function TerminalView({
               if (cached && cached.length > 0) {
                 terminal.write(cached);
                 terminal.write("\r\n\x1b[90m--- session restored ---\x1b[0m\r\n");
+                // Push restored content into scrollback so shell init
+                // clear-screen sequences don't destroy it
+                terminal.write("\r\n".repeat(terminal.rows));
               }
             } catch (err) {
               // "Cache not found" is expected for new panes — log anything else

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -456,7 +456,6 @@ export function TerminalView({
         // Open terminal now that container has real dimensions
         if (containerRef.current) {
           terminal.open(containerRef.current);
-
         }
         // WebGL renderer required for custom glyph drawing (box-drawing, block
         // elements). xterm.js v6 built-in renderer does not support customGlyphs.
@@ -611,7 +610,6 @@ export function TerminalView({
     } catch {
       /* xterm mock may not support options setter */
     }
-
   }, [currentSchemeName, colorSchemes, font]);
 
   // Reactively update xterm overviewRuler width when scrollbarStyle changes

--- a/ui/src/hooks/useSessionPersistence.ts
+++ b/ui/src/hooks/useSessionPersistence.ts
@@ -91,7 +91,10 @@ export function useSessionPersistence() {
             ? { claude: rawSettings.claude as import("@/lib/tauri-api").ClaudeSettings }
             : {}),
           ...(rawSettings.issueReporter
-            ? { issueReporter: rawSettings.issueReporter as import("@/lib/tauri-api").IssueReporterSettings }
+            ? {
+                issueReporter:
+                  rawSettings.issueReporter as import("@/lib/tauri-api").IssueReporterSettings,
+              }
             : {}),
         });
 
@@ -180,10 +183,10 @@ export function useSessionPersistence() {
         // Clean orphaned terminal output cache files
         const allPaneIds: string[] = [
           ...(rawSettings.workspaces?.flatMap((ws) =>
-            ws.panes.map((p) => p.id).filter((id): id is string => Boolean(id))
+            ws.panes.map((p) => p.id).filter((id): id is string => Boolean(id)),
           ) ?? []),
-          ...(rawSettings.docks?.flatMap((d) =>
-            d.panes?.map((p) => p.id).filter((id): id is string => Boolean(id)) ?? []
+          ...(rawSettings.docks?.flatMap(
+            (d) => d.panes?.map((p) => p.id).filter((id): id is string => Boolean(id)) ?? [],
           ) ?? []),
         ];
         if (allPaneIds.length > 0) {

--- a/ui/src/lib/window-close-handler.ts
+++ b/ui/src/lib/window-close-handler.ts
@@ -29,9 +29,7 @@ export function createCloseHandler(deps: CloseHandlerDeps) {
     try {
       await Promise.race([
         deps.saveBeforeClose().then(() => "saved" as const),
-        new Promise<"timeout">((resolve) =>
-          setTimeout(() => resolve("timeout"), deps.timeoutMs),
-        ),
+        new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), deps.timeoutMs)),
       ]);
     } catch {
       // Save failure is non-fatal — proceed to close

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
-import type { ClaudeSyncCwdMode, ClaudeSettings, IssueReporterSettings, MemoSettings } from "../lib/tauri-api";
+import type {
+  ClaudeSyncCwdMode,
+  ClaudeSettings,
+  IssueReporterSettings,
+  MemoSettings,
+} from "../lib/tauri-api";
 import {
   resolveSyncCwd,
   DEFAULT_SYNC_CWD_DEFAULTS,


### PR DESCRIPTION
## Summary
- 세션 복원된 터미널 내용이 쉘 초기화(`.bashrc`, starship 등)의 화면 클리어 시퀀스에 의해 즉시 사라지는 문제 수정
- 복원 내용을 스크롤백으로 밀어넣어 쉘이 뷰포트를 클리어해도 보존되도록 함
- 사용자는 스크롤업으로 이전 세션 내용 확인 가능

## Test plan
- [x] TerminalView 테스트 46개 모두 통과
- [ ] dev 빌드에서 앱 종료 → 재시작 후 스크롤업하여 이전 세션 내용 + "--- session restored ---" 구분선 확인
- [ ] 새 쉘 프롬프트가 깨끗한 뷰포트에서 시작되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)