### PR TITLE
fix: autofocus title input and add Ctrl+Enter shortcut in Report Issue

### DIFF
--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -215,6 +215,66 @@ describe("IssueReporterView", () => {
     });
   });
 
+  it("focuses title input when isFocused becomes true", async () => {
+    const { rerender } = render(<IssueReporterView isFocused={false} />);
+    const titleInput = screen.getByTestId("issue-title");
+    expect(document.activeElement).not.toBe(titleInput);
+
+    rerender(<IssueReporterView isFocused={true} />);
+    await waitFor(() => {
+      expect(document.activeElement).toBe(titleInput);
+    });
+  });
+
+  it("submits issue with Ctrl+Enter from title input", async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockResolvedValue("https://github.com/repo/issues/1");
+
+    render(<IssueReporterView isFocused={true} />);
+
+    await user.type(screen.getByTestId("issue-title"), "Test issue");
+    await user.keyboard("{Control>}{Enter}{/Control}");
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("submit_github_issue", {
+        title: "Test issue",
+        body: "",
+        screenshotPath: "/tmp/screenshot.png",
+      });
+    });
+  });
+
+  it("submits issue with Ctrl+Enter from body textarea", async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockResolvedValue("https://github.com/repo/issues/1");
+
+    render(<IssueReporterView isFocused={true} />);
+
+    await user.type(screen.getByTestId("issue-title"), "Test issue");
+    await user.click(screen.getByTestId("issue-body"));
+    await user.type(screen.getByTestId("issue-body"), "Some description");
+    await user.keyboard("{Control>}{Enter}{/Control}");
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("submit_github_issue", {
+        title: "Test issue",
+        body: "Some description",
+        screenshotPath: "/tmp/screenshot.png",
+      });
+    });
+  });
+
+  it("does not submit with Ctrl+Enter when title is empty", async () => {
+    const user = userEvent.setup();
+
+    render(<IssueReporterView isFocused={true} />);
+
+    await user.click(screen.getByTestId("issue-body"));
+    await user.keyboard("{Control>}{Enter}{/Control}");
+
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
   it("awaits shell open and handles errors gracefully", async () => {
     const user = userEvent.setup();
     mockInvoke.mockResolvedValue("https://github.com/repo/issues/1");

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -7,7 +7,7 @@ interface IssueReporterViewProps {
   isFocused?: boolean;
 }
 
-export function IssueReporterView({ isFocused }: IssueReporterViewProps = {}) {
+export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [screenshotPath, setScreenshotPath] = useState<string | null>(null);
@@ -29,21 +29,6 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps = {}) {
       titleRef.current?.focus();
     }
   }, [isFocused]);
-
-  // Ctrl+Enter to submit
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.key === "Enter") {
-        e.preventDefault();
-        handleSubmit();
-      }
-    };
-    const container = titleRef.current?.closest("[data-testid='issue-reporter-view']");
-    if (container) {
-      container.addEventListener("keydown", handleKeyDown as EventListener);
-      return () => container.removeEventListener("keydown", handleKeyDown as EventListener);
-    }
-  });
 
   const captureScreenshot = async () => {
     setState("capturing");
@@ -80,6 +65,13 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps = {}) {
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.ctrlKey && e.key === "Enter") {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
   const handleNewReport = () => {
     setTitle("");
     setBody("");
@@ -102,6 +94,7 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps = {}) {
     <div
       data-testid="issue-reporter-view"
       className="flex h-full flex-col"
+      onKeyDown={handleKeyDown}
       style={{
         color: "var(--text-primary)",
         background: "var(--bg-base)",

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -3,7 +3,11 @@ import { useSettingsStore } from "@/stores/settings-store";
 
 type SubmitState = "idle" | "capturing" | "submitting" | "success" | "error";
 
-export function IssueReporterView() {
+interface IssueReporterViewProps {
+  isFocused?: boolean;
+}
+
+export function IssueReporterView({ isFocused }: IssueReporterViewProps = {}) {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [screenshotPath, setScreenshotPath] = useState<string | null>(null);
@@ -11,12 +15,35 @@ export function IssueReporterView() {
   const [state, setState] = useState<SubmitState>("idle");
   const [resultMsg, setResultMsg] = useState("");
   const [showPreview, setShowPreview] = useState(true);
+  const titleRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const submittingRef = useRef(false);
 
   useEffect(() => {
     captureScreenshot();
   }, []);
+
+  // Auto-focus title input when view receives focus
+  useEffect(() => {
+    if (isFocused) {
+      titleRef.current?.focus();
+    }
+  }, [isFocused]);
+
+  // Ctrl+Enter to submit
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key === "Enter") {
+        e.preventDefault();
+        handleSubmit();
+      }
+    };
+    const container = titleRef.current?.closest("[data-testid='issue-reporter-view']");
+    if (container) {
+      container.addEventListener("keydown", handleKeyDown as EventListener);
+      return () => container.removeEventListener("keydown", handleKeyDown as EventListener);
+    }
+  });
 
   const captureScreenshot = async () => {
     setState("capturing");
@@ -182,6 +209,7 @@ export function IssueReporterView() {
 
       {/* Title */}
       <input
+        ref={titleRef}
         data-testid="issue-title"
         type="text"
         value={title}
@@ -230,6 +258,11 @@ export function IssueReporterView() {
             : state === "success"
               ? "Submitted!"
               : "Submit Issue"}
+          {state !== "submitting" && state !== "success" && (
+            <span className="ml-2 text-[10px] opacity-50" style={{ fontWeight: "normal" }}>
+              Ctrl+Enter
+            </span>
+          )}
         </button>
 
         {(state === "success" || state === "error") && (

--- a/ui/src/components/views/ViewRenderer.tsx
+++ b/ui/src/components/views/ViewRenderer.tsx
@@ -94,7 +94,13 @@ function FocusableView({
     if (isFocused) ref.current?.focus();
   }, [isFocused]);
   return (
-    <div ref={ref} data-testid={testId} className="h-full" tabIndex={-1} style={{ outline: "none" }}>
+    <div
+      ref={ref}
+      data-testid={testId}
+      className="h-full"
+      tabIndex={-1}
+      style={{ outline: "none" }}
+    >
       {children}
     </div>
   );
@@ -141,7 +147,7 @@ export function ViewRenderer({
     case "IssueReporterView":
       return (
         <FocusableView testId="view-issue-reporter" isFocused={isFocused}>
-          <IssueReporterView />
+          <IssueReporterView isFocused={isFocused} />
         </FocusableView>
       );
     case "MemoView": {


### PR DESCRIPTION
## Summary
- Report Issue view 포커스 시 title input에 자동으로 커서가 이동하도록 구현
- Ctrl+Enter 단축키로 이슈 제출 가능하도록 구현
- Submit 버튼 옆에 "Ctrl+Enter" 힌트 텍스트 표시

## Test plan
- [x] isFocused 시 title input autofocus 검증
- [x] Ctrl+Enter로 이슈 제출 검증
- [x] title이 비어있을 때 Ctrl+Enter 제출 방지 검증
- [x] 전체 테스트 통과 (16개)

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)