### PR TITLE
fix: LX_PROPAGATED=1 전파 명령을 완료 표시에서 제외

### DIFF
--- a/src-tauri/src/commands/ipc_dispatch.rs
+++ b/src-tauri/src/commands/ipc_dispatch.rs
@@ -515,7 +515,7 @@ fn build_sync_cd_command(converted_path: &str, profile: &str, is_claude: bool) -
 /// Unlike the old consume_propagation, this does NOT remove the entry —
 /// the flag stays active for the full PROPAGATION_TIMEOUT so that multiple
 /// OSC sequences (e.g. OSC 7 + OSC 9;9 from WSL) are all suppressed.
-fn is_propagated(state: &AppState, terminal_id: &str) -> Result<bool, String> {
+pub(crate) fn is_propagated(state: &AppState, terminal_id: &str) -> Result<bool, String> {
     let propagated = state.propagated_terminals.lock_or_err()?;
     if let Some(ts) = propagated.get(terminal_id) {
         Ok(ts.elapsed() < PROPAGATION_TIMEOUT)

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -496,17 +496,16 @@ fn dispatch_osc_action(
             let _ = super::ipc_dispatch::do_set_wsl_distro(state, terminal_id, &event.data);
         }
         OscAction::SetCommandStatus(field) => {
-            // Skip command status updates for propagated terminals (LX_PROPAGATED=1 cd).
-            // Command text (133;E) is already filtered by the preset condition,
-            // but ExitCode (133;D) and Preexec (133;C) carry no command text,
-            // so we check is_propagated() here.
-            if matches!(
-                field,
-                CommandStatusField::ExitCode | CommandStatusField::Preexec
-            ) {
-                if super::ipc_dispatch::is_propagated(state, terminal_id).unwrap_or(false) {
-                    return;
+            // Skip all command status updates for propagated terminals (LX_PROPAGATED=1 cd).
+            // Command text (133;E) is also filtered by the preset condition
+            // (CommandDoesNotStartWith), but we check is_propagated() here as
+            // defense-in-depth in case custom hooks bypass the preset condition.
+            match super::ipc_dispatch::is_propagated(state, terminal_id) {
+                Ok(true) => return,
+                Err(e) => {
+                    tracing::warn!(terminal_id, error = %e, "is_propagated check failed");
                 }
+                _ => {}
             }
 
             match field {

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -495,35 +495,50 @@ fn dispatch_osc_action(
         OscAction::SetWslDistro => {
             let _ = super::ipc_dispatch::do_set_wsl_distro(state, terminal_id, &event.data);
         }
-        OscAction::SetCommandStatus(field) => match field {
-            CommandStatusField::Command => {
-                let _ = super::ipc_dispatch::do_set_command_status(
-                    state,
-                    app,
-                    terminal_id,
-                    Some(&event.data),
-                    None,
-                );
+        OscAction::SetCommandStatus(field) => {
+            // Skip command status updates for propagated terminals (LX_PROPAGATED=1 cd).
+            // Command text (133;E) is already filtered by the preset condition,
+            // but ExitCode (133;D) and Preexec (133;C) carry no command text,
+            // so we check is_propagated() here.
+            if matches!(
+                field,
+                CommandStatusField::ExitCode | CommandStatusField::Preexec
+            ) {
+                if super::ipc_dispatch::is_propagated(state, terminal_id).unwrap_or(false) {
+                    return;
+                }
             }
-            CommandStatusField::ExitCode => {
-                let exit_code = event.data.parse::<i32>().ok();
-                let _ = super::ipc_dispatch::do_set_command_status(
-                    state,
-                    app,
-                    terminal_id,
-                    None,
-                    exit_code,
-                );
+
+            match field {
+                CommandStatusField::Command => {
+                    let _ = super::ipc_dispatch::do_set_command_status(
+                        state,
+                        app,
+                        terminal_id,
+                        Some(&event.data),
+                        None,
+                    );
+                }
+                CommandStatusField::ExitCode => {
+                    let exit_code = event.data.parse::<i32>().ok();
+                    let _ = super::ipc_dispatch::do_set_command_status(
+                        state,
+                        app,
+                        terminal_id,
+                        None,
+                        exit_code,
+                    );
+                }
+                CommandStatusField::Preexec => {
+                    let _ = super::ipc_dispatch::do_set_command_status(
+                        state,
+                        app,
+                        terminal_id,
+                        Some("__preexec__"),
+                        None,
+                    );
+                }
             }
-            CommandStatusField::Preexec => {
-                let _ = super::ipc_dispatch::do_set_command_status(
-                    state,
-                    app,
-                    terminal_id,
-                    Some("__preexec__"),
-                    None,
-                );
-            }
-        },
+        }
     }
 }

--- a/src-tauri/src/osc_hooks.rs
+++ b/src-tauri/src/osc_hooks.rs
@@ -18,6 +18,8 @@ pub enum OscCondition {
     ExitCodeNotEq(String),
     /// Matches when the command starts with any of the given prefixes.
     CommandStartsWith(Vec<String>),
+    /// Matches when the command does NOT start with any of the given prefixes.
+    CommandDoesNotStartWith(Vec<String>),
 }
 
 impl OscCondition {
@@ -37,6 +39,12 @@ impl OscCondition {
                 event.code == 133
                     && event.param.as_deref() == Some("E")
                     && prefixes.iter().any(|p| event.data.starts_with(p))
+            }
+            OscCondition::CommandDoesNotStartWith(prefixes) => {
+                // OSC 133;E — matches only when command does NOT start with any prefix.
+                event.code == 133
+                    && event.param.as_deref() == Some("E")
+                    && !prefixes.iter().any(|p| event.data.starts_with(p))
             }
         }
     }
@@ -180,11 +188,14 @@ pub fn default_presets() -> Vec<OscHookDef> {
             when: OscCondition::Always,
             action: OscAction::Notify { level: None },
         },
-        // track-command: OSC 133;E → set command text
+        // track-command: OSC 133;E → set command text (skip propagated commands)
         OscHookDef {
             osc: 133,
             param: ParamMatch::Exact("E"),
-            when: OscCondition::Always,
+            when: OscCondition::CommandDoesNotStartWith(vec![
+                "LX_PROPAGATED=1 ".to_string(),
+                "$env:LX_PROPAGATED".to_string(),
+            ]),
             action: OscAction::SetCommandStatus(CommandStatusField::Command),
         },
         // track-command-result: OSC 133;D → set exit code
@@ -319,6 +330,53 @@ mod tests {
 
         let other = make_event(133, Some("E"), "cargo build");
         assert!(!cond.evaluate(&other));
+    }
+
+    #[test]
+    fn condition_command_does_not_start_with() {
+        let cond = OscCondition::CommandDoesNotStartWith(vec![
+            "LX_PROPAGATED=1 ".into(),
+            "$env:LX_PROPAGATED".into(),
+        ]);
+
+        // Normal command → matches
+        let normal = make_event(133, Some("E"), "cargo build");
+        assert!(cond.evaluate(&normal));
+
+        // Propagated bash command → does NOT match
+        let propagated_bash = make_event(133, Some("E"), "LX_PROPAGATED=1 cd /home/user");
+        assert!(!cond.evaluate(&propagated_bash));
+
+        // Propagated PowerShell command → does NOT match
+        let propagated_ps = make_event(133, Some("E"), "$env:LX_PROPAGATED='1';cd C:\\Users");
+        assert!(!cond.evaluate(&propagated_ps));
+
+        // Wrong OSC code → does NOT match (condition requires 133;E)
+        let wrong_osc = make_event(7, None, "cargo build");
+        assert!(!cond.evaluate(&wrong_osc));
+    }
+
+    #[test]
+    fn track_command_skips_propagated() {
+        let presets = default_presets();
+
+        // Normal command → track-command fires
+        let normal = make_event(133, Some("E"), "npm test");
+        let matched = match_hooks(&normal, &presets);
+        let actions: Vec<_> = matched.iter().map(|h| &h.action).collect();
+        assert!(actions.contains(&&OscAction::SetCommandStatus(CommandStatusField::Command)));
+
+        // Propagated bash cd → track-command does NOT fire
+        let propagated = make_event(133, Some("E"), "LX_PROPAGATED=1 cd /foo");
+        let matched = match_hooks(&propagated, &presets);
+        let actions: Vec<_> = matched.iter().map(|h| &h.action).collect();
+        assert!(!actions.contains(&&OscAction::SetCommandStatus(CommandStatusField::Command)));
+
+        // Propagated PowerShell cd → track-command does NOT fire
+        let propagated_ps = make_event(133, Some("E"), "$env:LX_PROPAGATED='1';cd C:\\foo");
+        let matched = match_hooks(&propagated_ps, &presets);
+        let actions: Vec<_> = matched.iter().map(|h| &h.action).collect();
+        assert!(!actions.contains(&&OscAction::SetCommandStatus(CommandStatusField::Command)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- 앱 시작 시 CWD 동기화로 전파된 `LX_PROPAGATED=1 cd` 명령이 워크스페이스 목록에 "✓ 완료"로 표시되던 문제 수정
- `OscCondition::CommandDoesNotStartWith` variant 추가하여 `track-command` 프리셋에서 전파 명령 필터링 (133;E)
- `dispatch_osc_action`에서 `is_propagated()` 체크로 exit code/preexec (133;D/133;C)도 스킵

## Test plan
- [x] `cargo test --lib` 441개 전체 통과
- [x] 새 단위 테스트 2개 추가 (`condition_command_does_not_start_with`, `track_command_skips_propagated`)
- [ ] 앱 시작 후 워크스페이스 목록에 전파된 cd가 완료로 표시되지 않는지 확인
- [ ] 일반 명령 실행 시 완료 표시가 정상 동작하는지 확인

Fixes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)