### PR TITLE
fix: auto-dismiss notifications for active workspace on arrival

### DIFF
--- a/ui/src/components/views/NotificationPanel.test.tsx
+++ b/ui/src/components/views/NotificationPanel.test.tsx
@@ -41,9 +41,12 @@ describe("NotificationPanel", () => {
   });
 
   it("shows unread indicator for unread notifications", () => {
+    // Use non-active workspace to avoid auto-dismiss
+    useWorkspaceStore.getState().addWorkspace("Other", "default-layout");
+    const otherWsId = useWorkspaceStore.getState().workspaces[1].id;
     useNotificationStore.getState().addNotification({
       terminalId: "t1",
-      workspaceId: "ws-default",
+      workspaceId: otherWsId,
       message: "Build complete",
     });
 
@@ -53,23 +56,26 @@ describe("NotificationPanel", () => {
   });
 
   it("marks notifications as read when mark-read button clicked", () => {
+    // Use non-active workspace to avoid auto-dismiss
+    useWorkspaceStore.getState().addWorkspace("Other", "default-layout");
+    const otherWsId = useWorkspaceStore.getState().workspaces[1].id;
     useNotificationStore.getState().addNotification({
       terminalId: "t1",
-      workspaceId: "ws-default",
+      workspaceId: otherWsId,
       message: "Build complete",
     });
     useNotificationStore.getState().addNotification({
       terminalId: "t1",
-      workspaceId: "ws-default",
+      workspaceId: otherWsId,
       message: "Deploy done",
     });
 
     render(<NotificationPanel />);
 
-    const markReadBtn = screen.getByTestId("mark-read-ws-default");
+    const markReadBtn = screen.getByTestId(`mark-read-${otherWsId}`);
     fireEvent.click(markReadBtn);
 
-    expect(useNotificationStore.getState().getUnreadCount("ws-default")).toBe(0);
+    expect(useNotificationStore.getState().getUnreadCount(otherWsId)).toBe(0);
   });
 
   it("orders notifications by most recent first", () => {

--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -159,11 +159,14 @@ describe("WorkspaceSelectorView", () => {
       syncGroup: "Default",
       workspaceId: "ws-default",
     });
+    // Temporarily switch away so notification is not auto-dismissed
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
     useNotificationStore.getState().addNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "test msg",
     });
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
     render(<WorkspaceSelectorView />);
 
     await waitFor(() => {
@@ -198,11 +201,14 @@ describe("WorkspaceSelectorView", () => {
       syncGroup: "Default",
       workspaceId: "ws-default",
     });
+    // Temporarily switch away so notification is not auto-dismissed
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
     useNotificationStore.getState().addNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "Build done",
     });
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
     render(<WorkspaceSelectorView />);
 
     await waitFor(() => {
@@ -324,11 +330,14 @@ describe("WorkspaceSelectorView", () => {
       syncGroup: "Default",
       workspaceId: "ws-default",
     });
+    // Temporarily switch away so notification is not auto-dismissed
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
     useNotificationStore.getState().addNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "alert",
     });
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
     render(<WorkspaceSelectorView />);
 
     await waitFor(() => {
@@ -996,12 +1005,15 @@ describe("WorkspaceSelectorView", () => {
       lastExitCode: 1,
       lastCommandAt: Date.now(),
     });
+    // Temporarily switch away so notification is not auto-dismissed
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
     // Add notification only for terminal-p1
     useNotificationStore.getState().addNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "Build complete",
     });
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
 
     render(<WorkspaceSelectorView />);
 
@@ -1041,11 +1053,14 @@ describe("WorkspaceSelectorView", () => {
       lastCommand: "npm test",
       lastCommandAt: Date.now(),
     });
+    // Temporarily switch away so notification is not auto-dismissed
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
     useNotificationStore.getState().addNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "alert",
     });
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
 
     render(<WorkspaceSelectorView />);
 
@@ -1078,12 +1093,15 @@ describe("WorkspaceSelectorView", () => {
       workspaceId: "ws-default",
       label: "WSL",
     });
+    // Temporarily switch away so notification is not auto-dismissed
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
     // No command but notification exists
     useNotificationStore.getState().addNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "alert",
     });
+    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
 
     render(<WorkspaceSelectorView />);
 

--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -82,6 +82,29 @@ function buildSummariesFromStores(ids: string[]): TerminalSummaryResponse[] {
     .filter((s): s is TerminalSummaryResponse => s !== null);
 }
 
+/** Add a notification that bypasses auto-dismiss by temporarily switching away from the target workspace. */
+function addUnreadNotification(params: {
+  terminalId: string;
+  workspaceId: string;
+  message: string;
+}) {
+  const prev = useWorkspaceStore.getState().activeWorkspaceId;
+  if (prev === params.workspaceId) {
+    useWorkspaceStore.getState().addWorkspace("__temp__", "default-layout");
+    const tempId = useWorkspaceStore.getState().workspaces.find((w) => w.name === "__temp__")!.id;
+    useWorkspaceStore.getState().setActiveWorkspace(tempId);
+  }
+  useNotificationStore.getState().addNotification(params);
+  if (prev === params.workspaceId) {
+    useWorkspaceStore.getState().setActiveWorkspace(prev);
+    useWorkspaceStore
+      .getState()
+      .removeWorkspace(
+        useWorkspaceStore.getState().workspaces.find((w) => w.name === "__temp__")!.id,
+      );
+  }
+}
+
 describe("WorkspaceSelectorView", () => {
   beforeEach(() => {
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
@@ -159,14 +182,11 @@ describe("WorkspaceSelectorView", () => {
       syncGroup: "Default",
       workspaceId: "ws-default",
     });
-    // Temporarily switch away so notification is not auto-dismissed
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
-    useNotificationStore.getState().addNotification({
+    addUnreadNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "test msg",
     });
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
     render(<WorkspaceSelectorView />);
 
     await waitFor(() => {
@@ -201,14 +221,11 @@ describe("WorkspaceSelectorView", () => {
       syncGroup: "Default",
       workspaceId: "ws-default",
     });
-    // Temporarily switch away so notification is not auto-dismissed
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
-    useNotificationStore.getState().addNotification({
+    addUnreadNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "Build done",
     });
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
     render(<WorkspaceSelectorView />);
 
     await waitFor(() => {
@@ -330,14 +347,11 @@ describe("WorkspaceSelectorView", () => {
       syncGroup: "Default",
       workspaceId: "ws-default",
     });
-    // Temporarily switch away so notification is not auto-dismissed
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
-    useNotificationStore.getState().addNotification({
+    addUnreadNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "alert",
     });
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
     render(<WorkspaceSelectorView />);
 
     await waitFor(() => {
@@ -1005,15 +1019,12 @@ describe("WorkspaceSelectorView", () => {
       lastExitCode: 1,
       lastCommandAt: Date.now(),
     });
-    // Temporarily switch away so notification is not auto-dismissed
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
     // Add notification only for terminal-p1
-    useNotificationStore.getState().addNotification({
+    addUnreadNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "Build complete",
     });
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
 
     render(<WorkspaceSelectorView />);
 
@@ -1053,14 +1064,11 @@ describe("WorkspaceSelectorView", () => {
       lastCommand: "npm test",
       lastCommandAt: Date.now(),
     });
-    // Temporarily switch away so notification is not auto-dismissed
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
-    useNotificationStore.getState().addNotification({
+    addUnreadNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "alert",
     });
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
 
     render(<WorkspaceSelectorView />);
 
@@ -1093,15 +1101,12 @@ describe("WorkspaceSelectorView", () => {
       workspaceId: "ws-default",
       label: "WSL",
     });
-    // Temporarily switch away so notification is not auto-dismissed
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-temp" });
     // No command but notification exists
-    useNotificationStore.getState().addNotification({
+    addUnreadNotification({
       terminalId: "terminal-p1",
       workspaceId: "ws-default",
       message: "alert",
     });
-    useWorkspaceStore.setState({ activeWorkspaceId: "ws-default" });
 
     render(<WorkspaceSelectorView />);
 

--- a/ui/src/hooks/useAutomationBridge.test.ts
+++ b/ui/src/hooks/useAutomationBridge.test.ts
@@ -207,16 +207,19 @@ describe("handleAutomationRequest", () => {
   });
 
   it("gets workspace summary via automation API", () => {
+    // Use a non-active workspace so notifications stay unread (auto-dismiss applies to active ws)
+    useWorkspaceStore.getState().addWorkspace("WS2", "default-layout");
+    const ws2 = useWorkspaceStore.getState().workspaces[1];
     useTerminalStore.getState().registerInstance({
       id: "t1",
       profile: "WSL",
       syncGroup: "Default",
-      workspaceId: "ws-default",
+      workspaceId: ws2.id,
     });
     useTerminalStore.getState().updateInstanceInfo("t1", { branch: "main", cwd: "/home/user" });
     useNotificationStore.getState().addNotification({
       terminalId: "t1",
-      workspaceId: "ws-default",
+      workspaceId: ws2.id,
       message: "test",
     });
 
@@ -225,7 +228,7 @@ describe("handleAutomationRequest", () => {
       category: "query",
       target: "workspaces",
       method: "getSummary",
-      params: { id: "ws-default" },
+      params: { id: ws2.id },
     });
     expect(result.success).toBe(true);
     const data = result.data as Record<string, unknown>;

--- a/ui/src/stores/notification-store.test.ts
+++ b/ui/src/stores/notification-store.test.ts
@@ -181,8 +181,6 @@ describe("NotificationStore", () => {
 
   describe("auto-dismiss for active workspace", () => {
     it("marks notification as read immediately when added to the active workspace in workspace dismiss mode", () => {
-       
-      const _wsStore = useWorkspaceStore.getState();
       const activeWsId = useWorkspaceStore.getState().activeWorkspaceId;
 
       useNotificationStore.getState().addNotification({

--- a/ui/src/stores/notification-store.test.ts
+++ b/ui/src/stores/notification-store.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useNotificationStore } from "./notification-store";
+import { useWorkspaceStore } from "./workspace-store";
+import { useSettingsStore } from "./settings-store";
+import { useGridStore } from "./grid-store";
 
 describe("NotificationStore", () => {
   beforeEach(() => {
@@ -174,5 +177,93 @@ describe("NotificationStore", () => {
     expect(useNotificationStore.getState().hasUnreadForTerminal("terminal-p1")).toBe(true);
     expect(useNotificationStore.getState().hasUnreadForTerminal("terminal-p2")).toBe(true);
     expect(useNotificationStore.getState().hasUnreadForTerminal("terminal-p3")).toBe(false);
+  });
+
+  describe("auto-dismiss for active workspace", () => {
+    it("marks notification as read immediately when added to the active workspace in workspace dismiss mode", () => {
+       
+      const _wsStore = useWorkspaceStore.getState();
+      const activeWsId = useWorkspaceStore.getState().activeWorkspaceId;
+
+      useNotificationStore.getState().addNotification({
+        terminalId: "t1",
+        workspaceId: activeWsId,
+        message: "shell started",
+      });
+
+      const notifs = useNotificationStore.getState().notifications;
+      expect(notifs).toHaveLength(1);
+      expect(notifs[0].readAt).not.toBeNull();
+    });
+
+    it("does NOT auto-dismiss when notification is for a different workspace", () => {
+      useNotificationStore.getState().addNotification({
+        terminalId: "t1",
+        workspaceId: "ws-other",
+        message: "shell started",
+      });
+
+      const notifs = useNotificationStore.getState().notifications;
+      expect(notifs[0].readAt).toBeNull();
+    });
+
+    it("does NOT auto-dismiss when notificationDismiss is manual", () => {
+      const activeWsId = useWorkspaceStore.getState().activeWorkspaceId;
+      useSettingsStore.setState({
+        convenience: {
+          ...useSettingsStore.getState().convenience,
+          notificationDismiss: "manual",
+        },
+      });
+
+      useNotificationStore.getState().addNotification({
+        terminalId: "t1",
+        workspaceId: activeWsId,
+        message: "shell started",
+      });
+
+      const notifs = useNotificationStore.getState().notifications;
+      expect(notifs[0].readAt).toBeNull();
+    });
+
+    it("auto-dismisses in paneFocus mode when a pane is focused", () => {
+      const activeWsId = useWorkspaceStore.getState().activeWorkspaceId;
+      useSettingsStore.setState({
+        convenience: {
+          ...useSettingsStore.getState().convenience,
+          notificationDismiss: "paneFocus",
+        },
+      });
+      useGridStore.setState({ focusedPaneIndex: 0 });
+
+      useNotificationStore.getState().addNotification({
+        terminalId: "t1",
+        workspaceId: activeWsId,
+        message: "shell started",
+      });
+
+      const notifs = useNotificationStore.getState().notifications;
+      expect(notifs[0].readAt).not.toBeNull();
+    });
+
+    it("does NOT auto-dismiss in paneFocus mode when no pane is focused", () => {
+      const activeWsId = useWorkspaceStore.getState().activeWorkspaceId;
+      useSettingsStore.setState({
+        convenience: {
+          ...useSettingsStore.getState().convenience,
+          notificationDismiss: "paneFocus",
+        },
+      });
+      useGridStore.setState({ focusedPaneIndex: null });
+
+      useNotificationStore.getState().addNotification({
+        terminalId: "t1",
+        workspaceId: activeWsId,
+        message: "shell started",
+      });
+
+      const notifs = useNotificationStore.getState().notifications;
+      expect(notifs[0].readAt).toBeNull();
+    });
   });
 });

--- a/ui/src/stores/notification-store.ts
+++ b/ui/src/stores/notification-store.ts
@@ -1,4 +1,6 @@
 import { create } from "zustand";
+// Cross-store reads (getState snapshots) — direction: notification → {workspace, settings, grid}
+// Keep this unidirectional to avoid circular dependency issues.
 import { useWorkspaceStore } from "./workspace-store";
 import { useSettingsStore } from "./settings-store";
 import { useGridStore } from "./grid-store";

--- a/ui/src/stores/notification-store.ts
+++ b/ui/src/stores/notification-store.ts
@@ -1,4 +1,7 @@
 import { create } from "zustand";
+import { useWorkspaceStore } from "./workspace-store";
+import { useSettingsStore } from "./settings-store";
+import { useGridStore } from "./grid-store";
 
 export type NotificationLevel = "info" | "error" | "warning" | "success";
 
@@ -34,14 +37,23 @@ export const useNotificationStore = create<NotificationStoreState>()((set, get) 
   notifications: [],
 
   addNotification: ({ terminalId, workspaceId, message, level }) => {
+    const now = Date.now();
+    const dismissMode = useSettingsStore.getState().convenience.notificationDismiss;
+    const activeWsId = useWorkspaceStore.getState().activeWorkspaceId;
+
+    const shouldAutoDismiss =
+      workspaceId === activeWsId &&
+      (dismissMode === "workspace" ||
+        (dismissMode === "paneFocus" && useGridStore.getState().focusedPaneIndex !== null));
+
     const notification: Notification = {
       id: `notif-${++notifId}`,
       terminalId,
       workspaceId,
       message,
       level: level ?? "info",
-      createdAt: Date.now(),
-      readAt: null,
+      createdAt: now,
+      readAt: shouldAutoDismiss ? now : null,
     };
     set((state) => ({
       notifications: [...state.notifications, notification],

--- a/ui/src/test/e2e.test.ts
+++ b/ui/src/test/e2e.test.ts
@@ -1177,20 +1177,19 @@ describe("Cross-Store Integration E2E", () => {
       useTerminalStore.getState().updateInstanceInfo(id, { cwd: "/home/user/project" });
     }
 
-    // 3. Receive notification
-    const activeWsId = useWorkspaceStore.getState().activeWorkspaceId;
+    // 3. Receive notification for a non-active workspace
     useNotificationStore
       .getState()
-      .addNotification({ terminalId: "t1", workspaceId: activeWsId, message: "Build complete" });
+      .addNotification({ terminalId: "t1", workspaceId: "ws-other", message: "Build complete" });
 
-    // 4. Verify state
+    // 4. Verify state (active workspace is ws-1, notification is for ws-other so it stays unread)
     const instances = useTerminalStore.getState().instances;
     expect(instances.every((i) => i.cwd === "/home/user/project")).toBe(true);
-    expect(useNotificationStore.getState().getUnreadCount("ws-1")).toBe(1);
+    expect(useNotificationStore.getState().getUnreadCount("ws-other")).toBe(1);
 
     // 5. Switch workspace marks notification as read
-    useNotificationStore.getState().markWorkspaceAsRead("ws-1");
-    expect(useNotificationStore.getState().getUnreadCount("ws-1")).toBe(0);
+    useNotificationStore.getState().markWorkspaceAsRead("ws-other");
+    expect(useNotificationStore.getState().getUnreadCount("ws-other")).toBe(0);
   });
 
   it("should simulate sync-branch updating all group terminals", () => {
@@ -1249,27 +1248,30 @@ describe("Cross-Store Integration E2E", () => {
   });
 
   it("should handle notifications for multiple workspaces simultaneously", () => {
+    // active workspace is ws-1; create two more non-active workspaces
     useWorkspaceStore.getState().addWorkspace("WS2", "default-layout");
+    useWorkspaceStore.getState().addWorkspace("WS3", "default-layout");
     const ws2Id = useWorkspaceStore.getState().workspaces[1].id;
+    const ws3Id = useWorkspaceStore.getState().workspaces[2].id;
 
-    // Notifications arrive for both workspaces
+    // Notifications arrive for non-active workspaces (ws-1 is active, so use ws2/ws3)
     useNotificationStore
       .getState()
-      .addNotification({ terminalId: "t1", workspaceId: "ws-1", message: "Build failed" });
+      .addNotification({ terminalId: "t1", workspaceId: ws2Id, message: "Build failed" });
     useNotificationStore
       .getState()
-      .addNotification({ terminalId: "t1", workspaceId: ws2Id, message: "Tests passed" });
+      .addNotification({ terminalId: "t1", workspaceId: ws3Id, message: "Tests passed" });
     useNotificationStore
       .getState()
-      .addNotification({ terminalId: "t1", workspaceId: "ws-1", message: "Retry started" });
+      .addNotification({ terminalId: "t1", workspaceId: ws2Id, message: "Retry started" });
 
-    expect(useNotificationStore.getState().getUnreadCount("ws-1")).toBe(2);
-    expect(useNotificationStore.getState().getUnreadCount(ws2Id)).toBe(1);
+    expect(useNotificationStore.getState().getUnreadCount(ws2Id)).toBe(2);
+    expect(useNotificationStore.getState().getUnreadCount(ws3Id)).toBe(1);
 
-    // Mark ws-1 as read
-    useNotificationStore.getState().markWorkspaceAsRead("ws-1");
-    expect(useNotificationStore.getState().getUnreadCount("ws-1")).toBe(0);
-    expect(useNotificationStore.getState().getUnreadCount(ws2Id)).toBe(1); // Still unread
+    // Mark ws2 as read
+    useNotificationStore.getState().markWorkspaceAsRead(ws2Id);
+    expect(useNotificationStore.getState().getUnreadCount(ws2Id)).toBe(0);
+    expect(useNotificationStore.getState().getUnreadCount(ws3Id)).toBe(1); // Still unread
   });
 
   it("should simulate terminal close and sync group cleanup", () => {


### PR DESCRIPTION
## Summary
- 알림 추가 시 현재 활성 워크스페이스이면 `notificationDismiss` 설정에 따라 즉시 읽음 처리
  - `workspace` 모드: 즉시 해제
  - `paneFocus` 모드: 포커스된 pane이 있을 때만 해제
  - `manual` 모드: 해제 없음
- 앱 시작 시 셸 초기화로 발생하는 알림이 미읽음 상태로 남는 버그 수정

Fixes #107

## Test plan
- [x] auto-dismiss 테스트 5개 추가 (workspace/paneFocus/manual 모드별)
- [x] 기존 테스트 회귀 수정 (비활성 워크스페이스 사용)
- [x] 전체 프론트엔드 테스트 1169개 통과
- [x] Rust 백엔드 테스트 360개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)