### PR TITLE
fix: hide mouse cursor when typing in terminal

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -493,6 +493,41 @@ describe("TerminalView", () => {
     expect(mockClipboardWriteText).not.toHaveBeenCalled();
   });
 
+  // -- Hide mouse cursor on typing --
+
+  it("hides mouse cursor when typing in terminal (onKey)", async () => {
+    render(<TerminalView instanceId="t-cursor1" profile="PowerShell" syncGroup="" />);
+
+    // Capture the onKey callback
+    expect(mockOnKey).toHaveBeenCalled();
+    const onKeyCallback = mockOnKey.mock.calls[0][0];
+
+    // outerEl in the component is containerRef.current?.parentElement
+    // containerRef is on the inner div, parentElement is the data-testid div
+    const testIdDiv = screen.getByTestId("terminal-view-t-cursor1");
+    expect(testIdDiv.style.cursor).toBe("");
+
+    // Simulate typing via terminal.onKey
+    onKeyCallback({ key: "a", domEvent: new KeyboardEvent("keydown", { key: "a" }) });
+
+    expect(testIdDiv.style.cursor).toBe("none");
+  });
+
+  it("restores mouse cursor on mouse move after typing", async () => {
+    render(<TerminalView instanceId="t-cursor2" profile="PowerShell" syncGroup="" />);
+
+    const onKeyCallback = mockOnKey.mock.calls[0][0];
+    const testIdDiv = screen.getByTestId("terminal-view-t-cursor2");
+
+    // Type to hide cursor
+    onKeyCallback({ key: "a", domEvent: new KeyboardEvent("keydown", { key: "a" }) });
+    expect(testIdDiv.style.cursor).toBe("none");
+
+    // Move mouse to restore cursor
+    testIdDiv.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+    expect(testIdDiv.style.cursor).toBe("");
+  });
+
   // -- Ctrl+Wheel Zoom --
 
   it("increases font size on Ctrl+Wheel scroll up", async () => {

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -194,6 +194,7 @@ export function TerminalView({
     // DOM keydown for when focus is elsewhere (e.g., after clicking control bar).
     const outerEl = containerRef.current?.parentElement;
     terminal.onKey(() => {
+      if (outerEl) outerEl.style.cursor = "none";
       onKeyboardActivityRef.current?.();
     });
     const handleKeyDown = () => {


### PR DESCRIPTION
## Summary
- `terminal.onKey` 콜백에 `cursor = "none"` 설정 추가 — xterm이 keydown 이벤트를 내부적으로 소비하여 DOM keydown 리스너가 동작하지 않던 버그 수정
- 마우스를 움직이면 커서가 다시 복원되는 기존 동작은 그대로 유지
- 관련 테스트 2건 추가 (숨김 + 복원)

## Test plan
- [x] `vitest run` 전체 통과 (1117 tests)
- [x] 터미널에서 타이핑 시 마우스 커서 숨김 확인
- [x] 마우스 이동 시 커서 복원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)