### PR TITLE
fix: Claude Code 상태 마커 · (U+00B7) + SGR 174 지원

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -738,6 +738,7 @@ src-tauri/src/
 ├── osc.rs                    # OSC 이스케이프 시퀀스 파싱 (iter_osc_events)
 ├── osc_hooks.rs              # OSC 훅 시스템 (조건/액션 모델, 프리셋, match_hooks)
 ├── activity.rs               # 터미널 활동 상태 감지
+├── claude_bullet.rs          # Claude Code 상태 메시지 추출 + ANSI 스트리핑
 ├── state.rs                  # AppState — 전역 상태
 ├── commands/                 # Tauri IPC 커맨드 (프론트엔드 진입점)
 │   ├── mod.rs                # pub use 허브 (로직 없음)

--- a/src-tauri/src/claude_bullet.rs
+++ b/src-tauri/src/claude_bullet.rs
@@ -1,72 +1,100 @@
-//! Claude Code white-● message extraction and ANSI stripping utilities.
+//! Claude Code status-marker message extraction and ANSI stripping utilities.
 //!
-//! Scans raw PTY output for user-facing status messages emitted by Claude Code,
-//! identified by the bright-white `●` (U+25CF) marker with SGR 38;5;231 coloring.
+//! Scans raw PTY output for user-facing status messages emitted by Claude Code.
+//! Two marker variants are supported:
+//!   - Legacy: bright-white `●` (U+25CF) with SGR 38;5;231
+//!   - Current: salmon `·` (U+00B7) with SGR 38;5;174 (Claude brand color)
 //! Also provides general-purpose ANSI escape stripping.
 
 use crate::constants::BULLET_MESSAGE_SCAN_BYTES;
 
-/// UTF-8 bytes for ● (U+25CF BLACK CIRCLE)
-const BULLET: [u8; 3] = [0xe2, 0x97, 0x8f];
+/// Marker variants emitted by Claude Code for status messages.
+/// Each entry: (UTF-8 bytes of the marker char, SGR color prefix).
+const MARKERS: &[(&[u8], &[u8])] = &[
+    // Current (2025+): · (U+00B7 MIDDLE DOT) with salmon/terracotta color
+    (&[0xc2, 0xb7], b"\x1b[38;5;174m"),
+    // Legacy: ● (U+25CF BLACK CIRCLE) with bright-white color
+    (&[0xe2, 0x97, 0x8f], b"\x1b[38;5;231m"),
+];
 
-/// ANSI SGR prefix for 256-color foreground 231 (bright white).
-/// Claude Code uses this color for user-facing status messages.
-const SGR_FG_231: &[u8] = b"\x1b[38;5;231m";
-
-/// Extract the last white-● status message from Claude Code terminal output.
+/// Extract the last status-marker message from Claude Code terminal output.
 ///
-/// Scans raw PTY bytes for `●` (U+25CF) preceded by the bright-white ANSI color
-/// (`\x1b[38;5;231m`). Returns the text content after `●` with ANSI codes stripped.
-/// Non-white ● lines (e.g., gray tool-call markers) are skipped.
+/// Scans raw PTY bytes for known marker characters (`·` or `●`) preceded by their
+/// respective ANSI color codes. Returns the text content after the marker with
+/// ANSI codes stripped. Markers with non-matching colors are skipped.
 ///
 /// Claude Code uses TUI rendering with cursor-addressed output, so the message text
-/// may not be adjacent to `●` in the byte stream. We scan forward past cursor
+/// may not be adjacent to the marker in the byte stream. We scan forward past cursor
 /// control sequences to find the text, stopping at spinner characters or color changes.
 pub fn extract_white_bullet_message(data: &[u8]) -> Option<String> {
-    let mut last_message: Option<String> = None;
-    let mut pos = 0;
+    let mut best: Option<(usize, String)> = None; // (position, message)
 
-    while pos + BULLET.len() <= data.len() {
-        // Find next ● in the byte stream
-        let bullet_pos = match data[pos..]
-            .windows(BULLET.len())
-            .position(|w| w == BULLET)
-        {
-            Some(p) => pos + p,
-            None => break,
-        };
+    for &(marker_bytes, sgr_prefix) in MARKERS {
+        let mut pos = 0;
+        while pos + marker_bytes.len() <= data.len() {
+            let marker_pos = match data[pos..]
+                .windows(marker_bytes.len())
+                .position(|w| w == marker_bytes)
+            {
+                Some(p) => pos + p,
+                None => break,
+            };
 
-        // Check if preceded by SGR_FG_231, allowing whitespace/control chars
-        // between the SGR and ●. Real output patterns include:
-        //   \x1b[38;5;231m●      (direct)
-        //   \x1b[38;5;231m\n●    (newline gap)
-        //   \x1b[38;5;231m\r●    (carriage return gap)
-        let is_white = {
-            let mut scan = bullet_pos;
-            while scan > 0 && matches!(data[scan - 1], b'\n' | b'\r' | b' ') {
-                scan -= 1;
+            // Check if preceded by the expected SGR color. Between the SGR and the
+            // marker, allow whitespace (\r, \n, space) and CSI sequences (e.g.,
+            // cursor positioning \x1b[13;1H). Search backwards up to 50 bytes.
+            let has_color = 'color: {
+                let search_start = marker_pos.saturating_sub(50);
+                // Look for sgr_prefix in the window before the marker
+                let window = &data[search_start..marker_pos];
+                // Find the LAST occurrence of sgr_prefix in the window
+                let sgr_pos = window
+                    .windows(sgr_prefix.len())
+                    .rposition(|w| w == sgr_prefix);
+                if let Some(rel_pos) = sgr_pos {
+                    let abs_sgr_end = search_start + rel_pos + sgr_prefix.len();
+                    // Verify gap between SGR end and marker is only whitespace/CSI
+                    let gap = &data[abs_sgr_end..marker_pos];
+                    let mut gi = 0;
+                    while gi < gap.len() {
+                        match gap[gi] {
+                            b'\n' | b'\r' | b' ' => gi += 1,
+                            0x1b if gi + 1 < gap.len() && gap[gi + 1] == b'[' => {
+                                // Skip CSI sequence
+                                let mut j = gi + 2;
+                                while j < gap.len()
+                                    && !(gap[j].is_ascii_alphabetic() || gap[j] == b'~')
+                                {
+                                    j += 1;
+                                }
+                                gi = if j < gap.len() { j + 1 } else { j };
+                            }
+                            _ => break 'color false,
+                        }
+                    }
+                    break 'color gi == gap.len();
+                }
+                false
+            };
+
+            if has_color {
+                let text_start = marker_pos + marker_bytes.len();
+                let scan_end = (text_start + BULLET_MESSAGE_SCAN_BYTES).min(data.len());
+                let raw_text = String::from_utf8_lossy(&data[text_start..scan_end]);
+                let stripped = strip_ansi_for_bullet(&raw_text);
+                if !stripped.is_empty() {
+                    // Keep the last occurrence by position in the byte stream
+                    if best.as_ref().map_or(true, |(prev_pos, _)| marker_pos > *prev_pos) {
+                        best = Some((marker_pos, stripped));
+                    }
+                }
             }
-            scan >= SGR_FG_231.len()
-                && data[scan - SGR_FG_231.len()..scan] == *SGR_FG_231
-        };
 
-        if is_white {
-            // Scan forward from ● to collect message text.
-            // In TUI mode, text is cursor-addressed; in scrollback, text is inline.
-            // We scan up to BULLET_MESSAGE_SCAN_BYTES bytes, strip ANSI, and stop at spinner chars.
-            let text_start = bullet_pos + BULLET.len();
-            let scan_end = (text_start + BULLET_MESSAGE_SCAN_BYTES).min(data.len());
-            let raw_text = String::from_utf8_lossy(&data[text_start..scan_end]);
-            let stripped = strip_ansi_for_bullet(&raw_text);
-            if !stripped.is_empty() {
-                last_message = Some(stripped);
-            }
+            pos = marker_pos + marker_bytes.len();
         }
-
-        pos = bullet_pos + BULLET.len();
     }
 
-    last_message
+    best.map(|(_, msg)| msg)
 }
 
 /// Skip a single ANSI escape sequence starting at `bytes[i]`.
@@ -257,9 +285,10 @@ mod tests {
     #[test]
     fn white_bullet_tui_mode_cursor_addressed() {
         // Real TUI pattern: ● followed by cursor movements, then text at different position
+        let legacy_bullet: &[u8] = &[0xe2, 0x97, 0x8f]; // ● U+25CF
         let mut data = Vec::new();
         data.extend_from_slice(b"\x1b[38;5;231m\r");
-        data.extend_from_slice(&BULLET);
+        data.extend_from_slice(legacy_bullet);
         data.extend_from_slice(b"\x1b[m\x1b[1C\x1b[11X\x1b[11C\x1b[?2026h\x1b[?2026l\x1b[19;3H10");
         data.extend_from_slice("이고,".as_bytes());
         data.extend_from_slice(b"\x1b[1C");
@@ -300,7 +329,7 @@ mod tests {
         // ● message followed by ─── separator line (input area divider)
         let mut data = Vec::new();
         data.extend_from_slice(b"\x1b[38;5;231m\n");
-        data.extend_from_slice(&BULLET);
+        data.extend_from_slice(&[0xe2, 0x97, 0x8f]); // ● U+25CF
         data.extend_from_slice(" \x1b[m메시지 텍스트\n".as_bytes());
         data.extend_from_slice("──────────────────\n".as_bytes());
         data.extend_from_slice("❯ ".as_bytes());
@@ -317,6 +346,77 @@ mod tests {
             extract_white_bullet_message(data),
             Some("test-result is 42".to_string())
         );
+    }
+
+    // ── Current marker (· U+00B7 with SGR 174) tests ──
+
+    #[test]
+    fn middot_basic() {
+        // Current Claude Code pattern: salmon · followed by message
+        let data = b"\x1b[38;5;174m\xc2\xb7 Creating plan\n";
+        assert_eq!(
+            extract_white_bullet_message(data),
+            Some("Creating plan".to_string())
+        );
+    }
+
+    #[test]
+    fn middot_with_cursor_forward() {
+        // Real TUI: · followed by cursor-forward then text
+        let data = b"\x1b[38;5;174m\r\n\xc2\xb7\x1b[1CRead 3 files\n";
+        assert_eq!(
+            extract_white_bullet_message(data),
+            Some("Read 3 files".to_string())
+        );
+    }
+
+    #[test]
+    fn middot_ignores_wrong_color() {
+        // · with wrong color should be skipped
+        let data = b"\x1b[38;5;244m\xc2\xb7 gray status\n";
+        assert_eq!(extract_white_bullet_message(data), None);
+    }
+
+    #[test]
+    fn middot_real_tui_pattern() {
+        // Real captured pattern: SGR 174 + CR LF + · + cursor-forward + "Creating…"
+        let data = b"\x1b[38;5;174m\r\n\xc2\xb7\x1b[1CCreating\xe2\x80\xa6\x1b[38;5;244m\x1b[16;1H";
+        let msg = extract_white_bullet_message(data);
+        assert!(msg.is_some(), "Should extract · message from real TUI output");
+        let text = msg.unwrap();
+        assert!(
+            text.starts_with("Creating"),
+            "Should start with 'Creating': {text}"
+        );
+    }
+
+    #[test]
+    fn middot_stops_at_spinner() {
+        let data = b"\x1b[38;5;174m\xc2\xb7\x1b[1CUpdated auth.ts\x1b[38;5;174m\x1b[20;1H\xe2\x9c\xb6 Working";
+        let msg = extract_white_bullet_message(data).unwrap();
+        assert_eq!(msg, "Updated auth.ts");
+    }
+
+    #[test]
+    fn middot_with_cursor_position_between_sgr_and_marker() {
+        // Real TUI pattern: SGR 174 + cursor position CSI + · + cursor-forward + text
+        // \x1b[38;5;174m\x1b[13;1H·\x1b[1CCreating plan
+        let data = b"\x1b[38;5;174m\x1b[13;1H\xc2\xb7\x1b[1CCreating plan";
+        assert_eq!(
+            extract_white_bullet_message(data),
+            Some("Creating plan".to_string())
+        );
+    }
+
+    #[test]
+    fn mixed_legacy_and_current_picks_last() {
+        let mut data = Vec::new();
+        // Legacy ● with SGR 231
+        data.extend_from_slice(b"\x1b[38;5;231m\xe2\x97\x8f \x1b[mLegacy message\n");
+        // Current · with SGR 174
+        data.extend_from_slice(b"\x1b[38;5;174m\xc2\xb7\x1b[1CCurrent message\n");
+        let msg = extract_white_bullet_message(&data).unwrap();
+        assert_eq!(msg, "Current message");
     }
 
     // ── strip_ansi tests ──

--- a/src-tauri/src/claude_bullet.rs
+++ b/src-tauri/src/claude_bullet.rs
@@ -6,7 +6,7 @@
 //!   - Current: salmon `·` (U+00B7) with SGR 38;5;174 (Claude brand color)
 //! Also provides general-purpose ANSI escape stripping.
 
-use crate::constants::BULLET_MESSAGE_SCAN_BYTES;
+use crate::constants::STATUS_MESSAGE_SCAN_BYTES;
 
 /// Max bytes to search backward from a marker for its SGR color prefix.
 /// Covers the SGR sequence itself plus a few CSI cursor-position sequences
@@ -21,6 +21,10 @@ const MARKERS: &[(&[u8], &[u8])] = &[
     // Legacy: ● (U+25CF BLACK CIRCLE) with bright-white color
     (&[0xe2, 0x97, 0x8f], b"\x1b[38;5;231m"),
 ];
+
+/// Characters that terminate status message text scanning.
+/// Spinner chars (✶✻✽✢), both marker variants (● ·), separator (─), prompt (❯).
+const STOP_CHARS: &[char] = &['✶', '✻', '✽', '✢', '●', '·', '─', '❯'];
 
 /// Extract the last Claude Code status message from terminal output.
 ///
@@ -50,9 +54,7 @@ pub fn extract_claude_status_message(data: &[u8]) -> Option<String> {
             // cursor positioning \x1b[13;1H).
             let has_color = 'color: {
                 let search_start = marker_pos.saturating_sub(SGR_LOOKBACK_BYTES);
-                // Look for sgr_prefix in the window before the marker
                 let window = &data[search_start..marker_pos];
-                // Find the LAST occurrence of sgr_prefix in the window
                 let sgr_pos = window
                     .windows(sgr_prefix.len())
                     .rposition(|w| w == sgr_prefix);
@@ -65,14 +67,7 @@ pub fn extract_claude_status_message(data: &[u8]) -> Option<String> {
                         match gap[gi] {
                             b'\n' | b'\r' | b' ' => gi += 1,
                             0x1b if gi + 1 < gap.len() && gap[gi + 1] == b'[' => {
-                                // Skip CSI sequence
-                                let mut j = gi + 2;
-                                while j < gap.len()
-                                    && !(gap[j].is_ascii_alphabetic() || gap[j] == b'~')
-                                {
-                                    j += 1;
-                                }
-                                gi = if j < gap.len() { j + 1 } else { j };
+                                gi = skip_csi_params(gap, gi + 2);
                             }
                             _ => break 'color false,
                         }
@@ -84,9 +79,9 @@ pub fn extract_claude_status_message(data: &[u8]) -> Option<String> {
 
             if has_color {
                 let text_start = marker_pos + marker_bytes.len();
-                let scan_end = (text_start + BULLET_MESSAGE_SCAN_BYTES).min(data.len());
+                let scan_end = (text_start + STATUS_MESSAGE_SCAN_BYTES).min(data.len());
                 let raw_text = String::from_utf8_lossy(&data[text_start..scan_end]);
-                let stripped = strip_ansi_for_bullet(&raw_text);
+                let stripped = strip_ansi_inner(&raw_text, STOP_CHARS, true);
                 if !stripped.is_empty() {
                     // Keep the last occurrence by position in the byte stream
                     if best.as_ref().map_or(true, |(prev_pos, _)| marker_pos > *prev_pos) {
@@ -102,6 +97,16 @@ pub fn extract_claude_status_message(data: &[u8]) -> Option<String> {
     best.map(|(_, msg)| msg)
 }
 
+/// Skip CSI parameter bytes starting at `start` (after ESC [), returning the
+/// index past the final byte. Shared by `has_color` validation and `skip_ansi_escape`.
+fn skip_csi_params(bytes: &[u8], start: usize) -> usize {
+    let mut j = start;
+    while j < bytes.len() && !(bytes[j].is_ascii_alphabetic() || bytes[j] == b'~') {
+        j += 1;
+    }
+    if j < bytes.len() { j + 1 } else { j }
+}
+
 /// Skip a single ANSI escape sequence starting at `bytes[i]`.
 /// Returns `(new_index, csi_final_byte)` where `csi_final_byte` is `Some(b'C')` etc.
 /// for CSI sequences, `None` for OSC or other sequences.
@@ -110,16 +115,13 @@ fn skip_ansi_escape(bytes: &[u8], i: usize) -> (usize, Option<u8>) {
     match bytes[i + 1] {
         b'[' => {
             // CSI: ESC [ params final_byte
-            let mut j = i + 2;
-            while j < bytes.len() && !(bytes[j].is_ascii_alphabetic() || bytes[j] == b'~') {
-                j += 1;
-            }
-            if j < bytes.len() {
-                let final_byte = bytes[j];
-                (j + 1, Some(final_byte))
+            let end = skip_csi_params(bytes, i + 2);
+            let final_byte = if end > i + 2 && end - 1 < bytes.len() {
+                Some(bytes[end - 1])
             } else {
-                (j, None)
-            }
+                None
+            };
+            (end, final_byte)
         }
         b']' => {
             // OSC: skip to BEL or ST
@@ -143,10 +145,13 @@ fn skip_ansi_escape(bytes: &[u8], i: usize) -> (usize, Option<u8>) {
     }
 }
 
-/// Strip ANSI and extract message text for a status marker line.
-/// Converts cursor-forward (`\x1b[nC`) to spaces, strips all other ANSI,
-/// and stops at spinner characters (✶✻✽✢) or another marker (● / ·).
-fn strip_ansi_for_bullet(input: &str) -> String {
+/// Core ANSI stripping loop shared by `strip_ansi` and status message extraction.
+///
+/// - `stop_chars`: if non-empty, stops scanning when any of these chars is encountered.
+/// - `cursor_to_space`: if true, CSI cursor-forward (`ESC[nC`) is converted to a space.
+///
+/// The result is trimmed when `stop_chars` is non-empty (status message mode).
+fn strip_ansi_inner(input: &str, stop_chars: &[char], cursor_to_space: bool) -> String {
     let mut result = String::with_capacity(input.len());
     let bytes = input.as_bytes();
     let mut i = 0;
@@ -154,20 +159,19 @@ fn strip_ansi_for_bullet(input: &str) -> String {
     while i < bytes.len() {
         if bytes[i] == 0x1b && i + 1 < bytes.len() {
             let (next_i, final_byte) = skip_ansi_escape(bytes, i);
-            if final_byte == Some(b'C') {
-                result.push(' '); // Cursor forward → space
+            if cursor_to_space && final_byte == Some(b'C') {
+                result.push(' ');
             }
             i = next_i;
         } else {
-            // Check for spinner/stop characters
             let remaining = &input[i..];
-            // Stop at spinner chars, another ●, or input separator line (─)
-            for stop_char in ['✶', '✻', '✽', '✢', '●', '─', '❯'] {
-                if remaining.starts_with(stop_char) {
-                    return result.trim().to_string();
+            if !stop_chars.is_empty() {
+                for &ch in stop_chars {
+                    if remaining.starts_with(ch) {
+                        return result.trim().to_string();
+                    }
                 }
             }
-            // Regular character (safe: remaining is non-empty &str slice)
             if let Some(ch) = remaining.chars().next() {
                 result.push(ch);
                 i += ch.len_utf8();
@@ -177,31 +181,16 @@ fn strip_ansi_for_bullet(input: &str) -> String {
         }
     }
 
-    result.trim().to_string()
+    if stop_chars.is_empty() {
+        result
+    } else {
+        result.trim().to_string()
+    }
 }
 
 /// Strip ANSI escape sequences (CSI and OSC) from a string, returning plain text.
 pub fn strip_ansi(input: &str) -> String {
-    let mut result = String::with_capacity(input.len());
-    let bytes = input.as_bytes();
-    let mut i = 0;
-
-    while i < bytes.len() {
-        if bytes[i] == 0x1b && i + 1 < bytes.len() {
-            let (next_i, _) = skip_ansi_escape(bytes, i);
-            i = next_i;
-        } else {
-            let remaining = &input[i..];
-            if let Some(ch) = remaining.chars().next() {
-                result.push(ch);
-                i += ch.len_utf8();
-            } else {
-                break;
-            }
-        }
-    }
-
-    result
+    strip_ansi_inner(input, &[], false)
 }
 
 #[cfg(test)]
@@ -485,7 +474,6 @@ mod tests {
 
     #[test]
     fn strip_ansi_multibyte_utf8() {
-        // Verify strip_ansi correctly handles multibyte UTF-8 characters
         assert_eq!(
             strip_ansi("\x1b[38;5;231m한글 테스트\x1b[m"),
             "한글 테스트"
@@ -494,7 +482,6 @@ mod tests {
 
     #[test]
     fn strip_ansi_osc_with_st_terminator() {
-        // OSC terminated by ST (ESC \) should be fully stripped
         assert_eq!(
             strip_ansi("before\x1b]2;title\x1b\\after"),
             "beforeafter"

--- a/src-tauri/src/claude_bullet.rs
+++ b/src-tauri/src/claude_bullet.rs
@@ -8,6 +8,11 @@
 
 use crate::constants::BULLET_MESSAGE_SCAN_BYTES;
 
+/// Max bytes to search backward from a marker for its SGR color prefix.
+/// Covers the SGR sequence itself plus a few CSI cursor-position sequences
+/// that the TUI may insert between color and marker.
+const SGR_LOOKBACK_BYTES: usize = 50;
+
 /// Marker variants emitted by Claude Code for status messages.
 /// Each entry: (UTF-8 bytes of the marker char, SGR color prefix).
 const MARKERS: &[(&[u8], &[u8])] = &[
@@ -17,7 +22,7 @@ const MARKERS: &[(&[u8], &[u8])] = &[
     (&[0xe2, 0x97, 0x8f], b"\x1b[38;5;231m"),
 ];
 
-/// Extract the last status-marker message from Claude Code terminal output.
+/// Extract the last Claude Code status message from terminal output.
 ///
 /// Scans raw PTY bytes for known marker characters (`·` or `●`) preceded by their
 /// respective ANSI color codes. Returns the text content after the marker with
@@ -26,7 +31,7 @@ const MARKERS: &[(&[u8], &[u8])] = &[
 /// Claude Code uses TUI rendering with cursor-addressed output, so the message text
 /// may not be adjacent to the marker in the byte stream. We scan forward past cursor
 /// control sequences to find the text, stopping at spinner characters or color changes.
-pub fn extract_white_bullet_message(data: &[u8]) -> Option<String> {
+pub fn extract_claude_status_message(data: &[u8]) -> Option<String> {
     let mut best: Option<(usize, String)> = None; // (position, message)
 
     for &(marker_bytes, sgr_prefix) in MARKERS {
@@ -42,9 +47,9 @@ pub fn extract_white_bullet_message(data: &[u8]) -> Option<String> {
 
             // Check if preceded by the expected SGR color. Between the SGR and the
             // marker, allow whitespace (\r, \n, space) and CSI sequences (e.g.,
-            // cursor positioning \x1b[13;1H). Search backwards up to 50 bytes.
+            // cursor positioning \x1b[13;1H).
             let has_color = 'color: {
-                let search_start = marker_pos.saturating_sub(50);
+                let search_start = marker_pos.saturating_sub(SGR_LOOKBACK_BYTES);
                 // Look for sgr_prefix in the window before the marker
                 let window = &data[search_start..marker_pos];
                 // Find the LAST occurrence of sgr_prefix in the window
@@ -138,9 +143,9 @@ fn skip_ansi_escape(bytes: &[u8], i: usize) -> (usize, Option<u8>) {
     }
 }
 
-/// Strip ANSI and extract message text for a ● bullet line.
+/// Strip ANSI and extract message text for a status marker line.
 /// Converts cursor-forward (`\x1b[nC`) to spaces, strips all other ANSI,
-/// and stops at spinner characters (✶✻✽✢) or another ● bullet.
+/// and stops at spinner characters (✶✻✽✢) or another marker (● / ·).
 fn strip_ansi_for_bullet(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     let bytes = input.as_bytes();
@@ -203,99 +208,118 @@ pub fn strip_ansi(input: &str) -> String {
 mod tests {
     use super::*;
 
-    // ── extract_white_bullet_message tests ──
+    /// Legacy marker: ● (U+25CF BLACK CIRCLE)
+    const LEGACY_BULLET: &[u8] = &[0xe2, 0x97, 0x8f];
+    /// Current marker: · (U+00B7 MIDDLE DOT)
+    const MIDDOT: &[u8] = &[0xc2, 0xb7];
+
+    // ── Legacy marker (● U+25CF with SGR 231) tests ──
 
     #[test]
-    fn white_bullet_basic() {
-        let data = b"\x1b[38;5;231m\xe2\x97\x8f \x1b[mAll tests passed\n";
+    fn legacy_bullet_basic() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;231m");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" \x1b[mAll tests passed\n");
         assert_eq!(
-            extract_white_bullet_message(data),
+            extract_claude_status_message(&data),
             Some("All tests passed".to_string())
         );
     }
 
     #[test]
-    fn white_bullet_ignores_green() {
-        // Green ●: \x1b[38;5;2m●
-        let data = b"\x1b[38;5;2m\xe2\x97\x8f Bash(cargo test)\n";
-        assert_eq!(extract_white_bullet_message(data), None);
+    fn legacy_bullet_ignores_green() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;2m");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" Bash(cargo test)\n");
+        assert_eq!(extract_claude_status_message(&data), None);
     }
 
     #[test]
-    fn white_bullet_picks_last() {
+    fn legacy_bullet_picks_last() {
         let mut data = Vec::new();
-        // First white ●
-        data.extend_from_slice(b"\x1b[38;5;231m\xe2\x97\x8f \x1b[mFirst message\n");
-        // Green ● (should be skipped)
-        data.extend_from_slice(b"\x1b[38;5;2m\xe2\x97\x8f Bash(ls)\n");
-        // Second white ●
-        data.extend_from_slice(b"\x1b[38;5;231m\xe2\x97\x8f \x1b[mSecond message\n");
+        data.extend_from_slice(b"\x1b[38;5;231m");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" \x1b[mFirst message\n");
+        data.extend_from_slice(b"\x1b[38;5;2m");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" Bash(ls)\n");
+        data.extend_from_slice(b"\x1b[38;5;231m");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" \x1b[mSecond message\n");
         assert_eq!(
-            extract_white_bullet_message(&data),
+            extract_claude_status_message(&data),
             Some("Second message".to_string())
         );
     }
 
     #[test]
-    fn white_bullet_no_bullet_returns_none() {
-        let data = b"plain text without any bullets";
-        assert_eq!(extract_white_bullet_message(data), None);
+    fn no_marker_returns_none() {
+        let data = b"plain text without any markers";
+        assert_eq!(extract_claude_status_message(data), None);
     }
 
     #[test]
-    fn white_bullet_strips_ansi_in_content() {
-        // ● with ANSI codes inside the message text
-        let data = b"\x1b[38;5;231m\xe2\x97\x8f \x1b[mAll \x1b[1m1235\x1b[m tests passed\n";
+    fn legacy_bullet_strips_ansi_in_content() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;231m");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" \x1b[mAll \x1b[1m1235\x1b[m tests passed\n");
         assert_eq!(
-            extract_white_bullet_message(data),
+            extract_claude_status_message(&data),
             Some("All 1235 tests passed".to_string())
         );
     }
 
     #[test]
-    fn white_bullet_with_cr_newline() {
-        // Real terminal output often uses \r\n or just \r
-        let data = b"\x1b[38;5;231m\xe2\x97\x8f \x1b[mMessage here\r\n";
+    fn legacy_bullet_with_cr_newline() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;231m");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" \x1b[mMessage here\r\n");
         assert_eq!(
-            extract_white_bullet_message(data),
+            extract_claude_status_message(&data),
             Some("Message here".to_string())
         );
     }
 
     #[test]
-    fn white_bullet_with_newline_gap() {
-        // Real pattern: SGR_FG_231 + \n + ● (newline between SGR and bullet)
-        let data = b"\x1b[38;5;231m\n\xe2\x97\x8f \x1b[mHostname is AMD9950\n";
+    fn legacy_bullet_with_newline_gap() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;231m\n");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" \x1b[mHostname is AMD9950\n");
         assert_eq!(
-            extract_white_bullet_message(data),
+            extract_claude_status_message(&data),
             Some("Hostname is AMD9950".to_string())
         );
     }
 
     #[test]
-    fn white_bullet_with_cr_gap() {
-        // Real pattern: SGR_FG_231 + \r + ● (carriage return between SGR and bullet)
-        let data = b"\x1b[38;5;231m\r\xe2\x97\x8f \x1b[mStatus update\n";
+    fn legacy_bullet_with_cr_gap() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;231m\r");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" \x1b[mStatus update\n");
         assert_eq!(
-            extract_white_bullet_message(data),
+            extract_claude_status_message(&data),
             Some("Status update".to_string())
         );
     }
 
     #[test]
-    fn white_bullet_tui_mode_cursor_addressed() {
-        // Real TUI pattern: ● followed by cursor movements, then text at different position
-        let legacy_bullet: &[u8] = &[0xe2, 0x97, 0x8f]; // ● U+25CF
+    fn legacy_bullet_tui_mode_cursor_addressed() {
         let mut data = Vec::new();
         data.extend_from_slice(b"\x1b[38;5;231m\r");
-        data.extend_from_slice(legacy_bullet);
+        data.extend_from_slice(LEGACY_BULLET);
         data.extend_from_slice(b"\x1b[m\x1b[1C\x1b[11X\x1b[11C\x1b[?2026h\x1b[?2026l\x1b[19;3H10");
         data.extend_from_slice("이고,".as_bytes());
         data.extend_from_slice(b"\x1b[1C");
         data.extend_from_slice("안녕하세요!".as_bytes());
         data.extend_from_slice(b"\x1b[38;5;174m\x1b[21;1H");
         data.extend_from_slice("✶ Cont".as_bytes());
-        let msg = extract_white_bullet_message(&data);
+        let msg = extract_claude_status_message(&data);
         assert!(msg.is_some(), "Should extract message from TUI output");
         let text = msg.unwrap();
         assert!(text.contains("10"), "Should contain '10': {text}");
@@ -303,47 +327,51 @@ mod tests {
             text.contains("안녕하세요"),
             "Should contain greeting: {text}"
         );
-        // Should NOT contain spinner
         assert!(!text.contains("Cont"), "Should not contain spinner text: {text}");
     }
 
     #[test]
-    fn white_bullet_at_end_of_data() {
-        // No newline at end
-        let data = b"\x1b[38;5;231m\xe2\x97\x8f \x1b[mFinal status";
+    fn legacy_bullet_at_end_of_data() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;231m");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" \x1b[mFinal status");
         assert_eq!(
-            extract_white_bullet_message(data),
+            extract_claude_status_message(&data),
             Some("Final status".to_string())
         );
     }
 
     #[test]
-    fn white_bullet_empty_after_bullet_skipped() {
-        // ● with only whitespace/ANSI reset after it
-        let data = b"\x1b[38;5;231m\xe2\x97\x8f \x1b[m  \n";
-        assert_eq!(extract_white_bullet_message(data), None);
+    fn legacy_bullet_empty_after_marker_skipped() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;231m");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" \x1b[m  \n");
+        assert_eq!(extract_claude_status_message(&data), None);
     }
 
     #[test]
-    fn white_bullet_stops_at_separator_line() {
-        // ● message followed by ─── separator line (input area divider)
+    fn legacy_bullet_stops_at_separator_line() {
         let mut data = Vec::new();
         data.extend_from_slice(b"\x1b[38;5;231m\n");
-        data.extend_from_slice(&[0xe2, 0x97, 0x8f]); // ● U+25CF
+        data.extend_from_slice(LEGACY_BULLET);
         data.extend_from_slice(" \x1b[m메시지 텍스트\n".as_bytes());
         data.extend_from_slice("──────────────────\n".as_bytes());
         data.extend_from_slice("❯ ".as_bytes());
-        let msg = extract_white_bullet_message(&data).unwrap();
+        let msg = extract_claude_status_message(&data).unwrap();
         assert_eq!(msg, "메시지 텍스트");
         assert!(!msg.contains('─'), "Should not contain separator: {msg}");
     }
 
     #[test]
-    fn white_bullet_allows_normal_hyphen() {
-        // Normal hyphen-minus (-) in message should be preserved
-        let data = b"\x1b[38;5;231m\n\xe2\x97\x8f \x1b[mtest-result is 42\n";
+    fn legacy_bullet_allows_normal_hyphen() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;231m\n");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" \x1b[mtest-result is 42\n");
         assert_eq!(
-            extract_white_bullet_message(data),
+            extract_claude_status_message(&data),
             Some("test-result is 42".to_string())
         );
     }
@@ -352,36 +380,44 @@ mod tests {
 
     #[test]
     fn middot_basic() {
-        // Current Claude Code pattern: salmon · followed by message
-        let data = b"\x1b[38;5;174m\xc2\xb7 Creating plan\n";
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;174m");
+        data.extend_from_slice(MIDDOT);
+        data.extend_from_slice(b" Creating plan\n");
         assert_eq!(
-            extract_white_bullet_message(data),
+            extract_claude_status_message(&data),
             Some("Creating plan".to_string())
         );
     }
 
     #[test]
     fn middot_with_cursor_forward() {
-        // Real TUI: · followed by cursor-forward then text
-        let data = b"\x1b[38;5;174m\r\n\xc2\xb7\x1b[1CRead 3 files\n";
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;174m\r\n");
+        data.extend_from_slice(MIDDOT);
+        data.extend_from_slice(b"\x1b[1CRead 3 files\n");
         assert_eq!(
-            extract_white_bullet_message(data),
+            extract_claude_status_message(&data),
             Some("Read 3 files".to_string())
         );
     }
 
     #[test]
     fn middot_ignores_wrong_color() {
-        // · with wrong color should be skipped
-        let data = b"\x1b[38;5;244m\xc2\xb7 gray status\n";
-        assert_eq!(extract_white_bullet_message(data), None);
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;244m");
+        data.extend_from_slice(MIDDOT);
+        data.extend_from_slice(b" gray status\n");
+        assert_eq!(extract_claude_status_message(&data), None);
     }
 
     #[test]
     fn middot_real_tui_pattern() {
-        // Real captured pattern: SGR 174 + CR LF + · + cursor-forward + "Creating…"
-        let data = b"\x1b[38;5;174m\r\n\xc2\xb7\x1b[1CCreating\xe2\x80\xa6\x1b[38;5;244m\x1b[16;1H";
-        let msg = extract_white_bullet_message(data);
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;174m\r\n");
+        data.extend_from_slice(MIDDOT);
+        data.extend_from_slice(b"\x1b[1CCreating\xe2\x80\xa6\x1b[38;5;244m\x1b[16;1H");
+        let msg = extract_claude_status_message(&data);
         assert!(msg.is_some(), "Should extract · message from real TUI output");
         let text = msg.unwrap();
         assert!(
@@ -392,18 +428,22 @@ mod tests {
 
     #[test]
     fn middot_stops_at_spinner() {
-        let data = b"\x1b[38;5;174m\xc2\xb7\x1b[1CUpdated auth.ts\x1b[38;5;174m\x1b[20;1H\xe2\x9c\xb6 Working";
-        let msg = extract_white_bullet_message(data).unwrap();
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;174m");
+        data.extend_from_slice(MIDDOT);
+        data.extend_from_slice(b"\x1b[1CUpdated auth.ts\x1b[38;5;174m\x1b[20;1H\xe2\x9c\xb6 Working");
+        let msg = extract_claude_status_message(&data).unwrap();
         assert_eq!(msg, "Updated auth.ts");
     }
 
     #[test]
     fn middot_with_cursor_position_between_sgr_and_marker() {
-        // Real TUI pattern: SGR 174 + cursor position CSI + · + cursor-forward + text
-        // \x1b[38;5;174m\x1b[13;1H·\x1b[1CCreating plan
-        let data = b"\x1b[38;5;174m\x1b[13;1H\xc2\xb7\x1b[1CCreating plan";
+        let mut data = Vec::new();
+        data.extend_from_slice(b"\x1b[38;5;174m\x1b[13;1H");
+        data.extend_from_slice(MIDDOT);
+        data.extend_from_slice(b"\x1b[1CCreating plan");
         assert_eq!(
-            extract_white_bullet_message(data),
+            extract_claude_status_message(&data),
             Some("Creating plan".to_string())
         );
     }
@@ -411,11 +451,13 @@ mod tests {
     #[test]
     fn mixed_legacy_and_current_picks_last() {
         let mut data = Vec::new();
-        // Legacy ● with SGR 231
-        data.extend_from_slice(b"\x1b[38;5;231m\xe2\x97\x8f \x1b[mLegacy message\n");
-        // Current · with SGR 174
-        data.extend_from_slice(b"\x1b[38;5;174m\xc2\xb7\x1b[1CCurrent message\n");
-        let msg = extract_white_bullet_message(&data).unwrap();
+        data.extend_from_slice(b"\x1b[38;5;231m");
+        data.extend_from_slice(LEGACY_BULLET);
+        data.extend_from_slice(b" \x1b[mLegacy message\n");
+        data.extend_from_slice(b"\x1b[38;5;174m");
+        data.extend_from_slice(MIDDOT);
+        data.extend_from_slice(b"\x1b[1CCurrent message\n");
+        let msg = extract_claude_status_message(&data).unwrap();
         assert_eq!(msg, "Current message");
     }
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -268,6 +268,8 @@ pub fn create_terminal_session(
             // Prepend up to 64 bytes from previous chunk to handle splits where
             // the marker color/char arrives in one chunk and text in the next.
             let combined: std::borrow::Cow<[u8]> = {
+                // Using lock().ok() instead of lock_or_err(): in PTY callback,
+                // a poisoned lock is non-fatal (graceful degradation, not an error path).
                 let prev = lookback_buf.lock().ok();
                 let prev_data = prev.as_ref().map(|b| b.as_slice()).unwrap_or(&[]);
                 if prev_data.is_empty() {
@@ -285,7 +287,7 @@ pub fn create_terminal_session(
                 buf.clear();
                 buf.extend_from_slice(&data[data.len() - keep..]);
             }
-            if let Some(msg) = claude_bullet::extract_white_bullet_message(&combined) {
+            if let Some(msg) = claude_bullet::extract_claude_status_message(&combined) {
                 let mut changed = false;
                 if let Ok(mut terms) = state_for_pty.terminals.lock_or_err() {
                     if let Some(session) = terms.get_mut(&terminal_id) {

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -106,6 +106,8 @@ pub fn create_terminal_session(
     let app_clone = app.clone();
     let state_for_pty = Arc::clone(&*state);
     let claude_detected = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let lookback_buf: Arc<std::sync::Mutex<Vec<u8>>> =
+        Arc::new(std::sync::Mutex::new(Vec::with_capacity(64)));
     let presets = osc_hooks::default_presets();
     let pty_handle = pty::spawn_pty(&session, move |data| {
         // IMPORTANT: Each lock below is acquired and released independently (never nested).
@@ -258,11 +260,32 @@ pub fn create_terminal_session(
             }
         }
 
-        // ── Claude Code white-● message detection ──
+        // ── Claude Code status-marker message detection ──
         // Only runs for known Claude terminals. Extracts user-facing status
-        // messages (white ●) and stores as raw state in session.claude_message.
+        // messages (· or legacy ●) and stores as raw state in session.claude_message.
+        // Accumulates a small lookback buffer to handle cross-chunk marker splits.
         if claude_detected.load(std::sync::atomic::Ordering::Relaxed) {
-            if let Some(msg) = claude_bullet::extract_white_bullet_message(&data) {
+            // Prepend up to 64 bytes from previous chunk to handle splits where
+            // the marker color/char arrives in one chunk and text in the next.
+            let combined: std::borrow::Cow<[u8]> = {
+                let prev = lookback_buf.lock().ok();
+                let prev_data = prev.as_ref().map(|b| b.as_slice()).unwrap_or(&[]);
+                if prev_data.is_empty() {
+                    std::borrow::Cow::Borrowed(&data)
+                } else {
+                    let mut combined = Vec::with_capacity(prev_data.len() + data.len());
+                    combined.extend_from_slice(prev_data);
+                    combined.extend_from_slice(&data);
+                    std::borrow::Cow::Owned(combined)
+                }
+            };
+            // Update lookback: keep last 64 bytes for next chunk
+            if let Ok(mut buf) = lookback_buf.lock() {
+                let keep = 64.min(data.len());
+                buf.clear();
+                buf.extend_from_slice(&data[data.len() - keep..]);
+            }
+            if let Some(msg) = claude_bullet::extract_white_bullet_message(&combined) {
                 let mut changed = false;
                 if let Ok(mut terms) = state_for_pty.terminals.lock_or_err() {
                     if let Some(session) = terms.get_mut(&terminal_id) {

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -42,9 +42,9 @@ pub const PTY_WRITE_CHUNK_SIZE: usize = 1024;
 /// title sequences even when OSC 133 markers have scrolled out.
 pub const ACTIVITY_SCAN_BYTES: usize = 16384;
 
-/// Maximum number of bytes to scan forward from a white-● bullet to extract
-/// the message text. TUI cursor-addressing can spread text across many bytes.
-pub const BULLET_MESSAGE_SCAN_BYTES: usize = 500;
+/// Maximum bytes to scan forward from a Claude Code status marker (● or ·)
+/// to extract message text. TUI cursor-addressing can spread text across many bytes.
+pub const STATUS_MESSAGE_SCAN_BYTES: usize = 500;
 
 /// Fallback delay (ms) to arm the notify gate for shells without preexec
 /// (e.g., PowerShell which doesn't emit OSC 133;C/E). After this delay,


### PR DESCRIPTION
## Summary
- Claude Code 최신 버전이 상태 메시지 마커를 `●` (U+25CF, SGR 231)에서 `·` (U+00B7, SGR 174)로 변경하여 `claudeMessage` 추출이 작동하지 않던 문제 수정
- `MARKERS` 배열로 current(`·`)/legacy(`●`) 두 패턴 모두 지원
- SGR과 마커 사이 CSI 시퀀스(커서 위치 등) 허용하도록 `has_color` 체크 개선
- 64바이트 lookback 버퍼로 크로스-청크 마커 분리 대응
- 6개 신규 테스트 추가 (middot 패턴)

## Test plan
- [x] 기존 legacy ● 테스트 26개 전부 통과
- [ ] dev 인스턴스에서 WSL Claude Code 실행 → `claudeMessage` 필드 확인
- [ ] PowerShell Claude Code 실행 → `claudeMessage` 필드 확인
- [ ] WorkspaceSelectorView에서 상태 메시지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)