### PR TITLE
fix: 앱 포커스 손실 시 pane 포커스 테두리를 옅게 표시

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { useAutomationBridge } from "@/hooks/useAutomationBridge";
 import { saveBeforeClose } from "@/lib/persist-session";
 import { createCloseHandler } from "@/lib/window-close-handler";
 import { useWindowGeometry, captureWindowGeometry } from "@/hooks/useWindowGeometry";
+import { useAppFocus } from "@/hooks/useAppFocus";
 
 export function App() {
   useKeyboardShortcuts();
@@ -14,6 +15,7 @@ export function App() {
   const { loaded } = useSessionPersistence();
   useAutomationBridge();
   useWindowGeometry();
+  useAppFocus();
 
   // Save terminal state before window close (Alt+F4, OS close, etc.)
   const cleanupRef = useRef<(() => void) | null>(null);

--- a/ui/src/components/layout/Dock.tsx
+++ b/ui/src/components/layout/Dock.tsx
@@ -7,6 +7,7 @@ import { useGridStore } from "@/stores/grid-store";
 import { ViewRenderer } from "@/components/views/ViewRenderer";
 import { PaneControlBar } from "./PaneControlBar";
 import { PaneBoundaryHandles } from "./PaneBoundaryHandles";
+import { useUiStore } from "@/stores/ui-store";
 
 interface DockProps {
   position: DockPosition;
@@ -203,6 +204,7 @@ function DockGrid({
 }) {
   const focusedDock = useDockStore((s) => s.focusedDock);
   const focusedDockPaneId = useDockStore((s) => s.focusedDockPaneId);
+  const isAppFocused = useUiStore((s) => s.isAppFocused);
   const containerRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ w: 0, h: 0 });
   const [hoveredPane, setHoveredPane] = useState<string | null>(null);
@@ -280,7 +282,10 @@ function DockGrid({
             {isPaneFocused && (
               <div
                 className="pointer-events-none absolute inset-0"
-                style={{ boxShadow: "inset 0 0 0 1px var(--accent)", zIndex: 20 }}
+                style={{
+                  boxShadow: `inset 0 0 0 1px var(${isAppFocused ? "--accent" : "--accent-50"})`,
+                  zIndex: 20,
+                }}
               />
             )}
             <PaneControlBar

--- a/ui/src/components/layout/WorkspaceArea.test.tsx
+++ b/ui/src/components/layout/WorkspaceArea.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/components/views/TerminalView", () => ({
 import { WorkspaceArea } from "./WorkspaceArea";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useGridStore } from "@/stores/grid-store";
+import { useUiStore } from "@/stores/ui-store";
 describe("WorkspaceArea", () => {
   beforeEach(() => {
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
@@ -82,6 +83,16 @@ describe("WorkspaceArea", () => {
     expect(indicator).toBeInTheDocument();
     expect(indicator.style.boxShadow).toBe("inset 0 0 0 1px var(--accent)");
     expect(indicator.style.zIndex).toBe("20");
+  });
+
+  it("renders dimmed focus indicator when app is not focused", () => {
+    useGridStore.setState({ focusedPaneIndex: 0 });
+    useUiStore.setState({ isAppFocused: false });
+    render(<WorkspaceArea />);
+
+    const indicator = screen.getByTestId("pane-focus-indicator");
+    expect(indicator).toBeInTheDocument();
+    expect(indicator.style.boxShadow).toBe("inset 0 0 0 1px var(--accent-50)");
   });
 
   // -- Hover auto-hide --

--- a/ui/src/components/layout/WorkspaceArea.tsx
+++ b/ui/src/components/layout/WorkspaceArea.tsx
@@ -6,11 +6,13 @@ import { useSettingsStore, FALLBACK_PROFILE, type TerminalLocation } from "@/sto
 import { ViewRenderer } from "@/components/views/ViewRenderer";
 import { PaneBoundaryHandles } from "./PaneBoundaryHandles";
 import { PaneControlBar } from "./PaneControlBar";
+import { useUiStore } from "@/stores/ui-store";
 
 export function WorkspaceArea() {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const focusedPaneIndex = useGridStore((s) => s.focusedPaneIndex);
+  const isAppFocused = useUiStore((s) => s.isAppFocused);
   const setFocusedPane = useGridStore((s) => s.setFocusedPane);
   const automationHoverIndex = useGridStore((s) => s.automationHoverIndex);
   const focusedDock = useDockStore((s) => s.focusedDock);
@@ -106,7 +108,10 @@ export function WorkspaceArea() {
                     <div
                       data-testid="pane-focus-indicator"
                       className="pointer-events-none absolute inset-0"
-                      style={{ boxShadow: "inset 0 0 0 1px var(--accent)", zIndex: 20 }}
+                      style={{
+                        boxShadow: `inset 0 0 0 1px var(${isAppFocused ? "--accent" : "--accent-50"})`,
+                        zIndex: 20,
+                      }}
                     />
                   )}
                   <PaneControlBar

--- a/ui/src/hooks/useAppFocus.test.ts
+++ b/ui/src/hooks/useAppFocus.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { act } from "@testing-library/react";
+import { useUiStore } from "@/stores/ui-store";
+import { useAppFocus } from "./useAppFocus";
+
+describe("useAppFocus", () => {
+  beforeEach(() => {
+    useUiStore.setState(useUiStore.getInitialState());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sets isAppFocused to false on window blur", () => {
+    renderHook(() => useAppFocus());
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+
+    expect(useUiStore.getState().isAppFocused).toBe(false);
+  });
+
+  it("sets isAppFocused to true on window focus", () => {
+    useUiStore.setState({ isAppFocused: false });
+    renderHook(() => useAppFocus());
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(useUiStore.getState().isAppFocused).toBe(true);
+  });
+
+  it("cleans up event listeners on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderHook(() => useAppFocus());
+
+    unmount();
+
+    const removedEvents = removeSpy.mock.calls.map((call) => call[0]);
+    expect(removedEvents).toContain("focus");
+    expect(removedEvents).toContain("blur");
+  });
+});

--- a/ui/src/hooks/useAppFocus.ts
+++ b/ui/src/hooks/useAppFocus.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { useUiStore } from "@/stores/ui-store";
+
+/**
+ * Listens for window focus/blur events and updates `isAppFocused` in the UI store.
+ * When the app loses focus (e.g. Alt+Tab), pane focus indicators can be dimmed.
+ */
+export function useAppFocus() {
+  const setAppFocused = useUiStore((s) => s.setAppFocused);
+
+  useEffect(() => {
+    const onFocus = () => setAppFocused(true);
+    const onBlur = () => setAppFocused(false);
+
+    window.addEventListener("focus", onFocus);
+    window.addEventListener("blur", onBlur);
+
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      window.removeEventListener("blur", onBlur);
+    };
+  }, [setAppFocused]);
+}

--- a/ui/src/stores/ui-store.test.ts
+++ b/ui/src/stores/ui-store.test.ts
@@ -68,4 +68,15 @@ describe("ui-store", () => {
     expect(useUiStore.getState().settingsModalOpen).toBe(true);
     expect(useUiStore.getState().notificationPanelOpen).toBe(false);
   });
+
+  it("starts with app focused", () => {
+    expect(useUiStore.getState().isAppFocused).toBe(true);
+  });
+
+  it("sets app focused state", () => {
+    useUiStore.getState().setAppFocused(false);
+    expect(useUiStore.getState().isAppFocused).toBe(false);
+    useUiStore.getState().setAppFocused(true);
+    expect(useUiStore.getState().isAppFocused).toBe(true);
+  });
 });

--- a/ui/src/stores/ui-store.ts
+++ b/ui/src/stores/ui-store.ts
@@ -28,6 +28,8 @@ interface UiState {
   settingsNavTarget: string | null;
   /** Per-pane control bar mode, keyed by pane ID. Persisted via localStorage. */
   barModes: Record<string, ControlBarMode>;
+  /** Whether the app window is currently focused (not blurred to another app). */
+  isAppFocused: boolean;
 
   openSettingsModal: () => void;
   closeSettingsModal: () => void;
@@ -37,6 +39,7 @@ interface UiState {
   setSettingsNavTarget: (target: string | null) => void;
   setBarMode: (paneId: string, mode: ControlBarMode) => void;
   getBarMode: (paneId: string) => ControlBarMode;
+  setAppFocused: (focused: boolean) => void;
 }
 
 export const useUiStore = create<UiState>()((set, get) => ({
@@ -44,6 +47,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   notificationPanelOpen: false,
   settingsNavTarget: null,
   barModes: loadBarModes(),
+  isAppFocused: true,
 
   openSettingsModal: () => set({ settingsModalOpen: true, notificationPanelOpen: false }),
   closeSettingsModal: () => set({ settingsModalOpen: false }),
@@ -67,4 +71,5 @@ export const useUiStore = create<UiState>()((set, get) => ({
     });
   },
   getBarMode: (paneId) => get().barModes[paneId] ?? "hover",
+  setAppFocused: (focused) => set({ isAppFocused: focused }),
 }));


### PR DESCRIPTION
## Summary
- 앱이 외부로 포커스를 잃으면 pane 포커스 테두리(`box-shadow`)를 `var(--accent)` → `var(--accent-50)`으로 전환하여 시각적으로 구분
- `useAppFocus` 훅으로 `window` focus/blur 이벤트 감지, `ui-store`의 `isAppFocused` 상태로 관리
- WorkspaceArea와 Dock 모두에 동일하게 적용

## 변경 파일
- `ui/src/stores/ui-store.ts` — `isAppFocused` 상태 추가
- `ui/src/hooks/useAppFocus.ts` — (신규) window focus/blur 감지 훅
- `ui/src/App.tsx` — `useAppFocus()` 등록
- `ui/src/components/layout/WorkspaceArea.tsx` — dimmed border 적용
- `ui/src/components/layout/Dock.tsx` — dimmed border 적용

## Test plan
- [x] 단위 테스트: ui-store, useAppFocus, WorkspaceArea 테스트 추가
- [x] 전체 테스트 스위트 통과 (57 파일, 1284 테스트)

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)