### PR TITLE
fix: Claude CWD skip - single source of truth detection

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -102,6 +102,9 @@ pub fn create_terminal_session(
     let app_clone = app.clone();
     let output_buffers = state.output_buffers.clone();
     let buffer_terminal_id = id.clone();
+    let known_claude = state.known_claude_terminals.clone();
+    let claude_detect_id = id.clone();
+    let claude_detected = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let pty_handle = pty::spawn_pty(&session, move |data| {
         // Write to output buffer
         if let Ok(mut buffers) = output_buffers.lock() {
@@ -109,6 +112,21 @@ pub fn create_terminal_session(
                 buf.push(&data);
             }
         }
+
+        // Proactive Claude Code detection: scan each PTY output chunk for
+        // "Claude Code" in terminal title (OSC 0/2). Once detected, the terminal
+        // is permanently registered in known_claude_terminals (single source of truth).
+        // AtomicBool fast-path avoids scanning after first detection.
+        if !claude_detected.load(std::sync::atomic::Ordering::Relaxed) {
+            if any_terminal_title_contains(&data, "Claude Code") {
+                claude_detected.store(true, std::sync::atomic::Ordering::Relaxed);
+                if let Ok(mut known) = known_claude.lock() {
+                    known.insert(claude_detect_id.clone());
+                }
+                let _ = app_clone.emit("claude-terminal-detected", &claude_detect_id);
+            }
+        }
+
         let _ = app_clone.emit(&format!("terminal-output-{terminal_id}"), data);
     })?;
 
@@ -260,6 +278,29 @@ pub fn close_terminal_session(id: String, state: State<Arc<AppState>>) -> Result
     }
 
     Ok(())
+}
+
+/// Register a terminal as running Claude Code (single source of truth).
+/// Called by the frontend when it detects Claude from command text (OSC 133 E).
+/// The PTY callback also populates this from title detection, but the frontend
+/// may detect earlier via command text (e.g., user typed "claude").
+#[tauri::command]
+pub fn mark_claude_terminal(id: String, state: State<Arc<AppState>>) -> Result<bool, String> {
+    let mut known = state
+        .known_claude_terminals
+        .lock()
+        .map_err(|e| format!("Lock error: {e}"))?;
+    Ok(known.insert(id))
+}
+
+/// Check if a terminal is registered as running Claude Code.
+#[tauri::command]
+pub fn is_claude_terminal(id: String, state: State<Arc<AppState>>) -> Result<bool, String> {
+    let known = state
+        .known_claude_terminals
+        .lock()
+        .map_err(|e| format!("Lock error: {e}"))?;
+    Ok(known.contains(&id))
 }
 
 #[tauri::command]
@@ -3499,5 +3540,80 @@ mod tests {
             !filtered.contains(&"t2".to_string()),
             "Persistently known Claude terminal should be skipped"
         );
+    }
+
+    #[test]
+    fn proactive_claude_detection_from_pty_output_chunk() {
+        // Simulates the PTY callback scenario: a raw output chunk containing
+        // a Claude Code title should be detected by any_terminal_title_contains.
+        // In production, the PTY callback uses this to populate known_claude_terminals.
+        let chunk = b"\x1b]0;\xe2\x9c\xb3 Claude Code\x07some terminal output here";
+        assert!(any_terminal_title_contains(chunk, "Claude Code"));
+
+        // After registration (simulating PTY callback behavior),
+        // filter_targets_not_busy should skip the terminal
+        let state = AppState::new();
+        state
+            .known_claude_terminals
+            .lock()
+            .unwrap()
+            .insert("t-claude".to_string());
+        {
+            let mut buffers = state.output_buffers.lock().unwrap();
+            let mut buf = crate::output_buffer::TerminalOutputBuffer::default();
+            // Buffer now only has task title, no "Claude Code"
+            buf.push(b"\x1b]0;\xe2\x9c\xb6 Working on task\x07");
+            buffers.insert("t-claude".into(), buf);
+            let mut buf_normal = crate::output_buffer::TerminalOutputBuffer::default();
+            buf_normal.push(b"\x1b]133;D;0\x07prompt$ ");
+            buffers.insert("t-normal".into(), buf_normal);
+        }
+        let targets = vec!["t-normal".into(), "t-claude".into()];
+        let (filtered, _) =
+            filter_targets_not_busy(&state, &targets, &crate::settings::ClaudeSyncCwdMode::Skip);
+        assert!(filtered.contains(&"t-normal".to_string()));
+        assert!(
+            !filtered.contains(&"t-claude".to_string()),
+            "Proactively registered Claude terminal must be skipped in skip mode"
+        );
+    }
+
+    #[test]
+    fn mark_claude_terminal_returns_true_on_first_insert() {
+        let state = AppState::new();
+        let mut known = state.known_claude_terminals.lock().unwrap();
+        assert!(
+            known.insert("t1".to_string()),
+            "First insert should return true"
+        );
+        assert!(
+            !known.insert("t1".to_string()),
+            "Second insert should return false"
+        );
+    }
+
+    #[test]
+    fn is_claude_terminal_after_mark() {
+        let state = AppState::new();
+        {
+            let mut known = state.known_claude_terminals.lock().unwrap();
+            known.insert("t1".to_string());
+        }
+        let known = state.known_claude_terminals.lock().unwrap();
+        assert!(known.contains("t1"));
+        assert!(!known.contains("t2"));
+    }
+
+    #[test]
+    fn close_terminal_clears_claude_tracking() {
+        let state = AppState::new();
+        state
+            .known_claude_terminals
+            .lock()
+            .unwrap()
+            .insert("t1".to_string());
+        // Simulate close_terminal_session cleanup
+        state.known_claude_terminals.lock().unwrap().remove("t1");
+        assert!(!state.known_claude_terminals.lock().unwrap().contains("t1"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,8 @@ pub fn run() {
             commands::resize_terminal,
             commands::write_to_terminal,
             commands::close_terminal_session,
+            commands::mark_claude_terminal,
+            commands::is_claude_terminal,
             commands::get_sync_group_terminals,
             commands::handle_lx_message,
             commands::list_system_monospace_fonts,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -406,7 +406,7 @@ impl Default for ConvenienceSettings {
     }
 }
 
-fn default_memo_padding() -> u32 {
+fn default_view_padding() -> u32 {
     8
 }
 
@@ -420,13 +420,13 @@ pub struct IssueReporterSettings {
     /// When empty (default), gh is invoked directly.
     #[serde(default)]
     pub shell: String,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_top: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_right: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_bottom: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_left: u32,
 }
 
@@ -446,13 +446,13 @@ impl Default for IssueReporterSettings {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MemoSettings {
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_top: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_right: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_bottom: u32,
-    #[serde(default = "default_memo_padding")]
+    #[serde(default = "default_view_padding")]
     pub padding_left: u32,
 }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -407,13 +407,12 @@ impl Default for ConvenienceSettings {
 }
 
 fn default_memo_padding() -> u32 {
-    12
+    8
 }
 
 /// Issue reporter settings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[derive(Default)]
 pub struct IssueReporterSettings {
     /// Shell prefix for running gh commands.
     /// When set, gh is invoked as: `{shell_parts...} gh {args...}`
@@ -421,6 +420,26 @@ pub struct IssueReporterSettings {
     /// When empty (default), gh is invoked directly.
     #[serde(default)]
     pub shell: String,
+    #[serde(default = "default_memo_padding")]
+    pub padding_top: u32,
+    #[serde(default = "default_memo_padding")]
+    pub padding_right: u32,
+    #[serde(default = "default_memo_padding")]
+    pub padding_bottom: u32,
+    #[serde(default = "default_memo_padding")]
+    pub padding_left: u32,
+}
+
+impl Default for IssueReporterSettings {
+    fn default() -> Self {
+        Self {
+            shell: String::new(),
+            padding_top: 8,
+            padding_right: 8,
+            padding_bottom: 8,
+            padding_left: 8,
+        }
+    }
 }
 
 /// MemoView settings (padding, etc.).
@@ -440,10 +459,10 @@ pub struct MemoSettings {
 impl Default for MemoSettings {
     fn default() -> Self {
         Self {
-            padding_top: 12,
-            padding_right: 12,
-            padding_bottom: 12,
-            padding_left: 12,
+            padding_top: 8,
+            padding_right: 8,
+            padding_bottom: 8,
+            padding_left: 8,
         }
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -18,10 +18,12 @@ pub struct AppState {
     /// Terminals that recently received a propagated command (e.g., cd from sync-cwd).
     /// Used to suppress OSC echo loops. Entries expire after PROPAGATION_TIMEOUT.
     pub propagated_terminals: Mutex<HashMap<String, Instant>>,
-    /// Terminal IDs that have been detected as running Claude Code.
-    /// Once a terminal shows a "Claude Code" title, it stays marked until closed.
-    /// This prevents missed detection when Claude changes its title to a task description.
-    pub known_claude_terminals: Mutex<HashSet<String>>,
+    /// Single source of truth for Claude Code terminal detection.
+    /// Populated proactively by the PTY output callback (real-time) and
+    /// by frontend via `mark_claude_terminal` command (from command text detection).
+    /// Once a terminal is marked, it stays marked until the terminal session closes.
+    /// Both backend (CWD skip) and frontend (activity display) consume this state.
+    pub known_claude_terminals: Arc<Mutex<HashSet<String>>>,
 }
 
 impl AppState {
@@ -35,7 +37,7 @@ impl AppState {
             automation_channels: Mutex::new(HashMap::new()),
             automation_port: Mutex::new(None),
             propagated_terminals: Mutex::new(HashMap::new()),
-            known_claude_terminals: Mutex::new(HashSet::new()),
+            known_claude_terminals: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 }

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -27,12 +27,18 @@ vi.mock("@tauri-apps/api/window", () => {
     PhysicalSize: class {
       width: number;
       height: number;
-      constructor(w: number, h: number) { this.width = w; this.height = h; }
+      constructor(w: number, h: number) {
+        this.width = w;
+        this.height = h;
+      }
     },
     PhysicalPosition: class {
       x: number;
       y: number;
-      constructor(x: number, y: number) { this.x = x; this.y = y; }
+      constructor(x: number, y: number) {
+        this.x = x;
+        this.y = y;
+      }
     },
   };
 });
@@ -66,6 +72,8 @@ vi.mock("@/lib/tauri-api", () => {
     sendOsNotification: vi.fn().mockResolvedValue(undefined),
     onAutomationRequest: vi.fn().mockResolvedValue(unlisten),
     automationResponse: vi.fn().mockResolvedValue(undefined),
+    onClaudeTerminalDetected: vi.fn().mockResolvedValue(unlisten),
+    markClaudeTerminal: vi.fn().mockResolvedValue(true),
   };
 });
 

--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { IssueReporterView } from "./IssueReporterView";
+import { useSettingsStore } from "@/stores/settings-store";
 
 // Mock fetch for screenshot capture
 const mockFetch = vi.fn().mockResolvedValue({
@@ -25,6 +26,7 @@ vi.mock("@tauri-apps/plugin-shell", () => ({
 describe("IssueReporterView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useSettingsStore.setState(useSettingsStore.getInitialState());
     mockFetch.mockResolvedValue({
       json: () =>
         Promise.resolve({ path: "/tmp/screenshot.png", dataUrl: "data:image/png;base64,abc" }),
@@ -37,6 +39,28 @@ describe("IssueReporterView", () => {
     expect(screen.getByTestId("issue-title")).toBeInTheDocument();
     expect(screen.getByTestId("issue-body")).toBeInTheDocument();
     expect(screen.getByTestId("issue-submit")).toBeInTheDocument();
+  });
+
+  it("applies default padding (8px) from settings", () => {
+    render(<IssueReporterView />);
+    const view = screen.getByTestId("issue-reporter-view");
+    expect(view.style.padding).toBe("8px");
+  });
+
+  it("applies custom padding from settings", () => {
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      issueReporter: {
+        ...useSettingsStore.getState().issueReporter,
+        paddingTop: 20,
+        paddingRight: 10,
+        paddingBottom: 5,
+        paddingLeft: 15,
+      },
+    });
+    render(<IssueReporterView />);
+    const view = screen.getByTestId("issue-reporter-view");
+    expect(view.style.padding).toBe("20px 10px 5px 15px");
   });
 
   it("disables submit button after successful submission", async () => {

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -77,6 +77,7 @@ export function IssueReporterView() {
       className="flex h-full flex-col"
       style={{
         color: "var(--text-primary)",
+        background: "var(--bg-base)",
         padding: `${ir.paddingTop}px ${ir.paddingRight}px ${ir.paddingBottom}px ${ir.paddingLeft}px`,
       }}
     >

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { useSettingsStore } from "@/stores/settings-store";
 
 type SubmitState = "idle" | "capturing" | "submitting" | "success" | "error";
 
@@ -59,6 +60,8 @@ export function IssueReporterView() {
     setState("idle");
   };
 
+  const ir = useSettingsStore((s) => s.issueReporter);
+
   const fieldStyle: React.CSSProperties = {
     background: "var(--bg-base)",
     color: "var(--text-primary)",
@@ -71,8 +74,11 @@ export function IssueReporterView() {
   return (
     <div
       data-testid="issue-reporter-view"
-      className="flex h-full flex-col p-5"
-      style={{ color: "var(--text-primary)" }}
+      className="flex h-full flex-col"
+      style={{
+        color: "var(--text-primary)",
+        padding: `${ir.paddingTop}px ${ir.paddingRight}px ${ir.paddingBottom}px ${ir.paddingLeft}px`,
+      }}
     >
       {/* Header */}
       <div className="mb-4 flex items-center gap-2.5">

--- a/ui/src/components/views/MemoView.test.tsx
+++ b/ui/src/components/views/MemoView.test.tsx
@@ -99,10 +99,10 @@ describe("MemoView", () => {
     expect(textarea.style.padding).toBe("20px 10px 5px 15px");
   });
 
-  it("uses default padding (12px) when no memo settings customized", () => {
+  it("uses default padding (8px) when no memo settings customized", () => {
     render(<MemoView memoKey="pane-default-pad" />);
     const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
-    expect(textarea.style.padding).toBe("12px");
+    expect(textarea.style.padding).toBe("8px");
   });
 
   it("renders empty when loadMemo fails", async () => {

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1492,6 +1492,49 @@ function IssueReporterSection() {
             onChange={(e) => updateIssueReporter({ shell: e.target.value })}
           />
         </SettingRow>
+
+        {/* Padding */}
+        <div className="flex items-start gap-3 py-1.5">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+              Padding
+            </span>
+            <p
+              className="mt-0.5 text-[11px] leading-tight"
+              style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+            >
+              이슈 리포터 영역의 안쪽 여백 (px)
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="grid grid-cols-2 gap-2">
+              {(["Top", "Right", "Bottom", "Left"] as const).map((dir) => {
+                const key = `padding${dir}` as keyof typeof issueReporter;
+                return (
+                  <label key={dir} className="flex items-center gap-1.5">
+                    <span className="w-12 text-[11px]" style={{ color: "var(--text-secondary)" }}>
+                      {dir}
+                    </span>
+                    <input
+                      data-testid={`issue-reporter-padding-${dir.toLowerCase()}`}
+                      type="number"
+                      min={0}
+                      max={64}
+                      className={inputCls}
+                      style={{ width: 60 }}
+                      value={issueReporter[key]}
+                      onChange={(e) =>
+                        updateIssueReporter({
+                          [key]: Math.max(0, Math.min(64, Number(e.target.value) || 0)),
+                        })
+                      }
+                    />
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -108,6 +108,7 @@ vi.mock("@/lib/tauri-api", () => ({
   updateTerminalSyncGroup: vi.fn().mockResolvedValue(undefined),
   openExternal: (...args: unknown[]) => mockOpenExternal(...args),
   loadTerminalOutputCache: (...args: unknown[]) => mockLoadTerminalOutputCache(...args),
+  markClaudeTerminal: vi.fn().mockResolvedValue(true),
 }));
 
 describe("TerminalView", () => {

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -17,6 +17,7 @@ import {
   setTerminalCwdReceive,
   updateTerminalSyncGroup,
   openExternal,
+  markClaudeTerminal,
 } from "@/lib/tauri-api";
 import { colorSchemeToXtermTheme, type WTColorScheme } from "@/lib/color-scheme";
 import { processOscInOutput } from "@/hooks/useOscHooks";
@@ -246,6 +247,12 @@ export function TerminalView({
         ...(detected ? { activity: detected } : {}),
       });
 
+      // Notify backend when Claude is detected from title (single source of truth).
+      // PTY callback usually detects first, but this covers edge cases.
+      if (detected?.name === "Claude") {
+        markClaudeTerminal(instanceId).catch(() => {});
+      }
+
       if (transition === "completed") {
         updateInstanceInfo(instanceId, { lastExitCode: 0, lastCommandAt: Date.now() });
         const message = getClaudeCompletionMessage(prevTitle, title);
@@ -375,6 +382,9 @@ export function TerminalView({
         const cmdActivity = cmdMatch ? detectActivityFromCommand(cmdMatch[1]) : undefined;
         if (cmdActivity) {
           useTerminalStore.getState().updateInstanceInfo(instanceId, { activity: cmdActivity });
+          if (cmdActivity.name === "Claude") {
+            markClaudeTerminal(instanceId).catch(() => {});
+          }
         } else {
           const inst = useTerminalStore.getState().instances.find((i) => i.id === instanceId);
           if (inst?.activity?.type === "interactiveApp" && inst.activity.name !== "app") {
@@ -384,6 +394,9 @@ export function TerminalView({
             useTerminalStore.getState().updateInstanceInfo(instanceId, {
               activity: detected ?? { type: "interactiveApp", name: "app" },
             });
+            if (detected?.name === "Claude") {
+              markClaudeTerminal(instanceId).catch(() => {});
+            }
           }
         }
       } else if (leaveAlt && !enterAlt && inAltScreen) {

--- a/ui/src/hooks/useSyncEvents.test.ts
+++ b/ui/src/hooks/useSyncEvents.test.ts
@@ -11,6 +11,8 @@ const mockOnSyncBranch = vi.fn();
 const mockOnLxNotify = vi.fn();
 const mockOnSetTabTitle = vi.fn();
 const mockOnCommandStatus = vi.fn();
+const mockOnClaudeTerminalDetected = vi.fn();
+const mockMarkClaudeTerminal = vi.fn().mockResolvedValue(true);
 
 const mockSendDesktopNotification = vi.fn().mockResolvedValue(undefined);
 
@@ -20,6 +22,8 @@ vi.mock("@/lib/tauri-api", () => ({
   onLxNotify: (...args: unknown[]) => mockOnLxNotify(...args),
   onSetTabTitle: (...args: unknown[]) => mockOnSetTabTitle(...args),
   onCommandStatus: (...args: unknown[]) => mockOnCommandStatus(...args),
+  onClaudeTerminalDetected: (...args: unknown[]) => mockOnClaudeTerminalDetected(...args),
+  markClaudeTerminal: (...args: unknown[]) => mockMarkClaudeTerminal(...args),
   sendOsNotification: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -40,6 +44,7 @@ describe("useSyncEvents", () => {
     mockOnLxNotify.mockResolvedValue(unlisten);
     mockOnSetTabTitle.mockResolvedValue(unlisten);
     mockOnCommandStatus.mockResolvedValue(unlisten);
+    mockOnClaudeTerminalDetected.mockResolvedValue(unlisten);
   });
 
   it("registers sync-cwd listener on mount", () => {
@@ -246,5 +251,61 @@ describe("useSyncEvents", () => {
     callback({ message: "Build done", terminalId: "t1" });
 
     expect(mockSendDesktopNotification).not.toHaveBeenCalled();
+  });
+
+  it("registers claude-terminal-detected listener on mount", () => {
+    renderHook(() => useSyncEvents());
+    expect(mockOnClaudeTerminalDetected).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it("sets activity to Claude on claude-terminal-detected event", () => {
+    useTerminalStore.getState().registerInstance({
+      id: "t1",
+      profile: "WSL",
+      syncGroup: "g1",
+      workspaceId: "ws-1",
+    });
+
+    renderHook(() => useSyncEvents());
+
+    const callback = mockOnClaudeTerminalDetected.mock.calls[0][0];
+    callback("t1");
+
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+    expect(instance?.activity).toEqual({ type: "interactiveApp", name: "Claude" });
+  });
+
+  it("calls markClaudeTerminal when command text detects Claude", () => {
+    useTerminalStore.getState().registerInstance({
+      id: "t1",
+      profile: "WSL",
+      syncGroup: "g1",
+      workspaceId: "ws-1",
+    });
+
+    renderHook(() => useSyncEvents());
+
+    const callback = mockOnCommandStatus.mock.calls[0][0];
+    callback({ terminalId: "t1", command: "claude" });
+
+    expect(mockMarkClaudeTerminal).toHaveBeenCalledWith("t1");
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+    expect(instance?.activity).toEqual({ type: "interactiveApp", name: "Claude" });
+  });
+
+  it("does NOT call markClaudeTerminal for non-Claude commands", () => {
+    useTerminalStore.getState().registerInstance({
+      id: "t1",
+      profile: "WSL",
+      syncGroup: "g1",
+      workspaceId: "ws-1",
+    });
+
+    renderHook(() => useSyncEvents());
+
+    const callback = mockOnCommandStatus.mock.calls[0][0];
+    callback({ terminalId: "t1", command: "vim file.txt" });
+
+    expect(mockMarkClaudeTerminal).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -8,6 +8,8 @@ import {
   onLxNotify,
   onSetTabTitle,
   onCommandStatus,
+  onClaudeTerminalDetected,
+  markClaudeTerminal,
 } from "@/lib/tauri-api";
 import { sendDesktopNotification } from "./useOsNotification";
 import { detectActivityFromCommand } from "@/lib/activity-detection";
@@ -30,6 +32,21 @@ export function useSyncEvents() {
         }
       });
     }
+
+    // claude-terminal-detected: backend PTY callback detected Claude Code in terminal title.
+    // This is the single source of truth — set activity so frontend display matches.
+    trackListener(
+      onClaudeTerminalDetected((terminalId) => {
+        if (cancelled) return;
+        const { updateInstanceInfo, instances } = useTerminalStore.getState();
+        const instance = instances.find((i) => i.id === terminalId);
+        if (instance) {
+          updateInstanceInfo(terminalId, {
+            activity: { type: "interactiveApp", name: "Claude" },
+          });
+        }
+      }),
+    );
 
     // sync-cwd: update CWD for all targeted terminals + source
     trackListener(
@@ -112,6 +129,12 @@ export function useSyncEvents() {
           const appActivity = detectActivityFromCommand(data.command);
           if (appActivity) {
             update.activity = appActivity;
+            // Notify backend so known_claude_terminals (single source of truth) is updated.
+            // This covers the case where the user typed "claude" but the title
+            // hasn't been set yet (PTY callback hasn't seen "Claude Code" title).
+            if (appActivity.name === "Claude") {
+              markClaudeTerminal(data.terminalId).catch(() => {});
+            }
           } else {
             update.activity = { type: "running" };
           }

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -460,3 +460,25 @@ export async function automationResponse(
   });
   return invoke("automation_response", { responseJson });
 }
+
+// -- Claude terminal detection (single source of truth in backend) --
+
+/** Listen for Claude Code terminal detection events from the backend PTY callback. */
+export function onClaudeTerminalDetected(
+  callback: (terminalId: string) => void,
+): Promise<UnlistenFn> {
+  return listen<string>("claude-terminal-detected", (event) => {
+    callback(event.payload);
+  });
+}
+
+/** Register a terminal as running Claude Code in the backend (single source of truth).
+ *  Called when the frontend detects Claude from command text (OSC 133 E). */
+export async function markClaudeTerminal(id: string): Promise<boolean> {
+  return invoke("mark_claude_terminal", { id });
+}
+
+/** Check if a terminal is registered as Claude Code in the backend. */
+export async function isClaudeTerminal(id: string): Promise<boolean> {
+  return invoke("is_claude_terminal", { id });
+}

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -119,6 +119,10 @@ export interface ClaudeSettings {
 
 export interface IssueReporterSettings {
   shell: string;
+  paddingTop: number;
+  paddingRight: number;
+  paddingBottom: number;
+  paddingLeft: number;
 }
 
 export interface MemoSettings {

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -315,10 +315,18 @@ interface SettingsState {
 const defaultPadding: PaddingSettings = { top: 8, right: 8, bottom: 8, left: 8 };
 
 const DEFAULT_MEMO_PADDING: MemoSettings = {
-  paddingTop: 12,
-  paddingRight: 12,
-  paddingBottom: 12,
-  paddingLeft: 12,
+  paddingTop: 8,
+  paddingRight: 8,
+  paddingBottom: 8,
+  paddingLeft: 8,
+};
+
+const DEFAULT_ISSUE_REPORTER: IssueReporterSettings = {
+  shell: "",
+  paddingTop: 8,
+  paddingRight: 8,
+  paddingBottom: 8,
+  paddingLeft: 8,
 };
 
 export const DEFAULT_FONT: FontSettings = { face: "Cascadia Mono", size: 14, weight: "normal" };
@@ -657,7 +665,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   workspaceDisplay: { minimap: true, environment: true, activity: true, path: true, result: true },
   claude: { syncCwd: "skip" as ClaudeSyncCwdMode },
   memo: { ...DEFAULT_MEMO_PADDING },
-  issueReporter: { shell: "" },
+  issueReporter: { ...DEFAULT_ISSUE_REPORTER },
   syncCwdDefaults: { ...DEFAULT_SYNC_CWD_DEFAULTS },
 
   setAppTheme: (appThemeId) => set({ appThemeId }),
@@ -844,7 +852,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       : undefined;
     // Ensure issueReporter settings have all required fields with defaults
     const issueReporter = data.issueReporter
-      ? { shell: "", ...(data.issueReporter as Partial<IssueReporterSettings>) }
+      ? { ...DEFAULT_ISSUE_REPORTER, ...(data.issueReporter as Partial<IssueReporterSettings>) }
       : undefined;
     // Ensure memo settings have all fields (backwards compat)
     const memo = data.memo


### PR DESCRIPTION
## Summary
- **근본 원인**: `known_claude_terminals`가 sync-cwd 호출 시에만 지연(lazy) 갱신되어, Claude Code 타이틀이 16KB 스캔 윈도우 밖으로 밀린 뒤 첫 sync-cwd가 오면 감지 실패 → cd가 Claude에 전파됨
- **수정**: 백엔드 `known_claude_terminals`를 single source of truth로 확립. PTY 출력 콜백에서 실시간 감지 + 프론트엔드 모든 감지 경로에서 `markClaudeTerminal` IPC로 백엔드 동기화
- 감지 경로: PTY 콜백(primary), 커맨드 텍스트(OSC 133 E), 타이틀 변경(OSC 0/2), alt screen 진입

## Test plan
- [x] Rust 백엔드 327 테스트 통과 (신규 4개 포함)
- [x] 프론트엔드 1125 테스트 통과 (신규 4개 포함)
- [ ] 수동 검증: Claude Code 실행 중 다른 터미널에서 cd → Claude에 전파되지 않는지 확인

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)