### PR TITLE
fix: Claude Code 상태 표시 개선 + computeCommandStatus 구조화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@
   - 로깅: `eprintln!()` 대신 `tracing` 매크로 사용
 * **OSC 처리는 Rust 전용** (`ARCHITECTURE.md` §8.3 참조): OSC 이스케이프 시퀀스의 파싱(`osc.rs`), 훅 매칭(`osc_hooks.rs`), 액션 디스패치(`dispatch_osc_action`)는 모두 Rust PTY 콜백에서 단일 패스로 처리한다. 프론트엔드에서 OSC regex 파싱, 훅 조건 평가, IPC 라운드트립을 통한 OSC 처리를 하지 않는다. 프론트엔드는 Rust가 발행한 구조화 Tauri 이벤트(`terminal-title-changed`, `sync-cwd` 등)만 구독한다. 새 OSC 동작 추가 시 `osc_hooks.rs`에 프리셋을 추가하고 `dispatch_osc_action()`에서 분기한다.
 * **`color-mix()` 사용 금지**: `color-mix(in srgb, ...)` 등 현대 CSS 색상 함수는 html2canvas가 파싱하지 못해 스크린샷 API가 깨진다. 반투명 accent가 필요하면 `var(--accent-50)`, `var(--accent-20)` 등 `index.css`에 정의된 CSS 변수를 사용한다.
+* **원시 상태 분리 → 계산 함수로 표시 도출**: 여러 시스템(OSC 133, 타이틀 변경 등)이 관여하는 상태를 표시할 때, 각 시스템은 자기 원시 상태만 독립적으로 저장하고 하나의 공유 필드를 덮어쓰지 않는다. 최종 표시(아이콘, 색상 등)는 모든 원시 상태를 입력받는 단일 계산 함수에서 도출한다. 표시 규칙이 바뀌면 계산 함수만 수정한다.
 * **CWD는 모든 설계의 핵심**: CWD(현재 작업 디렉터리)는 SyncGroup을 통해 터미널 간 동기화되며, `terminalStore`에 중앙 관리된다. 새 View나 기능이 CWD 정보를 필요로 할 때 **백그라운드 셸을 생성하지 말고** `terminalStore`의 syncGroup CWD를 구독하여 사용한다. 파일 시스템 접근(디렉터리 목록 등)은 Rust 백엔드(`std::fs`)를 직접 호출한다.
 * **UI 코드 설계 원칙** (`ARCHITECTURE.md` §15 참조):
   - **CSS 변수 우선**: 모든 공통 값(색상, 간격, 반경, 폰트 크기, hover overlay)은 `index.css` `:root`에 CSS 변수로 정의. 하드코딩된 매직 넘버 금지.

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -388,7 +388,7 @@ function WorkspaceItem({
                           data-testid={`pane-cmd-badge-${ts.id}`}
                           className="shrink-0"
                           style={{
-                            color: tCmdStatus?.color,
+                            color: tCmdStatus.color,
                             border: ts.hasUnreadNotification
                               ? "1.5px solid var(--accent)"
                               : "1.5px solid transparent",
@@ -397,7 +397,7 @@ function WorkspaceItem({
                             lineHeight: 1,
                           }}
                         >
-                          {tCmdStatus?.icon}
+                          {tCmdStatus.icon}
                         </span>
                       ) : wsDisplay.result && ts.hasUnreadNotification ? (
                         <span

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -18,6 +18,7 @@ import { NotificationPanel } from "./NotificationPanel";
 import { PaneMinimap } from "./PaneMinimap";
 import type { WorkspacePane } from "@/stores/types";
 import type { TerminalActivityInfo } from "@/stores/terminal-store";
+import { isClaudeIdle } from "@/lib/activity-detection";
 import { persistSession } from "@/lib/persist-session";
 
 /** Abbreviate profile/view labels to max 3 characters. */
@@ -45,11 +46,19 @@ function getCommandIcon(
   exitCode: number | undefined,
   outputActive?: boolean,
   activity?: TerminalActivityInfo,
+  title?: string,
 ): string {
   if (exitCode === undefined) return "⏳";
   if (outputActive) return "⏳";
-  // If terminal activity indicates something is still running, override error display
-  if (activity?.type === "running" || activity?.type === "interactiveApp") return "⏳";
+  if (activity?.type === "running") return "⏳";
+  if (activity?.type === "interactiveApp") {
+    // Claude: idle (✳) → show exit code icon, working → ⏳
+    if (activity.name === "Claude") {
+      if (!title || !isClaudeIdle(title)) return "⏳";
+    } else {
+      return "⏳";
+    }
+  }
   return exitCode === 0 ? "✓" : "✗";
 }
 
@@ -58,11 +67,18 @@ function getCommandColor(
   exitCode: number | undefined,
   outputActive?: boolean,
   activity?: TerminalActivityInfo,
+  title?: string,
 ): string {
   if (exitCode === undefined) return "var(--yellow)";
   if (outputActive) return "var(--yellow)";
-  // If terminal activity indicates something is still running, override error display
-  if (activity?.type === "running" || activity?.type === "interactiveApp") return "var(--yellow)";
+  if (activity?.type === "running") return "var(--yellow)";
+  if (activity?.type === "interactiveApp") {
+    if (activity.name === "Claude") {
+      if (!title || !isClaudeIdle(title)) return "var(--yellow)";
+    } else {
+      return "var(--yellow)";
+    }
+  }
   return exitCode === 0 ? "var(--green)" : "var(--red)";
 }
 
@@ -132,10 +148,10 @@ function WorkspaceItem({
 
   const cmdInfo = summary.lastCommand;
   const cmdIcon = cmdInfo
-    ? getCommandIcon(cmdInfo.exitCode, cmdInfo.outputActive, cmdInfo.activity)
+    ? getCommandIcon(cmdInfo.exitCode, cmdInfo.outputActive, cmdInfo.activity, cmdInfo.title)
     : null;
   const cmdColor = cmdInfo
-    ? getCommandColor(cmdInfo.exitCode, cmdInfo.outputActive, cmdInfo.activity)
+    ? getCommandColor(cmdInfo.exitCode, cmdInfo.outputActive, cmdInfo.activity, cmdInfo.title)
     : undefined;
 
   return (
@@ -316,10 +332,10 @@ function WorkspaceItem({
                 const ts = summary.terminalSummaries.find((t) => t.id === termId);
                 if (!ts) return null;
                 const tCmdIcon = ts.lastCommand
-                  ? getCommandIcon(ts.lastExitCode, ts.outputActive, ts.activity)
+                  ? getCommandIcon(ts.lastExitCode, ts.outputActive, ts.activity, ts.title)
                   : null;
                 const tCmdColor = ts.lastCommand
-                  ? getCommandColor(ts.lastExitCode, ts.outputActive, ts.activity)
+                  ? getCommandColor(ts.lastExitCode, ts.outputActive, ts.activity, ts.title)
                   : undefined;
                 const actInfo = formatActivity(ts.activity, ts.title);
                 return (

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -6,6 +6,7 @@ import { useSettingsStore } from "@/stores/settings-store";
 import { sortWorkspaces } from "@/lib/workspace-sort";
 import {
   computeWorkspaceSummary,
+  computeCommandStatus,
   abbreviatePath,
   mntPathToWindows,
   formatCommand,
@@ -17,8 +18,6 @@ import { usePortDetection } from "@/hooks/usePortDetection";
 import { NotificationPanel } from "./NotificationPanel";
 import { PaneMinimap } from "./PaneMinimap";
 import type { WorkspacePane } from "@/stores/types";
-import type { TerminalActivityInfo } from "@/stores/terminal-store";
-import { isClaudeIdle } from "@/lib/activity-detection";
 import { persistSession } from "@/lib/persist-session";
 
 /** Abbreviate profile/view labels to max 3 characters. */
@@ -39,47 +38,6 @@ function isWindowsProfile(profile: string): boolean {
 
 function shortLabel(label: string): string {
   return LABEL_ABBREV[label] ?? label.slice(0, 3).toUpperCase();
-}
-
-/** Determine command status icon based on exit code, output activity, and terminal activity. */
-function getCommandIcon(
-  exitCode: number | undefined,
-  outputActive?: boolean,
-  activity?: TerminalActivityInfo,
-  title?: string,
-): string {
-  if (exitCode === undefined) return "⏳";
-  if (outputActive) return "⏳";
-  if (activity?.type === "running") return "⏳";
-  if (activity?.type === "interactiveApp") {
-    // Claude: idle (✳) → show exit code icon, working → ⏳
-    if (activity.name === "Claude") {
-      if (!title || !isClaudeIdle(title)) return "⏳";
-    } else {
-      return "⏳";
-    }
-  }
-  return exitCode === 0 ? "✓" : "✗";
-}
-
-/** Determine command status color based on exit code, output activity, and terminal activity. */
-function getCommandColor(
-  exitCode: number | undefined,
-  outputActive?: boolean,
-  activity?: TerminalActivityInfo,
-  title?: string,
-): string {
-  if (exitCode === undefined) return "var(--yellow)";
-  if (outputActive) return "var(--yellow)";
-  if (activity?.type === "running") return "var(--yellow)";
-  if (activity?.type === "interactiveApp") {
-    if (activity.name === "Claude") {
-      if (!title || !isClaudeIdle(title)) return "var(--yellow)";
-    } else {
-      return "var(--yellow)";
-    }
-  }
-  return exitCode === 0 ? "var(--green)" : "var(--red)";
 }
 
 function CountBadge({ count, testId }: { count: number; testId?: string }) {
@@ -147,12 +105,9 @@ function WorkspaceItem({
   const wsDisplay = useSettingsStore((s) => s.workspaceDisplay);
 
   const cmdInfo = summary.lastCommand;
-  const cmdIcon = cmdInfo
-    ? getCommandIcon(cmdInfo.exitCode, cmdInfo.outputActive, cmdInfo.activity, cmdInfo.title)
+  const cmdStatus = cmdInfo
+    ? computeCommandStatus(cmdInfo.exitCode, cmdInfo.outputActive, cmdInfo.activity, cmdInfo.title)
     : null;
-  const cmdColor = cmdInfo
-    ? getCommandColor(cmdInfo.exitCode, cmdInfo.outputActive, cmdInfo.activity, cmdInfo.title)
-    : undefined;
 
   return (
     <div
@@ -331,12 +286,9 @@ function WorkspaceItem({
                 const termId = `terminal-${pane.id}`;
                 const ts = summary.terminalSummaries.find((t) => t.id === termId);
                 if (!ts) return null;
-                const tCmdIcon = ts.lastCommand
-                  ? getCommandIcon(ts.lastExitCode, ts.outputActive, ts.activity, ts.title)
+                const tCmdStatus = ts.lastCommand
+                  ? computeCommandStatus(ts.lastExitCode, ts.outputActive, ts.activity, ts.title)
                   : null;
-                const tCmdColor = ts.lastCommand
-                  ? getCommandColor(ts.lastExitCode, ts.outputActive, ts.activity, ts.title)
-                  : undefined;
                 const actInfo = formatActivity(ts.activity, ts.title);
                 return (
                   <div
@@ -431,12 +383,12 @@ function WorkspaceItem({
                           </span>
                         </>
                       )}
-                      {wsDisplay.result && tCmdIcon ? (
+                      {wsDisplay.result && tCmdStatus?.icon ? (
                         <span
                           data-testid={`pane-cmd-badge-${ts.id}`}
                           className="shrink-0"
                           style={{
-                            color: tCmdColor,
+                            color: tCmdStatus?.color,
                             border: ts.hasUnreadNotification
                               ? "1.5px solid var(--accent)"
                               : "1.5px solid transparent",
@@ -445,7 +397,7 @@ function WorkspaceItem({
                             lineHeight: 1,
                           }}
                         >
-                          {tCmdIcon}
+                          {tCmdStatus?.icon}
                         </span>
                       ) : wsDisplay.result && ts.hasUnreadNotification ? (
                         <span
@@ -550,8 +502,8 @@ function WorkspaceItem({
       >
         {cmdInfo ? (
           <span className="flex items-center gap-1">
-            <span data-testid={`cmd-status-${ws.id}`} style={{ color: cmdColor }}>
-              {cmdIcon}
+            <span data-testid={`cmd-status-${ws.id}`} style={{ color: cmdStatus?.color }}>
+              {cmdStatus?.icon}
             </span>
             <span className="truncate" style={{ color: "var(--text-secondary)" }}>
               {formatCommand(cmdInfo.command)}

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -99,7 +99,6 @@ export function useSyncEvents() {
 
         if (transition === "completed") {
           updateInstanceInfo(data.terminalId, {
-            lastExitCode: 0,
             lastCommandAt: Date.now(),
           });
           // Only emit notification when notify gate is armed (prevents shell-init spam)
@@ -117,7 +116,6 @@ export function useSyncEvents() {
           const taskDesc = extractClaudeTaskDesc(data.title);
           updateInstanceInfo(data.terminalId, {
             lastCommand: taskDesc || "Claude task",
-            lastExitCode: undefined,
             lastCommandAt: Date.now(),
           });
         }

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -341,8 +341,8 @@ describe("parseClaudeMode", () => {
     expect(parseClaudeMode("✳ Danger mode active", claudeActivity)).toBe("danger");
   });
 
-  it("returns idle when title is undefined", () => {
-    expect(parseClaudeMode(undefined, claudeActivity)).toBe("idle");
+  it("returns undefined when title is undefined", () => {
+    expect(parseClaudeMode(undefined, claudeActivity)).toBeUndefined();
   });
 });
 

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -73,7 +73,7 @@ export function parseClaudeMode(
   activity: TerminalActivityInfo | undefined,
 ): ClaudeMode | undefined {
   if (activity?.type !== "interactiveApp" || activity.name !== "Claude") return undefined;
-  if (!title) return "idle";
+  if (!title) return undefined;
 
   // Priority: plan > danger > idle/working.
   // Claude Code title may contain both mode keywords and idle/working prefix.

--- a/ui/src/lib/workspace-summary.test.ts
+++ b/ui/src/lib/workspace-summary.test.ts
@@ -327,6 +327,22 @@ describe("getLastCommandForWorkspace — interactive app cleanup", () => {
     expect(getLastCommandForWorkspace(terminals)).toBeNull();
   });
 
+  it("includes terminal title in lastCommand for Claude idle detection", () => {
+    const terminals = [
+      makeTerminal({
+        id: "t1",
+        lastCommand: "Claude task",
+        lastExitCode: 0,
+        lastCommandAt: 200,
+        title: "✳ Claude Code",
+        activity: { type: "interactiveApp", name: "Claude" },
+      }),
+    ];
+    const result = getLastCommandForWorkspace(terminals);
+    expect(result?.title).toBe("✳ Claude Code");
+    expect(result?.activity).toEqual({ type: "interactiveApp", name: "Claude" });
+  });
+
   it("returns other terminal command after one terminal's command state was cleared", () => {
     const terminals = [
       makeTerminal({
@@ -506,28 +522,29 @@ describe("formatActivity", () => {
 
   it("returns Claude brand color (#D97757) for Claude app", () => {
     const result = formatActivity({ type: "interactiveApp", name: "Claude" });
-    expect(result.label).toContain("Claude");
+    expect(result.label).toBe("Claude");
     expect(result.color).toBe("#D97757");
   });
 
-  it("shows Claude mode from title", () => {
-    const result = formatActivity({ type: "interactiveApp", name: "Claude" }, "✶ Plan: approach");
-    expect(result.label).toContain("Plan");
-    expect(result.claudeMode).toBe("plan");
-    expect(result.color).toBe("var(--yellow)");
+  it("returns plain 'Claude' label regardless of title mode", () => {
+    const plan = formatActivity({ type: "interactiveApp", name: "Claude" }, "✶ Plan: approach");
+    expect(plan.label).toBe("Claude");
+    expect(plan.claudeMode).toBe("plan");
+    expect(plan.color).toBe("#D97757");
+
+    const danger = formatActivity({ type: "interactiveApp", name: "Claude" }, "✳ Danger mode");
+    expect(danger.label).toBe("Claude");
+    expect(danger.claudeMode).toBe("danger");
+
+    const idle = formatActivity({ type: "interactiveApp", name: "Claude" }, "✳ Claude Code");
+    expect(idle.label).toBe("Claude");
+    expect(idle.claudeMode).toBe("idle");
   });
 
-  it("shows Claude danger mode from title", () => {
-    const result = formatActivity({ type: "interactiveApp", name: "Claude" }, "✳ Danger mode");
-    expect(result.label).toContain("Danger");
-    expect(result.claudeMode).toBe("danger");
-    expect(result.color).toBe("var(--red)");
-  });
-
-  it("shows Ralph indicator from title", () => {
+  it("tracks Ralph state without changing label", () => {
     const result = formatActivity({ type: "interactiveApp", name: "Claude" }, "✶ Ralph: fixing");
     expect(result.ralph).toBe(true);
-    expect(result.label).toContain("®");
+    expect(result.label).toBe("Claude");
   });
 });
 

--- a/ui/src/lib/workspace-summary.test.ts
+++ b/ui/src/lib/workspace-summary.test.ts
@@ -6,6 +6,7 @@ import {
   getLastCommandForWorkspace,
   computeWorkspaceSummary,
   computeWorkspaceSummaryFromBackend,
+  computeCommandStatus,
   abbreviatePath,
   mntPathToWindows,
   formatRelativeTime,
@@ -663,6 +664,87 @@ describe("computeWorkspaceSummaryFromBackend", () => {
     ];
     const result = computeWorkspaceSummaryFromBackend("ws-1", summaries);
     expect(result.lastCommand?.activity).toEqual({ type: "running" });
+  });
+});
+
+describe("computeCommandStatus", () => {
+  // Shell commands
+  it("returns ⏳ when exitCode is undefined (command running)", () => {
+    const s = computeCommandStatus(undefined, false, { type: "shell" }, undefined);
+    expect(s.icon).toBe("⏳");
+    expect(s.color).toBe("var(--yellow)");
+  });
+
+  it("returns ✓ for exitCode 0", () => {
+    const s = computeCommandStatus(0, false, { type: "shell" }, undefined);
+    expect(s.icon).toBe("✓");
+    expect(s.color).toBe("var(--green)");
+  });
+
+  it("returns ✗ for non-zero exitCode", () => {
+    const s = computeCommandStatus(1, false, { type: "shell" }, undefined);
+    expect(s.icon).toBe("✗");
+    expect(s.color).toBe("var(--red)");
+  });
+
+  it("returns ⏳ when outputActive even with exitCode", () => {
+    const s = computeCommandStatus(0, true, { type: "shell" }, undefined);
+    expect(s.icon).toBe("⏳");
+  });
+
+  it("returns ⏳ for running activity", () => {
+    const s = computeCommandStatus(0, false, { type: "running" }, undefined);
+    expect(s.icon).toBe("⏳");
+  });
+
+  // Interactive apps (non-Claude)
+  it("returns ⏳ for generic interactiveApp", () => {
+    const s = computeCommandStatus(0, false, { type: "interactiveApp", name: "vim" }, undefined);
+    expect(s.icon).toBe("⏳");
+  });
+
+  // Claude: uses title idle detection
+  it("returns ✓ for Claude idle (✳ prefix)", () => {
+    const s = computeCommandStatus(
+      undefined,
+      false,
+      { type: "interactiveApp", name: "Claude" },
+      "✳ Claude Code",
+    );
+    expect(s.icon).toBe("✓");
+    expect(s.color).toBe("var(--green)");
+  });
+
+  it("returns ⏳ for Claude working (spinner prefix)", () => {
+    const s = computeCommandStatus(
+      undefined,
+      false,
+      { type: "interactiveApp", name: "Claude" },
+      "✶ fixing bug",
+    );
+    expect(s.icon).toBe("⏳");
+    expect(s.color).toBe("var(--yellow)");
+  });
+
+  it("returns ⏳ for Claude with no title", () => {
+    const s = computeCommandStatus(
+      undefined,
+      false,
+      { type: "interactiveApp", name: "Claude" },
+      undefined,
+    );
+    expect(s.icon).toBe("⏳");
+  });
+
+  it("ignores exitCode for Claude — uses title only", () => {
+    // exitCode=1 from sub-command, but Claude is idle → ✓
+    const s = computeCommandStatus(
+      1,
+      false,
+      { type: "interactiveApp", name: "Claude" },
+      "✳ Claude Code",
+    );
+    expect(s.icon).toBe("✓");
   });
 });
 

--- a/ui/src/lib/workspace-summary.ts
+++ b/ui/src/lib/workspace-summary.ts
@@ -9,6 +9,7 @@ export interface LastCommandInfo {
   timestamp: number;
   outputActive?: boolean; // true = terminal still producing output (e.g. subprocess running)
   activity?: TerminalActivityInfo; // terminal activity state (shell/running/interactiveApp)
+  title?: string; // terminal title — used to detect Claude idle/working via isClaudeIdle()
 }
 
 export interface TerminalSummaryInfo {
@@ -72,6 +73,7 @@ export function getLastCommandForWorkspace(terminals: TerminalInstance[]): LastC
     timestamp: t.lastCommandAt ?? t.lastActivityAt,
     outputActive: t.outputActive,
     activity: t.activity,
+    title: t.title,
   };
 }
 
@@ -161,6 +163,7 @@ export function computeWorkspaceSummaryFromBackend(
           timestamp: s.lastCommandAt,
           outputActive: s.outputActive,
           activity: s.activity as TerminalActivityInfo,
+          title: s.title ?? undefined,
         };
       }
     }
@@ -287,13 +290,6 @@ export function formatPorts(ports: number[], maxDisplay = 5): string {
   return `${shown}  +${ports.length - maxDisplay}`;
 }
 
-const CLAUDE_MODE_LABELS: Record<ClaudeMode, { suffix: string; icon: string }> = {
-  idle: { suffix: "", icon: "✳" },
-  working: { suffix: "", icon: "✶" },
-  plan: { suffix: " Plan", icon: "📋" },
-  danger: { suffix: " Danger", icon: "⚠" },
-};
-
 /** Get a display label for terminal activity state. */
 export function formatActivity(
   activity: TerminalActivityInfo | undefined,
@@ -314,11 +310,7 @@ export function formatActivity(
       if (activity.name === "Claude") {
         const mode = parseClaudeMode(title, activity);
         const ralph = isRalphActive(title);
-        const modeInfo = mode ? CLAUDE_MODE_LABELS[mode] : { suffix: "", icon: "" };
-        const label = `${modeInfo.icon} Claude${modeInfo.suffix}${ralph ? " ®" : ""}`.trim();
-        const color =
-          mode === "danger" ? "var(--red)" : mode === "plan" ? "var(--yellow)" : "#D97757";
-        return { label, color, claudeMode: mode, ralph };
+        return { label: "Claude", color: "#D97757", claudeMode: mode, ralph };
       }
       return { label: activity.name ?? "app", color: "var(--accent)" };
     }

--- a/ui/src/lib/workspace-summary.ts
+++ b/ui/src/lib/workspace-summary.ts
@@ -1,7 +1,12 @@
 import type { TerminalInstance, TerminalActivityInfo } from "@/stores/terminal-store";
 import type { Notification } from "@/stores/notification-store";
 import type { TerminalSummaryResponse } from "@/lib/tauri-api";
-import { parseClaudeMode, isRalphActive, type ClaudeMode } from "./activity-detection";
+import {
+  parseClaudeMode,
+  isClaudeIdle,
+  isRalphActive,
+  type ClaudeMode,
+} from "./activity-detection";
 
 export interface LastCommandInfo {
   command: string;
@@ -315,6 +320,42 @@ export function formatActivity(
       return { label: activity.name ?? "app", color: "var(--accent)" };
     }
   }
+}
+
+export interface CommandStatus {
+  icon: string; // "⏳" | "✓" | "✗"
+  color: string; // CSS color value
+}
+
+/**
+ * Compute final command status display from raw terminal states.
+ *
+ * Each system writes its own raw state independently:
+ *   - OSC 133;D → exitCode (shell owns this)
+ *   - OSC 0/2  → title (used for Claude idle/working detection)
+ *   - activity  → shell/running/interactiveApp
+ *
+ * This function is the single place that collapses them into ✓/⏳/✗.
+ */
+export function computeCommandStatus(
+  exitCode: number | undefined,
+  outputActive: boolean | undefined,
+  activity: TerminalActivityInfo | undefined,
+  title: string | undefined,
+): CommandStatus {
+  // Interactive app: Claude uses title idle detection, others always ⏳
+  if (activity?.type === "interactiveApp") {
+    if (activity.name === "Claude" && title && isClaudeIdle(title)) {
+      return { icon: "✓", color: "var(--green)" };
+    }
+    return { icon: "⏳", color: "var(--yellow)" };
+  }
+
+  // Shell command
+  if (exitCode === undefined) return { icon: "⏳", color: "var(--yellow)" };
+  if (outputActive) return { icon: "⏳", color: "var(--yellow)" };
+  if (activity?.type === "running") return { icon: "⏳", color: "var(--yellow)" };
+  return exitCode === 0 ? { icon: "✓", color: "var(--green)" } : { icon: "✗", color: "var(--red)" };
 }
 
 export function formatRelativeTime(ts: number): string {


### PR DESCRIPTION
## Summary
- `computeCommandStatus()` 단일 계산 함수 도입: 원시 상태(exitCode, outputActive, activity, title)를 받아 최종 icon/color 도출
- Claude 타이틀 전환에서 `lastExitCode` 직접 쓰기 제거 — OSC 133;D만 exitCode를 소유
- `formatActivity`의 Claude 라벨을 모드 아이콘 없이 "Claude"로 단순화
- WorkspaceSelectorView의 `getCommandIcon`/`getCommandColor` 삭제, `computeCommandStatus`로 교체
- CLAUDE.md에 원시 상태 분리 원칙 추가

## 설계
각 시스템이 독립적으로 원시 상태를 저장하고, 표시 로직은 단일 계산 함수에서 도출:
- **OSC 133;D** → `lastExitCode` (셸 소유)
- **OSC 0/2** → `title` (Claude idle/working 감지)
- **activity** → shell/running/interactiveApp
- **`computeCommandStatus()`** → 위 모든 상태를 입력받아 ✓/⏳/✗ 결정

## Test plan
- [x] computeCommandStatus 단위 테스트 (10 cases)
- [x] workspace-summary 테스트 통과 (82 tests)
- [x] 전체 프론트엔드 테스트 통과 (1315 tests)
- [ ] Claude Code 실행 후 idle 시 ✓, working 시 ⏳ 확인
- [ ] vim/htop 등 다른 interactiveApp은 기존대로 ⏳ 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)