### PR TITLE
fix: smart paste 인덴트/줄바꿈 제거 순서 수정

### DIFF
--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -410,6 +410,12 @@ pub struct ConvenienceSettings {
     /// Allow Alt+Arrow to navigate into/out of dock areas.
     #[serde(default = "default_true")]
     pub dock_arrow_nav: bool,
+    /// Smart remove indent: strip common leading whitespace when pasting.
+    #[serde(default = "default_true")]
+    pub smart_remove_indent: bool,
+    /// Smart remove line break: rejoin URLs split across lines when pasting.
+    #[serde(default = "default_true")]
+    pub smart_remove_line_break: bool,
 }
 
 impl Default for ConvenienceSettings {
@@ -422,6 +428,8 @@ impl Default for ConvenienceSettings {
             scrollbar_style: "overlay".to_string(),
             dock_persist_state: true,
             dock_arrow_nav: true,
+            smart_remove_indent: true,
+            smart_remove_line_break: true,
         }
     }
 }

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1096,6 +1096,62 @@ function ConvenienceSection() {
           </div>
         </div>
 
+        {/* Smart Remove Indent toggle */}
+        <div className="mt-3 flex items-start gap-3 py-1">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+              Smart Remove Indent
+            </span>
+            <p
+              className="mt-0.5 text-[11px] leading-tight"
+              style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+            >
+              붙여넣기 시 공통 들여쓰기 제거
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                data-testid="smart-remove-indent-toggle"
+                type="checkbox"
+                checked={convenience.smartRemoveIndent}
+                onChange={(e) => updateConvenience({ smartRemoveIndent: e.target.checked })}
+              />
+              <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+                {convenience.smartRemoveIndent ? "Enabled" : "Disabled"}
+              </span>
+            </label>
+          </div>
+        </div>
+
+        {/* Smart Remove Line Break toggle */}
+        <div className="mt-3 flex items-start gap-3 py-1">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+              Smart Remove Line Break
+            </span>
+            <p
+              className="mt-0.5 text-[11px] leading-tight"
+              style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+            >
+              붙여넣기 시 줄바꿈으로 깨진 URL 복원
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                data-testid="smart-remove-linebreak-toggle"
+                type="checkbox"
+                checked={convenience.smartRemoveLineBreak}
+                onChange={(e) => updateConvenience({ smartRemoveLineBreak: e.target.checked })}
+              />
+              <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+                {convenience.smartRemoveLineBreak ? "Enabled" : "Disabled"}
+              </span>
+            </label>
+          </div>
+        </div>
+
         {/* Copy On Select toggle */}
         <div className="mt-3 flex items-start gap-3 py-1">
           <div className="w-36 shrink-0 pt-1">

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -23,7 +23,7 @@ import { colorSchemeToXtermTheme, type WTColorScheme } from "@/lib/color-scheme"
 import { processOscInOutput, type NotifyGate } from "@/hooks/useOscHooks";
 import { getPresetHooks } from "@/lib/osc-presets";
 import type { OscHook } from "@/lib/osc-parser";
-import { applySmartTextTransforms } from "@/lib/smart-text";
+import { transformPasteContent } from "@/lib/smart-text";
 import { isLxShortcut } from "@/lib/lx-shortcuts";
 
 import {
@@ -198,13 +198,10 @@ export function TerminalView({
           smartPaste(convenience.pasteImageDir, profile)
             .then((result) => {
               if (result.pasteType !== "none" && result.content) {
-                const content =
-                  result.pasteType === "text"
-                    ? applySmartTextTransforms(result.content, {
-                        removeIndent: convenience.smartRemoveIndent,
-                        removeLineBreak: convenience.smartRemoveLineBreak,
-                      })
-                    : result.content;
+                const content = transformPasteContent(result.content, result.pasteType, {
+                  removeIndent: convenience.smartRemoveIndent,
+                  removeLineBreak: convenience.smartRemoveLineBreak,
+                });
                 terminal.paste(content);
               }
             })
@@ -478,13 +475,10 @@ export function TerminalView({
         smartPaste(conv.pasteImageDir, profile)
           .then((result) => {
             if (result.pasteType !== "none" && result.content) {
-              const content =
-                result.pasteType === "text"
-                  ? applySmartTextTransforms(result.content, {
-                      removeIndent: conv.smartRemoveIndent,
-                      removeLineBreak: conv.smartRemoveLineBreak,
-                    })
-                  : result.content;
+              const content = transformPasteContent(result.content, result.pasteType, {
+                removeIndent: conv.smartRemoveIndent,
+                removeLineBreak: conv.smartRemoveLineBreak,
+              });
               writeToTerminal(instanceId, content);
             }
           })

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -23,6 +23,7 @@ import { colorSchemeToXtermTheme, type WTColorScheme } from "@/lib/color-scheme"
 import { processOscInOutput, type NotifyGate } from "@/hooks/useOscHooks";
 import { getPresetHooks } from "@/lib/osc-presets";
 import type { OscHook } from "@/lib/osc-parser";
+import { applySmartTextTransforms } from "@/lib/smart-text";
 import { isLxShortcut } from "@/lib/lx-shortcuts";
 
 import {
@@ -197,7 +198,14 @@ export function TerminalView({
           smartPaste(convenience.pasteImageDir, profile)
             .then((result) => {
               if (result.pasteType !== "none" && result.content) {
-                terminal.paste(result.content);
+                const content =
+                  result.pasteType === "text"
+                    ? applySmartTextTransforms(result.content, {
+                        removeIndent: convenience.smartRemoveIndent,
+                        removeLineBreak: convenience.smartRemoveLineBreak,
+                      })
+                    : result.content;
+                terminal.paste(content);
               }
             })
             .catch(() => {}); // clipboard read failed — silently ignore
@@ -470,7 +478,14 @@ export function TerminalView({
         smartPaste(conv.pasteImageDir, profile)
           .then((result) => {
             if (result.pasteType !== "none" && result.content) {
-              writeToTerminal(instanceId, result.content);
+              const content =
+                result.pasteType === "text"
+                  ? applySmartTextTransforms(result.content, {
+                      removeIndent: conv.smartRemoveIndent,
+                      removeLineBreak: conv.smartRemoveLineBreak,
+                    })
+                  : result.content;
+              writeToTerminal(instanceId, content);
             }
           })
           .catch(() => {});

--- a/ui/src/lib/smart-text.test.ts
+++ b/ui/src/lib/smart-text.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { smartRemoveIndent, smartRemoveLineBreak, applySmartTextTransforms } from "./smart-text";
+import {
+  smartRemoveIndent,
+  smartRemoveLineBreak,
+  applySmartTextTransforms,
+  transformPasteContent,
+} from "./smart-text";
 
 // ============================================================
 // smartRemoveIndent
@@ -158,5 +163,36 @@ describe("applySmartTextTransforms", () => {
     expect(applySmartTextTransforms(input, { removeIndent: true, removeLineBreak: true })).toBe(
       "https://example.com/path",
     );
+  });
+
+  it("normalizes CRLF to LF before processing", () => {
+    const input = "  hello\r\n  world";
+    expect(applySmartTextTransforms(input, { removeIndent: true, removeLineBreak: false })).toBe(
+      "hello\nworld",
+    );
+  });
+
+  it("normalizes CRLF in URL before joining lines", () => {
+    const input = "https://example.com/pa\r\nth";
+    expect(applySmartTextTransforms(input, { removeIndent: false, removeLineBreak: true })).toBe(
+      "https://example.com/path",
+    );
+  });
+});
+
+// ============================================================
+// transformPasteContent
+// ============================================================
+describe("transformPasteContent", () => {
+  const opts = { removeIndent: true, removeLineBreak: true };
+
+  it("applies transforms for text paste type", () => {
+    const input = "  https://example.com/pa\n  th";
+    expect(transformPasteContent(input, "text", opts)).toBe("https://example.com/path");
+  });
+
+  it("returns content unchanged for non-text paste type", () => {
+    const input = "  some image data";
+    expect(transformPasteContent(input, "image", opts)).toBe("  some image data");
   });
 });

--- a/ui/src/lib/smart-text.test.ts
+++ b/ui/src/lib/smart-text.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { smartRemoveIndent, smartRemoveLineBreak, applySmartTextTransforms } from "./smart-text";
+
+// ============================================================
+// smartRemoveIndent
+// ============================================================
+describe("smartRemoveIndent", () => {
+  it("removes common leading spaces from all lines", () => {
+    const input = "  hello\n  world";
+    expect(smartRemoveIndent(input)).toBe("hello\nworld");
+  });
+
+  it("removes common leading spaces preserving relative indent", () => {
+    const input = "    line1\n      line2\n    line3";
+    expect(smartRemoveIndent(input)).toBe("line1\n  line2\nline3");
+  });
+
+  it("handles tabs as indent", () => {
+    const input = "\t\thello\n\t\tworld";
+    expect(smartRemoveIndent(input)).toBe("hello\nworld");
+  });
+
+  it("does nothing when there is no common indent", () => {
+    const input = "hello\n  world";
+    expect(smartRemoveIndent(input)).toBe("hello\n  world");
+  });
+
+  it("returns single line unchanged if no indent", () => {
+    expect(smartRemoveIndent("hello")).toBe("hello");
+  });
+
+  it("removes indent from single line", () => {
+    expect(smartRemoveIndent("  hello")).toBe("hello");
+  });
+
+  it("skips blank lines when computing common indent", () => {
+    const input = "  hello\n\n  world";
+    expect(smartRemoveIndent(input)).toBe("hello\n\nworld");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(smartRemoveIndent("")).toBe("");
+  });
+
+  it("handles all blank lines", () => {
+    expect(smartRemoveIndent("\n\n")).toBe("\n\n");
+  });
+
+  it("handles mixed space and tab (treats as different chars)", () => {
+    // When indent chars are mixed, common prefix stops at first difference
+    const input = " \thello\n \tworld";
+    expect(smartRemoveIndent(input)).toBe("hello\nworld");
+  });
+
+  it("preserves trailing newline", () => {
+    const input = "  hello\n  world\n";
+    expect(smartRemoveIndent(input)).toBe("hello\nworld\n");
+  });
+});
+
+// ============================================================
+// smartRemoveLineBreak
+// ============================================================
+describe("smartRemoveLineBreak", () => {
+  it("joins URL split across lines", () => {
+    const input = "https://example.com/path?foo=bar&ba\nz=qux";
+    expect(smartRemoveLineBreak(input)).toBe("https://example.com/path?foo=bar&baz=qux");
+  });
+
+  it("joins URL split across multiple lines", () => {
+    const input = "https://example.com/pa\nth?foo=bar&ba\nz=qux";
+    expect(smartRemoveLineBreak(input)).toBe("https://example.com/path?foo=bar&baz=qux");
+  });
+
+  it("does not touch non-URL multi-line text", () => {
+    const input = "hello\nworld\nfoo";
+    expect(smartRemoveLineBreak(input)).toBe("hello\nworld\nfoo");
+  });
+
+  it("does not touch single line URL", () => {
+    const input = "https://example.com/path";
+    expect(smartRemoveLineBreak(input)).toBe("https://example.com/path");
+  });
+
+  it("handles the issue example: indented URL with linebreaks", () => {
+    // After indent removal, the URL still has linebreaks that should be joined
+    const input =
+      "https://mcp.notion.com/authorize?response_type=code&client_id=nmy47PjpHdZy7dgr&code_challenge=1eVfRYoFxEoIOGh0CaAF30mz9UXYTgDXr7tXeGI-I2M&cod\ne_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A52516%2Fcallback&state=AHKfcaYPBT9Ndx-qH1TQKKbbBL7YaCg7tRJ2NeLROFE&resource=htt\nps%3A%2F%2Fmcp.notion.com%2Fmcp";
+    const expected =
+      "https://mcp.notion.com/authorize?response_type=code&client_id=nmy47PjpHdZy7dgr&code_challenge=1eVfRYoFxEoIOGh0CaAF30mz9UXYTgDXr7tXeGI-I2M&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A52516%2Fcallback&state=AHKfcaYPBT9Ndx-qH1TQKKbbBL7YaCg7tRJ2NeLROFE&resource=https%3A%2F%2Fmcp.notion.com%2Fmcp";
+    expect(smartRemoveLineBreak(input)).toBe(expected);
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(smartRemoveLineBreak("")).toBe("");
+  });
+
+  it("handles URL with http:// scheme", () => {
+    const input = "http://example.com/pa\nth";
+    expect(smartRemoveLineBreak(input)).toBe("http://example.com/path");
+  });
+
+  it("does not join lines when text has mixed URL and non-URL content", () => {
+    const input = "Check this:\nhttps://example.com/path";
+    expect(smartRemoveLineBreak(input)).toBe("Check this:\nhttps://example.com/path");
+  });
+
+  it("joins URL that is the only content (all lines form one URL)", () => {
+    const input = "https://example.com/very-long-\npath?query=value";
+    expect(smartRemoveLineBreak(input)).toBe("https://example.com/very-long-path?query=value");
+  });
+});
+
+// ============================================================
+// applySmartTextTransforms (composition)
+// ============================================================
+describe("applySmartTextTransforms", () => {
+  it("applies both indent removal and linebreak removal in order", () => {
+    // The exact issue scenario: 2-space indented URL with linebreaks
+    const input =
+      "  https://mcp.notion.com/authorize?response_type=code&client_id=nmy47PjpHdZy7dgr&code_challenge=1eVfRYoFxEoIOGh0CaAF30mz9UXYTgDXr7tXeGI-I2M&cod\n  e_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A52516%2Fcallback&state=AHKfcaYPBT9Ndx-qH1TQKKbbBL7YaCg7tRJ2NeLROFE&resource=htt\n  ps%3A%2F%2Fmcp.notion.com%2Fmcp";
+    const expected =
+      "https://mcp.notion.com/authorize?response_type=code&client_id=nmy47PjpHdZy7dgr&code_challenge=1eVfRYoFxEoIOGh0CaAF30mz9UXYTgDXr7tXeGI-I2M&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost%3A52516%2Fcallback&state=AHKfcaYPBT9Ndx-qH1TQKKbbBL7YaCg7tRJ2NeLROFE&resource=https%3A%2F%2Fmcp.notion.com%2Fmcp";
+    expect(applySmartTextTransforms(input, { removeIndent: true, removeLineBreak: true })).toBe(
+      expected,
+    );
+  });
+
+  it("applies only indent removal when removeLineBreak is false", () => {
+    const input = "  hello\n  world";
+    expect(applySmartTextTransforms(input, { removeIndent: true, removeLineBreak: false })).toBe(
+      "hello\nworld",
+    );
+  });
+
+  it("applies only linebreak removal when removeIndent is false", () => {
+    const input = "https://example.com/pa\nth";
+    expect(applySmartTextTransforms(input, { removeIndent: false, removeLineBreak: true })).toBe(
+      "https://example.com/path",
+    );
+  });
+
+  it("applies nothing when both are false", () => {
+    const input = "  hello\n  world";
+    expect(
+      applySmartTextTransforms(input, {
+        removeIndent: false,
+        removeLineBreak: false,
+      }),
+    ).toBe("  hello\n  world");
+  });
+
+  it("order matters: indent first, then linebreak", () => {
+    // If linebreak ran first on indented text, indent spaces would be in the URL
+    const input = "  https://example.com/pa\n  th";
+    // indent removal: "https://example.com/pa\nth"
+    // linebreak removal: "https://example.com/path"
+    expect(applySmartTextTransforms(input, { removeIndent: true, removeLineBreak: true })).toBe(
+      "https://example.com/path",
+    );
+  });
+});

--- a/ui/src/lib/smart-text.ts
+++ b/ui/src/lib/smart-text.ts
@@ -40,7 +40,10 @@ export function smartRemoveIndent(text: string): string {
 /**
  * Detect if the entire text (when all newlines are removed) forms a single URL.
  * If so, join lines by removing newlines.
- * Currently only applies to http:// and https:// URLs.
+ *
+ * Scope: http:// and https:// only. The \S+ pattern intentionally doesn't
+ * validate URL structure — in a clipboard-paste context, false positives
+ * (non-standard chars in a URL-shaped string) are harmless.
  */
 export function smartRemoveLineBreak(text: string): string {
   if (!text || !text.includes("\n")) return text;
@@ -63,11 +66,12 @@ export interface SmartTextOptions {
 
 /**
  * Apply smart text transforms in the correct order:
- * 1. Remove common indent
- * 2. Remove line breaks (for URLs)
+ * 1. Normalize \r\n to \n (Windows clipboard may contain CRLF)
+ * 2. Remove common indent
+ * 3. Remove line breaks (for URLs)
  */
 export function applySmartTextTransforms(text: string, options: SmartTextOptions): string {
-  let result = text;
+  let result = text.replace(/\r\n/g, "\n");
   if (options.removeIndent) {
     result = smartRemoveIndent(result);
   }
@@ -75,4 +79,18 @@ export function applySmartTextTransforms(text: string, options: SmartTextOptions
     result = smartRemoveLineBreak(result);
   }
   return result;
+}
+
+/**
+ * Transform paste result content using smart text settings.
+ * Centralises the "is it text? → apply transforms" logic shared by
+ * Ctrl+V and right-click paste paths.
+ */
+export function transformPasteContent(
+  content: string,
+  pasteType: string,
+  convenience: SmartTextOptions,
+): string {
+  if (pasteType !== "text") return content;
+  return applySmartTextTransforms(content, convenience);
 }

--- a/ui/src/lib/smart-text.ts
+++ b/ui/src/lib/smart-text.ts
@@ -1,0 +1,78 @@
+/**
+ * Smart text transforms for clipboard paste.
+ *
+ * 1. smartRemoveIndent — strip common leading whitespace from all lines
+ * 2. smartRemoveLineBreak — rejoin URLs that were split across lines
+ *
+ * The correct order is: indent first, then linebreak.
+ * If linebreak ran on indented text, the indent spaces would corrupt URLs.
+ */
+
+/**
+ * Remove the common leading whitespace (spaces/tabs) from every line.
+ * Blank lines are ignored when computing the common prefix but are preserved in output.
+ */
+export function smartRemoveIndent(text: string): string {
+  if (!text) return text;
+
+  const lines = text.split("\n");
+
+  // Find the minimum indent among non-blank lines
+  let minIndent = Infinity;
+  for (const line of lines) {
+    if (line.trim().length === 0) continue; // skip blank lines
+    const match = line.match(/^([ \t]*)/);
+    if (match) {
+      minIndent = Math.min(minIndent, match[1].length);
+    }
+  }
+
+  if (minIndent === 0 || minIndent === Infinity) return text;
+
+  return lines
+    .map((line) => {
+      if (line.trim().length === 0) return line; // preserve blank lines
+      return line.slice(minIndent);
+    })
+    .join("\n");
+}
+
+/**
+ * Detect if the entire text (when all newlines are removed) forms a single URL.
+ * If so, join lines by removing newlines.
+ * Currently only applies to http:// and https:// URLs.
+ */
+export function smartRemoveLineBreak(text: string): string {
+  if (!text || !text.includes("\n")) return text;
+
+  // Check if joining all lines produces a valid-looking URL
+  const joined = text.split("\n").join("");
+
+  // Must start with http:// or https://
+  if (/^https?:\/\/\S+$/.test(joined)) {
+    return joined;
+  }
+
+  return text;
+}
+
+export interface SmartTextOptions {
+  removeIndent: boolean;
+  removeLineBreak: boolean;
+}
+
+/**
+ * Apply smart text transforms in the correct order:
+ * 1. Remove common indent
+ * 2. Remove line breaks (for URLs)
+ */
+export function applySmartTextTransforms(text: string, options: SmartTextOptions): string {
+  let result = text;
+  if (options.removeIndent) {
+    result = smartRemoveIndent(result);
+  }
+  if (options.removeLineBreak) {
+    result = smartRemoveLineBreak(result);
+  }
+  return result;
+}

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -111,6 +111,10 @@ export async function loadWindowGeometry(): Promise<WindowGeometry | null> {
 export interface ConvenienceSettings {
   smartPaste: boolean;
   pasteImageDir: string;
+  /** Strip common leading whitespace when pasting. */
+  smartRemoveIndent: boolean;
+  /** Rejoin URLs split across lines when pasting. */
+  smartRemoveLineBreak: boolean;
 }
 
 export type ClaudeSyncCwdMode = "skip" | "command";

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -78,6 +78,10 @@ export interface ConvenienceSettings {
   dockPersistState: boolean;
   /** Allow Alt+Arrow to navigate into/out of dock areas. */
   dockArrowNav: boolean;
+  /** Strip common leading whitespace when pasting. */
+  smartRemoveIndent: boolean;
+  /** Rejoin URLs split across lines when pasting. */
+  smartRemoveLineBreak: boolean;
 }
 
 /** Which elements to display in WorkspaceSelectorView pane rows. */
@@ -701,6 +705,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     scrollbarStyle: "overlay" as const,
     dockPersistState: true,
     dockArrowNav: true,
+    smartRemoveIndent: true,
+    smartRemoveLineBreak: true,
   },
   workspaceDisplay: { minimap: true, environment: true, activity: true, path: true, result: true },
   claude: { syncCwd: "skip" as ClaudeSyncCwdMode, restoreSession: true, sessionMaxAgeHours: 24 },
@@ -883,6 +889,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
           scrollbarStyle: "overlay" as const,
           dockPersistState: true,
           dockArrowNav: true,
+          smartRemoveIndent: true,
+          smartRemoveLineBreak: true,
           ...(data.convenience as Partial<ConvenienceSettings>),
         }
       : undefined;


### PR DESCRIPTION
## Summary
- 스마트 붙여넣기 시 **인덴트 제거 → 줄바꿈 제거** 순서로 처리하도록 수정
- 인덴트가 있는 URL을 복사할 때 공백이 URL 중간에 끼어 깨지는 문제 해결
- Settings > Convenience에 두 기능의 개별 on/off 토글 추가

## Changes
- `ui/src/lib/smart-text.ts`: 순수 텍스트 변환 함수 (`smartRemoveIndent`, `smartRemoveLineBreak`, `applySmartTextTransforms`)
- `ui/src/components/views/TerminalView.tsx`: Ctrl+V/우클릭 paste에 변환 적용
- `ui/src/components/views/SettingsView.tsx`: Convenience 섹션에 토글 추가
- `ui/src/stores/settings-store.ts`, `ui/src/lib/tauri-api.ts`: 설정 필드 추가
- `src-tauri/src/settings/models.rs`: Rust 측 설정 구조체에 필드 추가

## Test plan
- [x] 프론트엔드 테스트 통과 (25개 신규 테스트 포함, 총 1349개)
- [x] 백엔드 Rust 테스트 통과 (60개)
- [ ] 인덴트된 URL 붙여넣기 시 URL이 올바르게 복원되는지 수동 확인
- [ ] Settings에서 각 기능 토글 시 동작 확인

Fixes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)