### PR TITLE
fix: WorkspaceSelectorView 커맨드 상태 아이콘 크기 통일

### DIFF
--- a/mcp-server/src/mcp.rs
+++ b/mcp-server/src/mcp.rs
@@ -251,6 +251,7 @@ fn discovery_file_candidates() -> Vec<std::path::PathBuf> {
 // -- HTTP client calls to Automation API --
 
 /// Add Bearer authorization header if key is available.
+#[allow(clippy::result_large_err)]
 fn auth_get(url: &str, key: Option<&str>) -> Result<ureq::Response, ureq::Error> {
     let mut req = ureq::get(url);
     if let Some(k) = key {
@@ -259,6 +260,7 @@ fn auth_get(url: &str, key: Option<&str>) -> Result<ureq::Response, ureq::Error>
     req.call()
 }
 
+#[allow(clippy::result_large_err)]
 fn auth_post(url: &str, body: Value, key: Option<&str>) -> Result<ureq::Response, ureq::Error> {
     let mut req = ureq::post(url);
     if let Some(k) = key {

--- a/mcp-server/src/mcp.rs
+++ b/mcp-server/src/mcp.rs
@@ -227,8 +227,16 @@ fn discovery_file_candidates() -> Vec<std::path::PathBuf> {
 
     #[cfg(target_os = "windows")]
     if let Ok(appdata) = std::env::var("APPDATA") {
-        paths.push(std::path::PathBuf::from(&appdata).join("laymux-dev").join("automation.json"));
-        paths.push(std::path::PathBuf::from(&appdata).join("laymux").join("automation.json"));
+        paths.push(
+            std::path::PathBuf::from(&appdata)
+                .join("laymux-dev")
+                .join("automation.json"),
+        );
+        paths.push(
+            std::path::PathBuf::from(&appdata)
+                .join("laymux")
+                .join("automation.json"),
+        );
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -239,7 +247,6 @@ fn discovery_file_candidates() -> Vec<std::path::PathBuf> {
 
     paths
 }
-
 
 // -- HTTP client calls to Automation API --
 
@@ -400,8 +407,12 @@ mod tests {
 
     #[test]
     fn tools_call_unknown_tool_returns_error() {
-        let resp =
-            handle_tools_call(&json!(6), &json!({"name": "bad"}), "http://localhost:1", None);
+        let resp = handle_tools_call(
+            &json!(6),
+            &json!({"name": "bad"}),
+            "http://localhost:1",
+            None,
+        );
         assert!(resp["result"]["isError"].as_bool().unwrap_or(false));
     }
 }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+#[cfg(target_os = "windows")]
 use crate::path_utils::windows_to_wsl_path;
 
 /// Result of a smart paste operation.

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -177,11 +177,9 @@ pub fn create_terminal_session(
             // This must happen regardless of hook matching — the backend always
             // tracks the latest CWD for each terminal.
             if event.code == 7 || (event.code == 9 && event.param.as_deref() == Some("9")) {
-                let raw_cwd = if event.code == 7 {
-                    &event.data
-                } else {
-                    &event.data // OSC 9;9 data already has "9;" stripped by iter_osc_events
-                };
+                // Both OSC 7 and OSC 9;9 provide CWD in event.data
+                // (OSC 9;9 "9;" prefix is already stripped by iter_osc_events)
+                let raw_cwd = &event.data;
                 let normalized = path_utils::normalize_wsl_path(raw_cwd);
                 let mut changed = false;
                 if let Ok(mut terms) = state_for_pty.terminals.lock_or_err() {

--- a/src-tauri/src/osc.rs
+++ b/src-tauri/src/osc.rs
@@ -130,8 +130,8 @@ fn extract_osc_param(code: u16, raw: &str) -> (Option<String>, String) {
         // OSC 9: ConEmu/WSL sends "9;<path>" for CWD
         // Regular OSC 9 notifications don't have this prefix
         9 => {
-            if raw.starts_with("9;") {
-                (Some("9".to_string()), raw[2..].to_string())
+            if let Some(stripped) = raw.strip_prefix("9;") {
+                (Some("9".to_string()), stripped.to_string())
             } else {
                 (None, raw.to_string())
             }

--- a/src-tauri/src/process.rs
+++ b/src-tauri/src/process.rs
@@ -10,6 +10,7 @@ use std::process::Command;
 ///
 /// On non-Windows platforms this is identical to `Command::new(program)`.
 pub fn headless_command<S: AsRef<std::ffi::OsStr>>(program: S) -> Command {
+    #[allow(unused_mut)] // mut needed on Windows for creation_flags()
     let mut cmd = Command::new(program);
 
     #[cfg(target_os = "windows")]

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -425,7 +425,13 @@ function WorkspaceItem({
                               ? "1.5px solid var(--accent)"
                               : "1.5px solid transparent",
                             borderRadius: "var(--radius-md)",
-                            padding: "0 1px",
+                            width: 16,
+                            height: 16,
+                            display: "inline-flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            boxSizing: "border-box",
+                            fontSize: 10,
                             lineHeight: 1,
                           }}
                         >

--- a/ui/src/hooks/useWindowGeometry.ts
+++ b/ui/src/hooks/useWindowGeometry.ts
@@ -124,12 +124,20 @@ export function useWindowGeometry() {
 
     import("@tauri-apps/api/window").then(({ getCurrentWindow }) => {
       const appWindow = getCurrentWindow();
-      appWindow.onMoved(() => {
-        snapshotGeometry().catch(() => {});
-      }).then((fn) => { unlistenMove = fn; });
-      appWindow.onResized(() => {
-        snapshotGeometry().catch(() => {});
-      }).then((fn) => { unlistenResize = fn; });
+      appWindow
+        .onMoved(() => {
+          snapshotGeometry().catch(() => {});
+        })
+        .then((fn) => {
+          unlistenMove = fn;
+        });
+      appWindow
+        .onResized(() => {
+          snapshotGeometry().catch(() => {});
+        })
+        .then((fn) => {
+          unlistenResize = fn;
+        });
     });
 
     return () => {


### PR DESCRIPTION
## Summary
- WorkspaceSelectorView의 커맨드 상태 아이콘(⏳/✓/✗)이 문자 종류와 알림 테두리 유무에 따라 크기가 달라지던 문제 수정
- 16×16 고정 크기 + `box-sizing: border-box` + flex 중앙 정렬로 모든 조합(아이콘 3종 × 알림 유/무)에서 동일한 크기 보장

## Test plan
- [x] WorkspaceSelectorView 단위 테스트 64개 통과
- [ ] 실제 UI에서 ✓(성공), ✗(실패), ⏳(실행중) 아이콘이 동일 크기로 표시되는지 확인
- [ ] 알림 테두리가 있을 때와 없을 때 아이콘 크기가 변하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)