### PR TITLE
feat: IssueReporterView padding 추가 및 기본값 8px

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -406,7 +406,7 @@ impl Default for ConvenienceSettings {
     }
 }
 
-fn default_memo_padding() -> u32 {
+fn default_view_padding() -> u32 {
     8
 }
 
@@ -420,13 +420,13 @@ pub struct IssueReporterSettings {
     /// When empty (default), gh is invoked directly.
     #[serde(default)]
     pub shell: String,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_top: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_right: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_bottom: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_left: u32,
 }
 
@@ -446,13 +446,13 @@ impl Default for IssueReporterSettings {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MemoSettings {
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_top: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_right: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_bottom: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_left: u32,
 }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -407,13 +407,12 @@ impl Default for ConvenienceSettings {
 }
 
 fn default_memo_padding() -> u32 {
-    12
+    8
 }
 
 /// Issue reporter settings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[derive(Default)]
 pub struct IssueReporterSettings {
     /// Shell prefix for running gh commands.
     /// When set, gh is invoked as: `{shell_parts...} gh {args...}`
@@ -421,6 +420,26 @@ pub struct IssueReporterSettings {
     /// When empty (default), gh is invoked directly.
     #[serde(default)]
     pub shell: String,
+    #[serde(default = "default_memo_padding")]
+    pub padding_top: u32,
+    #[serde(default = "default_memo_padding")]
+    pub padding_right: u32,
+    #[serde(default = "default_memo_padding")]
+    pub padding_bottom: u32,
+    #[serde(default = "default_memo_padding")]
+    pub padding_left: u32,
+}
+
+impl Default for IssueReporterSettings {
+    fn default() -> Self {
+        Self {
+            shell: String::new(),
+            padding_top: 8,
+            padding_right: 8,
+            padding_bottom: 8,
+            padding_left: 8,
+        }
+    }
 }
 
 /// MemoView settings (padding, etc.).
@@ -440,10 +459,10 @@ pub struct MemoSettings {
 impl Default for MemoSettings {
     fn default() -> Self {
         Self {
-            padding_top: 12,
-            padding_right: 12,
-            padding_bottom: 12,
-            padding_left: 12,
+            padding_top: 8,
+            padding_right: 8,
+            padding_bottom: 8,
+            padding_left: 8,
         }
     }
 }

--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { IssueReporterView } from "./IssueReporterView";
+import { useSettingsStore } from "@/stores/settings-store";
 
 // Mock fetch for screenshot capture
 const mockFetch = vi.fn().mockResolvedValue({
@@ -25,6 +26,7 @@ vi.mock("@tauri-apps/plugin-shell", () => ({
 describe("IssueReporterView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useSettingsStore.setState(useSettingsStore.getInitialState());
     mockFetch.mockResolvedValue({
       json: () =>
         Promise.resolve({ path: "/tmp/screenshot.png", dataUrl: "data:image/png;base64,abc" }),
@@ -37,6 +39,28 @@ describe("IssueReporterView", () => {
     expect(screen.getByTestId("issue-title")).toBeInTheDocument();
     expect(screen.getByTestId("issue-body")).toBeInTheDocument();
     expect(screen.getByTestId("issue-submit")).toBeInTheDocument();
+  });
+
+  it("applies default padding (8px) from settings", () => {
+    render(<IssueReporterView />);
+    const view = screen.getByTestId("issue-reporter-view");
+    expect(view.style.padding).toBe("8px");
+  });
+
+  it("applies custom padding from settings", () => {
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      issueReporter: {
+        ...useSettingsStore.getState().issueReporter,
+        paddingTop: 20,
+        paddingRight: 10,
+        paddingBottom: 5,
+        paddingLeft: 15,
+      },
+    });
+    render(<IssueReporterView />);
+    const view = screen.getByTestId("issue-reporter-view");
+    expect(view.style.padding).toBe("20px 10px 5px 15px");
   });
 
   it("disables submit button after successful submission", async () => {

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -77,6 +77,7 @@ export function IssueReporterView() {
       className="flex h-full flex-col"
       style={{
         color: "var(--text-primary)",
+        background: "var(--bg-base)",
         padding: `${ir.paddingTop}px ${ir.paddingRight}px ${ir.paddingBottom}px ${ir.paddingLeft}px`,
       }}
     >

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { useSettingsStore } from "@/stores/settings-store";
 
 type SubmitState = "idle" | "capturing" | "submitting" | "success" | "error";
 
@@ -59,6 +60,8 @@ export function IssueReporterView() {
     setState("idle");
   };
 
+  const ir = useSettingsStore((s) => s.issueReporter);
+
   const fieldStyle: React.CSSProperties = {
     background: "var(--bg-base)",
     color: "var(--text-primary)",
@@ -71,8 +74,11 @@ export function IssueReporterView() {
   return (
     <div
       data-testid="issue-reporter-view"
-      className="flex h-full flex-col p-5"
-      style={{ color: "var(--text-primary)" }}
+      className="flex h-full flex-col"
+      style={{
+        color: "var(--text-primary)",
+        padding: `${ir.paddingTop}px ${ir.paddingRight}px ${ir.paddingBottom}px ${ir.paddingLeft}px`,
+      }}
     >
       {/* Header */}
       <div className="mb-4 flex items-center gap-2.5">

--- a/ui/src/components/views/MemoView.test.tsx
+++ b/ui/src/components/views/MemoView.test.tsx
@@ -99,10 +99,10 @@ describe("MemoView", () => {
     expect(textarea.style.padding).toBe("20px 10px 5px 15px");
   });
 
-  it("uses default padding (12px) when no memo settings customized", () => {
+  it("uses default padding (8px) when no memo settings customized", () => {
     render(<MemoView memoKey="pane-default-pad" />);
     const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
-    expect(textarea.style.padding).toBe("12px");
+    expect(textarea.style.padding).toBe("8px");
   });
 
   it("renders empty when loadMemo fails", async () => {

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1492,6 +1492,49 @@ function IssueReporterSection() {
             onChange={(e) => updateIssueReporter({ shell: e.target.value })}
           />
         </SettingRow>
+
+        {/* Padding */}
+        <div className="flex items-start gap-3 py-1.5">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+              Padding
+            </span>
+            <p
+              className="mt-0.5 text-[11px] leading-tight"
+              style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+            >
+              이슈 리포터 영역의 안쪽 여백 (px)
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="grid grid-cols-2 gap-2">
+              {(["Top", "Right", "Bottom", "Left"] as const).map((dir) => {
+                const key = `padding${dir}` as keyof typeof issueReporter;
+                return (
+                  <label key={dir} className="flex items-center gap-1.5">
+                    <span className="w-12 text-[11px]" style={{ color: "var(--text-secondary)" }}>
+                      {dir}
+                    </span>
+                    <input
+                      data-testid={`issue-reporter-padding-${dir.toLowerCase()}`}
+                      type="number"
+                      min={0}
+                      max={64}
+                      className={inputCls}
+                      style={{ width: 60 }}
+                      value={issueReporter[key]}
+                      onChange={(e) =>
+                        updateIssueReporter({
+                          [key]: Math.max(0, Math.min(64, Number(e.target.value) || 0)),
+                        })
+                      }
+                    />
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -119,6 +119,10 @@ export interface ClaudeSettings {
 
 export interface IssueReporterSettings {
   shell: string;
+  paddingTop: number;
+  paddingRight: number;
+  paddingBottom: number;
+  paddingLeft: number;
 }
 
 export interface MemoSettings {

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -315,10 +315,18 @@ interface SettingsState {
 const defaultPadding: PaddingSettings = { top: 8, right: 8, bottom: 8, left: 8 };
 
 const DEFAULT_MEMO_PADDING: MemoSettings = {
-  paddingTop: 12,
-  paddingRight: 12,
-  paddingBottom: 12,
-  paddingLeft: 12,
+  paddingTop: 8,
+  paddingRight: 8,
+  paddingBottom: 8,
+  paddingLeft: 8,
+};
+
+const DEFAULT_ISSUE_REPORTER: IssueReporterSettings = {
+  shell: "",
+  paddingTop: 8,
+  paddingRight: 8,
+  paddingBottom: 8,
+  paddingLeft: 8,
 };
 
 export const DEFAULT_FONT: FontSettings = { face: "Cascadia Mono", size: 14, weight: "normal" };
@@ -657,7 +665,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   workspaceDisplay: { minimap: true, environment: true, activity: true, path: true, result: true },
   claude: { syncCwd: "skip" as ClaudeSyncCwdMode },
   memo: { ...DEFAULT_MEMO_PADDING },
-  issueReporter: { shell: "" },
+  issueReporter: { ...DEFAULT_ISSUE_REPORTER },
   syncCwdDefaults: { ...DEFAULT_SYNC_CWD_DEFAULTS },
 
   setAppTheme: (appThemeId) => set({ appThemeId }),
@@ -844,7 +852,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       : undefined;
     // Ensure issueReporter settings have all required fields with defaults
     const issueReporter = data.issueReporter
-      ? { shell: "", ...(data.issueReporter as Partial<IssueReporterSettings>) }
+      ? { ...DEFAULT_ISSUE_REPORTER, ...(data.issueReporter as Partial<IssueReporterSettings>) }
       : undefined;
     // Ensure memo settings have all fields (backwards compat)
     const memo = data.memo


### PR DESCRIPTION
## Summary
- IssueReporterView의 title, content 영역에 설정 가능한 padding 추가 (기본값 8px)
- MemoView 기본 padding도 12px → 8px로 변경
- SettingsView에 IssueReporter padding 설정 UI 추가
- padding 영역 배경색 설정으로 경계선 아티팩트 제거

## Test plan
- [x] IssueReporterView 기본 padding 8px 적용 테스트
- [x] IssueReporterView 커스텀 padding 적용 테스트
- [x] MemoView 기본 padding 8px 테스트
- [x] Rust settings 테스트 (63개 통과)
- [x] 프론트엔드 테스트 (86개 통과)
- [x] dev 인스턴스 스크린샷 확인

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)