### PR TITLE
fix: suppress startup notifications on workspace entry

### DIFF
--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -45,6 +45,9 @@ import {
 /** Default silence timeout for output idle detection (ms). */
 const OUTPUT_IDLE_TIMEOUT_MS = 5000;
 
+/** Duration to suppress notifications after terminal creation (ms). */
+const STARTUP_NOTIFICATION_SUPPRESS_MS = 3000;
+
 /** Resolve the workspace ID for a terminal instance (for notifications). */
 function resolveWorkspaceId(terminalId: string): string {
   const inst = useTerminalStore.getState().instances.find((i) => i.id === terminalId);
@@ -267,14 +270,16 @@ export function TerminalView({
 
       if (transition === "completed") {
         updateInstanceInfo(instanceId, { lastExitCode: 0, lastCommandAt: Date.now() });
-        const message = getClaudeCompletionMessage(prevTitle, title);
-        const wsId = resolveWorkspaceId(instanceId);
-        useNotificationStore.getState().addNotification({
-          terminalId: instanceId,
-          workspaceId: wsId,
-          message,
-          level: "success",
-        });
+        if (!startupSuppress) {
+          const message = getClaudeCompletionMessage(prevTitle, title);
+          const wsId = resolveWorkspaceId(instanceId);
+          useNotificationStore.getState().addNotification({
+            terminalId: instanceId,
+            workspaceId: wsId,
+            message,
+            level: "success",
+          });
+        }
       } else if (transition === "started") {
         const taskDesc = extractClaudeTaskDesc(title);
         updateInstanceInfo(instanceId, {
@@ -284,6 +289,13 @@ export function TerminalView({
         });
       }
     });
+
+    // Suppress notifications during startup to prevent alarm flood from
+    // shell-init OSC sequences (see issue #111).
+    let startupSuppress = true;
+    const startupTimer = setTimeout(() => {
+      startupSuppress = false;
+    }, STARTUP_NOTIFICATION_SUPPRESS_MS);
 
     // Build hooks list
     const hooks: OscHook[] = [
@@ -315,12 +327,14 @@ export function TerminalView({
       });
       const wsId = resolveWorkspaceId(instanceId);
       const cmdDesc = inst.lastCommand || "Command";
-      useNotificationStore.getState().addNotification({
-        terminalId: instanceId,
-        workspaceId: wsId,
-        message: `${cmdDesc} completed`,
-        level: "success",
-      });
+      if (!startupSuppress) {
+        useNotificationStore.getState().addNotification({
+          terminalId: instanceId,
+          workspaceId: wsId,
+          message: `${cmdDesc} completed`,
+          level: "success",
+        });
+      }
     });
 
     // Persistent TextDecoder with stream mode to handle UTF-8 characters
@@ -337,6 +351,7 @@ export function TerminalView({
       const text = streamDecoder.decode(data, { stream: true });
       processOscInOutput(text, hooks, instanceId, syncGroupRef.current, {
         skipSyncCwd: !cwdSendRef.current,
+        skipNotify: startupSuppress,
       });
 
       // Claude task detection from raw OSC 0 titles (bypasses xterm.js encoding issues)
@@ -357,14 +372,16 @@ export function TerminalView({
               lastExitCode: 0,
               lastCommandAt: Date.now(),
             });
-            const message = getClaudeCompletionMessage(prevTitle, rawTitle);
-            const wsId = resolveWorkspaceId(instanceId);
-            useNotificationStore.getState().addNotification({
-              terminalId: instanceId,
-              workspaceId: wsId,
-              message,
-              level: "success",
-            });
+            if (!startupSuppress) {
+              const message = getClaudeCompletionMessage(prevTitle, rawTitle);
+              const wsId = resolveWorkspaceId(instanceId);
+              useNotificationStore.getState().addNotification({
+                terminalId: instanceId,
+                workspaceId: wsId,
+                message,
+                level: "success",
+              });
+            }
           } else if (transition === "started") {
             const taskDesc = extractClaudeTaskDesc(rawTitle);
             useTerminalStore.getState().updateInstanceInfo(instanceId, {
@@ -566,6 +583,7 @@ export function TerminalView({
 
     return () => {
       cancelled = true;
+      clearTimeout(startupTimer);
       if (webglTimer !== undefined) clearTimeout(webglTimer);
       idleDetector.dispose();
       resizeObserver.disconnect();

--- a/ui/src/hooks/useOscHooks.test.ts
+++ b/ui/src/hooks/useOscHooks.test.ts
@@ -151,6 +151,46 @@ describe("processOscInOutput", () => {
     expect(call.path).toBe("//wsl.localhost/Ubuntu-22.04/home/user");
   });
 
+  it("skips notify actions when skipNotify is true", () => {
+    const notifyHooks: OscHook[] = [
+      {
+        osc: 133,
+        param: "D",
+        when: "exitCode === '0'",
+        run: "lx notify --level success 'Command completed'",
+      },
+      {
+        osc: 133,
+        param: "D",
+        run: "lx set-command-status --exit-code $exitCode",
+      },
+    ];
+    const output = "\x1b]133;D;0\x07";
+    processOscInOutput(output, notifyHooks, "t1", "g1", { skipNotify: true });
+
+    // notify should be skipped, but set-command-status should still fire
+    expect(mockHandleLxMessage).toHaveBeenCalledTimes(1);
+    const call = JSON.parse(mockHandleLxMessage.mock.calls[0][0]);
+    expect(call.action).toBe("set-command-status");
+  });
+
+  it("allows notify actions when skipNotify is false", () => {
+    const notifyHooks: OscHook[] = [
+      {
+        osc: 133,
+        param: "D",
+        when: "exitCode === '0'",
+        run: "lx notify --level success 'Command completed'",
+      },
+    ];
+    const output = "\x1b]133;D;0\x07";
+    processOscInOutput(output, notifyHooks, "t1", "g1", { skipNotify: false });
+
+    expect(mockHandleLxMessage).toHaveBeenCalledTimes(1);
+    const call = JSON.parse(mockHandleLxMessage.mock.calls[0][0]);
+    expect(call.action).toBe("notify");
+  });
+
   it("handles OSC 133 C (preexec) → set-command-status with command", () => {
     const preexecHooks: OscHook[] = [
       { osc: 133, param: "C", run: "lx set-command-status --command __preexec__" },

--- a/ui/src/hooks/useOscHooks.ts
+++ b/ui/src/hooks/useOscHooks.ts
@@ -17,7 +17,7 @@ export function processOscInOutput(
   hooks: OscHook[],
   terminalId: string,
   groupId: string,
-  options?: { skipSyncCwd?: boolean },
+  options?: { skipSyncCwd?: boolean; skipNotify?: boolean },
 ): void {
   if (hooks.length === 0) return;
 
@@ -72,6 +72,7 @@ export function processOscInOutput(
       const message = buildLxMessage(parsed, terminalId, groupId);
       if (message) {
         if (options?.skipSyncCwd && message.action === "sync-cwd") continue;
+        if (options?.skipNotify && message.action === "notify") continue;
         handleLxMessage(JSON.stringify(message)).catch(() => {});
       }
     }


### PR DESCRIPTION
## Summary
- 앱 시작 후 워크스페이스 최초 진입 시 셸 초기화 과정에서 OSC 133;D가 `notify-on-complete`/`notify-on-fail` hook을 트리거하여 알림이 다수 발생하던 문제 수정
- 각 TerminalView 인스턴스 생성 후 3초간 notification hook을 억제하는 startup suppression 메커니즘 추가
- `sync-cwd`, `sync-branch` 등 비알림 hook은 유예 기간 중에도 정상 동작

## Test plan
- [x] `skipNotify` 옵션 단위 테스트 (2개 추가)
- [x] 프론트엔드 전체 테스트 통과 (1194개)
- [x] 백엔드 전체 테스트 통과 (12개)
- [ ] 앱 실행 후 워크스페이스 진입 시 알림 폭발 없는지 수동 확인

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)