### PR TITLE
fix: prevent Delete key from closing pane in text inputs

### DIFF
--- a/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -217,6 +217,96 @@ describe("useKeyboardShortcuts", () => {
     expect(useWorkspaceStore.getState().workspaces[0].panes).toHaveLength(1);
   });
 
+  it("Delete key does nothing when focus is on an input element", () => {
+    useWorkspaceStore.setState({
+      ...useWorkspaceStore.getState(),
+      workspaces: [
+        {
+          id: "ws-default",
+          name: "Default",
+
+          panes: [
+            { id: "p1", x: 0, y: 0, w: 0.5, h: 1, view: { type: "TerminalView" } },
+            { id: "p2", x: 0.5, y: 0, w: 0.5, h: 1, view: { type: "EmptyView" } },
+          ],
+        },
+      ],
+    });
+
+    useGridStore.setState({ focusedPaneIndex: 1 });
+    renderHook(() => useKeyboardShortcuts());
+
+    // Create an input element, focus it, then fire Delete
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    fireKey("Delete");
+
+    expect(useWorkspaceStore.getState().workspaces[0].panes).toHaveLength(2);
+    document.body.removeChild(input);
+  });
+
+  it("Delete key does nothing when focus is on a textarea element", () => {
+    useWorkspaceStore.setState({
+      ...useWorkspaceStore.getState(),
+      workspaces: [
+        {
+          id: "ws-default",
+          name: "Default",
+
+          panes: [
+            { id: "p1", x: 0, y: 0, w: 0.5, h: 1, view: { type: "TerminalView" } },
+            { id: "p2", x: 0.5, y: 0, w: 0.5, h: 1, view: { type: "EmptyView" } },
+          ],
+        },
+      ],
+    });
+
+    useGridStore.setState({ focusedPaneIndex: 1 });
+    renderHook(() => useKeyboardShortcuts());
+
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    textarea.focus();
+
+    fireKey("Delete");
+
+    expect(useWorkspaceStore.getState().workspaces[0].panes).toHaveLength(2);
+    document.body.removeChild(textarea);
+  });
+
+  it("Delete key does nothing when focus is on a contentEditable element", () => {
+    useWorkspaceStore.setState({
+      ...useWorkspaceStore.getState(),
+      workspaces: [
+        {
+          id: "ws-default",
+          name: "Default",
+
+          panes: [
+            { id: "p1", x: 0, y: 0, w: 0.5, h: 1, view: { type: "TerminalView" } },
+            { id: "p2", x: 0.5, y: 0, w: 0.5, h: 1, view: { type: "EmptyView" } },
+          ],
+        },
+      ],
+    });
+
+    useGridStore.setState({ focusedPaneIndex: 1 });
+    renderHook(() => useKeyboardShortcuts());
+
+    const div = document.createElement("div");
+    div.setAttribute("contenteditable", "true");
+    div.tabIndex = 0; // Make focusable in jsdom
+    document.body.appendChild(div);
+    div.focus();
+
+    fireKey("Delete");
+
+    expect(useWorkspaceStore.getState().workspaces[0].panes).toHaveLength(2);
+    document.body.removeChild(div);
+  });
+
   it("Delete key does nothing when no pane is focused", () => {
     useWorkspaceStore.setState({
       ...useWorkspaceStore.getState(),

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -50,11 +50,27 @@ function navigateByNotification(direction: "recent" | "oldest") {
   markNotificationsAsRead(target.notificationIds);
 }
 
+/** Check if the currently focused element is a text-editable field (input, textarea, contentEditable). */
+function isTextInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA") return true;
+  if (
+    el instanceof HTMLElement &&
+    (el.isContentEditable || el.getAttribute("contenteditable") === "true")
+  )
+    return true;
+  return false;
+}
+
 export function useKeyboardShortcuts() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       // Delete key: remove focused pane (no modifier required)
+      // Skip when a text-editable element has focus (e.g. input, textarea, contentEditable)
       if (e.key === "Delete") {
+        if (isTextInputFocused()) return;
         const { focusedPaneIndex } = useGridStore.getState();
         if (focusedPaneIndex !== null) {
           e.preventDefault();


### PR DESCRIPTION
## Summary
- Delete 키가 input, textarea, contentEditable 요소에 포커스가 있을 때 pane을 닫지 않도록 수정
- `isTextInputFocused()` 헬퍼 함수 추가하여 텍스트 입력 중 Delete 키 이벤트를 무시

## Test plan
- [x] input 요소 포커스 시 Delete 키가 pane을 삭제하지 않는 것 검증
- [x] textarea 요소 포커스 시 Delete 키가 pane을 삭제하지 않는 것 검증
- [x] contentEditable 요소 포커스 시 Delete 키가 pane을 삭제하지 않는 것 검증
- [x] 전체 테스트 통과 (1136개)

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)