### PR TITLE
refactor: Dock/WorkspaceArea pane 렌더링 공통화

### DIFF
--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -240,7 +240,7 @@ export function AppLayout() {
           onSwitchView={(v: ViewType, config?: import("@/stores/types").ViewInstanceConfig) =>
             setDockActiveView(pos, v, config)
           }
-          onSplitPane={(dir, paneId) => splitDockPane(pos, dir, paneId)}
+          onSplitPane={(paneId, dir) => splitDockPane(pos, dir, paneId)}
           onRemovePane={(paneId) => removeDockPane(pos, paneId)}
           onSetPaneView={(paneId, view) => setDockPaneView(pos, paneId, view)}
           onResizePane={(paneId, delta) => resizeDockPane(pos, paneId, delta)}

--- a/ui/src/components/layout/Dock.test.tsx
+++ b/ui/src/components/layout/Dock.test.tsx
@@ -355,6 +355,6 @@ describe("Dock", () => {
     const pane = screen.getByTestId("dock-pane-dp-1");
     fireEvent.mouseEnter(pane);
     fireEvent.click(screen.getByTestId("pane-control-split-v"));
-    expect(onSplitPane).toHaveBeenCalledWith("vertical", "dp-1");
+    expect(onSplitPane).toHaveBeenCalledWith("dp-1", "vertical");
   });
 });

--- a/ui/src/components/layout/Dock.tsx
+++ b/ui/src/components/layout/Dock.tsx
@@ -1,4 +1,3 @@
-import { useState, useRef, useCallback, useEffect } from "react";
 import type { DockPosition, DockPane, ViewType, ViewInstanceConfig } from "@/stores/types";
 import { useDockStore } from "@/stores/dock-store";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -6,8 +5,8 @@ import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useGridStore } from "@/stores/grid-store";
 import { ViewRenderer } from "@/components/views/ViewRenderer";
 import { PaneControlBar } from "./PaneControlBar";
-import { PaneBoundaryHandles } from "./PaneBoundaryHandles";
-import { useUiStore } from "@/stores/ui-store";
+import { PaneGrid } from "./PaneGrid";
+import { useHoverTimer } from "@/hooks/useHoverTimer";
 
 interface DockProps {
   position: DockPosition;
@@ -53,32 +52,16 @@ export function Dock({
     return ws?.name ?? "";
   });
 
-  const [singleHovered, setSingleHovered] = useState(false);
-  const singleHoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const singleHover = useHoverTimer(hoverIdleSeconds);
 
-  const handleSingleHoverActivity = useCallback(() => {
-    setSingleHovered(true);
-    if (singleHoverTimerRef.current) clearTimeout(singleHoverTimerRef.current);
-    if (hoverIdleSeconds > 0) {
-      singleHoverTimerRef.current = setTimeout(
-        () => setSingleHovered(false),
-        hoverIdleSeconds * 1000,
-      );
-    }
-  }, [hoverIdleSeconds]);
-
-  useEffect(() => {
-    return () => {
-      if (singleHoverTimerRef.current) clearTimeout(singleHoverTimerRef.current);
-    };
-  }, []);
-
-  // Split panes rendering — 2D absolute positioned grid (same as WorkspaceArea)
+  // Split panes rendering — delegates to shared PaneGrid
   if (hasSplitPanes) {
     return (
       <DockGrid
         position={position}
         panes={panes}
+        activeWorkspaceId={activeWorkspaceId}
+        activeWsName={activeWsName}
         onSplitPane={onSplitPane}
         onRemovePane={onRemovePane}
         onSetPaneView={onSetPaneView}
@@ -94,12 +77,9 @@ export function Dock({
       data-testid={`dock-${position}`}
       className="flex h-full w-full overflow-hidden"
       style={{ background: "var(--bg-surface)", borderColor: "var(--border)" }}
-      onMouseEnter={handleSingleHoverActivity}
-      onMouseMove={handleSingleHoverActivity}
-      onMouseLeave={() => {
-        setSingleHovered(false);
-        if (singleHoverTimerRef.current) clearTimeout(singleHoverTimerRef.current);
-      }}
+      onMouseEnter={() => singleHover.activate("__single__")}
+      onMouseMove={() => singleHover.activate("__single__")}
+      onMouseLeave={singleHover.clear}
     >
       {showIconBar && (
         <div
@@ -129,7 +109,7 @@ export function Dock({
       <div className="relative min-w-0 flex-1">
         <PaneControlBar
           currentView={panes[0]?.view ?? { type: activeView ?? "EmptyView" }}
-          hovered={singleHovered}
+          hovered={singleHover.hoveredId !== null}
           actions={{
             onSplitH: onSplitPane ? () => onSplitPane("horizontal", singlePaneId) : undefined,
             onSplitV: onSplitPane ? () => onSplitPane("vertical", singlePaneId) : undefined,
@@ -186,10 +166,12 @@ export function Dock({
   );
 }
 
-/** 2D grid dock panes — uses absolute positioning like WorkspaceArea */
+/** Thin wrapper that configures PaneGrid for dock context */
 function DockGrid({
   position,
   panes,
+  activeWorkspaceId,
+  activeWsName,
   onSplitPane,
   onRemovePane,
   onSetPaneView,
@@ -197,6 +179,8 @@ function DockGrid({
 }: {
   position: DockPosition;
   panes: DockPane[];
+  activeWorkspaceId: string;
+  activeWsName: string;
   onSplitPane?: (direction: "horizontal" | "vertical", paneId?: string) => void;
   onRemovePane?: (paneId: string) => void;
   onSetPaneView?: (paneId: string, view: ViewInstanceConfig) => void;
@@ -204,152 +188,39 @@ function DockGrid({
 }) {
   const focusedDock = useDockStore((s) => s.focusedDock);
   const focusedDockPaneId = useDockStore((s) => s.focusedDockPaneId);
-  const isAppFocused = useUiStore((s) => s.isAppFocused);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [size, setSize] = useState({ w: 0, h: 0 });
-  const [hoveredPane, setHoveredPane] = useState<string | null>(null);
-  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const hoverIdleSeconds = useSettingsStore((s) => s.convenience.hoverIdleSeconds);
-  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
-  const activeWsName = useWorkspaceStore((s) => {
-    const ws = s.workspaces.find((w) => w.id === s.activeWorkspaceId);
-    return ws?.name ?? "";
-  });
-
-  const handlePaneHoverActivity = useCallback(
-    (paneId: string) => {
-      setHoveredPane(paneId);
-      if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
-      if (hoverIdleSeconds > 0) {
-        hoverTimerRef.current = setTimeout(() => setHoveredPane(null), hoverIdleSeconds * 1000);
-      }
-    },
-    [hoverIdleSeconds],
-  );
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const ro = new ResizeObserver((entries) => {
-      const { width, height } = entries[0].contentRect;
-      setSize({ w: width, h: height });
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
-    };
-  }, []);
 
   return (
-    <div
-      ref={containerRef}
-      data-testid={`dock-${position}`}
-      className="relative h-full w-full overflow-hidden"
-      style={{ background: "var(--bg-surface)" }}
-    >
-      {panes.map((pane) => {
-        const isHovered = hoveredPane === pane.id;
-        const isPaneFocused = focusedDock === position && focusedDockPaneId === pane.id;
-        return (
-          <div
-            key={pane.id}
-            data-testid={`dock-pane-${pane.id}`}
-            className="absolute overflow-hidden"
-            style={{
-              left: `${pane.x * 100}%`,
-              top: `${pane.y * 100}%`,
-              width: `${pane.w * 100}%`,
-              height: `${pane.h * 100}%`,
-              borderRight: "2px solid var(--border)",
-              borderBottom: "2px solid var(--border)",
-            }}
-            onMouseDown={(e) => {
-              e.stopPropagation();
-              useDockStore.getState().setFocusedDock(position, pane.id);
-              useGridStore.getState().setFocusedPane(null);
-            }}
-            onMouseEnter={() => handlePaneHoverActivity(pane.id)}
-            onMouseMove={() => handlePaneHoverActivity(pane.id)}
-            onMouseLeave={() => {
-              setHoveredPane(null);
-              if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
-            }}
-          >
-            {isPaneFocused && (
-              <div
-                className="pointer-events-none absolute inset-0"
-                style={{
-                  boxShadow: `inset 0 0 0 1px var(${isAppFocused ? "--accent" : "--accent-50"})`,
-                  zIndex: 20,
-                }}
-              />
-            )}
-            <PaneControlBar
-              currentView={pane.view}
-              hovered={isHovered}
-              actions={{
-                onSplitH: onSplitPane ? () => onSplitPane("horizontal", pane.id) : undefined,
-                onSplitV: onSplitPane ? () => onSplitPane("vertical", pane.id) : undefined,
-                onClear: () => onSetPaneView?.(pane.id, { type: "EmptyView" }),
-                onDelete:
-                  panes.length > 1 && onRemovePane ? () => onRemovePane(pane.id) : undefined,
-                onToggleCwdSend:
-                  onSetPaneView &&
-                  (pane.view.type === "TerminalView" || pane.view.type === "FileExplorerView")
-                    ? () =>
-                        onSetPaneView(pane.id, {
-                          ...pane.view,
-                          cwdSend: !((pane.view.cwdSend as boolean) ?? true),
-                        })
-                    : undefined,
-                onToggleCwdReceive:
-                  onSetPaneView &&
-                  (pane.view.type === "TerminalView" || pane.view.type === "FileExplorerView")
-                    ? () =>
-                        onSetPaneView(pane.id, {
-                          ...pane.view,
-                          cwdReceive: !((pane.view.cwdReceive as boolean) ?? true),
-                        })
-                    : undefined,
-              }}
-            >
-              <ViewRenderer
-                viewType={pane.view.type}
-                viewConfig={pane.view}
-                paneId={pane.id}
-                workspaceId={activeWorkspaceId}
-                workspaceName={activeWsName}
-                isFocused={isPaneFocused}
-                onSelectView={(config) => onSetPaneView?.(pane.id, config)}
-                emptyViewContext="dock"
-                location="dock"
-                onKeyboardActivity={() => {
-                  setHoveredPane(null);
-                  if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
-                }}
-              />
-            </PaneControlBar>
-          </div>
-        );
-      })}
-      <PaneBoundaryHandles
-        panes={panes}
-        containerWidth={size.w}
-        containerHeight={size.h}
-        getLatestPanes={() => useDockStore.getState().getDock(position)?.panes ?? []}
-        onResizePane={(idx, delta) => {
+    <PaneGrid
+      panes={panes}
+      containerTestId={`dock-${position}`}
+      containerClassName="relative h-full w-full overflow-hidden"
+      containerStyle={{ background: "var(--bg-surface)" }}
+      testIdFn={(pane) => `dock-pane-${pane.id}`}
+      isFocused={(paneId) => focusedDock === position && focusedDockPaneId === paneId}
+      onPaneFocus={(paneId) => {
+        useDockStore.getState().setFocusedDock(position, paneId);
+        useGridStore.getState().setFocusedPane(null);
+      }}
+      onSetPaneView={onSetPaneView}
+      onSplitPane={onSplitPane ? (paneId, dir) => onSplitPane(dir, paneId) : undefined}
+      onRemovePane={onRemovePane}
+      getCwdDefaults={() => ({ send: true, receive: true })}
+      workspaceId={activeWorkspaceId}
+      workspaceName={activeWsName}
+      emptyViewContext="dock"
+      location="dock"
+      boundaryHandlesProps={{
+        panes,
+        getLatestPanes: () => useDockStore.getState().getDock(position)?.panes ?? [],
+        onResizePane: (idx, delta) => {
           const pane = panes[idx];
           if (pane && onResizePane) onResizePane(pane.id, delta);
-        }}
-        onRemovePane={(idx) => {
+        },
+        onRemovePane: (idx) => {
           const pane = panes[idx];
           if (pane && onRemovePane) onRemovePane(pane.id);
-        }}
-      />
-    </div>
+        },
+      }}
+    />
   );
 }

--- a/ui/src/components/layout/Dock.tsx
+++ b/ui/src/components/layout/Dock.tsx
@@ -14,7 +14,7 @@ interface DockProps {
   views: ViewType[];
   panes: DockPane[];
   onSwitchView?: (view: ViewType, viewConfig?: ViewInstanceConfig) => void;
-  onSplitPane?: (direction: "horizontal" | "vertical", paneId?: string) => void;
+  onSplitPane?: (paneId: string, direction: "horizontal" | "vertical") => void;
   onRemovePane?: (paneId: string) => void;
   onSetPaneView?: (paneId: string, view: ViewInstanceConfig) => void;
   onResizePane?: (paneId: string, delta: Partial<Pick<DockPane, "x" | "y" | "w" | "h">>) => void;
@@ -111,8 +111,12 @@ export function Dock({
           currentView={panes[0]?.view ?? { type: activeView ?? "EmptyView" }}
           hovered={singleHover.hoveredId !== null}
           actions={{
-            onSplitH: onSplitPane ? () => onSplitPane("horizontal", singlePaneId) : undefined,
-            onSplitV: onSplitPane ? () => onSplitPane("vertical", singlePaneId) : undefined,
+            onSplitH:
+              onSplitPane && singlePaneId
+                ? () => onSplitPane(singlePaneId, "horizontal")
+                : undefined,
+            onSplitV:
+              onSplitPane && singlePaneId ? () => onSplitPane(singlePaneId, "vertical") : undefined,
             onClear:
               activeView && activeView !== "EmptyView"
                 ? singlePaneId && onSetPaneView
@@ -181,7 +185,7 @@ function DockGrid({
   panes: DockPane[];
   activeWorkspaceId: string;
   activeWsName: string;
-  onSplitPane?: (direction: "horizontal" | "vertical", paneId?: string) => void;
+  onSplitPane?: (paneId: string, direction: "horizontal" | "vertical") => void;
   onRemovePane?: (paneId: string) => void;
   onSetPaneView?: (paneId: string, view: ViewInstanceConfig) => void;
   onResizePane?: (paneId: string, delta: Partial<Pick<DockPane, "x" | "y" | "w" | "h">>) => void;
@@ -202,7 +206,7 @@ function DockGrid({
         useGridStore.getState().setFocusedPane(null);
       }}
       onSetPaneView={onSetPaneView}
-      onSplitPane={onSplitPane ? (paneId, dir) => onSplitPane(dir, paneId) : undefined}
+      onSplitPane={onSplitPane}
       onRemovePane={onRemovePane}
       getCwdDefaults={() => ({ send: true, receive: true })}
       workspaceId={activeWorkspaceId}

--- a/ui/src/components/layout/FocusIndicator.tsx
+++ b/ui/src/components/layout/FocusIndicator.tsx
@@ -1,0 +1,16 @@
+import { useUiStore } from "@/stores/ui-store";
+
+export function FocusIndicator({ testId }: { testId?: string }) {
+  const isAppFocused = useUiStore((s) => s.isAppFocused);
+
+  return (
+    <div
+      data-testid={testId}
+      className="pointer-events-none absolute inset-0"
+      style={{
+        boxShadow: `inset 0 0 0 1px var(${isAppFocused ? "--accent" : "--accent-50"})`,
+        zIndex: 20,
+      }}
+    />
+  );
+}

--- a/ui/src/components/layout/PaneGrid.test.tsx
+++ b/ui/src/components/layout/PaneGrid.test.tsx
@@ -63,12 +63,25 @@ describe("PaneGrid", () => {
     expect(screen.getByTestId("my-grid")).toBeInTheDocument();
   });
 
-  it("calls onSplitPane and onRemovePane through PaneControlBar", () => {
+  it("calls onSplitPane via PaneControlBar split button", () => {
     const onSplitPane = vi.fn();
+    render(<PaneGrid {...defaultProps} onSplitPane={onSplitPane} />);
+
+    // Hover to show PaneControlBar
+    fireEvent.mouseEnter(screen.getByTestId("test-pane-0"));
+    fireEvent.click(screen.getByTestId("pane-control-split-h"));
+
+    expect(onSplitPane).toHaveBeenCalledWith("pane-0", "horizontal");
+  });
+
+  it("calls onRemovePane via PaneControlBar delete button", () => {
     const onRemovePane = vi.fn();
-    render(<PaneGrid {...defaultProps} onSplitPane={onSplitPane} onRemovePane={onRemovePane} />);
-    // PaneControlBar renders split/delete buttons — verifying props are passed
-    expect(onSplitPane).not.toHaveBeenCalled();
-    expect(onRemovePane).not.toHaveBeenCalled();
+    render(<PaneGrid {...defaultProps} onRemovePane={onRemovePane} />);
+
+    // Hover to show PaneControlBar
+    fireEvent.mouseEnter(screen.getByTestId("test-pane-0"));
+    fireEvent.click(screen.getByTestId("pane-control-delete"));
+
+    expect(onRemovePane).toHaveBeenCalledWith("pane-0");
   });
 });

--- a/ui/src/components/layout/PaneGrid.test.tsx
+++ b/ui/src/components/layout/PaneGrid.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { PaneGrid, type GridPane } from "./PaneGrid";
+
+const makePanes = (count: number): GridPane[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `pane-${i}`,
+    view: { type: "TerminalView" as const },
+    x: i * (1 / count),
+    y: 0,
+    w: 1 / count,
+    h: 1,
+  }));
+
+describe("PaneGrid", () => {
+  const defaultProps = {
+    panes: makePanes(2),
+    testIdFn: (_p: GridPane, i: number) => `test-pane-${i}`,
+    isFocused: () => false,
+    onPaneFocus: vi.fn(),
+    workspaceId: "ws-1",
+    workspaceName: "Test WS",
+  };
+
+  it("renders all panes with correct test ids", () => {
+    render(<PaneGrid {...defaultProps} />);
+    expect(screen.getByTestId("test-pane-0")).toBeInTheDocument();
+    expect(screen.getByTestId("test-pane-1")).toBeInTheDocument();
+  });
+
+  it("calls onPaneFocus on mouseDown", () => {
+    const onPaneFocus = vi.fn();
+    render(<PaneGrid {...defaultProps} onPaneFocus={onPaneFocus} />);
+    fireEvent.mouseDown(screen.getByTestId("test-pane-0"));
+    expect(onPaneFocus).toHaveBeenCalledWith("pane-0");
+  });
+
+  it("renders FocusIndicator for focused pane", () => {
+    render(<PaneGrid {...defaultProps} isFocused={(id) => id === "pane-0"} />);
+    expect(screen.getByTestId("pane-focus-indicator")).toBeInTheDocument();
+  });
+
+  it("does not render FocusIndicator for unfocused panes", () => {
+    render(<PaneGrid {...defaultProps} isFocused={() => false} />);
+    expect(screen.queryByTestId("pane-focus-indicator")).not.toBeInTheDocument();
+  });
+
+  it("hides panes when isActive is false", () => {
+    render(<PaneGrid {...defaultProps} isActive={false} />);
+    const pane = screen.getByTestId("test-pane-0");
+    expect(pane.style.display).toBe("none");
+  });
+
+  it("does not call onPaneFocus when isActive is false", () => {
+    const onPaneFocus = vi.fn();
+    render(<PaneGrid {...defaultProps} isActive={false} onPaneFocus={onPaneFocus} />);
+    fireEvent.mouseDown(screen.getByTestId("test-pane-0"));
+    expect(onPaneFocus).not.toHaveBeenCalled();
+  });
+
+  it("renders with containerTestId", () => {
+    render(<PaneGrid {...defaultProps} containerTestId="my-grid" />);
+    expect(screen.getByTestId("my-grid")).toBeInTheDocument();
+  });
+
+  it("calls onSplitPane and onRemovePane through PaneControlBar", () => {
+    const onSplitPane = vi.fn();
+    const onRemovePane = vi.fn();
+    render(<PaneGrid {...defaultProps} onSplitPane={onSplitPane} onRemovePane={onRemovePane} />);
+    // PaneControlBar renders split/delete buttons — verifying props are passed
+    expect(onSplitPane).not.toHaveBeenCalled();
+    expect(onRemovePane).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/layout/PaneGrid.tsx
+++ b/ui/src/components/layout/PaneGrid.tsx
@@ -1,0 +1,192 @@
+import { useRef } from "react";
+import type { ViewInstanceConfig } from "@/stores/types";
+import type { TerminalLocation } from "@/stores/settings-store";
+import { ViewRenderer } from "@/components/views/ViewRenderer";
+import { PaneBoundaryHandles } from "./PaneBoundaryHandles";
+import { PaneControlBar } from "./PaneControlBar";
+import { FocusIndicator } from "./FocusIndicator";
+import { useContainerSize } from "@/hooks/useContainerSize";
+import { useHoverTimer } from "@/hooks/useHoverTimer";
+import { useSettingsStore } from "@/stores/settings-store";
+
+export interface GridPane {
+  id: string;
+  view: ViewInstanceConfig;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+interface CwdDefaults {
+  send: boolean;
+  receive: boolean;
+}
+
+export interface PaneGridProps {
+  panes: GridPane[];
+  /** Generates data-testid for each pane. */
+  testIdFn: (pane: GridPane, index: number) => string | undefined;
+
+  // Focus management (core difference between workspace and dock)
+  isFocused: (paneId: string) => boolean;
+  onPaneFocus: (paneId: string) => void;
+
+  // Pane operations
+  onSetPaneView?: (paneId: string, config: ViewInstanceConfig) => void;
+  onSplitPane?: (paneId: string, dir: "horizontal" | "vertical") => void;
+  onRemovePane?: (paneId: string) => void;
+
+  // CWD toggle defaults
+  getCwdDefaults?: (view: ViewInstanceConfig) => CwdDefaults;
+
+  // ViewRenderer common props
+  workspaceId: string;
+  workspaceName: string;
+  emptyViewContext?: "pane" | "dock";
+  location?: TerminalLocation;
+
+  // Optional: visibility (WorkspaceArea uses display:none for inactive ws)
+  isActive?: boolean;
+
+  // Optional: external hover override (automationHoverIndex)
+  isHoveredOverride?: (paneId: string) => boolean;
+
+  // PaneBoundaryHandles override props
+  boundaryHandlesProps?: {
+    panes?: Array<{ x: number; y: number; w: number; h: number }>;
+    getLatestPanes?: () => Array<{ x: number; y: number; w: number; h: number }>;
+    onResizePane?: (
+      index: number,
+      delta: Partial<{ x: number; y: number; w: number; h: number }>,
+    ) => void;
+    onRemovePane?: (index: number) => void;
+  };
+
+  // Container props
+  containerTestId?: string;
+  containerClassName?: string;
+  containerStyle?: React.CSSProperties;
+}
+
+export function PaneGrid({
+  panes,
+  testIdFn,
+  isFocused,
+  onPaneFocus,
+  onSetPaneView,
+  onSplitPane,
+  onRemovePane,
+  getCwdDefaults,
+  workspaceId,
+  workspaceName,
+  emptyViewContext,
+  location,
+  isActive = true,
+  isHoveredOverride,
+  boundaryHandlesProps,
+  containerTestId,
+  containerClassName = "relative h-full w-full",
+  containerStyle,
+}: PaneGridProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const size = useContainerSize(containerRef);
+  const hoverIdleSeconds = useSettingsStore((s) => s.convenience.hoverIdleSeconds);
+  const hover = useHoverTimer(hoverIdleSeconds);
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid={containerTestId}
+      className={containerClassName}
+      style={containerStyle}
+    >
+      {panes.map((pane, i) => {
+        const focused = isFocused(pane.id);
+        const isHovered = hover.hoveredId === pane.id || (isHoveredOverride?.(pane.id) ?? false);
+
+        const hasCwdView =
+          pane.view.type === "TerminalView" || pane.view.type === "FileExplorerView";
+
+        return (
+          <div
+            key={pane.id}
+            data-testid={testIdFn(pane, i)}
+            className="absolute overflow-hidden"
+            onMouseDown={() => {
+              if (!isActive) return;
+              onPaneFocus(pane.id);
+            }}
+            onMouseEnter={() => isActive && hover.activate(pane.id)}
+            onMouseMove={() => isActive && hover.activate(pane.id)}
+            onMouseLeave={hover.clear}
+            style={{
+              left: `${pane.x * 100}%`,
+              top: `${pane.y * 100}%`,
+              width: `${pane.w * 100}%`,
+              height: `${pane.h * 100}%`,
+              display: isActive ? undefined : "none",
+              borderRight: "2px solid var(--border)",
+              borderBottom: "2px solid var(--border)",
+            }}
+          >
+            {focused && <FocusIndicator testId="pane-focus-indicator" />}
+            <PaneControlBar
+              currentView={pane.view}
+              hovered={isActive && isHovered}
+              actions={{
+                onChangeView: onSetPaneView
+                  ? (config) => onSetPaneView(pane.id, config)
+                  : undefined,
+                onSplitH: onSplitPane ? () => onSplitPane(pane.id, "horizontal") : undefined,
+                onSplitV: onSplitPane ? () => onSplitPane(pane.id, "vertical") : undefined,
+                onClear: onSetPaneView
+                  ? () => onSetPaneView(pane.id, { type: "EmptyView" })
+                  : undefined,
+                onDelete:
+                  panes.length > 1 && onRemovePane ? () => onRemovePane(pane.id) : undefined,
+                onToggleCwdSend:
+                  hasCwdView && onSetPaneView && getCwdDefaults
+                    ? () => {
+                        const defaults = getCwdDefaults(pane.view);
+                        const current = (pane.view.cwdSend as boolean | undefined) ?? defaults.send;
+                        onSetPaneView(pane.id, { ...pane.view, cwdSend: !current });
+                      }
+                    : undefined,
+                onToggleCwdReceive:
+                  hasCwdView && onSetPaneView && getCwdDefaults
+                    ? () => {
+                        const defaults = getCwdDefaults(pane.view);
+                        const current =
+                          (pane.view.cwdReceive as boolean | undefined) ?? defaults.receive;
+                        onSetPaneView(pane.id, { ...pane.view, cwdReceive: !current });
+                      }
+                    : undefined,
+              }}
+            >
+              <ViewRenderer
+                viewType={pane.view.type}
+                viewConfig={pane.view}
+                onSelectView={
+                  onSetPaneView ? (config) => onSetPaneView(pane.id, config) : undefined
+                }
+                workspaceName={workspaceName}
+                workspaceId={workspaceId}
+                paneId={pane.id}
+                isFocused={focused}
+                emptyViewContext={emptyViewContext}
+                location={location}
+                onKeyboardActivity={hover.clear}
+              />
+            </PaneControlBar>
+          </div>
+        );
+      })}
+      <PaneBoundaryHandles
+        containerWidth={size.w}
+        containerHeight={size.h}
+        {...boundaryHandlesProps}
+      />
+    </div>
+  );
+}

--- a/ui/src/components/layout/PaneGrid.tsx
+++ b/ui/src/components/layout/PaneGrid.tsx
@@ -113,7 +113,8 @@ export function PaneGrid({
             key={pane.id}
             data-testid={testIdFn(pane, i)}
             className="absolute overflow-hidden"
-            onMouseDown={() => {
+            onMouseDown={(e) => {
+              e.stopPropagation();
               if (!isActive) return;
               onPaneFocus(pane.id);
             }}
@@ -182,11 +183,13 @@ export function PaneGrid({
           </div>
         );
       })}
-      <PaneBoundaryHandles
-        containerWidth={size.w}
-        containerHeight={size.h}
-        {...boundaryHandlesProps}
-      />
+      {isActive && (
+        <PaneBoundaryHandles
+          containerWidth={size.w}
+          containerHeight={size.h}
+          {...boundaryHandlesProps}
+        />
+      )}
     </div>
   );
 }

--- a/ui/src/components/layout/PaneGrid.tsx
+++ b/ui/src/components/layout/PaneGrid.tsx
@@ -187,7 +187,10 @@ export function PaneGrid({
         <PaneBoundaryHandles
           containerWidth={size.w}
           containerHeight={size.h}
-          {...boundaryHandlesProps}
+          panes={boundaryHandlesProps?.panes}
+          getLatestPanes={boundaryHandlesProps?.getLatestPanes}
+          onResizePane={boundaryHandlesProps?.onResizePane}
+          onRemovePane={boundaryHandlesProps?.onRemovePane}
         />
       )}
     </div>

--- a/ui/src/components/layout/WorkspaceArea.test.tsx
+++ b/ui/src/components/layout/WorkspaceArea.test.tsx
@@ -242,9 +242,7 @@ describe("WorkspaceArea", () => {
 
     // Both workspaces should have their pane divs in the DOM
     // WS1 panes visible, WS2 panes hidden (display: none)
-    const allDivs = document.querySelectorAll(
-      "[data-testid='workspace-area'] > [class*='absolute']",
-    );
+    const allDivs = document.querySelectorAll("[data-testid='workspace-area'] [class*='absolute']");
     const hiddenDivs = Array.from(allDivs).filter(
       (el) => (el as HTMLElement).style.display === "none",
     );

--- a/ui/src/components/layout/WorkspaceArea.tsx
+++ b/ui/src/components/layout/WorkspaceArea.tsx
@@ -33,55 +33,32 @@ export function WorkspaceArea() {
       {workspaces.map((ws) => {
         const isActive = ws.id === activeWorkspaceId;
         if (!mountedWsIds.has(ws.id)) return null;
+        const idxOf = (paneId: string) => ws.panes.findIndex((p) => p.id === paneId);
         return (
           <PaneGrid
             key={ws.id}
             panes={ws.panes}
             isActive={isActive}
             testIdFn={(_pane, i) => (isActive ? `workspace-pane-${i}` : undefined)}
-            isFocused={(paneId) => {
-              const idx = ws.panes.findIndex((p) => p.id === paneId);
-              return isActive && focusedPaneIndex === idx && focusedDock === null;
-            }}
+            isFocused={(paneId) =>
+              isActive && focusedPaneIndex === idxOf(paneId) && focusedDock === null
+            }
             onPaneFocus={(paneId) => {
-              const idx = ws.panes.findIndex((p) => p.id === paneId);
-              setFocusedPane(idx);
+              setFocusedPane(idxOf(paneId));
               useDockStore.getState().setFocusedDock(null);
             }}
             onSetPaneView={
-              isActive
-                ? (paneId, config) => {
-                    const idx = ws.panes.findIndex((p) => p.id === paneId);
-                    setPaneView(idx, config);
-                  }
-                : undefined
+              isActive ? (paneId, config) => setPaneView(idxOf(paneId), config) : undefined
             }
-            onSplitPane={
-              isActive
-                ? (paneId, dir) => {
-                    const idx = ws.panes.findIndex((p) => p.id === paneId);
-                    splitPane(idx, dir);
-                  }
-                : undefined
-            }
-            onRemovePane={
-              isActive && ws.panes.length > 1
-                ? (paneId) => {
-                    const idx = ws.panes.findIndex((p) => p.id === paneId);
-                    removePane(idx);
-                  }
-                : undefined
-            }
+            onSplitPane={isActive ? (paneId, dir) => splitPane(idxOf(paneId), dir) : undefined}
+            onRemovePane={isActive ? (paneId) => removePane(idxOf(paneId)) : undefined}
             getCwdDefaults={(view: ViewInstanceConfig) => {
               const profileName = (view.profile as string) || defaultProfile || FALLBACK_PROFILE;
               return resolveSyncCwdForProfile(profileName, location);
             }}
             isHoveredOverride={
               isActive && automationHoverIndex !== null
-                ? (paneId) => {
-                    const idx = ws.panes.findIndex((p) => p.id === paneId);
-                    return automationHoverIndex === idx;
-                  }
+                ? (paneId) => automationHoverIndex === idxOf(paneId)
                 : undefined
             }
             workspaceId={ws.id}

--- a/ui/src/components/layout/WorkspaceArea.tsx
+++ b/ui/src/components/layout/WorkspaceArea.tsx
@@ -33,7 +33,8 @@ export function WorkspaceArea() {
       {workspaces.map((ws) => {
         const isActive = ws.id === activeWorkspaceId;
         if (!mountedWsIds.has(ws.id)) return null;
-        const idxOf = (paneId: string) => ws.panes.findIndex((p) => p.id === paneId);
+        const indexMap = new Map(ws.panes.map((p, i) => [p.id, i]));
+        const idxOf = (paneId: string) => indexMap.get(paneId) ?? -1;
         return (
           <PaneGrid
             key={ws.id}

--- a/ui/src/components/layout/WorkspaceArea.tsx
+++ b/ui/src/components/layout/WorkspaceArea.tsx
@@ -1,175 +1,95 @@
-import React, { useRef, useState, useEffect, useCallback } from "react";
+import React, { useState } from "react";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useGridStore } from "@/stores/grid-store";
 import { useDockStore } from "@/stores/dock-store";
 import { useSettingsStore, FALLBACK_PROFILE, type TerminalLocation } from "@/stores/settings-store";
-import { ViewRenderer } from "@/components/views/ViewRenderer";
-import { PaneBoundaryHandles } from "./PaneBoundaryHandles";
-import { PaneControlBar } from "./PaneControlBar";
-import { useUiStore } from "@/stores/ui-store";
+import type { ViewInstanceConfig } from "@/stores/types";
+import { PaneGrid } from "./PaneGrid";
 
 export function WorkspaceArea() {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const focusedPaneIndex = useGridStore((s) => s.focusedPaneIndex);
-  const isAppFocused = useUiStore((s) => s.isAppFocused);
   const setFocusedPane = useGridStore((s) => s.setFocusedPane);
   const automationHoverIndex = useGridStore((s) => s.automationHoverIndex);
   const focusedDock = useDockStore((s) => s.focusedDock);
   const setPaneView = useWorkspaceStore((s) => s.setPaneView);
   const splitPane = useWorkspaceStore((s) => s.splitPane);
   const removePane = useWorkspaceStore((s) => s.removePane);
-  const hoverIdleSeconds = useSettingsStore((s) => s.convenience.hoverIdleSeconds);
   const defaultProfile = useSettingsStore((s) => s.defaultProfile);
   const resolveSyncCwdForProfile = useSettingsStore((s) => s.resolveSyncCwdForProfile);
   const location: TerminalLocation = "workspace";
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [size, setSize] = useState({ w: 0, h: 0 });
-  const [hoveredPane, setHoveredPane] = useState<string | null>(null);
-  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Lazy mount: only render panes for workspaces that have been activated at least once.
   // Prevents unnecessary TerminalView/WebGL initialization for never-visited workspaces,
   // reducing GPU pressure at startup (fixes WebView2 GPU process crash).
-  // Track ever-activated workspace IDs. Uses React's "set state during render"
-  // pattern to grow the set monotonically without cascading effect renders.
   const [mountedWsIds, setMountedWsIds] = useState(() => new Set([activeWorkspaceId]));
   if (!mountedWsIds.has(activeWorkspaceId)) {
     setMountedWsIds(new Set(mountedWsIds).add(activeWorkspaceId));
   }
 
-  const handlePaneHoverActivity = useCallback(
-    (paneId: string) => {
-      setHoveredPane(paneId);
-      if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
-      if (hoverIdleSeconds > 0) {
-        hoverTimerRef.current = setTimeout(() => setHoveredPane(null), hoverIdleSeconds * 1000);
-      }
-    },
-    [hoverIdleSeconds],
-  );
-
-  useEffect(() => {
-    return () => {
-      if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
-    };
-  }, []);
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const ro = new ResizeObserver((entries) => {
-      const { width, height } = entries[0].contentRect;
-      setSize({ w: width, h: height });
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
-
   return (
-    <div ref={containerRef} data-testid="workspace-area" className="relative h-full w-full">
+    <div data-testid="workspace-area" className="relative h-full w-full">
       {workspaces.map((ws) => {
         const isActive = ws.id === activeWorkspaceId;
         if (!mountedWsIds.has(ws.id)) return null;
         return (
-          <React.Fragment key={ws.id}>
-            {ws.panes.map((pane, i) => {
-              const isFocused = isActive && focusedPaneIndex === i && focusedDock === null;
-              const isHovered = hoveredPane === pane.id || (isActive && automationHoverIndex === i);
-
-              return (
-                <div
-                  key={pane.id}
-                  data-testid={isActive ? `workspace-pane-${i}` : undefined}
-                  className="absolute overflow-hidden"
-                  onMouseDown={() => {
-                    if (!isActive) return;
-                    setFocusedPane(i);
-                    useDockStore.getState().setFocusedDock(null);
-                  }}
-                  onMouseEnter={() => isActive && handlePaneHoverActivity(pane.id)}
-                  onMouseMove={() => isActive && handlePaneHoverActivity(pane.id)}
-                  onMouseLeave={() => {
-                    setHoveredPane(null);
-                    if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
-                  }}
-                  style={{
-                    left: `${pane.x * 100}%`,
-                    top: `${pane.y * 100}%`,
-                    width: `${pane.w * 100}%`,
-                    height: `${pane.h * 100}%`,
-                    display: isActive ? undefined : "none",
-                    borderRight: "2px solid var(--border)",
-                    borderBottom: "2px solid var(--border)",
-                  }}
-                >
-                  {/* Focus indicator overlay — above content, like Dock */}
-                  {isFocused && (
-                    <div
-                      data-testid="pane-focus-indicator"
-                      className="pointer-events-none absolute inset-0"
-                      style={{
-                        boxShadow: `inset 0 0 0 1px var(${isAppFocused ? "--accent" : "--accent-50"})`,
-                        zIndex: 20,
-                      }}
-                    />
-                  )}
-                  <PaneControlBar
-                    currentView={pane.view}
-                    hovered={isActive && isHovered}
-                    actions={{
-                      onChangeView: isActive ? (config) => setPaneView(i, config) : undefined,
-                      onSplitH: isActive ? () => splitPane(i, "horizontal") : undefined,
-                      onSplitV: isActive ? () => splitPane(i, "vertical") : undefined,
-                      onClear: isActive ? () => setPaneView(i, { type: "EmptyView" }) : undefined,
-                      onDelete: isActive && ws.panes.length > 1 ? () => removePane(i) : undefined,
-                      onToggleCwdSend:
-                        isActive &&
-                        (pane.view.type === "TerminalView" || pane.view.type === "FileExplorerView")
-                          ? () => {
-                              const profileName =
-                                (pane.view.profile as string) || defaultProfile || FALLBACK_PROFILE;
-                              const resolved = resolveSyncCwdForProfile(profileName, location);
-                              const current =
-                                (pane.view.cwdSend as boolean | undefined) ?? resolved.send;
-                              setPaneView(i, { ...pane.view, cwdSend: !current });
-                            }
-                          : undefined,
-                      onToggleCwdReceive:
-                        isActive &&
-                        (pane.view.type === "TerminalView" || pane.view.type === "FileExplorerView")
-                          ? () => {
-                              const profileName =
-                                (pane.view.profile as string) || defaultProfile || FALLBACK_PROFILE;
-                              const resolved = resolveSyncCwdForProfile(profileName, location);
-                              const current =
-                                (pane.view.cwdReceive as boolean | undefined) ?? resolved.receive;
-                              setPaneView(i, { ...pane.view, cwdReceive: !current });
-                            }
-                          : undefined,
-                    }}
-                  >
-                    <ViewRenderer
-                      viewType={pane.view.type}
-                      viewConfig={pane.view}
-                      onSelectView={isActive ? (config) => setPaneView(i, config) : undefined}
-                      workspaceName={ws.name}
-                      workspaceId={ws.id}
-                      paneId={pane.id}
-                      isFocused={isFocused}
-                      onKeyboardActivity={() => {
-                        setHoveredPane(null);
-                        if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
-                      }}
-                    />
-                  </PaneControlBar>
-                </div>
-              );
-            })}
-          </React.Fragment>
+          <PaneGrid
+            key={ws.id}
+            panes={ws.panes}
+            isActive={isActive}
+            testIdFn={(_pane, i) => (isActive ? `workspace-pane-${i}` : undefined)}
+            isFocused={(paneId) => {
+              const idx = ws.panes.findIndex((p) => p.id === paneId);
+              return isActive && focusedPaneIndex === idx && focusedDock === null;
+            }}
+            onPaneFocus={(paneId) => {
+              const idx = ws.panes.findIndex((p) => p.id === paneId);
+              setFocusedPane(idx);
+              useDockStore.getState().setFocusedDock(null);
+            }}
+            onSetPaneView={
+              isActive
+                ? (paneId, config) => {
+                    const idx = ws.panes.findIndex((p) => p.id === paneId);
+                    setPaneView(idx, config);
+                  }
+                : undefined
+            }
+            onSplitPane={
+              isActive
+                ? (paneId, dir) => {
+                    const idx = ws.panes.findIndex((p) => p.id === paneId);
+                    splitPane(idx, dir);
+                  }
+                : undefined
+            }
+            onRemovePane={
+              isActive && ws.panes.length > 1
+                ? (paneId) => {
+                    const idx = ws.panes.findIndex((p) => p.id === paneId);
+                    removePane(idx);
+                  }
+                : undefined
+            }
+            getCwdDefaults={(view: ViewInstanceConfig) => {
+              const profileName = (view.profile as string) || defaultProfile || FALLBACK_PROFILE;
+              return resolveSyncCwdForProfile(profileName, location);
+            }}
+            isHoveredOverride={
+              isActive && automationHoverIndex !== null
+                ? (paneId) => {
+                    const idx = ws.panes.findIndex((p) => p.id === paneId);
+                    return automationHoverIndex === idx;
+                  }
+                : undefined
+            }
+            workspaceId={ws.id}
+            workspaceName={ws.name}
+            location="workspace"
+          />
         );
       })}
-      <PaneBoundaryHandles containerWidth={size.w} containerHeight={size.h} />
     </div>
   );
 }

--- a/ui/src/hooks/useContainerSize.test.ts
+++ b/ui/src/hooks/useContainerSize.test.ts
@@ -1,0 +1,68 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useContainerSize } from "./useContainerSize";
+
+describe("useContainerSize", () => {
+  let mockObserve: ReturnType<typeof vi.fn>;
+  let mockDisconnect: ReturnType<typeof vi.fn>;
+  let observerCallback: ResizeObserverCallback;
+  let OriginalResizeObserver: typeof ResizeObserver;
+
+  beforeEach(() => {
+    mockObserve = vi.fn();
+    mockDisconnect = vi.fn();
+    OriginalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        observerCallback = cb;
+      }
+      observe = mockObserve;
+      unobserve = vi.fn();
+      disconnect = mockDisconnect;
+    } as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = OriginalResizeObserver;
+  });
+
+  it("returns initial size {w:0, h:0}", () => {
+    const ref = { current: document.createElement("div") };
+    const { result } = renderHook(() => useContainerSize(ref));
+    expect(result.current).toEqual({ w: 0, h: 0 });
+  });
+
+  it("observes the element from the ref", () => {
+    const el = document.createElement("div");
+    const ref = { current: el };
+    renderHook(() => useContainerSize(ref));
+    expect(mockObserve).toHaveBeenCalledWith(el);
+  });
+
+  it("updates size when ResizeObserver fires", () => {
+    const ref = { current: document.createElement("div") };
+    const { result } = renderHook(() => useContainerSize(ref));
+
+    act(() => {
+      observerCallback(
+        [{ contentRect: { width: 800, height: 600 } } as unknown as ResizeObserverEntry],
+        {} as ResizeObserver,
+      );
+    });
+
+    expect(result.current).toEqual({ w: 800, h: 600 });
+  });
+
+  it("disconnects on unmount", () => {
+    const ref = { current: document.createElement("div") };
+    const { unmount } = renderHook(() => useContainerSize(ref));
+    unmount();
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it("does not observe if ref.current is null", () => {
+    const ref = { current: null };
+    renderHook(() => useContainerSize(ref));
+    expect(mockObserve).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/hooks/useContainerSize.ts
+++ b/ui/src/hooks/useContainerSize.ts
@@ -12,7 +12,7 @@ export function useContainerSize(containerRef: RefObject<HTMLElement | null>) {
     });
     ro.observe(el);
     return () => ro.disconnect();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [containerRef]);
 
   return size;
 }

--- a/ui/src/hooks/useContainerSize.ts
+++ b/ui/src/hooks/useContainerSize.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect, type RefObject } from "react";
+
+export function useContainerSize(containerRef: RefObject<HTMLElement | null>) {
+  const [size, setSize] = useState({ w: 0, h: 0 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      setSize({ w: width, h: height });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return size;
+}

--- a/ui/src/hooks/useHoverTimer.test.ts
+++ b/ui/src/hooks/useHoverTimer.test.ts
@@ -1,0 +1,70 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useHoverTimer } from "./useHoverTimer";
+
+describe("useHoverTimer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("initially has null hoveredId", () => {
+    const { result } = renderHook(() => useHoverTimer(5));
+    expect(result.current.hoveredId).toBeNull();
+  });
+
+  it("sets hoveredId on activate", () => {
+    const { result } = renderHook(() => useHoverTimer(5));
+    act(() => result.current.activate("pane-1"));
+    expect(result.current.hoveredId).toBe("pane-1");
+  });
+
+  it("clears hoveredId after idle timeout", () => {
+    const { result } = renderHook(() => useHoverTimer(3));
+    act(() => result.current.activate("pane-1"));
+    expect(result.current.hoveredId).toBe("pane-1");
+
+    act(() => vi.advanceTimersByTime(3000));
+    expect(result.current.hoveredId).toBeNull();
+  });
+
+  it("resets timer on repeated activate", () => {
+    const { result } = renderHook(() => useHoverTimer(3));
+    act(() => result.current.activate("pane-1"));
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current.hoveredId).toBe("pane-1");
+
+    act(() => result.current.activate("pane-1"));
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current.hoveredId).toBe("pane-1");
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.hoveredId).toBeNull();
+  });
+
+  it("clears immediately on clear()", () => {
+    const { result } = renderHook(() => useHoverTimer(5));
+    act(() => result.current.activate("pane-1"));
+    act(() => result.current.clear());
+    expect(result.current.hoveredId).toBeNull();
+  });
+
+  it("does not auto-clear when hoverIdleSeconds is 0", () => {
+    const { result } = renderHook(() => useHoverTimer(0));
+    act(() => result.current.activate("pane-1"));
+    act(() => vi.advanceTimersByTime(10000));
+    expect(result.current.hoveredId).toBe("pane-1");
+  });
+
+  it("cleans up timer on unmount", () => {
+    const { result, unmount } = renderHook(() => useHoverTimer(3));
+    act(() => result.current.activate("pane-1"));
+    unmount();
+    // Should not throw
+    act(() => vi.advanceTimersByTime(5000));
+  });
+});

--- a/ui/src/hooks/useHoverTimer.ts
+++ b/ui/src/hooks/useHoverTimer.ts
@@ -1,0 +1,30 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+
+export function useHoverTimer(hoverIdleSeconds: number) {
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const activate = useCallback(
+    (id: string) => {
+      setHoveredId(id);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (hoverIdleSeconds > 0) {
+        timerRef.current = setTimeout(() => setHoveredId(null), hoverIdleSeconds * 1000);
+      }
+    },
+    [hoverIdleSeconds],
+  );
+
+  const clear = useCallback(() => {
+    setHoveredId(null);
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return { hoveredId, activate, clear };
+}


### PR DESCRIPTION
## Summary
- WorkspaceArea와 DockGrid에서 중복되던 2D 그리드 pane 렌더링을 `PaneGrid` 공통 컴포넌트로 통합
- `useContainerSize`, `useHoverTimer` 커스텀 훅 추출 (각각 2곳, 3곳 중복 제거)
- `FocusIndicator` 컴포넌트 추출 (앱 blur 시 포커스 테두리 dimmed 처리 포함)
- 포커스 관리, CWD 기본값 등 Workspace/Dock 차이는 콜백 props로 분리

## 변경 파일
- 신규: `PaneGrid.tsx`, `FocusIndicator.tsx`, `useContainerSize.ts`, `useHoverTimer.ts` + 테스트
- 수정: `WorkspaceArea.tsx` (175→96줄), `Dock.tsx` (355→228줄)

## Test plan
- [x] 전체 프론트엔드 테스트 통과 (60 파일, 1304 테스트)
- [x] Rust 테스트 통과 (12 테스트)
- [x] PaneGrid 단위 테스트 8건 추가
- [x] useContainerSize 테스트 5건, useHoverTimer 테스트 7건 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)