### PR TITLE
fix: show proper labels for non-terminal views in WorkspaceSelectorView

### DIFF
--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -1510,4 +1510,62 @@ describe("WorkspaceSelectorView", () => {
       expect(screen.getByText("/mnt/c/Users/kochul")).toBeInTheDocument();
     });
   });
+
+  it("displays IssueReporterView pane with proper label instead of ---", () => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "ws-issue",
+          name: "Issue WS",
+          panes: [
+            {
+              id: "pane-issue1",
+              x: 0,
+              y: 0,
+              w: 1,
+              h: 1,
+              view: { type: "IssueReporterView" },
+            },
+          ],
+        },
+      ],
+      activeWorkspaceId: "ws-issue",
+    });
+
+    render(<WorkspaceSelectorView />);
+
+    // Should NOT show "---" (the Empty abbreviation)
+    const wsRow = screen.getByTestId("ws-row-2-ws-issue");
+    expect(wsRow.textContent).not.toBe("---");
+    // Should show a meaningful label for IssueReporterView
+    expect(wsRow.textContent).toContain("ISS");
+  });
+
+  it("displays MemoView pane with proper label instead of ---", () => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "ws-memo",
+          name: "Memo WS",
+          panes: [
+            {
+              id: "pane-memo1",
+              x: 0,
+              y: 0,
+              w: 1,
+              h: 1,
+              view: { type: "MemoView" },
+            },
+          ],
+        },
+      ],
+      activeWorkspaceId: "ws-memo",
+    });
+
+    render(<WorkspaceSelectorView />);
+
+    const wsRow = screen.getByTestId("ws-row-2-ws-memo");
+    expect(wsRow.textContent).not.toBe("---");
+    expect(wsRow.textContent).toContain("MEM");
+  });
 });

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -25,10 +25,7 @@ const LABEL_ABBREV: Record<string, string> = {
   Debian: "DEB",
   Browser: "WEB",
   Empty: "---",
-  IssueReporterView: "ISS",
-  MemoView: "MEM",
-  SettingsView: "SET",
-  WorkspaceSelectorView: "WRK",
+  EmptyView: "---",
 };
 /** Check if a profile is a Windows-native shell (PowerShell, CMD) that uses Windows paths. */
 function isWindowsProfile(profile: string): boolean {
@@ -511,8 +508,6 @@ function WorkspaceItem({
                 );
               }
               // EmptyView or other view types (IssueReporterView, MemoView, etc.)
-              const viewLabel =
-                pane.view.type === "EmptyView" ? shortLabel("Empty") : shortLabel(pane.view.type);
               return (
                 <div
                   key={pane.id}
@@ -547,7 +542,7 @@ function WorkspaceItem({
                       className="shrink-0 font-medium"
                       style={{ color: "var(--text-secondary)", opacity: 0.4 }}
                     >
-                      {viewLabel}
+                      {shortLabel(pane.view.type)}
                     </span>
                   </div>
                 </div>

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -25,6 +25,10 @@ const LABEL_ABBREV: Record<string, string> = {
   Debian: "DEB",
   Browser: "WEB",
   Empty: "---",
+  IssueReporterView: "ISS",
+  MemoView: "MEM",
+  SettingsView: "SET",
+  WorkspaceSelectorView: "WRK",
 };
 /** Check if a profile is a Windows-native shell (PowerShell, CMD) that uses Windows paths. */
 function isWindowsProfile(profile: string): boolean {
@@ -506,7 +510,9 @@ function WorkspaceItem({
                   </div>
                 );
               }
-              // EmptyView or other view types
+              // EmptyView or other view types (IssueReporterView, MemoView, etc.)
+              const viewLabel =
+                pane.view.type === "EmptyView" ? shortLabel("Empty") : shortLabel(pane.view.type);
               return (
                 <div
                   key={pane.id}
@@ -541,7 +547,7 @@ function WorkspaceItem({
                       className="shrink-0 font-medium"
                       style={{ color: "var(--text-secondary)", opacity: 0.4 }}
                     >
-                      {shortLabel("Empty")}
+                      {viewLabel}
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- WorkspaceSelectorView에서 IssueReporterView 등 비터미널/비브라우저 view가 "---"로 표시되던 문제 수정
- LABEL_ABBREV에 IssueReporterView(ISS), MemoView(MEM), SettingsView(SET), WorkspaceSelectorView(WRK) 약어 추가
- fallback 렌더링에서 실제 view type을 사용하도록 수정

## Test plan
- [x] IssueReporterView pane이 "ISS" 약어로 표시되는 것 검증
- [x] MemoView pane이 "MEM" 약어로 표시되는 것 검증
- [x] 전체 테스트 통과 (1135개)

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)