### PR TITLE
fix: arm NotifyGate with fallback timer for PowerShell (#119)

### DIFF
--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -62,6 +62,7 @@ function resolveWorkspaceId(terminalId: string): string {
 // Multiple simultaneous WebGL inits can trigger ACCESS_VIOLATION in msedge.dll.
 let webglInitCount = 0;
 const WEBGL_STAGGER_MS = 150;
+const NOTIFY_GATE_FALLBACK_MS = 3000;
 
 /** Reset the stagger counter (for tests). */
 export function _resetWebglStagger(): void {
@@ -299,7 +300,7 @@ export function TerminalView({
     notifyGate.fallbackTimer = setTimeout(() => {
       notifyGate.armed = true;
       notifyGate.fallbackTimer = undefined;
-    }, 3000);
+    }, NOTIFY_GATE_FALLBACK_MS);
 
     // Build hooks list
     const hooks: OscHook[] = [

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -293,7 +293,13 @@ export function TerminalView({
     // Gate notifications until the first user command is observed (OSC 133;C/E).
     // Shell-init OSC 133;D sequences arrive before any C/E, so they are
     // suppressed automatically without an arbitrary timeout (see issue #111).
+    // Fallback timer arms the gate after 3s for shells without preexec (e.g.
+    // PowerShell which doesn't emit OSC 133;C/E). See issue #119.
     const notifyGate: NotifyGate = { armed: false };
+    notifyGate.fallbackTimer = setTimeout(() => {
+      notifyGate.armed = true;
+      notifyGate.fallbackTimer = undefined;
+    }, 3000);
 
     // Build hooks list
     const hooks: OscHook[] = [
@@ -596,6 +602,7 @@ export function TerminalView({
     return () => {
       cancelled = true;
       if (webglTimer !== undefined) clearTimeout(webglTimer);
+      if (notifyGate.fallbackTimer !== undefined) clearTimeout(notifyGate.fallbackTimer);
       idleDetector.dispose();
       resizeObserver.disconnect();
       outerContainer?.removeEventListener("contextmenu", handleContextMenu);

--- a/ui/src/hooks/useOscHooks.test.ts
+++ b/ui/src/hooks/useOscHooks.test.ts
@@ -265,6 +265,21 @@ describe("processOscInOutput", () => {
     expect(calls.some((c: { action: string }) => c.action === "notify")).toBe(true);
   });
 
+  it("clears fallbackTimer when OSC 133;C arms the gate", () => {
+    const hooks: OscHook[] = [
+      { osc: 133, param: "C", run: "lx set-command-status --command __preexec__" },
+    ];
+    const timer = setTimeout(() => {}, 10000);
+    const gate: { armed: boolean; fallbackTimer?: ReturnType<typeof setTimeout> } = {
+      armed: false,
+      fallbackTimer: timer,
+    };
+
+    processOscInOutput("\x1b]133;C\x07", hooks, "t1", "g1", { notifyGate: gate });
+    expect(gate.armed).toBe(true);
+    expect(gate.fallbackTimer).toBeUndefined();
+  });
+
   it("handles OSC 133 C (preexec) → set-command-status with command", () => {
     const preexecHooks: OscHook[] = [
       { osc: 133, param: "C", run: "lx set-command-status --command __preexec__" },

--- a/ui/src/hooks/useOscHooks.ts
+++ b/ui/src/hooks/useOscHooks.ts
@@ -42,6 +42,10 @@ export function processOscInOutput(
       (event.param === "C" || event.param === "E")
     ) {
       options.notifyGate.armed = true;
+      if (options.notifyGate.fallbackTimer !== undefined) {
+        clearTimeout(options.notifyGate.fallbackTimer);
+        options.notifyGate.fallbackTimer = undefined;
+      }
     }
 
     const matched = matchHook(hooks, event);
@@ -98,10 +102,13 @@ export function processOscInOutput(
 
 /**
  * Mutable gate object: notify actions are suppressed until `armed` becomes true.
- * OSC 133;C/E (user command execution) arms the gate automatically.
+ * Armed by either:
+ * - OSC 133;C/E (user command execution) — immediate, cancels fallback timer
+ * - Fallback timer — for shells without preexec (e.g. PowerShell)
  */
 export interface NotifyGate {
   armed: boolean;
+  fallbackTimer?: ReturnType<typeof setTimeout>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- PowerShell 셸 통합은 OSC 133;C/E(preexec)를 발행하지 않아 NotifyGate가 영원히 unarmed 상태로 남아 모든 알림이 차단되는 버그 수정
- 3초 fallback 타이머를 추가하여 C/E 없이도 gate가 자동 arm되도록 변경
- Bash/WSL은 기존대로 C/E 수신 시 즉시 arm (타이머 취소)

## Test plan
- [x] 기존 테스트 1235개 전체 통과
- [x] fallbackTimer 클리어 테스트 추가
- [ ] PowerShell 터미널에서 Claude Code 작업 완료 시 알림 발생 확인
- [ ] WSL 터미널에서 기존 동작 유지 확인
- [ ] 셸 시작 직후 3초 이내 거짓 알림 없음 확인 (#111 회귀 없음)

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)