### PR TITLE
refactor: View 구조 표준화 — ControlBar + ViewHeader 통합

### DIFF
--- a/ui/src/components/layout/PaneControlBar.integration.test.tsx
+++ b/ui/src/components/layout/PaneControlBar.integration.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/persist-session", () => ({
+  persistSession: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/tauri-api", () => ({
+  createTerminalSession: vi.fn().mockResolvedValue(undefined),
+  writeToTerminal: vi.fn().mockResolvedValue(undefined),
+  resizeTerminal: vi.fn().mockResolvedValue(undefined),
+  closeTerminalSession: vi.fn().mockResolvedValue(undefined),
+  onTerminalOutput: vi.fn().mockResolvedValue(() => {}),
+  loadSettings: vi.fn().mockResolvedValue({}),
+  saveSettings: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { PaneControlBar } from "./PaneControlBar";
+import { ViewHeader } from "@/components/ui/ViewHeader";
+import { useSettingsStore } from "@/stores/settings-store";
+
+/**
+ * PaneControlBar + ViewHeader 통합 테스트.
+ * ViewHeader가 children 내부에 있을 때 PaneControlBar의 자체 바가 숨겨지고,
+ * ViewHeader에 pane 제어가 통합되는지 검증한다.
+ */
+describe("PaneControlBar + ViewHeader integration", () => {
+  const defaultView = { type: "TerminalView" as const, profile: "PowerShell" };
+  const defaultActions = {
+    onSplitH: vi.fn(),
+    onSplitV: vi.fn(),
+    onClear: vi.fn(),
+    onChangeView: vi.fn(),
+  };
+
+  beforeEach(() => {
+    useSettingsStore.setState(useSettingsStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  it("suppresses PaneControlBar own bar when ViewHeader exists (pinned mode)", async () => {
+    const user = userEvent.setup();
+    render(
+      <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
+        <ViewHeader testId="view-header">My View</ViewHeader>
+        <div>body</div>
+      </PaneControlBar>,
+    );
+    // Pin the control bar
+    await user.click(screen.getByTestId("pane-control-pin"));
+    // PaneControlBar의 자체 pinned 바는 숨겨져야 함
+    expect(screen.queryByTestId("pane-control-bar")).not.toBeInTheDocument();
+    // ViewHeader 내부에 pane 제어가 표시됨
+    expect(screen.getByTestId("pane-control-bar-content")).toBeInTheDocument();
+    // View 콘텐츠도 표시됨
+    expect(screen.getByText("My View")).toBeInTheDocument();
+  });
+
+  it("shows pane controls in ViewHeader on hover", () => {
+    render(
+      <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
+        <ViewHeader testId="view-header">Title</ViewHeader>
+        <div>body</div>
+      </PaneControlBar>,
+    );
+    // hover 모드 + hovered=true → ViewHeader에 pane 제어 표시
+    expect(screen.getByTestId("pane-control-bar-content")).toBeInTheDocument();
+    // PaneControlBar 자체 hover overlay는 없음
+    expect(screen.queryByTestId("pane-control-bar")).not.toBeInTheDocument();
+  });
+
+  it("hides pane controls in ViewHeader when not hovered", () => {
+    render(
+      <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={false}>
+        <ViewHeader testId="view-header">Title</ViewHeader>
+        <div>body</div>
+      </PaneControlBar>,
+    );
+    expect(screen.queryByTestId("pane-control-bar-content")).not.toBeInTheDocument();
+    expect(screen.getByText("Title")).toBeInTheDocument();
+  });
+
+  it("shows minimized button in ViewHeader when minimized + hovered", async () => {
+    const user = userEvent.setup();
+    render(
+      <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
+        <ViewHeader testId="view-header">Title</ViewHeader>
+        <div>body</div>
+      </PaneControlBar>,
+    );
+    // Minimize: click minimize button from hover bar controls
+    await user.click(screen.getByTestId("pane-control-minimize"));
+    // ViewHeader 안에 ⋯ 버튼이 표시됨
+    expect(screen.getByTestId("pane-control-menu-btn")).toBeInTheDocument();
+    // PaneControlBar 자체 MinimizedButton은 없음 (ViewHeader가 대신 처리)
+    expect(screen.getByText("Title")).toBeInTheDocument();
+  });
+
+  it("without ViewHeader, PaneControlBar works as before", () => {
+    render(
+      <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
+        <div>no header view</div>
+      </PaneControlBar>,
+    );
+    // 기존 동작: hover 모드 자체 바 표시
+    expect(screen.getByTestId("pane-control-bar")).toBeInTheDocument();
+  });
+
+  it("pane control buttons in ViewHeader are functional", async () => {
+    const user = userEvent.setup();
+    render(
+      <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
+        <ViewHeader>Title</ViewHeader>
+        <div>body</div>
+      </PaneControlBar>,
+    );
+    // ViewHeader 내부의 split 버튼 클릭
+    await user.click(screen.getByTestId("pane-control-split-h"));
+    expect(defaultActions.onSplitH).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -383,7 +383,8 @@ export function PaneControlBar({ currentView, actions, hovered, children }: Pane
     () => (
       <BarContent currentView={currentView} actions={actions} mode={mode} onSetMode={setMode} />
     ),
-    [currentView, actions, mode],
+    // setMode는 useState setter라 참조 안정적이지만 exhaustive-deps 일관성 위해 포함
+    [currentView, actions, mode, setMode],
   );
 
   const registerHeader = useCallback(() => setHasViewHeader(true), []);
@@ -398,7 +399,7 @@ export function PaneControlBar({ currentView, actions, hovered, children }: Pane
       registerHeader,
       unregisterHeader,
     }),
-    [paneControls, mode, hovered, registerHeader, unregisterHeader],
+    [paneControls, mode, hovered, setMode, registerHeader, unregisterHeader],
   );
 
   return (

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { useSettingsStore } from "@/stores/settings-store";
 import type { ViewInstanceConfig, ViewType } from "@/stores/types";
 import { PaneControlContext } from "./PaneControlContext";
@@ -386,16 +386,19 @@ export function PaneControlBar({ currentView, actions, hovered, children }: Pane
     [currentView, actions, mode],
   );
 
+  const registerHeader = useCallback(() => setHasViewHeader(true), []);
+  const unregisterHeader = useCallback(() => setHasViewHeader(false), []);
+
   const ctxValue = useMemo(
     () => ({
       paneControls,
       mode,
       hovered,
       onSetMode: setMode,
-      registerHeader: () => setHasViewHeader(true),
-      unregisterHeader: () => setHasViewHeader(false),
+      registerHeader,
+      unregisterHeader,
     }),
-    [paneControls, mode, hovered],
+    [paneControls, mode, hovered, registerHeader, unregisterHeader],
   );
 
   return (

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useSettingsStore } from "@/stores/settings-store";
 import type { ViewInstanceConfig, ViewType } from "@/stores/types";
+import { PaneControlContext } from "./PaneControlContext";
 
 /**
  * 컨트롤 바 표시 모드. 각 모드는 독립적이며 서브 상태를 갖지 않는다.
@@ -365,6 +366,7 @@ function MinimizedButton({ onExpand }: { onExpand: () => void }) {
 // ─── Main component ─────────────────────────────────────
 export function PaneControlBar({ currentView, actions, hovered, children }: PaneControlBarProps) {
   const [mode, setMode] = useState<ControlBarMode>("hover");
+  const [hasViewHeader, setHasViewHeader] = useState(false);
   const showBar = mode === "pinned" || (mode === "hover" && hovered);
   const isPinned = mode === "pinned";
 
@@ -377,38 +379,36 @@ export function PaneControlBar({ currentView, actions, hovered, children }: Pane
         ? "pane-control-pinned"
         : "pane-control-hover";
 
+  const paneControls = useMemo(
+    () => (
+      <BarContent currentView={currentView} actions={actions} mode={mode} onSetMode={setMode} />
+    ),
+    [currentView, actions, mode],
+  );
+
+  const ctxValue = useMemo(
+    () => ({
+      paneControls,
+      mode,
+      hovered,
+      onSetMode: setMode,
+      registerHeader: () => setHasViewHeader(true),
+      unregisterHeader: () => setHasViewHeader(false),
+    }),
+    [paneControls, mode, hovered],
+  );
+
   return (
-    <div className="flex h-full w-full flex-col" data-testid={modeTestId}>
-      {/* Pinned bar: 상단에 고정, 공간 차지 */}
-      {isPinned && (
-        <div
-          data-testid="pane-control-bar"
-          className="ui-toolbar shrink-0"
-          style={{
-            background: barBg,
-            borderBottom: `1px solid ${borderClr}`,
-          }}
-        >
-          <BarContent currentView={currentView} actions={actions} mode={mode} onSetMode={setMode} />
-        </div>
-      )}
-
-      {/* children은 항상 이 위치에 렌더링 — 모드 전환으로 리마운트되지 않음 */}
-      <div className="relative min-h-0 flex-1">
-        {children}
-
-        {/* Hover bar: absolute overlay */}
-        {!isPinned && mode !== "minimized" && showBar && (
+    <PaneControlContext.Provider value={ctxValue}>
+      <div className="flex h-full w-full flex-col" data-testid={modeTestId}>
+        {/* Pinned bar: ViewHeader가 없는 View만 자체 바 렌더 */}
+        {isPinned && !hasViewHeader && (
           <div
             data-testid="pane-control-bar"
-            className="absolute right-1 top-1 z-20 flex items-center"
+            className="ui-toolbar shrink-0"
             style={{
-              height: BAR_H,
-              background: barBgHover,
-              backdropFilter: "blur(8px)",
-              borderBottom: `1px solid ${sepClr}`,
-              borderLeft: `1px solid ${sepClr}`,
-              borderRadius: "0 0 0 var(--radius-lg)",
+              background: barBg,
+              borderBottom: `1px solid ${borderClr}`,
             }}
           >
             <BarContent
@@ -420,9 +420,39 @@ export function PaneControlBar({ currentView, actions, hovered, children }: Pane
           </div>
         )}
 
-        {/* Minimized: 3-dot 버튼만 표시. 클릭하면 hover 모드로 복귀. */}
-        {mode === "minimized" && hovered && <MinimizedButton onExpand={() => setMode("hover")} />}
+        {/* children은 항상 이 위치에 렌더링 — 모드 전환으로 리마운트되지 않음 */}
+        <div className="relative min-h-0 flex-1">
+          {children}
+
+          {/* Hover bar: ViewHeader가 없는 View만 overlay */}
+          {!isPinned && !hasViewHeader && mode !== "minimized" && showBar && (
+            <div
+              data-testid="pane-control-bar"
+              className="absolute right-1 top-1 z-20 flex items-center"
+              style={{
+                height: BAR_H,
+                background: barBgHover,
+                backdropFilter: "blur(8px)",
+                borderBottom: `1px solid ${sepClr}`,
+                borderLeft: `1px solid ${sepClr}`,
+                borderRadius: "0 0 0 var(--radius-lg)",
+              }}
+            >
+              <BarContent
+                currentView={currentView}
+                actions={actions}
+                mode={mode}
+                onSetMode={setMode}
+              />
+            </div>
+          )}
+
+          {/* Minimized: ViewHeader가 없는 View만 3-dot 버튼 */}
+          {mode === "minimized" && !hasViewHeader && hovered && (
+            <MinimizedButton onExpand={() => setMode("hover")} />
+          )}
+        </div>
       </div>
-    </div>
+    </PaneControlContext.Provider>
   );
 }

--- a/ui/src/components/layout/PaneControlContext.tsx
+++ b/ui/src/components/layout/PaneControlContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext, type ReactNode } from "react";
+import type { ControlBarMode } from "./PaneControlBar";
+
+export interface PaneControlContextValue {
+  /** BarContent 렌더 결과 (split, delete, view selector 등) */
+  paneControls: ReactNode;
+  /** 현재 컨트롤 바 모드 */
+  mode: ControlBarMode;
+  /** Pane이 hover 상태인지 */
+  hovered: boolean;
+  /** 모드 변경 */
+  onSetMode: (m: ControlBarMode) => void;
+  /** ViewHeader가 마운트되면 호출 — PaneControlBar 자체 바 렌더 억제 */
+  registerHeader: () => void;
+  /** ViewHeader가 언마운트되면 호출 */
+  unregisterHeader: () => void;
+}
+
+export const PaneControlContext = createContext<PaneControlContextValue | null>(null);
+
+export function usePaneControl(): PaneControlContextValue | null {
+  return useContext(PaneControlContext);
+}

--- a/ui/src/components/ui/ViewBody.tsx
+++ b/ui/src/components/ui/ViewBody.tsx
@@ -1,0 +1,33 @@
+import { forwardRef } from "react";
+
+type ViewBodyVariant = "scroll" | "full";
+
+interface ViewBodyProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  /** "scroll": flex-1 + overflow-auto (기본), "full": relative + flex-1 (터미널/에디터용) */
+  variant?: ViewBodyVariant;
+  testId?: string;
+}
+
+const variantClasses: Record<ViewBodyVariant, string> = {
+  scroll: "flex-1 overflow-auto",
+  full: "relative flex-1",
+};
+
+/** View 본문 영역. variant에 따라 스크롤 또는 전체 채움 모드를 제공한다. */
+export const ViewBody = forwardRef<HTMLDivElement, ViewBodyProps>(
+  ({ children, variant = "scroll", className, testId, ...rest }, ref) => {
+    return (
+      <div
+        ref={ref}
+        data-testid={testId}
+        className={`${variantClasses[variant]} ${className ?? ""}`.trim()}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+ViewBody.displayName = "ViewBody";

--- a/ui/src/components/ui/ViewHeader.test.tsx
+++ b/ui/src/components/ui/ViewHeader.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { ViewHeader } from "./ViewHeader";
+import {
+  PaneControlContext,
+  type PaneControlContextValue,
+} from "@/components/layout/PaneControlContext";
+
+function makeCtx(overrides: Partial<PaneControlContextValue> = {}): PaneControlContextValue {
+  return {
+    paneControls: <div data-testid="mock-pane-controls">controls</div>,
+    mode: "hover",
+    hovered: false,
+    onSetMode: vi.fn(),
+    registerHeader: vi.fn(),
+    unregisterHeader: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderWithCtx(ctx: PaneControlContextValue, ui: React.ReactElement) {
+  return render(<PaneControlContext.Provider value={ctx}>{ui}</PaneControlContext.Provider>);
+}
+
+describe("ViewHeader with PaneControlContext", () => {
+  it("calls registerHeader on mount and unregisterHeader on unmount", () => {
+    const ctx = makeCtx();
+    const { unmount } = renderWithCtx(ctx, <ViewHeader>Title</ViewHeader>);
+    expect(ctx.registerHeader).toHaveBeenCalledOnce();
+    unmount();
+    expect(ctx.unregisterHeader).toHaveBeenCalledOnce();
+  });
+
+  it("shows pane controls when pinned", () => {
+    const ctx = makeCtx({ mode: "pinned" });
+    renderWithCtx(ctx, <ViewHeader testId="header">Title</ViewHeader>);
+    expect(screen.getByTestId("mock-pane-controls")).toBeInTheDocument();
+  });
+
+  it("shows pane controls when hover + hovered", () => {
+    const ctx = makeCtx({ mode: "hover", hovered: true });
+    renderWithCtx(ctx, <ViewHeader>Title</ViewHeader>);
+    expect(screen.getByTestId("mock-pane-controls")).toBeInTheDocument();
+  });
+
+  it("hides pane controls when hover + not hovered", () => {
+    const ctx = makeCtx({ mode: "hover", hovered: false });
+    renderWithCtx(ctx, <ViewHeader>Title</ViewHeader>);
+    expect(screen.queryByTestId("mock-pane-controls")).not.toBeInTheDocument();
+  });
+
+  it("shows minimized button when minimized + hovered", () => {
+    const ctx = makeCtx({ mode: "minimized", hovered: true });
+    renderWithCtx(ctx, <ViewHeader>Title</ViewHeader>);
+    expect(screen.getByTestId("pane-control-menu-btn")).toBeInTheDocument();
+    expect(screen.queryByTestId("mock-pane-controls")).not.toBeInTheDocument();
+  });
+
+  it("hides minimized button when minimized + not hovered", () => {
+    const ctx = makeCtx({ mode: "minimized", hovered: false });
+    renderWithCtx(ctx, <ViewHeader>Title</ViewHeader>);
+    expect(screen.queryByTestId("pane-control-menu-btn")).not.toBeInTheDocument();
+  });
+
+  it("clicking minimized button calls onSetMode('hover')", async () => {
+    const user = userEvent.setup();
+    const ctx = makeCtx({ mode: "minimized", hovered: true });
+    renderWithCtx(ctx, <ViewHeader>Title</ViewHeader>);
+    await user.click(screen.getByTestId("pane-control-menu-btn"));
+    expect(ctx.onSetMode).toHaveBeenCalledWith("hover");
+  });
+
+  it("always renders view content regardless of mode", () => {
+    const ctx = makeCtx({ mode: "minimized", hovered: false });
+    renderWithCtx(ctx, <ViewHeader>My View Title</ViewHeader>);
+    expect(screen.getByText("My View Title")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ui/ViewHeader.tsx
+++ b/ui/src/components/ui/ViewHeader.tsx
@@ -1,0 +1,76 @@
+import { useEffect } from "react";
+import { usePaneControl } from "@/components/layout/PaneControlContext";
+
+interface ViewHeaderProps {
+  children: React.ReactNode;
+  className?: string;
+  borderBottom?: boolean;
+  testId?: string;
+}
+
+/**
+ * View 통합 헤더.
+ *
+ * PaneControlContext가 있으면:
+ * - pinned / hover+hovered: View 콘텐츠 + pane 제어를 한 줄에 표시
+ * - hover+!hovered / minimized+!hovered: View 콘텐츠만 표시
+ * - minimized+hovered: View 콘텐츠 + ⋯ 버튼
+ *
+ * Context 없이도 독립적으로 동작한다 (Dock 등).
+ */
+export function ViewHeader({ children, className, borderBottom = true, testId }: ViewHeaderProps) {
+  const ctx = usePaneControl();
+
+  // PaneControlBar에 "ViewHeader가 존재함"을 알린다.
+  useEffect(() => {
+    ctx?.registerHeader();
+    return () => ctx?.unregisterHeader();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const showPaneControls = ctx && (ctx.mode === "pinned" || (ctx.mode === "hover" && ctx.hovered));
+  const showMinimizedBtn = ctx && ctx.mode === "minimized" && ctx.hovered;
+
+  return (
+    <div
+      data-testid={testId}
+      className={`ui-toolbar shrink-0 ${className ?? ""}`.trim()}
+      style={{
+        background: "var(--bg-surface)",
+        ...(borderBottom ? { borderBottom: "1px solid var(--border)" } : {}),
+      }}
+    >
+      <div className="flex min-w-0 flex-1 items-center">{children}</div>
+      {showPaneControls && (
+        <div data-testid="pane-control-bar-content" onClick={(e) => e.stopPropagation()}>
+          {ctx.paneControls}
+        </div>
+      )}
+      {showMinimizedBtn && (
+        <button
+          data-testid="pane-control-menu-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            ctx.onSetMode("hover");
+          }}
+          className="hover-bg-strong flex shrink-0 cursor-pointer items-center justify-center rounded"
+          style={{
+            width: "var(--btn-min-w)",
+            height: "var(--btn-min-w)",
+            color: "var(--text-secondary)",
+            border: "none",
+            borderRadius: "var(--radius-sm)",
+            transition: "background var(--transition-fast)",
+          }}
+          title="Expand control bar"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
+            <circle cx="3" cy="6" r="1" />
+            <circle cx="6" cy="6" r="1" />
+            <circle cx="9" cy="6" r="1" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/ui/ViewHeader.tsx
+++ b/ui/src/components/ui/ViewHeader.tsx
@@ -20,13 +20,14 @@ interface ViewHeaderProps {
  */
 export function ViewHeader({ children, className, borderBottom = true, testId }: ViewHeaderProps) {
   const ctx = usePaneControl();
+  const registerHeader = ctx?.registerHeader;
+  const unregisterHeader = ctx?.unregisterHeader;
 
   // PaneControlBar에 "ViewHeader가 존재함"을 알린다.
   useEffect(() => {
-    ctx?.registerHeader();
-    return () => ctx?.unregisterHeader();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    registerHeader?.();
+    return () => unregisterHeader?.();
+  }, [registerHeader, unregisterHeader]);
 
   const showPaneControls = ctx && (ctx.mode === "pinned" || (ctx.mode === "hover" && ctx.hovered));
   const showMinimizedBtn = ctx && ctx.mode === "minimized" && ctx.hovered;

--- a/ui/src/components/ui/ViewShell.test.tsx
+++ b/ui/src/components/ui/ViewShell.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ViewShell } from "./ViewShell";
+import { ViewBody } from "./ViewBody";
+import { ViewHeader } from "./ViewHeader";
+
+describe("ViewShell", () => {
+  it("renders children", () => {
+    render(
+      <ViewShell>
+        <div data-testid="child">hello</div>
+      </ViewShell>,
+    );
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("applies testId as data-testid", () => {
+    render(<ViewShell testId="my-view">content</ViewShell>);
+    expect(screen.getByTestId("my-view")).toBeInTheDocument();
+  });
+
+  it("has flex column layout classes", () => {
+    render(<ViewShell testId="shell">content</ViewShell>);
+    const el = screen.getByTestId("shell");
+    expect(el.className).toContain("flex");
+    expect(el.className).toContain("flex-col");
+    expect(el.className).toContain("h-full");
+    expect(el.className).toContain("w-full");
+  });
+
+  it("passes extra className", () => {
+    render(
+      <ViewShell testId="shell" className="extra">
+        content
+      </ViewShell>,
+    );
+    expect(screen.getByTestId("shell").className).toContain("extra");
+  });
+
+  it("passes style prop", () => {
+    render(
+      <ViewShell testId="shell" style={{ outline: "none" }}>
+        content
+      </ViewShell>,
+    );
+    expect(screen.getByTestId("shell").style.outline).toBe("none");
+  });
+});
+
+describe("ViewBody", () => {
+  it("renders children", () => {
+    render(
+      <ViewBody>
+        <div data-testid="body-child">content</div>
+      </ViewBody>,
+    );
+    expect(screen.getByTestId("body-child")).toBeInTheDocument();
+  });
+
+  it('default variant "scroll" has flex-1 and overflow-auto', () => {
+    render(<ViewBody testId="body">content</ViewBody>);
+    const el = screen.getByTestId("body");
+    expect(el.className).toContain("flex-1");
+    expect(el.className).toContain("overflow-auto");
+  });
+
+  it('variant "full" has relative flex-1 without overflow-auto', () => {
+    render(
+      <ViewBody testId="body" variant="full">
+        content
+      </ViewBody>,
+    );
+    const el = screen.getByTestId("body");
+    expect(el.className).toContain("flex-1");
+    expect(el.className).toContain("relative");
+    expect(el.className).not.toContain("overflow-auto");
+  });
+
+  it("passes className and style", () => {
+    render(
+      <ViewBody testId="body" className="p-4" style={{ color: "red" }}>
+        content
+      </ViewBody>,
+    );
+    const el = screen.getByTestId("body");
+    expect(el.className).toContain("p-4");
+    expect(el.style.color).toBe("red");
+  });
+});
+
+describe("ViewHeader", () => {
+  it("renders children", () => {
+    render(<ViewHeader>My Title</ViewHeader>);
+    expect(screen.getByText("My Title")).toBeInTheDocument();
+  });
+
+  it("uses ui-toolbar class", () => {
+    render(<ViewHeader testId="header">Title</ViewHeader>);
+    const el = screen.getByTestId("header");
+    expect(el.className).toContain("ui-toolbar");
+    expect(el.className).toContain("shrink-0");
+  });
+
+  it("has default border-bottom", () => {
+    render(<ViewHeader testId="header">Title</ViewHeader>);
+    const el = screen.getByTestId("header");
+    expect(el.style.borderBottom).toContain("1px solid");
+  });
+
+  it("borderBottom=false removes border", () => {
+    render(
+      <ViewHeader testId="header" borderBottom={false}>
+        Title
+      </ViewHeader>,
+    );
+    const el = screen.getByTestId("header");
+    expect(el.style.borderBottom).toBe("");
+  });
+
+  it("passes extra className", () => {
+    render(
+      <ViewHeader testId="header" className="px-1">
+        Title
+      </ViewHeader>,
+    );
+    expect(screen.getByTestId("header").className).toContain("px-1");
+  });
+
+  it("works standalone without PaneControlContext", () => {
+    render(<ViewHeader testId="header">Standalone</ViewHeader>);
+    // No pane controls should appear — just the children
+    expect(screen.getByText("Standalone")).toBeInTheDocument();
+    expect(screen.queryByTestId("pane-control-bar-content")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ui/ViewShell.tsx
+++ b/ui/src/components/ui/ViewShell.tsx
@@ -1,0 +1,24 @@
+import { forwardRef } from "react";
+
+interface ViewShellProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  testId?: string;
+}
+
+/** 모든 View의 최외곽 구조 컨테이너. flex column 레이아웃을 제공한다. */
+export const ViewShell = forwardRef<HTMLDivElement, ViewShellProps>(
+  ({ children, testId, className, ...rest }, ref) => {
+    return (
+      <div
+        ref={ref}
+        data-testid={testId}
+        className={`flex h-full w-full flex-col ${className ?? ""}`.trim()}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+ViewShell.displayName = "ViewShell";

--- a/ui/src/components/views/FileExplorerView.tsx
+++ b/ui/src/components/views/FileExplorerView.tsx
@@ -12,6 +12,9 @@ import {
 // convertFileSrc no longer needed — images are returned as data URLs
 import { shellEscape, joinPath, parentPath } from "@/lib/file-explorer-parse";
 import { TerminalView } from "./TerminalView";
+import { ViewShell } from "@/components/ui/ViewShell";
+import { ViewHeader } from "@/components/ui/ViewHeader";
+import { ViewBody } from "@/components/ui/ViewBody";
 
 export interface FileExplorerViewProps {
   instanceId: string;
@@ -528,25 +531,15 @@ export function FileExplorerView({
 
   if (mode.type === "viewing") {
     return (
-      <div
+      <ViewShell
+        testId="file-explorer-view"
+        className="outline-none"
         ref={containerRef}
-        data-testid="file-explorer-view"
-        className="flex h-full w-full flex-col"
         tabIndex={-1}
-        style={{ outline: "none" }}
         onKeyDown={handleKeyDown}
         onMouseDown={handleMouseDown}
       >
-        {/* Viewer title bar */}
-        <div
-          className="flex items-center shrink-0 px-3 border-b"
-          style={{
-            height: "var(--bar-h)",
-            borderColor: "var(--border)",
-            background: "var(--bg-surface)",
-          }}
-          data-testid="file-explorer-viewer-titlebar"
-        >
+        <ViewHeader className="px-3" testId="file-explorer-viewer-titlebar">
           <span className="flex-1 text-xs truncate" style={{ color: "var(--text-primary)" }}>
             {mode.filePath}
           </span>
@@ -558,10 +551,9 @@ export function FileExplorerView({
           >
             ✕
           </button>
-        </div>
+        </ViewHeader>
 
-        {/* Viewer content */}
-        <div className="flex-1 overflow-auto" style={listStyle}>
+        <ViewBody style={listStyle}>
           {mode.viewerType === "terminal" && mode.command ? (
             <div className="h-full" data-testid="file-explorer-viewer-terminal">
               <TerminalView
@@ -610,33 +602,23 @@ export function FileExplorerView({
               Loading...
             </div>
           )}
-        </div>
-      </div>
+        </ViewBody>
+      </ViewShell>
     );
   }
 
   // --- Listing mode ---
   return (
-    <div
+    <ViewShell
       ref={containerRef}
-      data-testid="file-explorer-view"
-      className="flex h-full w-full flex-col"
+      testId="file-explorer-view"
+      className="outline-none"
       tabIndex={-1}
-      style={{ outline: "none" }}
       onKeyDown={handleKeyDown}
       onMouseDown={handleMouseDown}
       onContextMenu={handleContextMenu}
     >
-      {/* Path bar with back/forward buttons */}
-      <div
-        className="flex items-center shrink-0 px-1 border-b"
-        style={{
-          height: 28,
-          borderColor: "var(--border)",
-          background: "var(--bg-surface)",
-        }}
-        data-testid="file-explorer-path-bar"
-      >
+      <ViewHeader className="px-1" testId="file-explorer-path-bar">
         <button
           onClick={goBack}
           disabled={!canGoBack}
@@ -666,15 +648,9 @@ export function FileExplorerView({
         <span className="text-xs truncate ml-1" style={{ color: "var(--text-primary)" }}>
           {currentCwd || "..."}
         </span>
-      </div>
+      </ViewHeader>
 
-      {/* File list */}
-      <div
-        ref={listRef}
-        className="flex-1 overflow-auto"
-        style={listStyle}
-        data-testid="file-explorer-list"
-      >
+      <ViewBody ref={listRef} style={listStyle} testId="file-explorer-list">
         {loading ? (
           <div
             className="flex items-center justify-center h-full"
@@ -731,7 +707,7 @@ export function FileExplorerView({
             </div>
           ))
         )}
-      </div>
-    </div>
+      </ViewBody>
+    </ViewShell>
   );
 }

--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -43,8 +43,8 @@ describe("IssueReporterView", () => {
 
   it("applies default padding (8px) from settings", () => {
     render(<IssueReporterView />);
-    const view = screen.getByTestId("issue-reporter-view");
-    expect(view.style.padding).toBe("8px");
+    const body = screen.getByTestId("issue-reporter-body");
+    expect(body.style.padding).toBe("8px");
   });
 
   it("applies custom padding from settings", () => {
@@ -59,8 +59,8 @@ describe("IssueReporterView", () => {
       },
     });
     render(<IssueReporterView />);
-    const view = screen.getByTestId("issue-reporter-view");
-    expect(view.style.padding).toBe("20px 10px 5px 15px");
+    const body = screen.getByTestId("issue-reporter-body");
+    expect(body.style.padding).toBe("20px 10px 5px 15px");
   });
 
   it("disables submit button after successful submission", async () => {

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -89,6 +89,7 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
   return (
     <ViewShell
       testId="issue-reporter-view"
+      onKeyDown={handleKeyDown}
       style={{ color: "var(--text-primary)", background: "var(--bg-base)" }}
     >
       <ViewHeader className="gap-2.5 px-2" testId="issue-reporter-header">
@@ -105,7 +106,6 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
       <ViewBody
         testId="issue-reporter-body"
         className="flex flex-col"
-        onKeyDown={handleKeyDown}
         style={{
           padding: `${ir.paddingTop}px ${ir.paddingRight}px ${ir.paddingBottom}px ${ir.paddingLeft}px`,
         }}

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -1,6 +1,9 @@
 import { useState, useRef, useEffect } from "react";
 import { useSettingsStore } from "@/stores/settings-store";
 import { FocusInput, inputStyle } from "@/components/ui/FormControls";
+import { ViewShell } from "@/components/ui/ViewShell";
+import { ViewHeader } from "@/components/ui/ViewHeader";
+import { ViewBody } from "@/components/ui/ViewBody";
 
 type SubmitState = "idle" | "capturing" | "submitting" | "success" | "error";
 
@@ -84,221 +87,220 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
   const appFont = useSettingsStore((s) => s.appFont);
 
   return (
-    <div
-      data-testid="issue-reporter-view"
-      className="flex h-full flex-col"
-      onKeyDown={handleKeyDown}
-      style={{
-        color: "var(--text-primary)",
-        background: "var(--bg-base)",
-        padding: `${ir.paddingTop}px ${ir.paddingRight}px ${ir.paddingBottom}px ${ir.paddingLeft}px`,
-      }}
+    <ViewShell
+      testId="issue-reporter-view"
+      style={{ color: "var(--text-primary)", background: "var(--bg-base)" }}
     >
-      {/* Header */}
-      <div className="mb-4 flex items-center gap-2.5">
-        <svg width="18" height="18" viewBox="0 0 16 16" fill="none">
+      <ViewHeader className="gap-2.5 px-2" testId="issue-reporter-header">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
           <circle cx="8" cy="8" r="7" stroke="var(--accent)" strokeWidth="1.5" />
           <path d="M8 4v5" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round" />
           <circle cx="8" cy="11.5" r="0.8" fill="var(--accent)" />
         </svg>
-        <div>
-          <span className="text-sm font-semibold">Report Issue</span>
-          <span
-            className="ml-2 text-[10px]"
-            style={{ color: "var(--text-secondary)", opacity: 0.5 }}
-          >
-            via gh CLI
-          </span>
-        </div>
-      </div>
-
-      {/* Screenshot status */}
-      <div
-        className="mb-4 flex items-center gap-2.5 rounded px-3.5 py-2.5"
+        <span className="text-sm font-semibold">Report Issue</span>
+        <span className="text-[10px]" style={{ color: "var(--text-secondary)", opacity: 0.5 }}>
+          via gh CLI
+        </span>
+      </ViewHeader>
+      <ViewBody
+        testId="issue-reporter-body"
         style={{
-          background: "var(--bg-overlay)",
-          border: "1px solid var(--border)",
-          borderRadius: "var(--radius-md)",
+          padding: `${ir.paddingTop}px ${ir.paddingRight}px ${ir.paddingBottom}px ${ir.paddingLeft}px`,
         }}
       >
-        {screenshotPath ? (
-          <button
-            onClick={() => setShowPreview((v) => !v)}
-            className="flex flex-1 cursor-pointer items-center gap-2.5 text-left"
-            style={{ background: "transparent", border: "none" }}
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-              <rect
-                x="1"
-                y="2"
-                width="12"
-                height="10"
-                rx="1.5"
-                stroke="var(--green)"
-                strokeWidth="1.2"
-              />
-              <circle cx="5" cy="6" r="1.5" stroke="var(--green)" strokeWidth="1" />
-              <path
-                d="M3 11l3-3 2 1.5 3-4"
-                stroke="var(--green)"
-                strokeWidth="1"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-            <span className="truncate text-[11px]" style={{ color: "var(--green)" }}>
-              Screenshot captured
-            </span>
-            <span className="text-[9px]" style={{ color: "var(--text-secondary)", opacity: 0.5 }}>
-              {showPreview ? "hide" : "preview"}
-            </span>
-          </button>
-        ) : (
-          <span className="flex-1 text-[11px]" style={{ color: "var(--text-secondary)" }}>
-            {state === "capturing" ? "Capturing..." : "No screenshot"}
-          </span>
-        )}
-        <button
-          onClick={captureScreenshot}
-          className="hover-bg shrink-0 cursor-pointer rounded px-2.5 py-1 text-[10px] font-medium"
-          style={{
-            color: "var(--accent)",
-            border: "1px solid var(--accent-20)",
-            borderRadius: "var(--radius-md)",
-          }}
-        >
-          Recapture
-        </button>
-      </div>
-
-      {/* Screenshot preview */}
-      {showPreview && screenshotDataUrl && (
-        <div
-          className="mb-4 overflow-hidden rounded"
-          style={{ border: "1px solid var(--border)", borderRadius: "var(--radius-md)" }}
-        >
-          <img
-            src={screenshotDataUrl}
-            alt="Screenshot preview"
-            className="w-full"
-            style={{ maxHeight: 200, objectFit: "contain", background: "#000" }}
-          />
-        </div>
-      )}
-
-      {/* Title */}
-      <FocusInput
-        ref={titleRef}
-        data-testid="issue-title"
-        type="text"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        placeholder="Issue title"
-        className="mb-3 w-full rounded px-3 py-2 text-xs"
-      />
-
-      {/* Body */}
-      <textarea
-        ref={textareaRef}
-        data-testid="issue-body"
-        value={body}
-        onChange={(e) => setBody(e.target.value)}
-        placeholder="Describe the issue..."
-        className="mb-4 min-h-0 w-full flex-1 resize-none rounded px-3 py-2 leading-relaxed"
-        style={{
-          ...inputStyle,
-          minHeight: 80,
-          fontFamily: ir.fontFamily || appFont.face,
-          fontSize: `${ir.fontSize || appFont.size}px`,
-          fontWeight: ir.fontWeight || appFont.weight,
-        }}
-      />
-
-      {/* Submit bar */}
-      <div
-        className="flex items-center gap-3 rounded px-3.5 py-3"
-        style={{
-          background: "var(--bg-overlay)",
-          border: "1px solid var(--border)",
-          borderRadius: "var(--radius-md)",
-        }}
-      >
-        <button
-          data-testid="issue-submit"
-          onClick={handleSubmit}
-          disabled={!title.trim() || state === "submitting" || state === "success"}
-          className="cursor-pointer px-5 py-1.5 text-xs font-medium"
-          style={{
-            background: state === "success" ? "var(--green)" : "var(--accent)",
-            color: "var(--bg-base)",
-            border: "none",
-            borderRadius: "var(--radius-md)",
-            opacity: !title.trim() || state === "submitting" || state === "success" ? 0.4 : 1,
-            transition: "opacity 0.15s",
-          }}
-        >
-          {state === "submitting"
-            ? "Submitting..."
-            : state === "success"
-              ? "Submitted!"
-              : "Submit Issue"}
-          {state !== "submitting" && state !== "success" && (
-            <span className="ml-2 text-[10px] opacity-50" style={{ fontWeight: "normal" }}>
-              Ctrl+Enter
-            </span>
-          )}
-        </button>
-
-        {(state === "success" || state === "error") && (
-          <button
-            data-testid="issue-new-report"
-            onClick={handleNewReport}
-            className="cursor-pointer px-4 py-1.5 text-xs font-medium"
+        <div className="flex h-full flex-col" onKeyDown={handleKeyDown}>
+          {/* Screenshot status */}
+          <div
+            className="mb-4 flex items-center gap-2.5 rounded px-3.5 py-2.5"
             style={{
-              background: "transparent",
-              color: "var(--accent)",
-              border: "1px solid var(--accent-20)",
+              background: "var(--bg-overlay)",
+              border: "1px solid var(--border)",
               borderRadius: "var(--radius-md)",
             }}
           >
-            New Report
-          </button>
-        )}
+            {screenshotPath ? (
+              <button
+                onClick={() => setShowPreview((v) => !v)}
+                className="flex flex-1 cursor-pointer items-center gap-2.5 text-left"
+                style={{ background: "transparent", border: "none" }}
+              >
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                  <rect
+                    x="1"
+                    y="2"
+                    width="12"
+                    height="10"
+                    rx="1.5"
+                    stroke="var(--green)"
+                    strokeWidth="1.2"
+                  />
+                  <circle cx="5" cy="6" r="1.5" stroke="var(--green)" strokeWidth="1" />
+                  <path
+                    d="M3 11l3-3 2 1.5 3-4"
+                    stroke="var(--green)"
+                    strokeWidth="1"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                <span className="truncate text-[11px]" style={{ color: "var(--green)" }}>
+                  Screenshot captured
+                </span>
+                <span
+                  className="text-[9px]"
+                  style={{ color: "var(--text-secondary)", opacity: 0.5 }}
+                >
+                  {showPreview ? "hide" : "preview"}
+                </span>
+              </button>
+            ) : (
+              <span className="flex-1 text-[11px]" style={{ color: "var(--text-secondary)" }}>
+                {state === "capturing" ? "Capturing..." : "No screenshot"}
+              </span>
+            )}
+            <button
+              onClick={captureScreenshot}
+              className="hover-bg shrink-0 cursor-pointer rounded px-2.5 py-1 text-[10px] font-medium"
+              style={{
+                color: "var(--accent)",
+                border: "1px solid var(--accent-20)",
+                borderRadius: "var(--radius-md)",
+              }}
+            >
+              Recapture
+            </button>
+          </div>
 
-        {state === "success" && resultMsg && (
-          <span className="truncate text-[11px]" style={{ color: "var(--green)" }}>
-            ✓
-          </span>
-        )}
-        {state === "error" && (
-          <span className="truncate text-[11px]" style={{ color: "var(--red)" }}>
-            {resultMsg}
-          </span>
-        )}
-      </div>
+          {/* Screenshot preview */}
+          {showPreview && screenshotDataUrl && (
+            <div
+              className="mb-4 overflow-hidden rounded"
+              style={{ border: "1px solid var(--border)", borderRadius: "var(--radius-md)" }}
+            >
+              <img
+                src={screenshotDataUrl}
+                alt="Screenshot preview"
+                className="w-full"
+                style={{ maxHeight: 200, objectFit: "contain", background: "#000" }}
+              />
+            </div>
+          )}
 
-      {/* Issue link */}
-      {state === "success" && resultMsg && (
-        <a
-          data-testid="issue-link"
-          href={resultMsg}
-          onClick={async (e) => {
-            e.preventDefault();
-            try {
-              const { open } = await import("@tauri-apps/plugin-shell");
-              await open(resultMsg);
-            } catch (e) {
-              console.warn("shell.open failed, falling back to window.open:", e);
-              window.open(resultMsg, "_blank");
-            }
-          }}
-          className="mt-2 truncate text-[11px] underline"
-          style={{ color: "var(--accent)", cursor: "pointer" }}
-          title={resultMsg}
-        >
-          {resultMsg}
-        </a>
-      )}
-    </div>
+          {/* Title */}
+          <FocusInput
+            ref={titleRef}
+            data-testid="issue-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Issue title"
+            className="mb-3 w-full rounded px-3 py-2 text-xs"
+          />
+
+          {/* Body */}
+          <textarea
+            ref={textareaRef}
+            data-testid="issue-body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Describe the issue..."
+            className="mb-4 min-h-0 w-full flex-1 resize-none rounded px-3 py-2 leading-relaxed"
+            style={{
+              ...inputStyle,
+              minHeight: 80,
+              fontFamily: ir.fontFamily || appFont.face,
+              fontSize: `${ir.fontSize || appFont.size}px`,
+              fontWeight: ir.fontWeight || appFont.weight,
+            }}
+          />
+
+          {/* Submit bar */}
+          <div
+            className="flex items-center gap-3 rounded px-3.5 py-3"
+            style={{
+              background: "var(--bg-overlay)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius-md)",
+            }}
+          >
+            <button
+              data-testid="issue-submit"
+              onClick={handleSubmit}
+              disabled={!title.trim() || state === "submitting" || state === "success"}
+              className="cursor-pointer px-5 py-1.5 text-xs font-medium"
+              style={{
+                background: state === "success" ? "var(--green)" : "var(--accent)",
+                color: "var(--bg-base)",
+                border: "none",
+                borderRadius: "var(--radius-md)",
+                opacity: !title.trim() || state === "submitting" || state === "success" ? 0.4 : 1,
+                transition: "opacity 0.15s",
+              }}
+            >
+              {state === "submitting"
+                ? "Submitting..."
+                : state === "success"
+                  ? "Submitted!"
+                  : "Submit Issue"}
+              {state !== "submitting" && state !== "success" && (
+                <span className="ml-2 text-[10px] opacity-50" style={{ fontWeight: "normal" }}>
+                  Ctrl+Enter
+                </span>
+              )}
+            </button>
+
+            {(state === "success" || state === "error") && (
+              <button
+                data-testid="issue-new-report"
+                onClick={handleNewReport}
+                className="cursor-pointer px-4 py-1.5 text-xs font-medium"
+                style={{
+                  background: "transparent",
+                  color: "var(--accent)",
+                  border: "1px solid var(--accent-20)",
+                  borderRadius: "var(--radius-md)",
+                }}
+              >
+                New Report
+              </button>
+            )}
+
+            {state === "success" && resultMsg && (
+              <span className="truncate text-[11px]" style={{ color: "var(--green)" }}>
+                ✓
+              </span>
+            )}
+            {state === "error" && (
+              <span className="truncate text-[11px]" style={{ color: "var(--red)" }}>
+                {resultMsg}
+              </span>
+            )}
+          </div>
+
+          {/* Issue link */}
+          {state === "success" && resultMsg && (
+            <a
+              data-testid="issue-link"
+              href={resultMsg}
+              onClick={async (e) => {
+                e.preventDefault();
+                try {
+                  const { open } = await import("@tauri-apps/plugin-shell");
+                  await open(resultMsg);
+                } catch (e) {
+                  console.warn("shell.open failed, falling back to window.open:", e);
+                  window.open(resultMsg, "_blank");
+                }
+              }}
+              className="mt-2 truncate text-[11px] underline"
+              style={{ color: "var(--accent)", cursor: "pointer" }}
+              title={resultMsg}
+            >
+              {resultMsg}
+            </a>
+          )}
+        </div>
+      </ViewBody>
+    </ViewShell>
   );
 }

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -92,7 +92,7 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
       style={{ color: "var(--text-primary)", background: "var(--bg-base)" }}
     >
       <ViewHeader className="gap-2.5 px-2" testId="issue-reporter-header">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <svg width="18" height="18" viewBox="0 0 16 16" fill="none">
           <circle cx="8" cy="8" r="7" stroke="var(--accent)" strokeWidth="1.5" />
           <path d="M8 4v5" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round" />
           <circle cx="8" cy="11.5" r="0.8" fill="var(--accent)" />
@@ -104,202 +104,199 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
       </ViewHeader>
       <ViewBody
         testId="issue-reporter-body"
+        className="flex flex-col"
+        onKeyDown={handleKeyDown}
         style={{
           padding: `${ir.paddingTop}px ${ir.paddingRight}px ${ir.paddingBottom}px ${ir.paddingLeft}px`,
         }}
       >
-        <div className="flex h-full flex-col" onKeyDown={handleKeyDown}>
-          {/* Screenshot status */}
-          <div
-            className="mb-4 flex items-center gap-2.5 rounded px-3.5 py-2.5"
+        {/* Screenshot status */}
+        <div
+          className="mb-4 flex items-center gap-2.5 rounded px-3.5 py-2.5"
+          style={{
+            background: "var(--bg-overlay)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-md)",
+          }}
+        >
+          {screenshotPath ? (
+            <button
+              onClick={() => setShowPreview((v) => !v)}
+              className="flex flex-1 cursor-pointer items-center gap-2.5 text-left"
+              style={{ background: "transparent", border: "none" }}
+            >
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                <rect
+                  x="1"
+                  y="2"
+                  width="12"
+                  height="10"
+                  rx="1.5"
+                  stroke="var(--green)"
+                  strokeWidth="1.2"
+                />
+                <circle cx="5" cy="6" r="1.5" stroke="var(--green)" strokeWidth="1" />
+                <path
+                  d="M3 11l3-3 2 1.5 3-4"
+                  stroke="var(--green)"
+                  strokeWidth="1"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              <span className="truncate text-[11px]" style={{ color: "var(--green)" }}>
+                Screenshot captured
+              </span>
+              <span className="text-[9px]" style={{ color: "var(--text-secondary)", opacity: 0.5 }}>
+                {showPreview ? "hide" : "preview"}
+              </span>
+            </button>
+          ) : (
+            <span className="flex-1 text-[11px]" style={{ color: "var(--text-secondary)" }}>
+              {state === "capturing" ? "Capturing..." : "No screenshot"}
+            </span>
+          )}
+          <button
+            onClick={captureScreenshot}
+            className="hover-bg shrink-0 cursor-pointer rounded px-2.5 py-1 text-[10px] font-medium"
             style={{
-              background: "var(--bg-overlay)",
-              border: "1px solid var(--border)",
+              color: "var(--accent)",
+              border: "1px solid var(--accent-20)",
               borderRadius: "var(--radius-md)",
             }}
           >
-            {screenshotPath ? (
-              <button
-                onClick={() => setShowPreview((v) => !v)}
-                className="flex flex-1 cursor-pointer items-center gap-2.5 text-left"
-                style={{ background: "transparent", border: "none" }}
-              >
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                  <rect
-                    x="1"
-                    y="2"
-                    width="12"
-                    height="10"
-                    rx="1.5"
-                    stroke="var(--green)"
-                    strokeWidth="1.2"
-                  />
-                  <circle cx="5" cy="6" r="1.5" stroke="var(--green)" strokeWidth="1" />
-                  <path
-                    d="M3 11l3-3 2 1.5 3-4"
-                    stroke="var(--green)"
-                    strokeWidth="1"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-                <span className="truncate text-[11px]" style={{ color: "var(--green)" }}>
-                  Screenshot captured
-                </span>
-                <span
-                  className="text-[9px]"
-                  style={{ color: "var(--text-secondary)", opacity: 0.5 }}
-                >
-                  {showPreview ? "hide" : "preview"}
-                </span>
-              </button>
-            ) : (
-              <span className="flex-1 text-[11px]" style={{ color: "var(--text-secondary)" }}>
-                {state === "capturing" ? "Capturing..." : "No screenshot"}
+            Recapture
+          </button>
+        </div>
+
+        {/* Screenshot preview */}
+        {showPreview && screenshotDataUrl && (
+          <div
+            className="mb-4 overflow-hidden rounded"
+            style={{ border: "1px solid var(--border)", borderRadius: "var(--radius-md)" }}
+          >
+            <img
+              src={screenshotDataUrl}
+              alt="Screenshot preview"
+              className="w-full"
+              style={{ maxHeight: 200, objectFit: "contain", background: "#000" }}
+            />
+          </div>
+        )}
+
+        {/* Title */}
+        <FocusInput
+          ref={titleRef}
+          data-testid="issue-title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Issue title"
+          className="mb-3 w-full rounded px-3 py-2 text-xs"
+        />
+
+        {/* Body */}
+        <textarea
+          ref={textareaRef}
+          data-testid="issue-body"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Describe the issue..."
+          className="mb-4 min-h-0 w-full flex-1 resize-none rounded px-3 py-2 leading-relaxed"
+          style={{
+            ...inputStyle,
+            minHeight: 80,
+            fontFamily: ir.fontFamily || appFont.face,
+            fontSize: `${ir.fontSize || appFont.size}px`,
+            fontWeight: ir.fontWeight || appFont.weight,
+          }}
+        />
+
+        {/* Submit bar */}
+        <div
+          className="flex items-center gap-3 rounded px-3.5 py-3"
+          style={{
+            background: "var(--bg-overlay)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-md)",
+          }}
+        >
+          <button
+            data-testid="issue-submit"
+            onClick={handleSubmit}
+            disabled={!title.trim() || state === "submitting" || state === "success"}
+            className="cursor-pointer px-5 py-1.5 text-xs font-medium"
+            style={{
+              background: state === "success" ? "var(--green)" : "var(--accent)",
+              color: "var(--bg-base)",
+              border: "none",
+              borderRadius: "var(--radius-md)",
+              opacity: !title.trim() || state === "submitting" || state === "success" ? 0.4 : 1,
+              transition: "opacity 0.15s",
+            }}
+          >
+            {state === "submitting"
+              ? "Submitting..."
+              : state === "success"
+                ? "Submitted!"
+                : "Submit Issue"}
+            {state !== "submitting" && state !== "success" && (
+              <span className="ml-2 text-[10px] opacity-50" style={{ fontWeight: "normal" }}>
+                Ctrl+Enter
               </span>
             )}
+          </button>
+
+          {(state === "success" || state === "error") && (
             <button
-              onClick={captureScreenshot}
-              className="hover-bg shrink-0 cursor-pointer rounded px-2.5 py-1 text-[10px] font-medium"
+              data-testid="issue-new-report"
+              onClick={handleNewReport}
+              className="cursor-pointer px-4 py-1.5 text-xs font-medium"
               style={{
+                background: "transparent",
                 color: "var(--accent)",
                 border: "1px solid var(--accent-20)",
                 borderRadius: "var(--radius-md)",
               }}
             >
-              Recapture
+              New Report
             </button>
-          </div>
-
-          {/* Screenshot preview */}
-          {showPreview && screenshotDataUrl && (
-            <div
-              className="mb-4 overflow-hidden rounded"
-              style={{ border: "1px solid var(--border)", borderRadius: "var(--radius-md)" }}
-            >
-              <img
-                src={screenshotDataUrl}
-                alt="Screenshot preview"
-                className="w-full"
-                style={{ maxHeight: 200, objectFit: "contain", background: "#000" }}
-              />
-            </div>
           )}
 
-          {/* Title */}
-          <FocusInput
-            ref={titleRef}
-            data-testid="issue-title"
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="Issue title"
-            className="mb-3 w-full rounded px-3 py-2 text-xs"
-          />
-
-          {/* Body */}
-          <textarea
-            ref={textareaRef}
-            data-testid="issue-body"
-            value={body}
-            onChange={(e) => setBody(e.target.value)}
-            placeholder="Describe the issue..."
-            className="mb-4 min-h-0 w-full flex-1 resize-none rounded px-3 py-2 leading-relaxed"
-            style={{
-              ...inputStyle,
-              minHeight: 80,
-              fontFamily: ir.fontFamily || appFont.face,
-              fontSize: `${ir.fontSize || appFont.size}px`,
-              fontWeight: ir.fontWeight || appFont.weight,
-            }}
-          />
-
-          {/* Submit bar */}
-          <div
-            className="flex items-center gap-3 rounded px-3.5 py-3"
-            style={{
-              background: "var(--bg-overlay)",
-              border: "1px solid var(--border)",
-              borderRadius: "var(--radius-md)",
-            }}
-          >
-            <button
-              data-testid="issue-submit"
-              onClick={handleSubmit}
-              disabled={!title.trim() || state === "submitting" || state === "success"}
-              className="cursor-pointer px-5 py-1.5 text-xs font-medium"
-              style={{
-                background: state === "success" ? "var(--green)" : "var(--accent)",
-                color: "var(--bg-base)",
-                border: "none",
-                borderRadius: "var(--radius-md)",
-                opacity: !title.trim() || state === "submitting" || state === "success" ? 0.4 : 1,
-                transition: "opacity 0.15s",
-              }}
-            >
-              {state === "submitting"
-                ? "Submitting..."
-                : state === "success"
-                  ? "Submitted!"
-                  : "Submit Issue"}
-              {state !== "submitting" && state !== "success" && (
-                <span className="ml-2 text-[10px] opacity-50" style={{ fontWeight: "normal" }}>
-                  Ctrl+Enter
-                </span>
-              )}
-            </button>
-
-            {(state === "success" || state === "error") && (
-              <button
-                data-testid="issue-new-report"
-                onClick={handleNewReport}
-                className="cursor-pointer px-4 py-1.5 text-xs font-medium"
-                style={{
-                  background: "transparent",
-                  color: "var(--accent)",
-                  border: "1px solid var(--accent-20)",
-                  borderRadius: "var(--radius-md)",
-                }}
-              >
-                New Report
-              </button>
-            )}
-
-            {state === "success" && resultMsg && (
-              <span className="truncate text-[11px]" style={{ color: "var(--green)" }}>
-                ✓
-              </span>
-            )}
-            {state === "error" && (
-              <span className="truncate text-[11px]" style={{ color: "var(--red)" }}>
-                {resultMsg}
-              </span>
-            )}
-          </div>
-
-          {/* Issue link */}
           {state === "success" && resultMsg && (
-            <a
-              data-testid="issue-link"
-              href={resultMsg}
-              onClick={async (e) => {
-                e.preventDefault();
-                try {
-                  const { open } = await import("@tauri-apps/plugin-shell");
-                  await open(resultMsg);
-                } catch (e) {
-                  console.warn("shell.open failed, falling back to window.open:", e);
-                  window.open(resultMsg, "_blank");
-                }
-              }}
-              className="mt-2 truncate text-[11px] underline"
-              style={{ color: "var(--accent)", cursor: "pointer" }}
-              title={resultMsg}
-            >
+            <span className="truncate text-[11px]" style={{ color: "var(--green)" }}>
+              ✓
+            </span>
+          )}
+          {state === "error" && (
+            <span className="truncate text-[11px]" style={{ color: "var(--red)" }}>
               {resultMsg}
-            </a>
+            </span>
           )}
         </div>
+
+        {/* Issue link */}
+        {state === "success" && resultMsg && (
+          <a
+            data-testid="issue-link"
+            href={resultMsg}
+            onClick={async (e) => {
+              e.preventDefault();
+              try {
+                const { open } = await import("@tauri-apps/plugin-shell");
+                await open(resultMsg);
+              } catch (e) {
+                console.warn("shell.open failed, falling back to window.open:", e);
+                window.open(resultMsg, "_blank");
+              }
+            }}
+            className="mt-2 truncate text-[11px] underline"
+            style={{ color: "var(--accent)", cursor: "pointer" }}
+            title={resultMsg}
+          >
+            {resultMsg}
+          </a>
+        )}
       </ViewBody>
     </ViewShell>
   );

--- a/ui/src/components/views/MemoView.tsx
+++ b/ui/src/components/views/MemoView.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { loadMemo, saveMemo, clipboardWriteText } from "@/lib/tauri-api";
 import { useSettingsStore } from "@/stores/settings-store";
 import { splitParagraphs } from "@/lib/memo-paragraphs";
+import { ViewShell } from "@/components/ui/ViewShell";
+import { ViewHeader } from "@/components/ui/ViewHeader";
+import { ViewBody } from "@/components/ui/ViewBody";
 
 const DEBOUNCE_MS = 300;
 
@@ -160,20 +163,13 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
   );
 
   return (
-    <div data-testid="memo-view" className="flex h-full w-full flex-col">
-      <div
-        className="ui-toolbar shrink-0 px-2"
-        style={{
-          background: "var(--bg-surface)",
-          borderBottom: "1px solid var(--border)",
-          color: "var(--text-secondary)",
-          fontSize: "var(--fs-sm)",
-          fontWeight: 600,
-        }}
-      >
-        Memo
-      </div>
-      <div className="relative flex-1" onMouseLeave={handleMouseLeave}>
+    <ViewShell testId="memo-view">
+      <ViewHeader className="px-2" testId="memo-header">
+        <span style={{ color: "var(--text-secondary)", fontSize: "var(--fs-sm)", fontWeight: 600 }}>
+          Memo
+        </span>
+      </ViewHeader>
+      <ViewBody variant="full" onMouseLeave={handleMouseLeave}>
         <textarea
           ref={textareaRef}
           data-testid="memo-textarea"
@@ -204,8 +200,8 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
             fontSize={effectiveFontSize}
           />
         )}
-      </div>
-    </div>
+      </ViewBody>
+    </ViewShell>
   );
 }
 

--- a/ui/src/components/views/NotificationPanel.tsx
+++ b/ui/src/components/views/NotificationPanel.tsx
@@ -43,7 +43,7 @@ export function NotificationPanel({ workspaceId }: NotificationPanelProps = {}) 
       <ViewBody>
         {sorted.length === 0 ? (
           <div
-            className="flex flex-1 h-full items-center justify-center"
+            className="flex h-full items-center justify-center"
             style={{ color: "var(--text-secondary)" }}
           >
             <p className="text-xs">No notifications</p>

--- a/ui/src/components/views/NotificationPanel.tsx
+++ b/ui/src/components/views/NotificationPanel.tsx
@@ -2,6 +2,9 @@ import { useNotificationStore, type NotificationLevel } from "@/stores/notificat
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { formatRelativeTime } from "@/lib/workspace-summary";
+import { ViewShell } from "@/components/ui/ViewShell";
+import { ViewHeader } from "@/components/ui/ViewHeader";
+import { ViewBody } from "@/components/ui/ViewBody";
 
 const levelColorMap: Record<NotificationLevel, string> = {
   error: "var(--red)",
@@ -32,98 +35,99 @@ export function NotificationPanel({ workspaceId }: NotificationPanelProps = {}) 
   const workspaceIds = [...new Set(sorted.map((n) => n.workspaceId))];
 
   return (
-    <div
-      data-testid="notification-panel"
-      className="flex h-full flex-col overflow-y-auto"
-      style={{ color: "var(--text-primary)" }}
-    >
-      <div
-        className="ui-toolbar justify-between px-2"
-        style={{ borderBottom: "1px solid var(--border)" }}
-      >
+    <ViewShell testId="notification-panel" style={{ color: "var(--text-primary)" }}>
+      <ViewHeader className="justify-between px-2" testId="notification-header">
         <span className="text-sm font-medium">Notifications</span>
-      </div>
+      </ViewHeader>
 
-      {sorted.length === 0 ? (
-        <div
-          className="flex flex-1 items-center justify-center"
-          style={{ color: "var(--text-secondary)" }}
-        >
-          <p className="text-xs">No notifications</p>
-        </div>
-      ) : (
-        <div className="flex flex-col">
-          {workspaceIds.map((wsId) => {
-            const wsNotifs = sorted.filter((n) => n.workspaceId === wsId);
-            const hasUnread = wsNotifs.some((n) => n.readAt === null);
-            return (
-              <div key={wsId}>
-                <div
-                  className="flex items-center justify-between px-3 py-1"
-                  style={{
-                    background: "var(--bg-surface)",
-                    borderBottom: "1px solid var(--border)",
-                  }}
-                >
-                  <span className="text-xs font-medium" style={{ color: "var(--text-secondary)" }}>
-                    {workspaces.find((w) => w.id === wsId)?.name ?? wsId}
-                  </span>
-                  {hasUnread && (
-                    <button
-                      data-testid={`mark-read-${wsId}`}
-                      onClick={() => markWorkspaceAsRead(wsId)}
-                      className="cursor-pointer text-xs"
-                      style={{
-                        color: "var(--accent)",
-                        background: "none",
-                        border: "none",
-                      }}
+      <ViewBody>
+        {sorted.length === 0 ? (
+          <div
+            className="flex flex-1 h-full items-center justify-center"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            <p className="text-xs">No notifications</p>
+          </div>
+        ) : (
+          <div className="flex flex-col">
+            {workspaceIds.map((wsId) => {
+              const wsNotifs = sorted.filter((n) => n.workspaceId === wsId);
+              const hasUnread = wsNotifs.some((n) => n.readAt === null);
+              return (
+                <div key={wsId}>
+                  <div
+                    className="flex items-center justify-between px-3 py-1"
+                    style={{
+                      background: "var(--bg-surface)",
+                      borderBottom: "1px solid var(--border)",
+                    }}
+                  >
+                    <span
+                      className="text-xs font-medium"
+                      style={{ color: "var(--text-secondary)" }}
                     >
-                      Mark read
-                    </button>
-                  )}
+                      {workspaces.find((w) => w.id === wsId)?.name ?? wsId}
+                    </span>
+                    {hasUnread && (
+                      <button
+                        data-testid={`mark-read-${wsId}`}
+                        onClick={() => markWorkspaceAsRead(wsId)}
+                        className="cursor-pointer text-xs"
+                        style={{
+                          color: "var(--accent)",
+                          background: "none",
+                          border: "none",
+                        }}
+                      >
+                        Mark read
+                      </button>
+                    )}
+                  </div>
+                  {wsNotifs.map((n) => {
+                    const terminal = terminalInstances.find((t) => t.id === n.terminalId);
+                    return (
+                      <div
+                        key={n.id}
+                        data-testid={`notification-item-${n.id}`}
+                        data-read={n.readAt !== null ? "true" : "false"}
+                        className="flex items-start gap-2 px-3 py-1.5"
+                        style={{
+                          borderBottom: "1px solid var(--border)",
+                          opacity: n.readAt !== null ? 0.6 : 1,
+                        }}
+                      >
+                        {/* Terminal label */}
+                        <span
+                          className="w-14 shrink-0 truncate text-xs"
+                          style={{ color: "var(--text-secondary)" }}
+                        >
+                          [{terminal?.label ?? "?"}]
+                        </span>
+
+                        {/* Message with level color */}
+                        <span
+                          className="flex-1 truncate text-xs"
+                          style={{ color: levelColorMap[n.level] }}
+                        >
+                          {n.message}
+                        </span>
+
+                        {/* Relative time */}
+                        <span
+                          className="shrink-0 text-xs"
+                          style={{ color: "var(--text-secondary)" }}
+                        >
+                          {formatRelativeTime(n.createdAt)}
+                        </span>
+                      </div>
+                    );
+                  })}
                 </div>
-                {wsNotifs.map((n) => {
-                  const terminal = terminalInstances.find((t) => t.id === n.terminalId);
-                  return (
-                    <div
-                      key={n.id}
-                      data-testid={`notification-item-${n.id}`}
-                      data-read={n.readAt !== null ? "true" : "false"}
-                      className="flex items-start gap-2 px-3 py-1.5"
-                      style={{
-                        borderBottom: "1px solid var(--border)",
-                        opacity: n.readAt !== null ? 0.6 : 1,
-                      }}
-                    >
-                      {/* Terminal label */}
-                      <span
-                        className="w-14 shrink-0 truncate text-xs"
-                        style={{ color: "var(--text-secondary)" }}
-                      >
-                        [{terminal?.label ?? "?"}]
-                      </span>
-
-                      {/* Message with level color */}
-                      <span
-                        className="flex-1 truncate text-xs"
-                        style={{ color: levelColorMap[n.level] }}
-                      >
-                        {n.message}
-                      </span>
-
-                      {/* Relative time */}
-                      <span className="shrink-0 text-xs" style={{ color: "var(--text-secondary)" }}>
-                        {formatRelativeTime(n.createdAt)}
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </div>
+              );
+            })}
+          </div>
+        )}
+      </ViewBody>
+    </ViewShell>
   );
 }


### PR DESCRIPTION
## Summary

Closes #131

- PaneControlBar와 View 내부 헤더를 React Context 기반으로 통합하여 pinned 모드에서 이중 바(56px)를 단일 통합 헤더(28px)로 축소
- 새 공통 컴포넌트 4개 추가: `PaneControlContext`, `ViewHeader`, `ViewBody`, `ViewShell`
- MemoView, NotificationPanel, IssueReporterView, FileExplorerView 마이그레이션 완료
- 헤더 없는 View(TerminalView, EmptyView)는 기존 PaneControlBar 동작 그대로 유지

### ViewHeader 동작 모드

| 모드 | 동작 |
|------|------|
| pinned | `[View 콘텐츠 \| pane 제어]` 한 줄 |
| hover + hovered | `[View 콘텐츠 \| pane 제어]` 한 줄 |
| hover + !hovered | `[View 콘텐츠]`만 표시 |
| minimized + hovered | `[View 콘텐츠 \| ⋯ 버튼]` |
| minimized + !hovered | `[View 콘텐츠]`만 표시 |

## Test plan

- [x] 전체 단위 테스트 1353개 통과 (59 파일)
- [x] ViewHeader/ViewBody/ViewShell 단위 테스트 23개 추가
- [x] PaneControlBar + ViewHeader 통합 테스트 6개 추가
- [x] TypeScript 타입 체크 통과
- [x] ESLint + Prettier 통과
- [x] 스크린샷 시각 검증 — MemoView, FileExplorerView, TerminalView 모두 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)