### PR TITLE
feat: MemoView 단락 복사 및 선택 시 자동 복사 기능 추가

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -467,7 +467,30 @@ impl Default for IssueReporterSettings {
     }
 }
 
-/// MemoView settings (padding, etc.).
+/// Paragraph copy feature settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoParagraphCopySettings {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_min_blank_lines")]
+    pub min_blank_lines: u32,
+}
+
+fn default_min_blank_lines() -> u32 {
+    2
+}
+
+impl Default for MemoParagraphCopySettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            min_blank_lines: 2,
+        }
+    }
+}
+
+/// MemoView settings (padding, copy features, etc.).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MemoSettings {
@@ -479,6 +502,12 @@ pub struct MemoSettings {
     pub padding_bottom: u32,
     #[serde(default = "default_view_padding")]
     pub padding_left: u32,
+    /// Paragraph copy: show copy button on hover for paragraphs separated by N+ blank lines.
+    #[serde(default)]
+    pub paragraph_copy: MemoParagraphCopySettings,
+    /// Automatically copy selected text to clipboard (like terminal copyOnSelect).
+    #[serde(default)]
+    pub copy_on_select: bool,
 }
 
 impl Default for MemoSettings {
@@ -488,6 +517,8 @@ impl Default for MemoSettings {
             padding_right: 8,
             padding_bottom: 8,
             padding_left: 8,
+            paragraph_copy: MemoParagraphCopySettings::default(),
+            copy_on_select: false,
         }
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -508,6 +508,9 @@ pub struct MemoSettings {
     /// Automatically copy selected text to clipboard (like terminal copyOnSelect).
     #[serde(default)]
     pub copy_on_select: bool,
+    /// Double-click to select entire paragraph (requires paragraph_copy enabled).
+    #[serde(default = "default_true")]
+    pub dbl_click_paragraph_select: bool,
 }
 
 impl Default for MemoSettings {
@@ -519,6 +522,7 @@ impl Default for MemoSettings {
             padding_left: 8,
             paragraph_copy: MemoParagraphCopySettings::default(),
             copy_on_select: false,
+            dbl_click_paragraph_select: true,
         }
     }
 }

--- a/ui/src/components/views/MemoView.test.tsx
+++ b/ui/src/components/views/MemoView.test.tsx
@@ -4,6 +4,13 @@ import { MemoView } from "./MemoView";
 import { loadMemo, saveMemo } from "@/lib/tauri-api";
 import { useSettingsStore } from "@/stores/settings-store";
 
+// Mock clipboard API
+Object.assign(navigator, {
+  clipboard: {
+    writeText: vi.fn().mockResolvedValue(undefined),
+  },
+});
+
 vi.mock("@/lib/tauri-api", () => ({
   loadMemo: vi.fn().mockResolvedValue(""),
   saveMemo: vi.fn().mockResolvedValue(undefined),
@@ -91,7 +98,14 @@ describe("MemoView", () => {
   it("applies memo padding from settings", () => {
     useSettingsStore.setState({
       ...useSettingsStore.getState(),
-      memo: { paddingTop: 20, paddingRight: 10, paddingBottom: 5, paddingLeft: 15 },
+      memo: {
+        paddingTop: 20,
+        paddingRight: 10,
+        paddingBottom: 5,
+        paddingLeft: 15,
+        paragraphCopy: { enabled: true, minBlankLines: 2 },
+        copyOnSelect: false,
+      },
     });
 
     render(<MemoView memoKey="pane-pad" />);
@@ -114,5 +128,147 @@ describe("MemoView", () => {
 
     const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
     expect(textarea.value).toBe("");
+  });
+
+  describe("paragraph copy feature", () => {
+    it("renders paragraph copy buttons when enabled and text has paragraphs", async () => {
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        memo: {
+          ...useSettingsStore.getState().memo,
+          paragraphCopy: { enabled: true, minBlankLines: 2 },
+        },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("abc\n\n\ndef");
+      render(<MemoView memoKey="pane-para" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      // Should render paragraph overlay container
+      const overlay = screen.getByTestId("paragraph-overlay");
+      expect(overlay).toBeInTheDocument();
+
+      // Should have 2 paragraph regions
+      const regions = screen.getAllByTestId(/^paragraph-region-/);
+      expect(regions).toHaveLength(2);
+    });
+
+    it("does not render paragraph overlay when feature is disabled", async () => {
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        memo: {
+          ...useSettingsStore.getState().memo,
+          paragraphCopy: { enabled: false, minBlankLines: 2 },
+        },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("abc\n\n\ndef");
+      render(<MemoView memoKey="pane-disabled" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(screen.queryByTestId("paragraph-overlay")).not.toBeInTheDocument();
+    });
+
+    it("does not render paragraph overlay when only one paragraph exists", async () => {
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        memo: {
+          ...useSettingsStore.getState().memo,
+          paragraphCopy: { enabled: true, minBlankLines: 2 },
+        },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("abc\ndef");
+      render(<MemoView memoKey="pane-single" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(screen.queryByTestId("paragraph-overlay")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("copyOnSelect feature", () => {
+    it("copies selected text on mouseup when enabled", async () => {
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        memo: {
+          ...useSettingsStore.getState().memo,
+          copyOnSelect: true,
+        },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("hello world");
+      render(<MemoView memoKey="pane-cos" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      // Simulate text selection
+      const selection = {
+        toString: () => "hello",
+        removeAllRanges: vi.fn(),
+      };
+      vi.spyOn(window, "getSelection").mockReturnValue(selection as unknown as Selection);
+
+      const textarea = screen.getByTestId("memo-textarea");
+      fireEvent.mouseUp(textarea);
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello");
+    });
+
+    it("does not copy on mouseup when copyOnSelect is disabled", async () => {
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        memo: {
+          ...useSettingsStore.getState().memo,
+          copyOnSelect: false,
+        },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("hello world");
+      render(<MemoView memoKey="pane-cos-off" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      const selection = {
+        toString: () => "hello",
+        removeAllRanges: vi.fn(),
+      };
+      vi.spyOn(window, "getSelection").mockReturnValue(selection as unknown as Selection);
+
+      vi.mocked(navigator.clipboard.writeText).mockClear();
+      const textarea = screen.getByTestId("memo-textarea");
+      fireEvent.mouseUp(textarea);
+
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    });
+
+    it("does not copy when no text is selected", async () => {
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        memo: {
+          ...useSettingsStore.getState().memo,
+          copyOnSelect: true,
+        },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("hello world");
+      render(<MemoView memoKey="pane-cos-empty" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      const selection = {
+        toString: () => "",
+        removeAllRanges: vi.fn(),
+      };
+      vi.spyOn(window, "getSelection").mockReturnValue(selection as unknown as Selection);
+
+      vi.mocked(navigator.clipboard.writeText).mockClear();
+      const textarea = screen.getByTestId("memo-textarea");
+      fireEvent.mouseUp(textarea);
+
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    });
   });
 });

--- a/ui/src/components/views/MemoView.test.tsx
+++ b/ui/src/components/views/MemoView.test.tsx
@@ -1,20 +1,14 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoView } from "./MemoView";
-import { loadMemo, saveMemo } from "@/lib/tauri-api";
+import { loadMemo, saveMemo, clipboardWriteText } from "@/lib/tauri-api";
 import { useSettingsStore } from "@/stores/settings-store";
-
-// Mock clipboard API
-Object.assign(navigator, {
-  clipboard: {
-    writeText: vi.fn().mockResolvedValue(undefined),
-  },
-});
 
 vi.mock("@/lib/tauri-api", () => ({
   loadMemo: vi.fn().mockResolvedValue(""),
   saveMemo: vi.fn().mockResolvedValue(undefined),
   saveSettings: vi.fn().mockResolvedValue(undefined),
+  clipboardWriteText: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("MemoView", () => {
@@ -131,7 +125,7 @@ describe("MemoView", () => {
   });
 
   describe("paragraph copy feature", () => {
-    it("renders paragraph copy buttons when enabled and text has paragraphs", async () => {
+    it("renders paragraph overlay when enabled and text has paragraphs", async () => {
       useSettingsStore.setState({
         ...useSettingsStore.getState(),
         memo: {
@@ -187,6 +181,102 @@ describe("MemoView", () => {
 
       expect(screen.queryByTestId("paragraph-overlay")).not.toBeInTheDocument();
     });
+
+    it("overlay does not block textarea input (pointer-events-none)", async () => {
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        memo: {
+          ...useSettingsStore.getState().memo,
+          paragraphCopy: { enabled: true, minBlankLines: 2 },
+        },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("abc\n\n\ndef");
+      render(<MemoView memoKey="pane-no-block" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      // Overlay should have pointer-events-none
+      const overlay = screen.getByTestId("paragraph-overlay");
+      expect(overlay.className).toContain("pointer-events-none");
+
+      // Textarea should still be interactable
+      const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "typed text" } });
+      expect(textarea.value).toBe("typed text");
+    });
+  });
+
+  describe("double-click paragraph select", () => {
+    it("selects entire paragraph on double-click when paragraphCopy is enabled", async () => {
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        memo: {
+          ...useSettingsStore.getState().memo,
+          paragraphCopy: { enabled: true, minBlankLines: 2 },
+          copyOnSelect: false,
+        },
+      });
+      // "abc" = line 0, "" = line 1, "" = line 2, "def\nggg" = lines 3-4
+      vi.mocked(loadMemo).mockResolvedValue("abc\n\n\ndef\nggg");
+      render(<MemoView memoKey="pane-dbl" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
+      // Place cursor in "def" (offset 6 = start of line 3)
+      textarea.setSelectionRange(6, 6);
+      fireEvent.doubleClick(textarea);
+
+      // Should select "def\nggg" (start=6, end=13 exclusive)
+      expect(textarea.selectionStart).toBe(6);
+      expect(textarea.selectionEnd).toBe(13);
+    });
+
+    it("copies paragraph on double-click when copyOnSelect is also enabled", async () => {
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        memo: {
+          ...useSettingsStore.getState().memo,
+          paragraphCopy: { enabled: true, minBlankLines: 2 },
+          copyOnSelect: true,
+        },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("abc\n\n\ndef\nggg");
+      render(<MemoView memoKey="pane-dbl-copy" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      vi.mocked(clipboardWriteText).mockClear();
+      const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
+      textarea.setSelectionRange(6, 6);
+      fireEvent.doubleClick(textarea);
+
+      expect(clipboardWriteText).toHaveBeenCalledWith("def\nggg");
+    });
+
+    it("falls back to default behavior when paragraphCopy is disabled", async () => {
+      useSettingsStore.setState({
+        ...useSettingsStore.getState(),
+        memo: {
+          ...useSettingsStore.getState().memo,
+          paragraphCopy: { enabled: false, minBlankLines: 2 },
+        },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("abc\n\n\ndef");
+      render(<MemoView memoKey="pane-dbl-off" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      vi.mocked(clipboardWriteText).mockClear();
+      const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
+      // double-click should not trigger paragraph selection
+      fireEvent.doubleClick(textarea);
+      expect(clipboardWriteText).not.toHaveBeenCalled();
+    });
   });
 
   describe("copyOnSelect feature", () => {
@@ -214,7 +304,7 @@ describe("MemoView", () => {
       const textarea = screen.getByTestId("memo-textarea");
       fireEvent.mouseUp(textarea);
 
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello");
+      expect(clipboardWriteText).toHaveBeenCalledWith("hello");
     });
 
     it("does not copy on mouseup when copyOnSelect is disabled", async () => {
@@ -237,11 +327,11 @@ describe("MemoView", () => {
       };
       vi.spyOn(window, "getSelection").mockReturnValue(selection as unknown as Selection);
 
-      vi.mocked(navigator.clipboard.writeText).mockClear();
+      vi.mocked(clipboardWriteText).mockClear();
       const textarea = screen.getByTestId("memo-textarea");
       fireEvent.mouseUp(textarea);
 
-      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+      expect(clipboardWriteText).not.toHaveBeenCalled();
     });
 
     it("does not copy when no text is selected", async () => {
@@ -264,11 +354,11 @@ describe("MemoView", () => {
       };
       vi.spyOn(window, "getSelection").mockReturnValue(selection as unknown as Selection);
 
-      vi.mocked(navigator.clipboard.writeText).mockClear();
+      vi.mocked(clipboardWriteText).mockClear();
       const textarea = screen.getByTestId("memo-textarea");
       fireEvent.mouseUp(textarea);
 
-      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+      expect(clipboardWriteText).not.toHaveBeenCalled();
     });
   });
 });

--- a/ui/src/components/views/MemoView.tsx
+++ b/ui/src/components/views/MemoView.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { loadMemo, saveMemo } from "@/lib/tauri-api";
 import { useSettingsStore } from "@/stores/settings-store";
+import { splitParagraphs } from "@/lib/memo-paragraphs";
 
 const DEBOUNCE_MS = 300;
 
@@ -63,6 +64,24 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
 
   const memo = useSettingsStore((s) => s.memo);
 
+  // Paragraph copy feature
+  const paragraphs = useMemo(() => {
+    if (!memo.paragraphCopy.enabled) return [];
+    return splitParagraphs(text, memo.paragraphCopy.minBlankLines);
+  }, [text, memo.paragraphCopy.enabled, memo.paragraphCopy.minBlankLines]);
+
+  const showParagraphOverlay = memo.paragraphCopy.enabled && paragraphs.length > 1;
+
+  // Copy on select feature
+  const handleMouseUp = useCallback(() => {
+    if (!memo.copyOnSelect) return;
+    const selection = window.getSelection();
+    const selectedText = selection?.toString() ?? "";
+    if (selectedText) {
+      navigator.clipboard.writeText(selectedText).catch(() => {});
+    }
+  }, [memo.copyOnSelect]);
+
   return (
     <div data-testid="memo-view" className="flex h-full w-full flex-col">
       <div
@@ -78,22 +97,124 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
       >
         Memo
       </div>
-      <textarea
-        ref={textareaRef}
-        data-testid="memo-textarea"
-        value={text}
-        onChange={handleChange}
-        className="h-full w-full flex-1 resize-none border-none outline-none"
-        style={{
-          background: "var(--bg-base)",
-          color: "var(--text-primary)",
-          fontFamily: "inherit",
-          fontSize: "13px",
-          lineHeight: "1.6",
-          padding: `${memo.paddingTop}px ${memo.paddingRight}px ${memo.paddingBottom}px ${memo.paddingLeft}px`,
-        }}
-        spellCheck={false}
-      />
+      <div className="relative flex-1">
+        <textarea
+          ref={textareaRef}
+          data-testid="memo-textarea"
+          value={text}
+          onChange={handleChange}
+          onMouseUp={handleMouseUp}
+          className="h-full w-full resize-none border-none outline-none"
+          style={{
+            background: "var(--bg-base)",
+            color: "var(--text-primary)",
+            fontFamily: "inherit",
+            fontSize: "13px",
+            lineHeight: "1.6",
+            padding: `${memo.paddingTop}px ${memo.paddingRight}px ${memo.paddingBottom}px ${memo.paddingLeft}px`,
+          }}
+          spellCheck={false}
+        />
+        {showParagraphOverlay && (
+          <ParagraphOverlay
+            paragraphs={paragraphs}
+            paddingTop={memo.paddingTop}
+            paddingLeft={memo.paddingLeft}
+            paddingRight={memo.paddingRight}
+            textareaRef={textareaRef}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// --- Paragraph overlay ---
+
+interface ParagraphOverlayProps {
+  paragraphs: { text: string; startLine: number; endLine: number }[];
+  paddingTop: number;
+  paddingLeft: number;
+  paddingRight: number;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+function ParagraphOverlay({
+  paragraphs,
+  paddingTop,
+  paddingLeft,
+  paddingRight,
+  textareaRef,
+}: ParagraphOverlayProps) {
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const [copied, setCopied] = useState<number | null>(null);
+  const lineHeight = 13 * 1.6; // fontSize * lineHeight
+
+  const handleCopy = (index: number) => {
+    const para = paragraphs[index];
+    navigator.clipboard.writeText(para.text).catch(() => {});
+    setCopied(index);
+    setTimeout(() => setCopied(null), 1500);
+  };
+
+  // Calculate scroll offset
+  const [scrollTop, setScrollTop] = useState(0);
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const onScroll = () => setScrollTop(textarea.scrollTop);
+    textarea.addEventListener("scroll", onScroll);
+    return () => textarea.removeEventListener("scroll", onScroll);
+  }, [textareaRef]);
+
+  return (
+    <div
+      data-testid="paragraph-overlay"
+      className="pointer-events-none absolute inset-0 overflow-hidden"
+    >
+      {paragraphs.map((para, i) => {
+        const top = paddingTop + para.startLine * lineHeight - scrollTop;
+        const height = (para.endLine - para.startLine + 1) * lineHeight;
+
+        return (
+          <div
+            key={i}
+            data-testid={`paragraph-region-${i}`}
+            className="pointer-events-auto absolute"
+            style={{
+              top,
+              left: 0,
+              right: 0,
+              height,
+              paddingLeft,
+              paddingRight,
+            }}
+            onMouseEnter={() => setHoveredIndex(i)}
+            onMouseLeave={() => setHoveredIndex(null)}
+          >
+            {hoveredIndex === i && (
+              <button
+                data-testid={`paragraph-copy-btn-${i}`}
+                className="absolute flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px]"
+                style={{
+                  top: 0,
+                  right: paddingRight + 4,
+                  background: "var(--bg-overlay)",
+                  color: "var(--text-secondary)",
+                  border: "1px solid var(--border)",
+                  cursor: "pointer",
+                  zIndex: 10,
+                  opacity: 0.9,
+                }}
+                onClick={() => handleCopy(i)}
+                title="단락 복사"
+              >
+                {copied === i ? "Copied!" : "Copy"}
+              </button>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/ui/src/components/views/MemoView.tsx
+++ b/ui/src/components/views/MemoView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { loadMemo, saveMemo } from "@/lib/tauri-api";
+import { loadMemo, saveMemo, clipboardWriteText } from "@/lib/tauri-api";
 import { useSettingsStore } from "@/stores/settings-store";
 import { splitParagraphs } from "@/lib/memo-paragraphs";
 
@@ -72,15 +72,90 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
 
   const showParagraphOverlay = memo.paragraphCopy.enabled && paragraphs.length > 1;
 
+  // Paragraph hover detection via textarea mouse position
+  const [hoveredParagraph, setHoveredParagraph] = useState<number | null>(null);
+  const lineHeight = 13 * 1.6; // fontSize * lineHeight
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLTextAreaElement>) => {
+      if (!showParagraphOverlay) return;
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      const rect = textarea.getBoundingClientRect();
+      const y = e.clientY - rect.top + textarea.scrollTop - memo.paddingTop;
+      const line = Math.floor(y / lineHeight);
+      const idx = paragraphs.findIndex(
+        (p) => line >= p.startLine && line <= p.endLine,
+      );
+      setHoveredParagraph(idx >= 0 ? idx : null);
+    },
+    [showParagraphOverlay, paragraphs, memo.paddingTop, lineHeight],
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    setHoveredParagraph(null);
+  }, []);
+
   // Copy on select feature
   const handleMouseUp = useCallback(() => {
     if (!memo.copyOnSelect) return;
     const selection = window.getSelection();
     const selectedText = selection?.toString() ?? "";
     if (selectedText) {
-      navigator.clipboard.writeText(selectedText).catch(() => {});
+      clipboardWriteText(selectedText).catch(() => {});
     }
   }, [memo.copyOnSelect]);
+
+  // Double-click to select paragraph
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent<HTMLTextAreaElement>) => {
+      if (!showParagraphOverlay || !memo.dblClickParagraphSelect) return;
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      const cursorPos = textarea.selectionStart;
+      const lines = text.split("\n");
+
+      // Map cursor position to line number
+      let charCount = 0;
+      let cursorLine = 0;
+      for (let i = 0; i < lines.length; i++) {
+        charCount += lines[i].length + 1; // +1 for \n
+        if (charCount > cursorPos) {
+          cursorLine = i;
+          break;
+        }
+      }
+
+      // Find which paragraph this line belongs to
+      const paraIdx = paragraphs.findIndex(
+        (p) => cursorLine >= p.startLine && cursorLine <= p.endLine,
+      );
+      if (paraIdx < 0) return;
+
+      const para = paragraphs[paraIdx];
+
+      // Calculate character offsets for this paragraph
+      let startOffset = 0;
+      for (let i = 0; i < para.startLine; i++) {
+        startOffset += lines[i].length + 1;
+      }
+      let endOffset = startOffset;
+      for (let i = para.startLine; i <= para.endLine; i++) {
+        endOffset += lines[i].length + (i < para.endLine ? 1 : 0);
+      }
+
+      // Prevent default word selection and select paragraph instead
+      e.preventDefault();
+      textarea.setSelectionRange(startOffset, endOffset);
+
+      // Copy if copyOnSelect is enabled
+      if (memo.copyOnSelect) {
+        clipboardWriteText(para.text).catch(() => {});
+      }
+    },
+    [showParagraphOverlay, memo.dblClickParagraphSelect, text, paragraphs, memo.copyOnSelect],
+  );
 
   return (
     <div data-testid="memo-view" className="flex h-full w-full flex-col">
@@ -97,13 +172,15 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
       >
         Memo
       </div>
-      <div className="relative flex-1">
+      <div className="relative flex-1" onMouseLeave={handleMouseLeave}>
         <textarea
           ref={textareaRef}
           data-testid="memo-textarea"
           value={text}
           onChange={handleChange}
           onMouseUp={handleMouseUp}
+          onMouseMove={handleMouseMove}
+          onDoubleClick={handleDoubleClick}
           className="h-full w-full resize-none border-none outline-none"
           style={{
             background: "var(--bg-base)",
@@ -119,8 +196,8 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
           <ParagraphOverlay
             paragraphs={paragraphs}
             paddingTop={memo.paddingTop}
-            paddingLeft={memo.paddingLeft}
             paddingRight={memo.paddingRight}
+            hoveredIndex={hoveredParagraph}
             textareaRef={textareaRef}
           />
         )}
@@ -134,27 +211,30 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
 interface ParagraphOverlayProps {
   paragraphs: { text: string; startLine: number; endLine: number }[];
   paddingTop: number;
-  paddingLeft: number;
   paddingRight: number;
+  hoveredIndex: number | null;
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
 }
 
 function ParagraphOverlay({
   paragraphs,
   paddingTop,
-  paddingLeft,
   paddingRight,
+  hoveredIndex,
   textareaRef,
 }: ParagraphOverlayProps) {
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [copied, setCopied] = useState<number | null>(null);
   const lineHeight = 13 * 1.6; // fontSize * lineHeight
 
-  const handleCopy = (index: number) => {
+  const handleCopy = (e: React.MouseEvent, index: number) => {
+    e.preventDefault();
+    e.stopPropagation();
     const para = paragraphs[index];
-    navigator.clipboard.writeText(para.text).catch(() => {});
+    clipboardWriteText(para.text).catch(() => {});
     setCopied(index);
     setTimeout(() => setCopied(null), 1500);
+    // Return focus to textarea after copy
+    textareaRef.current?.focus();
   };
 
   // Calculate scroll offset
@@ -174,31 +254,20 @@ function ParagraphOverlay({
     >
       {paragraphs.map((para, i) => {
         const top = paddingTop + para.startLine * lineHeight - scrollTop;
-        const height = (para.endLine - para.startLine + 1) * lineHeight;
 
         return (
           <div
             key={i}
             data-testid={`paragraph-region-${i}`}
-            className="pointer-events-auto absolute"
-            style={{
-              top,
-              left: 0,
-              right: 0,
-              height,
-              paddingLeft,
-              paddingRight,
-            }}
-            onMouseEnter={() => setHoveredIndex(i)}
-            onMouseLeave={() => setHoveredIndex(null)}
+            className="absolute"
+            style={{ top, right: 0 }}
           >
             {hoveredIndex === i && (
               <button
                 data-testid={`paragraph-copy-btn-${i}`}
-                className="absolute flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px]"
+                className="pointer-events-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px]"
                 style={{
-                  top: 0,
-                  right: paddingRight + 4,
+                  marginRight: paddingRight + 4,
                   background: "var(--bg-overlay)",
                   color: "var(--text-secondary)",
                   border: "1px solid var(--border)",
@@ -206,7 +275,7 @@ function ParagraphOverlay({
                   zIndex: 10,
                   opacity: 0.9,
                 }}
-                onClick={() => handleCopy(i)}
+                onMouseDown={(e) => handleCopy(e, i)}
                 title="단락 복사"
               >
                 {copied === i ? "Copied!" : "Copy"}

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1721,6 +1721,34 @@ function MemoSection() {
           </div>
         </div>
 
+        {/* Double-click Paragraph Select */}
+        <div className="flex items-start gap-3 py-1.5">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+              더블클릭 단락 선택
+            </span>
+            <p
+              className="mt-0.5 text-[11px] leading-tight"
+              style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+            >
+              더블클릭 시 해당 단락 전체를 선택
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <label className="flex items-center gap-1.5">
+              <input
+                data-testid="memo-dbl-click-paragraph-select"
+                type="checkbox"
+                checked={memo.dblClickParagraphSelect}
+                onChange={(e) => updateMemo({ dblClickParagraphSelect: e.target.checked })}
+              />
+              <span className="text-[12px]" style={{ color: "var(--text-secondary)" }}>
+                활성화
+              </span>
+            </label>
+          </div>
+        </div>
+
         {/* Copy on Select */}
         <div className="flex items-start gap-3 py-1.5">
           <div className="w-36 shrink-0 pt-1">

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1634,7 +1634,11 @@ function MemoSection() {
           <div className="min-w-0 flex-1">
             <div className="grid grid-cols-2 gap-2">
               {(["Top", "Right", "Bottom", "Left"] as const).map((dir) => {
-                const key = `padding${dir}` as keyof typeof memo;
+                const key = `padding${dir}` as
+                  | "paddingTop"
+                  | "paddingRight"
+                  | "paddingBottom"
+                  | "paddingLeft";
                 return (
                   <label key={dir} className="flex items-center gap-1.5">
                     <span className="w-12 text-[11px]" style={{ color: "var(--text-secondary)" }}>
@@ -1658,6 +1662,90 @@ function MemoSection() {
                 );
               })}
             </div>
+          </div>
+        </div>
+
+        {/* Paragraph Copy */}
+        <div className="flex items-start gap-3 py-1.5">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+              단락 복사
+            </span>
+            <p
+              className="mt-0.5 text-[11px] leading-tight"
+              style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+            >
+              N줄 이상 빈 줄로 구분된 단락에 복사 버튼 표시
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-1.5">
+                <input
+                  data-testid="memo-paragraph-copy-enabled"
+                  type="checkbox"
+                  checked={memo.paragraphCopy.enabled}
+                  onChange={(e) =>
+                    updateMemo({
+                      paragraphCopy: { ...memo.paragraphCopy, enabled: e.target.checked },
+                    })
+                  }
+                />
+                <span className="text-[12px]" style={{ color: "var(--text-secondary)" }}>
+                  활성화
+                </span>
+              </label>
+              <label className="flex items-center gap-1.5">
+                <span className="text-[11px]" style={{ color: "var(--text-secondary)" }}>
+                  빈 줄 수
+                </span>
+                <input
+                  data-testid="memo-paragraph-copy-min-blank-lines"
+                  type="number"
+                  min={1}
+                  max={10}
+                  className={inputCls}
+                  style={{ width: 50 }}
+                  value={memo.paragraphCopy.minBlankLines}
+                  onChange={(e) =>
+                    updateMemo({
+                      paragraphCopy: {
+                        ...memo.paragraphCopy,
+                        minBlankLines: Math.max(1, Math.min(10, Number(e.target.value) || 1)),
+                      },
+                    })
+                  }
+                />
+              </label>
+            </div>
+          </div>
+        </div>
+
+        {/* Copy on Select */}
+        <div className="flex items-start gap-3 py-1.5">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+              선택 시 복사
+            </span>
+            <p
+              className="mt-0.5 text-[11px] leading-tight"
+              style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+            >
+              텍스트 드래그 선택 시 자동으로 클립보드에 복사
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <label className="flex items-center gap-1.5">
+              <input
+                data-testid="memo-copy-on-select"
+                type="checkbox"
+                checked={memo.copyOnSelect}
+                onChange={(e) => updateMemo({ copyOnSelect: e.target.checked })}
+              />
+              <span className="text-[12px]" style={{ color: "var(--text-secondary)" }}>
+                활성화
+              </span>
+            </label>
           </div>
         </div>
       </div>

--- a/ui/src/lib/memo-paragraphs.test.ts
+++ b/ui/src/lib/memo-paragraphs.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { splitParagraphs, type Paragraph } from "./memo-paragraphs";
+
+describe("splitParagraphs", () => {
+  it("returns the entire text as one paragraph when no blank lines", () => {
+    const result = splitParagraphs("abc\ndef\nghi", 2);
+    expect(result).toEqual<Paragraph[]>([{ text: "abc\ndef\nghi", startLine: 0, endLine: 2 }]);
+  });
+
+  it("splits on 2+ consecutive blank lines when minBlankLines=2", () => {
+    // "abc\n\n\ndef\n\nggg"
+    // Lines: abc(0), ""(1), ""(2), def(3), ""(4), ggg(5)
+    // 2 consecutive blanks at lines 1-2 => split
+    // 1 blank at line 4 => no split
+    const result = splitParagraphs("abc\n\n\ndef\n\nggg", 2);
+    expect(result).toEqual<Paragraph[]>([
+      { text: "abc", startLine: 0, endLine: 0 },
+      { text: "def\n\nggg", startLine: 3, endLine: 5 },
+    ]);
+  });
+
+  it("returns one paragraph when minBlankLines=3 and only 2 consecutive blanks exist", () => {
+    const result = splitParagraphs("abc\n\n\ndef\n\nggg", 3);
+    expect(result).toEqual<Paragraph[]>([
+      { text: "abc\n\n\ndef\n\nggg", startLine: 0, endLine: 5 },
+    ]);
+  });
+
+  it("handles empty text", () => {
+    const result = splitParagraphs("", 2);
+    expect(result).toEqual<Paragraph[]>([]);
+  });
+
+  it("handles text with only blank lines", () => {
+    const result = splitParagraphs("\n\n\n", 2);
+    // Lines: ""(0), ""(1), ""(2), ""(3)
+    // All blank - should return empty paragraphs trimmed away or a single empty paragraph
+    expect(result).toEqual<Paragraph[]>([]);
+  });
+
+  it("handles multiple paragraph splits", () => {
+    const result = splitParagraphs("a\n\n\nb\n\n\nc", 2);
+    expect(result).toEqual<Paragraph[]>([
+      { text: "a", startLine: 0, endLine: 0 },
+      { text: "b", startLine: 3, endLine: 3 },
+      { text: "c", startLine: 6, endLine: 6 },
+    ]);
+  });
+
+  it("handles minBlankLines=1", () => {
+    const result = splitParagraphs("a\n\nb", 1);
+    expect(result).toEqual<Paragraph[]>([
+      { text: "a", startLine: 0, endLine: 0 },
+      { text: "b", startLine: 2, endLine: 2 },
+    ]);
+  });
+
+  it("trims leading/trailing blank lines from paragraphs", () => {
+    const result = splitParagraphs("\n\n\nabc\n\n\n\ndef", 2);
+    expect(result).toEqual<Paragraph[]>([
+      { text: "abc", startLine: 3, endLine: 3 },
+      { text: "def", startLine: 7, endLine: 7 },
+    ]);
+  });
+});

--- a/ui/src/lib/memo-paragraphs.ts
+++ b/ui/src/lib/memo-paragraphs.ts
@@ -1,0 +1,78 @@
+/**
+ * Represents a paragraph extracted from memo text.
+ * startLine / endLine are 0-based line indices (inclusive).
+ */
+export interface Paragraph {
+  text: string;
+  startLine: number;
+  endLine: number;
+}
+
+/**
+ * Split text into paragraphs separated by N or more consecutive blank lines.
+ *
+ * A "blank line" is a line that is empty or contains only whitespace.
+ * Leading/trailing blank lines are trimmed from each paragraph.
+ * Paragraphs that are entirely blank after trimming are discarded.
+ *
+ * @param text The full memo text
+ * @param minBlankLines Minimum number of consecutive blank lines to trigger a split (default: 2)
+ * @returns Array of Paragraph objects
+ */
+export function splitParagraphs(text: string, minBlankLines: number): Paragraph[] {
+  const lines = text.split("\n");
+
+  // Find split points: indices where minBlankLines consecutive blank lines START
+  const isBlank = (line: string) => line.trim() === "";
+
+  // Group consecutive lines into paragraphs by finding separator regions
+  const paragraphs: Paragraph[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    // Skip leading blank lines
+    if (isBlank(lines[i])) {
+      i++;
+      continue;
+    }
+
+    // Start of a paragraph
+    const start = i;
+    let end = i;
+
+    while (i < lines.length) {
+      // Check if we hit a separator (minBlankLines consecutive blanks)
+      if (isBlank(lines[i])) {
+        let blankCount = 0;
+        let j = i;
+        while (j < lines.length && isBlank(lines[j])) {
+          blankCount++;
+          j++;
+        }
+
+        if (blankCount >= minBlankLines) {
+          // This is a separator - end the paragraph before the blanks
+          break;
+        } else {
+          // Not enough blanks to be a separator - include them in the paragraph
+          end = j - 1;
+          i = j;
+        }
+      } else {
+        end = i;
+        i++;
+      }
+    }
+
+    // Extract paragraph text (from start to end inclusive)
+    const paragraphText = lines.slice(start, end + 1).join("\n");
+    paragraphs.push({ text: paragraphText, startLine: start, endLine: end });
+
+    // Skip separator blank lines
+    while (i < lines.length && isBlank(lines[i])) {
+      i++;
+    }
+  }
+
+  return paragraphs;
+}

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -131,11 +131,20 @@ export interface IssueReporterSettings {
   paddingLeft: number;
 }
 
+export interface MemoParagraphCopySettings {
+  enabled: boolean;
+  minBlankLines: number;
+}
+
 export interface MemoSettings {
   paddingTop: number;
   paddingRight: number;
   paddingBottom: number;
   paddingLeft: number;
+  /** Paragraph copy feature: show copy button on hover for paragraphs separated by N+ blank lines. */
+  paragraphCopy: MemoParagraphCopySettings;
+  /** Automatically copy selected text to clipboard (like terminal copyOnSelect). */
+  copyOnSelect: boolean;
 }
 
 export interface WorkspaceDisplaySettings {

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -145,6 +145,8 @@ export interface MemoSettings {
   paragraphCopy: MemoParagraphCopySettings;
   /** Automatically copy selected text to clipboard (like terminal copyOnSelect). */
   copyOnSelect: boolean;
+  /** Double-click to select entire paragraph (requires paragraphCopy enabled). */
+  dblClickParagraphSelect: boolean;
 }
 
 export interface WorkspaceDisplaySettings {

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -329,6 +329,7 @@ const DEFAULT_MEMO: MemoSettings = {
   paddingLeft: 8,
   paragraphCopy: { enabled: true, minBlankLines: 2 },
   copyOnSelect: false,
+  dblClickParagraphSelect: true,
 };
 
 const DEFAULT_ISSUE_REPORTER: IssueReporterSettings = {

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -322,11 +322,13 @@ interface SettingsState {
 
 const defaultPadding: PaddingSettings = { top: 8, right: 8, bottom: 8, left: 8 };
 
-const DEFAULT_MEMO_PADDING: MemoSettings = {
+const DEFAULT_MEMO: MemoSettings = {
   paddingTop: 8,
   paddingRight: 8,
   paddingBottom: 8,
   paddingLeft: 8,
+  paragraphCopy: { enabled: true, minBlankLines: 2 },
+  copyOnSelect: false,
 };
 
 const DEFAULT_ISSUE_REPORTER: IssueReporterSettings = {
@@ -673,7 +675,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   },
   workspaceDisplay: { minimap: true, environment: true, activity: true, path: true, result: true },
   claude: { syncCwd: "skip" as ClaudeSyncCwdMode, restoreSession: true, sessionMaxAgeHours: 24 },
-  memo: { ...DEFAULT_MEMO_PADDING },
+  memo: { ...DEFAULT_MEMO },
   issueReporter: { ...DEFAULT_ISSUE_REPORTER },
   syncCwdDefaults: { ...DEFAULT_SYNC_CWD_DEFAULTS },
   workspaceSortOrder: "manual" as WorkspaceSortOrder,
@@ -873,7 +875,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       : undefined;
     // Ensure memo settings have all fields (backwards compat)
     const memo = data.memo
-      ? { ...DEFAULT_MEMO_PADDING, ...(data.memo as Partial<MemoSettings>) }
+      ? { ...DEFAULT_MEMO, ...(data.memo as Partial<MemoSettings>) }
       : undefined;
     // Ensure syncCwdDefaults settings have all fields (backwards compat)
     const syncCwdDefaults = data.syncCwdDefaults


### PR DESCRIPTION
## Summary
- **단락 복사 기능**: N줄 이상 빈 줄로 구분된 단락에 마우스를 가져가면 복사 버튼이 표시되어 클릭 시 해당 단락을 클립보드에 복사 (기본 N=2, 설정 가능)
- **선택 시 자동 복사 (copyOnSelect)**: 텍스트를 드래그로 선택하면 자동으로 클립보드에 복사 (터미널의 copyOnSelect와 동일한 동작)
- 두 기능 모두 settings.json의 memo 섹션에서 켜기/끄기 가능하며, SettingsView에 UI 추가

## 변경 파일
| 파일 | 설명 |
|------|------|
| `src-tauri/src/settings.rs` | Rust 설정 타입에 memo.paragraphCopy, memo.copyOnSelect 추가 |
| `ui/src/components/views/MemoView.tsx` | 단락 복사 오버레이 및 copyOnSelect 구현 |
| `ui/src/components/views/MemoView.test.tsx` | 두 기능에 대한 테스트 추가 |
| `ui/src/components/views/SettingsView.tsx` | 메모 설정 섹션에 UI 추가 |
| `ui/src/lib/memo-paragraphs.ts` | 단락 파싱 유틸리티 |
| `ui/src/lib/memo-paragraphs.test.ts` | 단락 파싱 유틸리티 테스트 |
| `ui/src/lib/tauri-api.ts` | API 타입 정의 추가 |
| `ui/src/stores/settings-store.ts` | 설정 스토어에 memo 기본값 추가 |

## Test plan
- [ ] `npx vitest run` 프론트엔드 테스트 통과 확인
- [ ] `cargo test` 백엔드 테스트 통과 확인
- [ ] MemoView에서 빈 줄 2개 이상으로 구분된 텍스트 입력 후 단락 복사 버튼 동작 확인
- [ ] 텍스트 드래그 선택 시 자동 복사 동작 확인
- [ ] 설정에서 각 기능 켜기/끄기 동작 확인

Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)