### PR TITLE
fix: WorkspaceSelectorView 섹션 라벨 위계 복원 및 SVG viewBox 수정

### DIFF
--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -92,15 +92,9 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
       onKeyDown={handleKeyDown}
       style={{ color: "var(--text-primary)", background: "var(--bg-base)" }}
     >
-      <ViewHeader className="gap-2.5 px-2" testId="issue-reporter-header">
-        <svg width="18" height="18" viewBox="0 0 16 16" fill="none">
-          <circle cx="8" cy="8" r="7" stroke="var(--accent)" strokeWidth="1.5" />
-          <path d="M8 4v5" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round" />
-          <circle cx="8" cy="11.5" r="0.8" fill="var(--accent)" />
-        </svg>
-        <span className="text-sm font-semibold">Report Issue</span>
-        <span className="text-[10px]" style={{ color: "var(--text-secondary)", opacity: 0.5 }}>
-          via gh CLI
+      <ViewHeader className="px-2" testId="issue-reporter-header">
+        <span style={{ color: "var(--text-secondary)", fontSize: "var(--fs-sm)", fontWeight: 600 }}>
+          Report Issue
         </span>
       </ViewHeader>
       <ViewBody

--- a/ui/src/components/views/NotificationPanel.tsx
+++ b/ui/src/components/views/NotificationPanel.tsx
@@ -37,7 +37,9 @@ export function NotificationPanel({ workspaceId }: NotificationPanelProps = {}) 
   return (
     <ViewShell testId="notification-panel" style={{ color: "var(--text-primary)" }}>
       <ViewHeader className="justify-between px-2" testId="notification-header">
-        <span className="text-sm font-medium">Notifications</span>
+        <span style={{ color: "var(--text-secondary)", fontSize: "var(--fs-sm)", fontWeight: 600 }}>
+          Notifications
+        </span>
       </ViewHeader>
 
       <ViewBody>

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -874,8 +874,13 @@ export function WorkspaceSelectorView() {
       {/* New Workspace: Layout picker */}
       <div className="mx-2 mt-2 mb-1 shrink-0" data-testid="new-workspace-panel">
         <p
-          className="mb-1.5"
-          style={{ color: "var(--text-secondary)", fontSize: "var(--fs-sm)", fontWeight: 600 }}
+          className="mb-1.5 uppercase tracking-wider"
+          style={{
+            color: "var(--text-secondary)",
+            fontSize: "var(--fs-xs)",
+            fontWeight: 500,
+            opacity: 0.7,
+          }}
         >
           New Workspace
         </p>
@@ -907,7 +912,15 @@ export function WorkspaceSelectorView() {
 
       {/* Sort order toggle */}
       <div className="mx-2 mb-1 flex items-center justify-between">
-        <span style={{ color: "var(--text-secondary)", fontSize: "var(--fs-sm)", fontWeight: 600 }}>
+        <span
+          className="uppercase tracking-wider"
+          style={{
+            color: "var(--text-secondary)",
+            fontSize: "var(--fs-xs)",
+            fontWeight: 500,
+            opacity: 0.7,
+          }}
+        >
           Workspaces
         </span>
         <button
@@ -928,7 +941,7 @@ export function WorkspaceSelectorView() {
               : "Sort: Notification (most recent first)"
           }
         >
-          <svg width="12" height="12" viewBox="0 0 10 10" fill="none">
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
             {workspaceSortOrder === "manual" ? (
               <>
                 <rect x="1" y="1" width="8" height="1.5" rx="0.5" fill="currentColor" />

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -874,8 +874,8 @@ export function WorkspaceSelectorView() {
       {/* New Workspace: Layout picker */}
       <div className="mx-2 mt-2 mb-1 shrink-0" data-testid="new-workspace-panel">
         <p
-          className="mb-1.5 text-[10px] font-medium uppercase tracking-wider"
-          style={{ color: "var(--text-secondary)", opacity: 0.5 }}
+          className="mb-1.5"
+          style={{ color: "var(--text-secondary)", fontSize: "var(--fs-sm)", fontWeight: 600 }}
         >
           New Workspace
         </p>
@@ -907,10 +907,7 @@ export function WorkspaceSelectorView() {
 
       {/* Sort order toggle */}
       <div className="mx-2 mb-1 flex items-center justify-between">
-        <span
-          className="text-[10px] font-medium uppercase tracking-wider"
-          style={{ color: "var(--text-secondary)", opacity: 0.5 }}
-        >
+        <span style={{ color: "var(--text-secondary)", fontSize: "var(--fs-sm)", fontWeight: 600 }}>
           Workspaces
         </span>
         <button
@@ -931,7 +928,7 @@ export function WorkspaceSelectorView() {
               : "Sort: Notification (most recent first)"
           }
         >
-          <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+          <svg width="12" height="12" viewBox="0 0 10 10" fill="none">
             {workspaceSortOrder === "manual" ? (
               <>
                 <rect x="1" y="1" width="8" height="1.5" rx="0.5" fill="currentColor" />


### PR DESCRIPTION
## Summary
- WorkspaceSelectorView의 섹션 라벨("New Workspace", "Workspaces")을 ViewHeader 타이틀과 구분되는 소제목 스타일로 복원 (`uppercase`, `tracking-wider`, `--fs-xs`(10px), `opacity: 0.7`)
- SVG sort-order 아이콘의 `width/height`(12)와 `viewBox`(0 0 10 10) 불일치를 수정 — 원래 크기(10x10)로 통일
- PR #147 리뷰에서 제기된 이슈 3, 4에 대한 후속 수정

## Test plan
- [x] TypeScript 컴파일 통과
- [x] dev 인스턴스에서 시각 확인 — 섹션 라벨이 ViewHeader보다 작고 연하게 표시됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)