### PR TITLE
feat: add app-wide default font and unify font settings UI

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -457,12 +457,15 @@ pub struct IssueReporterSettings {
     pub padding_bottom: u32,
     #[serde(default = "default_view_padding")]
     pub padding_left: u32,
-    /// Font family for issue reporter textarea. Empty string = inherit.
+    /// Font family override. Empty string = inherit from app_font.
     #[serde(default)]
     pub font_family: String,
-    /// Font size for issue reporter textarea.
+    /// Font size override. 0 = inherit from app_font.
     #[serde(default = "default_view_font_size")]
     pub font_size: u16,
+    /// Font weight override. Empty string = inherit from app_font.
+    #[serde(default)]
+    pub font_weight: String,
 }
 
 impl Default for IssueReporterSettings {
@@ -475,6 +478,7 @@ impl Default for IssueReporterSettings {
             padding_left: 8,
             font_family: String::new(),
             font_size: 13,
+            font_weight: String::new(),
         }
     }
 }
@@ -523,12 +527,15 @@ pub struct MemoSettings {
     /// Double-click to select entire paragraph (requires paragraph_copy enabled).
     #[serde(default = "default_true")]
     pub dbl_click_paragraph_select: bool,
-    /// Font family for memo textarea. Empty string = inherit.
+    /// Font family override. Empty string = inherit from app_font.
     #[serde(default)]
     pub font_family: String,
-    /// Font size for memo textarea.
+    /// Font size override. 0 = inherit from app_font.
     #[serde(default = "default_view_font_size")]
     pub font_size: u16,
+    /// Font weight override. Empty string = inherit from app_font.
+    #[serde(default)]
+    pub font_weight: String,
 }
 
 impl Default for MemoSettings {
@@ -543,6 +550,7 @@ impl Default for MemoSettings {
             dbl_click_paragraph_select: true,
             font_family: String::new(),
             font_size: 13,
+            font_weight: String::new(),
         }
     }
 }
@@ -606,6 +614,9 @@ pub struct Settings {
     pub keybindings: Vec<Keybinding>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font: Option<FontSettings>,
+    /// App-wide default font for non-terminal views (Memo, Issue Reporter, etc.).
+    #[serde(default)]
+    pub app_font: FontSettings,
     #[serde(default = "default_profile")]
     pub default_profile: String,
     #[serde(default)]
@@ -668,6 +679,7 @@ impl Default for Settings {
             ],
             keybindings: Vec::new(),
             font: None,
+            app_font: FontSettings::default(),
             default_profile: default_profile(),
             profile_defaults: ProfileDefaults::default(),
             view_order: Vec::new(),

--- a/src-tauri/tests/e2e_test.rs
+++ b/src-tauri/tests/e2e_test.rs
@@ -70,6 +70,11 @@ fn settings_round_trip_with_full_config() {
             },
         ],
         font: None,
+        app_font: FontSettings {
+            face: "Consolas".into(),
+            size: 15,
+            weight: "semi-bold".into(),
+        },
         default_profile: "Ubuntu".into(),
         profile_defaults: ProfileDefaults::default(),
         view_order: vec![],

--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -316,13 +316,21 @@ describe("IssueReporterView", () => {
       expect(textarea.style.fontFamily).toBe("Monaco");
     });
 
-    it("uses inherit when fontFamily is empty", () => {
+    it("inherits appFont when fontFamily/fontSize/fontWeight are empty/zero", () => {
       useSettingsStore.setState({
-        issueReporter: { ...useSettingsStore.getState().issueReporter, fontFamily: "" },
+        issueReporter: {
+          ...useSettingsStore.getState().issueReporter,
+          fontFamily: "",
+          fontSize: 0,
+          fontWeight: "",
+        },
+        appFont: { face: "Fira Code", size: 15, weight: "bold" },
       });
       render(<IssueReporterView />);
       const textarea = screen.getByTestId("issue-body") as HTMLTextAreaElement;
-      expect(textarea.style.fontFamily).toBe("inherit");
+      expect(textarea.style.fontFamily).toBe('"Fira Code"');
+      expect(textarea.style.fontSize).toBe("15px");
+      expect(textarea.style.fontWeight).toBe("bold");
     });
 
     it("applies custom fontSize from settings to textarea", () => {
@@ -334,7 +342,11 @@ describe("IssueReporterView", () => {
       expect(textarea.style.fontSize).toBe("16px");
     });
 
-    it("defaults to 13px fontSize", () => {
+    it("defaults to appFont size when fontSize is 0", () => {
+      useSettingsStore.setState({
+        issueReporter: { ...useSettingsStore.getState().issueReporter, fontSize: 0 },
+        appFont: { face: "Cascadia Mono", size: 13, weight: "normal" },
+      });
       render(<IssueReporterView />);
       const textarea = screen.getByTestId("issue-body") as HTMLTextAreaElement;
       expect(textarea.style.fontSize).toBe("13px");

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -80,6 +80,7 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
   };
 
   const ir = useSettingsStore((s) => s.issueReporter);
+  const appFont = useSettingsStore((s) => s.appFont);
 
   const fieldStyle: React.CSSProperties = {
     background: "var(--bg-base)",
@@ -223,8 +224,9 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
         style={{
           ...fieldStyle,
           minHeight: 80,
-          fontFamily: ir.fontFamily || "inherit",
-          fontSize: `${ir.fontSize || 13}px`,
+          fontFamily: ir.fontFamily || appFont.face,
+          fontSize: `${ir.fontSize || appFont.size}px`,
+          fontWeight: ir.fontWeight || appFont.weight,
         }}
       />
 

--- a/ui/src/components/views/MemoView.test.tsx
+++ b/ui/src/components/views/MemoView.test.tsx
@@ -375,16 +375,19 @@ describe("MemoView", () => {
       expect(textarea.style.fontFamily).toBe("Consolas");
     });
 
-    it("uses inherit when fontFamily is empty", async () => {
+    it("inherits appFont when fontFamily/fontSize/fontWeight are empty/zero", async () => {
       useSettingsStore.setState({
-        memo: { ...useSettingsStore.getState().memo, fontFamily: "" },
+        memo: { ...useSettingsStore.getState().memo, fontFamily: "", fontSize: 0, fontWeight: "" },
+        appFont: { face: "Fira Code", size: 15, weight: "bold" },
       });
       render(<MemoView memoKey="pane-1" />);
       await act(async () => {
         await vi.runAllTimersAsync();
       });
       const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
-      expect(textarea.style.fontFamily).toBe("inherit");
+      expect(textarea.style.fontFamily).toBe('"Fira Code"');
+      expect(textarea.style.fontSize).toBe("15px");
+      expect(textarea.style.fontWeight).toBe("bold");
     });
 
     it("applies custom fontSize from settings", async () => {
@@ -399,7 +402,11 @@ describe("MemoView", () => {
       expect(textarea.style.fontSize).toBe("18px");
     });
 
-    it("defaults to 13px fontSize", async () => {
+    it("defaults to appFont size when fontSize is 0", async () => {
+      useSettingsStore.setState({
+        memo: { ...useSettingsStore.getState().memo, fontSize: 0 },
+        appFont: { face: "Cascadia Mono", size: 13, weight: "normal" },
+      });
       render(<MemoView memoKey="pane-1" />);
       await act(async () => {
         await vi.runAllTimersAsync();

--- a/ui/src/components/views/MemoView.tsx
+++ b/ui/src/components/views/MemoView.tsx
@@ -63,6 +63,7 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
   };
 
   const memo = useSettingsStore((s) => s.memo);
+  const appFont = useSettingsStore((s) => s.appFont);
 
   // Paragraph copy feature
   const paragraphs = useMemo(() => {
@@ -74,7 +75,9 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
 
   // Paragraph hover detection via textarea mouse position
   const [hoveredParagraph, setHoveredParagraph] = useState<number | null>(null);
-  const effectiveFontSize = memo.fontSize || 13;
+  const effectiveFontSize = memo.fontSize || appFont.size;
+  const effectiveFontFamily = memo.fontFamily || appFont.face;
+  const effectiveFontWeight = memo.fontWeight || appFont.weight;
   const lineHeight = effectiveFontSize * 1.6; // fontSize * lineHeight
 
   const handleMouseMove = useCallback(
@@ -184,8 +187,9 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
           style={{
             background: "var(--bg-base)",
             color: "var(--text-primary)",
-            fontFamily: memo.fontFamily || "inherit",
+            fontFamily: effectiveFontFamily,
             fontSize: `${effectiveFontSize}px`,
+            fontWeight: effectiveFontWeight,
             lineHeight: "1.6",
             padding: `${memo.paddingTop}px ${memo.paddingRight}px ${memo.paddingBottom}px ${memo.paddingLeft}px`,
           }}

--- a/ui/src/components/views/SettingsView.test.tsx
+++ b/ui/src/components/views/SettingsView.test.tsx
@@ -41,7 +41,8 @@ describe("SettingsView", () => {
     const user = userEvent.setup();
     render(<SettingsView />);
     await user.click(screen.getByTestId("nav-profile-defaults"));
-    expect(screen.getByText("Font")).toBeInTheDocument();
+    // "Font" appears in both nav sidebar and profile defaults section
+    expect(screen.getAllByText("Font").length).toBeGreaterThanOrEqual(2);
     const input = screen.getByTestId("font-face-input") as HTMLInputElement;
     expect(input.value).toBe("Cascadia Mono");
   });
@@ -261,8 +262,8 @@ describe("SettingsView", () => {
     const tabBar = screen.getByTestId("profile-tabs");
     await user.click(within(tabBar).getByText("Additional Settings"));
 
-    // Font fields
-    expect(screen.getByText("Font")).toBeInTheDocument();
+    // Font fields (multiple "Font" text: nav sidebar + profile section)
+    expect(screen.getAllByText("Font").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByTestId("font-face-input")).toBeInTheDocument();
     // Appearance fields
     expect(screen.getByText("Cursor Shape")).toBeInTheDocument();

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -269,18 +269,43 @@ function StartupSection() {
 
 // -- Shared: Font fields (used by both Defaults and Profile) --
 
+function FontSection() {
+  const storeAppFont = useSettingsStore((s) => s.appFont);
+  const setAppFont = useSettingsStore((s) => s.setAppFont);
+  const monoFonts = useMonospacedFonts();
+  const [draftFont, setDraftFont] = useDraft("appFont", storeAppFont, setAppFont);
+
+  return (
+    <div>
+      <SectionTitle>Font</SectionTitle>
+      <p className="mb-3 text-[11px]" style={{ color: "var(--text-secondary)", opacity: 0.6 }}>
+        앱 기본 폰트. Memo, Issue Reporter 등 비터미널 뷰에서 상속됩니다. 터미널 폰트는 Profile
+        Defaults에서 설정합니다.
+      </p>
+      <FontFields
+        font={draftFont}
+        onChange={setDraftFont}
+        monoFonts={monoFonts}
+        faceDesc="Default font for non-terminal views"
+      />
+    </div>
+  );
+}
+
 function FontFields({
   font,
   onChange,
   defaults,
   showReset,
   monoFonts,
+  faceDesc,
 }: {
   font: FontSettings;
   onChange: (font: FontSettings) => void;
   defaults?: FontSettings;
   showReset?: boolean;
   monoFonts: string[];
+  faceDesc?: string;
 }) {
   const isDefault = defaults && JSON.stringify(font) === JSON.stringify(defaults);
   const resetBtn =
@@ -309,7 +334,7 @@ function FontFields({
           </h4>
           {resetBtn}
         </div>
-        <SettingRow label="Font Face" desc="Monospaced font for terminals">
+        <SettingRow label="Font Face" desc={faceDesc ?? "Monospaced font for terminals"}>
           <FocusSelect
             data-testid="font-face-input"
             value={font.face}
@@ -1531,6 +1556,8 @@ function ClaudeSection() {
 function IssueReporterSection() {
   const storeIssueReporter = useSettingsStore((s) => s.issueReporter);
   const setIssueReporter = useSettingsStore((s) => s.setIssueReporter);
+  const appFont = useSettingsStore((s) => s.appFont);
+  const monoFonts = useMonospacedFonts();
   const [issueReporter, setDraftIssueReporter] = useDraft(
     "issueReporter",
     storeIssueReporter,
@@ -1539,9 +1566,32 @@ function IssueReporterSection() {
   const updateIssueReporter = (partial: Partial<typeof issueReporter>) =>
     setDraftIssueReporter((prev) => ({ ...prev, ...partial }));
 
+  // Adapt flat fontFamily/fontSize/fontWeight to FontSettings for FontFields
+  const irFont: FontSettings = {
+    face: issueReporter.fontFamily || appFont.face,
+    size: issueReporter.fontSize || appFont.size,
+    weight: issueReporter.fontWeight || appFont.weight,
+  };
+
   return (
     <div>
       <SectionTitle>Issue Reporter</SectionTitle>
+
+      {/* Font (inherits from App Font) */}
+      <FontFields
+        font={irFont}
+        onChange={(f) => {
+          updateIssueReporter({
+            fontFamily: f.face === appFont.face ? "" : f.face,
+            fontSize: f.size === appFont.size ? 0 : f.size,
+            fontWeight: f.weight === appFont.weight ? "" : f.weight,
+          });
+        }}
+        defaults={appFont}
+        showReset
+        monoFonts={monoFonts}
+        faceDesc="비워두면 앱 기본 폰트 상속"
+      />
 
       <div style={cardStyle} className="p-4">
         <SettingRow
@@ -1554,34 +1604,6 @@ function IssueReporterSection() {
             placeholder='예: wsl.exe -d "My Distro" --'
             value={issueReporter.shell}
             onChange={(e) => updateIssueReporter({ shell: e.target.value })}
-          />
-        </SettingRow>
-
-        {/* Font */}
-        <SettingRow label="Font Family" desc="텍스트 영역의 폰트. 비워두면 기본 폰트 상속.">
-          <FocusInput
-            data-testid="issue-reporter-font-family"
-            className={inputCls}
-            placeholder="예: Consolas, monospace"
-            value={issueReporter.fontFamily}
-            onChange={(e) => updateIssueReporter({ fontFamily: e.target.value })}
-          />
-        </SettingRow>
-
-        <SettingRow label="Font Size" desc="텍스트 영역의 폰트 크기 (px). 기본값: 13">
-          <input
-            data-testid="issue-reporter-font-size"
-            type="number"
-            min={8}
-            max={32}
-            className={inputCls}
-            style={{ width: 60 }}
-            value={issueReporter.fontSize}
-            onChange={(e) =>
-              updateIssueReporter({
-                fontSize: Math.max(8, Math.min(32, Number(e.target.value) || 13)),
-              })
-            }
           />
         </SettingRow>
 
@@ -1637,43 +1659,40 @@ function IssueReporterSection() {
 function MemoSection() {
   const storeMemo = useSettingsStore((s) => s.memo);
   const setMemo = useSettingsStore((s) => s.setMemo);
+  const appFont = useSettingsStore((s) => s.appFont);
+  const monoFonts = useMonospacedFonts();
   const [memo, setDraftMemo] = useDraft("memo", storeMemo, (v) => setMemo(v));
   const updateMemo = (partial: Partial<typeof memo>) =>
     setDraftMemo((prev) => ({ ...prev, ...partial }));
+
+  // Adapt flat fontFamily/fontSize/fontWeight to FontSettings for FontFields
+  const memoFont: FontSettings = {
+    face: memo.fontFamily || appFont.face,
+    size: memo.fontSize || appFont.size,
+    weight: memo.fontWeight || appFont.weight,
+  };
 
   return (
     <div>
       <SectionTitle>Memo</SectionTitle>
 
+      {/* Font (inherits from App Font) */}
+      <FontFields
+        font={memoFont}
+        onChange={(f) => {
+          updateMemo({
+            fontFamily: f.face === appFont.face ? "" : f.face,
+            fontSize: f.size === appFont.size ? 0 : f.size,
+            fontWeight: f.weight === appFont.weight ? "" : f.weight,
+          });
+        }}
+        defaults={appFont}
+        showReset
+        monoFonts={monoFonts}
+        faceDesc="비워두면 앱 기본 폰트 상속"
+      />
+
       <div style={cardStyle} className="p-4">
-        {/* Font */}
-        <SettingRow label="Font Family" desc="메모 텍스트 영역의 폰트. 비워두면 기본 폰트 상속.">
-          <FocusInput
-            data-testid="memo-font-family"
-            className={inputCls}
-            placeholder="예: Consolas, monospace"
-            value={memo.fontFamily}
-            onChange={(e) => updateMemo({ fontFamily: e.target.value })}
-          />
-        </SettingRow>
-
-        <SettingRow label="Font Size" desc="메모 텍스트 영역의 폰트 크기 (px). 기본값: 13">
-          <input
-            data-testid="memo-font-size"
-            type="number"
-            min={8}
-            max={32}
-            className={inputCls}
-            style={{ width: 60 }}
-            value={memo.fontSize}
-            onChange={(e) =>
-              updateMemo({
-                fontSize: Math.max(8, Math.min(32, Number(e.target.value) || 13)),
-              })
-            }
-          />
-        </SettingRow>
-
         {/* Padding */}
         <div className="flex items-start gap-3 py-1.5">
           <div className="w-36 shrink-0 pt-1">
@@ -2436,6 +2455,16 @@ export function SettingsView() {
             Startup
           </button>
           <button
+            data-testid="nav-font"
+            className="w-full px-4 py-2 text-left text-[13px]"
+            style={navBtnStyle("font")}
+            onClick={() => setActiveNav("font")}
+            onMouseEnter={() => setNavHover("font")}
+            onMouseLeave={() => setNavHover(null)}
+          >
+            Font
+          </button>
+          <button
             className="w-full px-4 py-2 text-left text-[13px]"
             style={navBtnStyle("colorSchemes")}
             onClick={() => setActiveNav("colorSchemes")}
@@ -2582,6 +2611,7 @@ export function SettingsView() {
         >
           <div className="p-4 pb-14" style={{ maxWidth: 720 }}>
             {activeNav === "startup" && <StartupSection />}
+            {activeNav === "font" && <FontSection />}
             {activeNav === "defaults" && <DefaultsSection />}
             {activeNav.startsWith("profile-") && (
               <ProfileSection key={activeNav} profileIndex={parseInt(activeNav.split("-")[1])} />

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -161,6 +161,7 @@ async function persistSessionCore(): Promise<void> {
     claude: { ...settingsState.claude },
     memo: { ...settingsState.memo },
     issueReporter: { ...settingsState.issueReporter },
+    appFont: { ...settingsState.appFont },
     syncCwdDefaults: { ...settingsState.syncCwdDefaults },
     docks: dockState.docks.map((d) => ({
       position: d.position,

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -131,6 +131,7 @@ export interface IssueReporterSettings {
   paddingLeft: number;
   fontFamily: string;
   fontSize: number;
+  fontWeight: string;
 }
 
 export interface MemoParagraphCopySettings {
@@ -151,6 +152,7 @@ export interface MemoSettings {
   dblClickParagraphSelect: boolean;
   fontFamily: string;
   fontSize: number;
+  fontWeight: string;
 }
 
 export interface WorkspaceDisplaySettings {
@@ -183,6 +185,7 @@ export interface Settings {
   profiles: Profile[];
   keybindings: Keybinding[];
   font?: FontSettings;
+  appFont?: FontSettings;
   defaultProfile: string;
   profileDefaults?: ProfileDefaults;
   syncCwdDefaults?: SyncCwdDefaults;

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -268,6 +268,7 @@ interface SettingsState {
   claude: ClaudeSettings;
   memo: MemoSettings;
   issueReporter: IssueReporterSettings;
+  appFont: FontSettings;
   syncCwdDefaults: SyncCwdDefaults;
   workspaceSortOrder: WorkspaceSortOrder;
 
@@ -279,6 +280,7 @@ interface SettingsState {
   setClaude: (data: Partial<ClaudeSettings>) => void;
   setMemo: (data: Partial<MemoSettings>) => void;
   setIssueReporter: (data: Partial<IssueReporterSettings>) => void;
+  setAppFont: (font: FontSettings) => void;
   setWorkspaceSortOrder: (order: WorkspaceSortOrder) => void;
   setProfileDefaults: (data: Partial<ProfileDefaults>) => void;
   setSyncCwdDefaults: (data: Partial<SyncCwdDefaults>) => void;
@@ -313,6 +315,7 @@ interface SettingsState {
         | "claude"
         | "memo"
         | "issueReporter"
+        | "appFont"
         | "syncCwdDefaults"
         | "workspaceSortOrder"
       >
@@ -332,6 +335,7 @@ const DEFAULT_MEMO: MemoSettings = {
   dblClickParagraphSelect: true,
   fontFamily: "",
   fontSize: 13,
+  fontWeight: "",
 };
 
 const DEFAULT_ISSUE_REPORTER: IssueReporterSettings = {
@@ -342,9 +346,13 @@ const DEFAULT_ISSUE_REPORTER: IssueReporterSettings = {
   paddingLeft: 8,
   fontFamily: "",
   fontSize: 13,
+  fontWeight: "",
 };
 
 export const DEFAULT_FONT: FontSettings = { face: "Cascadia Mono", size: 14, weight: "normal" };
+
+/** Default app font for non-terminal views (Memo, Issue Reporter, etc.). */
+export const DEFAULT_APP_FONT: FontSettings = { face: "Cascadia Mono", size: 13, weight: "normal" };
 
 /** Fallback profile name when defaultProfile is unset. */
 export const FALLBACK_PROFILE = "PowerShell";
@@ -682,6 +690,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   claude: { syncCwd: "skip" as ClaudeSyncCwdMode, restoreSession: true, sessionMaxAgeHours: 24 },
   memo: { ...DEFAULT_MEMO },
   issueReporter: { ...DEFAULT_ISSUE_REPORTER },
+  appFont: { ...DEFAULT_APP_FONT },
   syncCwdDefaults: { ...DEFAULT_SYNC_CWD_DEFAULTS },
   workspaceSortOrder: "manual" as WorkspaceSortOrder,
 
@@ -711,6 +720,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     set((state) => ({
       issueReporter: { ...state.issueReporter, ...data },
     })),
+
+  setAppFont: (font) => set({ appFont: font }),
 
   setWorkspaceSortOrder: (order) => set({ workspaceSortOrder: order }),
 
@@ -874,6 +885,10 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
           ...(data.claude as Partial<ClaudeSettings>),
         }
       : undefined;
+    // Ensure appFont has all fields (backwards compat)
+    const appFont = data.appFont
+      ? { ...DEFAULT_APP_FONT, ...data.appFont, weight: data.appFont.weight ?? "normal" }
+      : undefined;
     // Ensure issueReporter settings have all required fields with defaults
     const issueReporter = data.issueReporter
       ? { ...DEFAULT_ISSUE_REPORTER, ...(data.issueReporter as Partial<IssueReporterSettings>) }
@@ -911,6 +926,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       ...(claude ? { claude } : {}),
       ...(issueReporter ? { issueReporter } : {}),
       ...(memo ? { memo } : {}),
+      ...(appFont ? { appFont } : {}),
       ...(syncCwdDefaults ? { syncCwdDefaults } : {}),
     }));
   },


### PR DESCRIPTION
## Summary
- Settings에 **Font** 메뉴 추가 — 앱 전역 기본 폰트(`appFont`) 설정
- MemoView/IssueReporterView가 자체 폰트 미설정 시 `appFont`에서 상속
- Memo/IssueReporter의 폰트 설정 UI를 Profile과 동일한 `FontFields` 컴포넌트로 통일 (드롭다운 폰트 선택, weight, Reset 버튼)

## Test plan
- [x] Rust e2e 테스트 통과 (56개)
- [x] 프론트엔드 단위 테스트 통과 (1234개)
- [x] TypeScript 타입 체크 통과
- [x] 빌드 성공
- [x] dev 인스턴스 스크린샷 검증: Font/Memo/IssueReporter 섹션 UI 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)