### PR TITLE
fix: Claude Code 종료 후 상태가 유지되는 버그 수정

### DIFF
--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -357,4 +357,26 @@ mod tests {
             Some("vim".to_string())
         );
     }
+
+    #[test]
+    fn claude_removed_from_known_returns_false() {
+        let state = AppState::new();
+        let tid = "terminal-test";
+
+        // Insert into known_claude_terminals
+        state
+            .known_claude_terminals
+            .lock()
+            .unwrap()
+            .insert(tid.to_string());
+        assert!(is_claude_terminal_from_buffer(&state, tid, None));
+
+        // Remove (simulates Claude exit detection)
+        state
+            .known_claude_terminals
+            .lock()
+            .unwrap()
+            .remove(tid);
+        assert!(!is_claude_terminal_from_buffer(&state, tid, None));
+    }
 }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -163,11 +163,7 @@ pub fn create_terminal_session(
                 && !event.data.contains("Claude Code")
             {
                 claude_detected.store(false, std::sync::atomic::Ordering::Relaxed);
-                // Remove from known_claude_terminals so is_claude_terminal_from_buffer()
-                // no longer reports this terminal as running Claude Code.
-                if let Ok(mut known) = state_for_pty.known_claude_terminals.lock_or_err() {
-                    known.remove(&terminal_id);
-                }
+                // Lock ordering: terminals (1) before known_claude_terminals (3)
                 if let Ok(mut terms) = state_for_pty.terminals.lock_or_err() {
                     if let Some(session) = terms.get_mut(&terminal_id) {
                         if session.claude_message.is_some() {
@@ -181,6 +177,11 @@ pub fn create_terminal_session(
                             );
                         }
                     }
+                }
+                // Remove from known_claude_terminals so is_claude_terminal_from_buffer()
+                // no longer reports this terminal as running Claude Code.
+                if let Ok(mut known) = state_for_pty.known_claude_terminals.lock_or_err() {
+                    known.remove(&terminal_id);
                 }
             }
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -156,12 +156,18 @@ pub fn create_terminal_session(
             }
 
             // Claude Code exit detection: title no longer contains "Claude Code"
-            // Clears stale claude_message so re-launching won't briefly show old status.
+            // Clears stale claude_message and removes from known_claude_terminals
+            // so activity detection correctly returns to "shell".
             if (event.code == 0 || event.code == 2)
                 && claude_detected.load(std::sync::atomic::Ordering::Relaxed)
                 && !event.data.contains("Claude Code")
             {
                 claude_detected.store(false, std::sync::atomic::Ordering::Relaxed);
+                // Remove from known_claude_terminals so is_claude_terminal_from_buffer()
+                // no longer reports this terminal as running Claude Code.
+                if let Ok(mut known) = state_for_pty.known_claude_terminals.lock_or_err() {
+                    known.remove(&terminal_id);
+                }
                 if let Ok(mut terms) = state_for_pty.terminals.lock_or_err() {
                     if let Some(session) = terms.get_mut(&terminal_id) {
                         if session.claude_message.is_some() {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -40,7 +40,8 @@ pub struct AppState {
     /// Single source of truth for Claude Code terminal detection.
     /// Populated proactively by the PTY output callback (real-time) and
     /// by frontend via `mark_claude_terminal` command (from command text detection).
-    /// Once a terminal is marked, it stays marked until the terminal session closes.
+    /// Removed when the terminal title no longer contains "Claude Code" (exit detection)
+    /// or when the terminal session closes.
     /// Both backend (CWD skip) and frontend (activity display) consume this state.
     pub known_claude_terminals: Arc<Mutex<HashSet<String>>>,
     /// Single source of truth for terminal notifications.

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -96,6 +96,10 @@ export function useSyncEvents() {
         // Activity detection from interactive app (Rust already detected this)
         if (data.interactiveApp) {
           updates.activity = { type: "interactiveApp", name: data.interactiveApp };
+        } else if (instance?.activity?.type === "interactiveApp") {
+          // Interactive app exited — title no longer matches any app pattern.
+          // Reset to shell so stale Claude/vim indicators don't persist.
+          updates.activity = { type: "shell" };
         }
 
         updateInstanceInfo(data.terminalId, updates as Parameters<typeof updateInstanceInfo>[1]);


### PR DESCRIPTION
## Summary
- **Backend**: Claude Code 종료 감지 시 `known_claude_terminals` HashSet에서 터미널 ID를 제거하여 `is_claude_terminal_from_buffer()`가 즉시 `false`를 반환하도록 수정
- **Frontend**: `terminal-title-changed` 이벤트에서 `interactiveApp`이 `null`이고 이전 activity가 `interactiveApp`이었으면 `"shell"`로 리셋하도록 수정
- 단위 테스트 추가: `known_claude_terminals`에서 제거 후 올바르게 `false` 반환 검증

## Test plan
- [x] `cargo test activity::tests` — 18개 전체 통과
- [x] `cargo check` — 컴파일 성공
- [x] `npx tsc --noEmit` — TypeScript 타입 체크 통과
- [ ] 수동 테스트: Claude Code 진입 → 종료 → 터미널 상태가 ⏳에서 shell로 복원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)