### PR TITLE
fix: 우클릭 붙여넣기 내용 잘림 수정 (bracketed paste 통일)

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -402,9 +402,9 @@ describe("TerminalView", () => {
       expect(mockSmartPaste).toHaveBeenCalledWith("", "PowerShell");
     });
 
-    // Right-click paste writes directly to PTY (no bracketed paste block)
+    // Right-click paste uses terminal.paste() for bracketed paste support (same as Ctrl+V)
     await vi.waitFor(() => {
-      expect(mockWriteToTerminal).toHaveBeenCalledWith("t-rc1", "pasted text");
+      expect(mockPaste).toHaveBeenCalledWith("pasted text");
     });
   });
 

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -382,7 +382,7 @@ export function TerminalView({
         );
         terminal.clearSelection();
       } else {
-        // No selection → paste directly to PTY (no bracketed paste = no paste highlight block)
+        // No selection → paste via terminal.paste() (same as Ctrl+V for bracketed paste support)
         const { convenience: conv } = useSettingsStore.getState();
         smartPaste(conv.pasteImageDir, profile)
           .then((result) => {
@@ -394,7 +394,7 @@ export function TerminalView({
               if (shouldBlockLargePaste(content, conv.largePasteWarning)) {
                 return;
               }
-              writeToTerminal(instanceId, content);
+              terminal.paste(content);
             }
           })
           .catch(() => {});


### PR DESCRIPTION
## Summary
- 우클릭 붙여넣기가 `writeToTerminal()`로 직접 PTY에 쓰면서 bracketed paste mode가 적용되지 않아 멀티라인 텍스트가 잘리는 문제 수정
- Ctrl+V와 동일하게 `terminal.paste()`를 사용하도록 통일하여 bracketed paste 지원
- 기존 테스트를 새 동작에 맞게 업데이트

## 변경 내용

| 파일 | 변경 |
|------|------|
| `ui/src/components/views/TerminalView.tsx` | 우클릭 paste에서 `writeToTerminal()` → `terminal.paste()` |
| `ui/src/components/views/TerminalView.test.tsx` | 테스트가 `mockPaste` 호출을 검증하도록 수정 |

## 원인 분석

| | Ctrl+V | 우클릭 (수정 전) | 우클릭 (수정 후) |
|--|--------|-----------------|-----------------|
| 클립보드 읽기 | `smartPaste()` (Rust) | `smartPaste()` (Rust) | `smartPaste()` (Rust) |
| PTY 쓰기 | `terminal.paste()` | `writeToTerminal()` | `terminal.paste()` |
| Bracketed Paste | ✅ | ❌ | ✅ |

## Test plan
- [x] TerminalView 테스트 53개 통과
- [x] 전체 프론트엔드 테스트 1332개 통과
- [ ] 수동 검증: 멀티라인 텍스트 우클릭 붙여넣기 시 전체가 입력되는지 확인

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)