### PR TITLE
fix: 터미널 복사 시 trailing whitespace/빈줄 제거

### DIFF
--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -20,7 +20,7 @@ import {
   markClaudeTerminal,
 } from "@/lib/tauri-api";
 import { colorSchemeToXtermTheme, type WTColorScheme } from "@/lib/color-scheme";
-import { transformPasteContent } from "@/lib/smart-text";
+import { transformPasteContent, trimSelectionTrailingWhitespace } from "@/lib/smart-text";
 import { isLxShortcut } from "@/lib/lx-shortcuts";
 
 import { detectActivityFromTitle, detectActivityFromCommand } from "@/lib/activity-detection";
@@ -237,7 +237,9 @@ export function TerminalView({
     terminal.onSelectionChange(() => {
       const { convenience: conv } = useSettingsStore.getState();
       if (conv.copyOnSelect && terminal.hasSelection()) {
-        clipboardWriteText(terminal.getSelection()).catch(() => {});
+        clipboardWriteText(trimSelectionTrailingWhitespace(terminal.getSelection())).catch(
+          () => {},
+        );
       }
     });
 
@@ -375,7 +377,9 @@ export function TerminalView({
       e.preventDefault();
       if (terminal.hasSelection()) {
         // Selection exists → copy to clipboard via Tauri, then clear
-        clipboardWriteText(terminal.getSelection()).catch(() => {});
+        clipboardWriteText(trimSelectionTrailingWhitespace(terminal.getSelection())).catch(
+          () => {},
+        );
         terminal.clearSelection();
       } else {
         // No selection → paste directly to PTY (no bracketed paste = no paste highlight block)

--- a/ui/src/lib/smart-text.test.ts
+++ b/ui/src/lib/smart-text.test.ts
@@ -46,6 +46,11 @@ describe("trimSelectionTrailingWhitespace", () => {
     expect(trimSelectionTrailingWhitespace(input)).toBe("hello");
   });
 
+  it("handles single line with trailing newline", () => {
+    const input = "hello\n";
+    expect(trimSelectionTrailingWhitespace(input)).toBe("hello");
+  });
+
   it("returns empty string for empty input", () => {
     expect(trimSelectionTrailingWhitespace("")).toBe("");
   });

--- a/ui/src/lib/smart-text.test.ts
+++ b/ui/src/lib/smart-text.test.ts
@@ -4,7 +4,71 @@ import {
   smartRemoveLineBreak,
   applySmartTextTransforms,
   transformPasteContent,
+  trimSelectionTrailingWhitespace,
 } from "./smart-text";
+
+// ============================================================
+// trimSelectionTrailingWhitespace
+// ============================================================
+describe("trimSelectionTrailingWhitespace", () => {
+  it("removes trailing spaces from each line", () => {
+    const input = "hello   \nworld   ";
+    expect(trimSelectionTrailingWhitespace(input)).toBe("hello\nworld");
+  });
+
+  it("removes trailing tabs from each line", () => {
+    const input = "hello\t\t\nworld\t";
+    expect(trimSelectionTrailingWhitespace(input)).toBe("hello\nworld");
+  });
+
+  it("removes trailing blank lines (empty lines at the end)", () => {
+    const input = "hello\nworld\n\n\n";
+    expect(trimSelectionTrailingWhitespace(input)).toBe("hello\nworld");
+  });
+
+  it("removes trailing blank lines that are only whitespace", () => {
+    const input = "hello\nworld\n   \n  \n";
+    expect(trimSelectionTrailingWhitespace(input)).toBe("hello\nworld");
+  });
+
+  it("preserves internal blank lines", () => {
+    const input = "hello\n\nworld";
+    expect(trimSelectionTrailingWhitespace(input)).toBe("hello\n\nworld");
+  });
+
+  it("preserves leading whitespace (indent)", () => {
+    const input = "  hello   \n  world   ";
+    expect(trimSelectionTrailingWhitespace(input)).toBe("  hello\n  world");
+  });
+
+  it("handles single line with trailing spaces", () => {
+    const input = "hello   ";
+    expect(trimSelectionTrailingWhitespace(input)).toBe("hello");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(trimSelectionTrailingWhitespace("")).toBe("");
+  });
+
+  it("returns empty string for whitespace-only input", () => {
+    expect(trimSelectionTrailingWhitespace("   \n  \n   ")).toBe("");
+  });
+
+  it("does not modify text without trailing whitespace", () => {
+    const input = "hello\nworld";
+    expect(trimSelectionTrailingWhitespace(input)).toBe("hello\nworld");
+  });
+
+  it("handles CRLF line endings", () => {
+    const input = "hello   \r\nworld   \r\n\r\n";
+    expect(trimSelectionTrailingWhitespace(input)).toBe("hello\r\nworld");
+  });
+
+  it("handles mixed trailing whitespace (spaces and tabs)", () => {
+    const input = "hello \t \nworld\t \t";
+    expect(trimSelectionTrailingWhitespace(input)).toBe("hello\nworld");
+  });
+});
 
 // ============================================================
 // smartRemoveIndent

--- a/ui/src/lib/smart-text.ts
+++ b/ui/src/lib/smart-text.ts
@@ -1,12 +1,42 @@
 /**
- * Smart text transforms for clipboard paste.
+ * Smart text transforms for clipboard paste and copy.
  *
+ * Copy transforms:
+ * - trimSelectionTrailingWhitespace — strip trailing whitespace from xterm.js selection
+ *
+ * Paste transforms:
  * 1. smartRemoveIndent — strip common leading whitespace from all lines
  * 2. smartRemoveLineBreak — rejoin URLs that were split across lines
  *
  * The correct order is: indent first, then linebreak.
  * If linebreak ran on indented text, the indent spaces would corrupt URLs.
  */
+
+/**
+ * Remove trailing whitespace from each line, then remove trailing blank lines.
+ *
+ * xterm.js getSelection() pads each line with trailing spaces to fill the
+ * terminal width, and includes empty lines at the end of the selection.
+ * This function cleans up the selection text before writing to clipboard.
+ */
+export function trimSelectionTrailingWhitespace(text: string): string {
+  if (!text) return text;
+
+  // Detect line ending style (CRLF vs LF)
+  const hasCRLF = text.includes("\r\n");
+  const lineEnding = hasCRLF ? "\r\n" : "\n";
+  const lines = text.split(lineEnding);
+
+  // Remove trailing whitespace from each line
+  const trimmed = lines.map((line) => line.replace(/[ \t]+$/, ""));
+
+  // Remove trailing blank lines
+  while (trimmed.length > 0 && trimmed[trimmed.length - 1] === "") {
+    trimmed.pop();
+  }
+
+  return trimmed.join(lineEnding);
+}
 
 /**
  * Remove the common leading whitespace (spaces/tabs) from every line.


### PR DESCRIPTION
## Summary
- xterm.js `getSelection()`이 터미널 너비만큼 trailing space를 패딩하고 선택 끝에 빈줄을 포함하는 문제 수정
- `trimSelectionTrailingWhitespace()` 함수 추가: 각 줄의 trailing whitespace 제거 + trailing 빈줄 제거
- `TerminalView`의 복사(copy-on-select, Ctrl+Shift+C) 두 경로 모두에 적용

## Changes
- `ui/src/lib/smart-text.ts` — `trimSelectionTrailingWhitespace()` 함수 추가
- `ui/src/lib/smart-text.test.ts` — 13개 테스트 케이스 추가 (CRLF, 빈줄, indent 보존 등)
- `ui/src/components/views/TerminalView.tsx` — 복사 시 `trimSelectionTrailingWhitespace()` 적용

## Test plan
- [x] `npx vitest run` 단위 테스트 통과
- [ ] 터미널에서 텍스트 복사 후 붙여넣기하여 빈줄이 제거되었는지 확인

Fixes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)