### PR TITLE
fix: Claude Code 종료 시 notification 미갱신 수정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,11 @@
 * **`color-mix()` 사용 금지**: `color-mix(in srgb, ...)` 등 현대 CSS 색상 함수는 html2canvas가 파싱하지 못해 스크린샷 API가 깨진다. 반투명 accent가 필요하면 `var(--accent-50)`, `var(--accent-20)` 등 `index.css`에 정의된 CSS 변수를 사용한다.
 * **원시 상태 분리 → 계산 함수로 표시 도출**: 여러 시스템(OSC 133, 타이틀 변경 등)이 관여하는 상태를 표시할 때, 각 시스템은 자기 원시 상태만 독립적으로 저장하고 하나의 공유 필드를 덮어쓰지 않는다. 최종 표시(아이콘, 색상 등)는 모든 원시 상태를 입력받는 단일 계산 함수에서 도출한다. 표시 규칙이 바뀌면 계산 함수만 수정한다.
 * **CWD는 모든 설계의 핵심**: CWD(현재 작업 디렉터리)는 SyncGroup을 통해 터미널 간 동기화되며, `terminalStore`에 중앙 관리된다. 새 View나 기능이 CWD 정보를 필요로 할 때 **백그라운드 셸을 생성하지 말고** `terminalStore`의 syncGroup CWD를 구독하여 사용한다. 파일 시스템 접근(디렉터리 목록 등)은 Rust 백엔드(`std::fs`)를 직접 호출한다.
+* **Claude Code 자동화 테스트 시 주의사항**: dev 터미널에서 `claude` 명령으로 Claude Code를 자동 실행할 때, 다음 절차를 따른다:
+  1. `claude\r\n` 전송 후 **10초 대기** (Claude Code 초기화 시간)
+  2. 터미널 출력(`GET /api/v1/terminals/:id/output`)에서 **"trust" 문자열 확인** — "Yes, I trust this folder" 프롬프트가 나타나면 `y\r\n` 전송하여 통과. 이 프롬프트는 해당 프로젝트 디렉터리에 처음 접근할 때 나타나며, PowerShell/WSL 모두 발생할 수 있다.
+  3. trust 통과 후 또는 trust 없을 때, **"Claude Code" 문자열이 타이틀에 나타날 때까지 폴링** (3초 간격, 최대 60초). `GET /api/v1/terminals`의 `title` 필드에 "Claude Code"가 포함되거나 activity가 `{"type":"interactiveApp","name":"Claude"}`이면 준비 완료.
+  4. 종료: Ctrl+C(`\u0003`)를 0.3초 간격으로 2회 전송. 5초 대기 후 activity가 "shell"로 변경되었는지 확인.
 * **UI 코드 설계 원칙** (`ARCHITECTURE.md` §15 참조):
   - **CSS 변수 우선**: 모든 공통 값(색상, 간격, 반경, 폰트 크기, hover overlay)은 `index.css` `:root`에 CSS 변수로 정의. 하드코딩된 매직 넘버 금지.
   - **호버/인터랙션**: `onMouseEnter/Leave`에서 `style.background` 직접 조작 금지. CSS 호버 클래스(`.hover-bg` 등)를 사용.

--- a/src-tauri/src/osc.rs
+++ b/src-tauri/src/osc.rs
@@ -97,8 +97,10 @@ impl<'a> Iterator for OscEventIter<'a> {
             self.pos = next_pos;
 
             let raw_payload = String::from_utf8_lossy(&self.data[payload_start..payload_end]);
-            if raw_payload.is_empty() && code != 133 {
-                // Skip empty payloads (except OSC 133 which can have param-only like "B")
+            if raw_payload.is_empty() && !matches!(code, 0 | 2 | 133) {
+                // Skip empty payloads — except:
+                // - OSC 0/2: empty title is valid (title reset, e.g. after Claude Code exits)
+                // - OSC 133: can have param-only like "B"
                 continue;
             }
 
@@ -482,6 +484,26 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].code, 133);
         assert_eq!(events[0].param, Some("B".to_string()));
+        assert_eq!(events[0].data, "");
+    }
+
+    #[test]
+    fn iter_osc0_empty_title() {
+        // OSC 0 with empty payload = title reset (e.g. after Claude Code exits).
+        // Must NOT be skipped — the empty title is meaningful.
+        let data = b"\x1b]0;\x07";
+        let events: Vec<OscEvent> = iter_osc_events(data).collect();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].code, 0);
+        assert_eq!(events[0].data, "");
+    }
+
+    #[test]
+    fn iter_osc2_empty_title() {
+        let data = b"\x1b]2;\x07";
+        let events: Vec<OscEvent> = iter_osc_events(data).collect();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].code, 2);
         assert_eq!(events[0].data, "");
     }
 }

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -109,7 +109,16 @@ export function useSyncEvents() {
         const currentActivity = data.interactiveApp
           ? { type: "interactiveApp" as const, name: data.interactiveApp }
           : instance?.activity;
-        const transition = detectClaudeTaskTransition(prevTitle, data.title, currentActivity);
+        const claudeExited =
+          !data.interactiveApp &&
+          instance?.activity?.type === "interactiveApp" &&
+          instance.activity.name === "Claude";
+        const transition = detectClaudeTaskTransition(
+          prevTitle,
+          data.title,
+          currentActivity,
+          claudeExited,
+        );
         previousClaudeTitleMap.set(data.terminalId, data.title);
 
         if (transition === "completed") {

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -148,54 +148,54 @@ describe("detectClaudeTaskTransition", () => {
 
   it("detects completed: spinner → ✳ with Claude activity", () => {
     expect(
-      detectClaudeTaskTransition("✶ Working on feature", "✳ Feature done", claudeActivity),
+      detectClaudeTaskTransition("✶ Working on feature", "✳ Feature done", claudeActivity, false),
     ).toBe("completed");
   });
 
   it("detects started: ✳ → spinner with Claude activity", () => {
-    expect(detectClaudeTaskTransition("✳ Claude Code", "✶ Working on task", claudeActivity)).toBe(
+    expect(detectClaudeTaskTransition("✳ Claude Code", "✶ Working on task", claudeActivity, false)).toBe(
       "started",
     );
   });
 
   it("returns null for same state: spinner → spinner (still working)", () => {
-    expect(detectClaudeTaskTransition("✶ Task A", "✻ Task B", claudeActivity)).toBeNull();
+    expect(detectClaudeTaskTransition("✶ Task A", "✻ Task B", claudeActivity, false)).toBeNull();
   });
 
   it("returns null for same state ✳ → ✳ (still idle)", () => {
     expect(
-      detectClaudeTaskTransition("✳ Claude Code", "✳ Something else", claudeActivity),
+      detectClaudeTaskTransition("✳ Claude Code", "✳ Something else", claudeActivity, false),
     ).toBeNull();
   });
 
   it("returns null for non-Claude activity even with matching prefixes", () => {
-    expect(detectClaudeTaskTransition("✶ Working", "✳ Done", vimActivity)).toBeNull();
-    expect(detectClaudeTaskTransition("✶ Working", "✳ Done", shellActivity)).toBeNull();
+    expect(detectClaudeTaskTransition("✶ Working", "✳ Done", vimActivity, false)).toBeNull();
+    expect(detectClaudeTaskTransition("✶ Working", "✳ Done", shellActivity, false)).toBeNull();
   });
 
   it("returns null when activity is undefined", () => {
-    expect(detectClaudeTaskTransition("✶ Working", "✳ Done", undefined)).toBeNull();
+    expect(detectClaudeTaskTransition("✶ Working", "✳ Done", undefined, false)).toBeNull();
   });
 
   it("does not return started on first title set (previousTitle undefined)", () => {
-    expect(detectClaudeTaskTransition(undefined, "✶ Starting task", claudeActivity)).toBeNull();
+    expect(detectClaudeTaskTransition(undefined, "✶ Starting task", claudeActivity, false)).toBeNull();
   });
 
   it("returns null for titles without spinner or ✳ prefix", () => {
     // Both non-idle, non-spinner plain text → both treated as "working" → null
-    expect(detectClaudeTaskTransition("Claude Code", "Something", claudeActivity)).toBeNull();
+    expect(detectClaudeTaskTransition("Claude Code", "Something", claudeActivity, false)).toBeNull();
   });
 
   it("detects completed with various spinner characters", () => {
-    expect(detectClaudeTaskTransition("✻ Building", "✳ Done", claudeActivity)).toBe("completed");
-    expect(detectClaudeTaskTransition("✽ Running", "✳ Done", claudeActivity)).toBe("completed");
-    expect(detectClaudeTaskTransition("✢ Testing", "✳ Done", claudeActivity)).toBe("completed");
-    expect(detectClaudeTaskTransition("· Thinking", "✳ Done", claudeActivity)).toBe("completed");
-    expect(detectClaudeTaskTransition("* Working", "✳ Done", claudeActivity)).toBe("completed");
+    expect(detectClaudeTaskTransition("✻ Building", "✳ Done", claudeActivity, false)).toBe("completed");
+    expect(detectClaudeTaskTransition("✽ Running", "✳ Done", claudeActivity, false)).toBe("completed");
+    expect(detectClaudeTaskTransition("✢ Testing", "✳ Done", claudeActivity, false)).toBe("completed");
+    expect(detectClaudeTaskTransition("· Thinking", "✳ Done", claudeActivity, false)).toBe("completed");
+    expect(detectClaudeTaskTransition("* Working", "✳ Done", claudeActivity, false)).toBe("completed");
   });
 
   it("detects completed when previousTitle is spinner and new is ✳ Claude Code (idle)", () => {
-    expect(detectClaudeTaskTransition("✶ Building project", "✳ Claude Code", claudeActivity)).toBe(
+    expect(detectClaudeTaskTransition("✶ Building project", "✳ Claude Code", claudeActivity, false)).toBe(
       "completed",
     );
   });
@@ -224,7 +224,7 @@ describe("detectClaudeTaskTransition", () => {
   it("detects completed with garbled ✳ encoding", () => {
     const garbledIdle = "\udce2\uc454 Claude Code";
     const garbledWorking = "\udce2\uc7fc Claude Code";
-    expect(detectClaudeTaskTransition(garbledWorking, garbledIdle, claudeActivity)).toBe(
+    expect(detectClaudeTaskTransition(garbledWorking, garbledIdle, claudeActivity, false)).toBe(
       "completed",
     );
   });
@@ -232,7 +232,7 @@ describe("detectClaudeTaskTransition", () => {
   it("detects started with garbled encoding", () => {
     const garbledIdle = "\udce2\uc454 Claude Code";
     const garbledWorking = "\udce2\uc7fc Working on task";
-    expect(detectClaudeTaskTransition(garbledIdle, garbledWorking, claudeActivity)).toBe("started");
+    expect(detectClaudeTaskTransition(garbledIdle, garbledWorking, claudeActivity, false)).toBe("started");
   });
 });
 

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -201,6 +201,26 @@ describe("detectClaudeTaskTransition", () => {
   });
 
   // Garbled encoding tests (Windows CP949 path)
+  it("detects completed when Claude exits while working (claudeExited=true)", () => {
+    // Claude was working (spinner), then exited entirely (title changed to shell prompt)
+    expect(
+      detectClaudeTaskTransition("✶ Building project", "bash", claudeActivity, true),
+    ).toBe("completed");
+  });
+
+  it("returns null when Claude exits while idle (claudeExited=true)", () => {
+    // Claude was idle, user exited → no task was in progress, no notification needed
+    expect(
+      detectClaudeTaskTransition("✳ Claude Code", "bash", claudeActivity, true),
+    ).toBeNull();
+  });
+
+  it("detects completed when Claude exits with various spinner prefixes", () => {
+    expect(detectClaudeTaskTransition("✻ Fix bug", "user@host:~", claudeActivity, true)).toBe("completed");
+    expect(detectClaudeTaskTransition("✽ Running", "zsh", claudeActivity, true)).toBe("completed");
+    expect(detectClaudeTaskTransition("· Thinking", "PowerShell", claudeActivity, true)).toBe("completed");
+  });
+
   it("detects completed with garbled ✳ encoding", () => {
     const garbledIdle = "\udce2\uc454 Claude Code";
     const garbledWorking = "\udce2\uc7fc Claude Code";

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -157,7 +157,7 @@ export function detectClaudeTaskTransition(
   previousTitle: string | undefined,
   newTitle: string,
   activity: TerminalActivityInfo | undefined,
-  claudeExited?: boolean,
+  claudeExited: boolean,
 ): ClaudeTaskTransition | null {
   if (activity?.type !== "interactiveApp" || activity.name !== "Claude") return null;
   if (previousTitle === undefined) return null;

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -157,11 +157,18 @@ export function detectClaudeTaskTransition(
   previousTitle: string | undefined,
   newTitle: string,
   activity: TerminalActivityInfo | undefined,
+  claudeExited?: boolean,
 ): ClaudeTaskTransition | null {
   if (activity?.type !== "interactiveApp" || activity.name !== "Claude") return null;
   if (previousTitle === undefined) return null;
 
   const wasIdle = isClaudeIdle(previousTitle);
+
+  // Claude exited entirely: working → exit = completed, idle → exit = no transition
+  if (claudeExited) {
+    return wasIdle ? null : "completed";
+  }
+
   const nowIdle = isClaudeIdle(newTitle);
 
   if (!wasIdle && nowIdle) return "completed";


### PR DESCRIPTION
## Summary
- Claude Code 종료 후 activity가 "Claude"로 남고 notification이 생성되지 않던 버그 수정
- **근본 원인**: 셸이 Claude 종료 후 빈 OSC 0 (`\e]0;\a`)을 보내지만, `iter_osc_events`가 빈 페이로드를 skip하여 기존 OSC 0/2 기반 종료 감지가 실행되지 않음
- OSC 0/2 빈 페이로드 허용 + `detectClaudeTaskTransition`에 `claudeExited` 파라미터 추가

## Changes
| 파일 | 변경 |
|------|------|
| `osc.rs` | OSC 0/2 빈 페이로드 skip 제외 (빈 타이틀 = 유효한 리셋 시그널) |
| `activity-detection.ts` | `claudeExited` 파라미터 추가 — working→exit = "completed" |
| `useSyncEvents.ts` | Claude 종료 감지 플래그 계산 및 전달 |
| `CLAUDE.md` | Claude Code 자동화 테스트 시 trust 프롬프트 처리 지침 추가 |

## Test plan
- [x] Rust unit tests: `cargo test --lib` — 463 passed
- [x] UI unit tests: `vitest run` — 90 passed
- [x] WSL dev 테스트: Claude Code 실행 → idle에서 Ctrl+C 종료 → activity "shell"로 리셋 확인
- [x] PowerShell dev 테스트: Claude Code 실행 → idle에서 Ctrl+C 종료 → activity "shell"로 리셋 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)