### PR TITLE
fix: MemoView 본문 클릭 시 pane 포커스 이동 안 되는 버그 수정

### DIFF
--- a/ui/src/components/layout/WorkspaceArea.test.tsx
+++ b/ui/src/components/layout/WorkspaceArea.test.tsx
@@ -161,4 +161,19 @@ describe("WorkspaceArea", () => {
     const indicators = screen.getAllByTestId("pane-focus-indicator");
     expect(indicators).toHaveLength(1);
   });
+
+  it("sets focused pane on mouseDown inside MemoView textarea", () => {
+    // Setup: split into 2 panes, set pane 1 as MemoView, focus pane 0
+    useWorkspaceStore.getState().splitPane(0, "horizontal");
+    useWorkspaceStore.getState().setPaneView(1, { type: "MemoView" });
+    useGridStore.setState({ focusedPaneIndex: 0 });
+
+    render(<WorkspaceArea />);
+
+    // mouseDown on pane 1's MemoView textarea should set focus to pane 1
+    const textarea = screen.getByTestId("memo-textarea");
+    fireEvent.mouseDown(textarea);
+
+    expect(useGridStore.getState().focusedPaneIndex).toBe(1);
+  });
 });

--- a/ui/src/components/layout/WorkspaceArea.tsx
+++ b/ui/src/components/layout/WorkspaceArea.tsx
@@ -67,7 +67,7 @@ export function WorkspaceArea() {
               key={pane.id}
               data-testid={isActive ? `workspace-pane-${i}` : undefined}
               className="absolute overflow-hidden"
-              onClick={() => {
+              onMouseDown={() => {
                 if (!isActive) return;
                 setFocusedPane(i);
                 useDockStore.getState().setFocusedDock(null);


### PR DESCRIPTION
## Summary
- WorkspaceArea pane의 포커스 핸들러를 `onClick`에서 `onMouseDown`으로 변경
- MemoView textarea 클릭 시 pane 포커스가 정상적으로 이동하도록 수정
- Dock 영역에서 이미 사용 중인 `onMouseDown` 패턴과 통일

## 원인
textarea가 `mousedown` 시점에 자체 DOM focus를 가져가면서 pane div의 `click` 이벤트가 발생하지 않는 경우가 있었음

Fixes #89

## Test plan
- [x] 기존 1116개 테스트 전체 통과
- [x] MemoView textarea mouseDown 시 포커스 이동 테스트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)