### PR TITLE
Refactor activity handler abstraction

### DIFF
--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -10,7 +10,7 @@ import {
   abbreviatePath,
   mntPathToWindows,
   formatCommand,
-  CLAUDE_MSG_TRUNCATE_LEN,
+  ACTIVITY_MSG_TRUNCATE_LEN,
   formatRelativeTime,
   formatActivity,
 } from "@/lib/workspace-summary";
@@ -129,7 +129,7 @@ function WorkspaceItem({
     ? computeCommandStatus(
         cmdInfo.exitCode,
         cmdInfo.outputActive,
-        cmdInfo.claudeMessage,
+        cmdInfo.activityMessage,
         cmdInfo.activity,
         cmdInfo.title,
         claudeSettings.statusMessageMode,
@@ -320,7 +320,7 @@ function WorkspaceItem({
                     ? computeCommandStatus(
                         ts.lastExitCode,
                         ts.outputActive,
-                        ts.claudeMessage,
+                        ts.activityMessage,
                         ts.activity,
                         ts.title,
                       )
@@ -548,7 +548,7 @@ function WorkspaceItem({
             <span className="truncate" style={{ color: "var(--text-secondary)" }}>
               {formatCommand(
                 cmdStatus?.text ?? cmdInfo.command,
-                cmdStatus?.text ? CLAUDE_MSG_TRUNCATE_LEN : undefined,
+                cmdStatus?.text ? ACTIVITY_MSG_TRUNCATE_LEN : undefined,
               )}
             </span>
             <span style={{ color: "var(--text-secondary)", opacity: 0.4 }}>

--- a/ui/src/hooks/useSyncEvents.test.ts
+++ b/ui/src/hooks/useSyncEvents.test.ts
@@ -297,7 +297,7 @@ describe("useSyncEvents", () => {
     expect(mockOnClaudeMessageChanged).toHaveBeenCalledWith(expect.any(Function));
   });
 
-  it("updates terminal claudeMessage on claude-message-changed event", () => {
+  it("updates terminal activityMessage on claude-message-changed event", () => {
     useTerminalStore.getState().registerInstance({
       id: "t1",
       profile: "WSL",
@@ -311,7 +311,7 @@ describe("useSyncEvents", () => {
     callback({ terminalId: "t1", message: "모든 테스트 통과했습니다." });
 
     const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
-    expect(instance?.claudeMessage).toBe("모든 테스트 통과했습니다.");
+    expect(instance?.activityMessage).toBe("모든 테스트 통과했습니다.");
   });
 
   it("calls markClaudeTerminal when command text detects Claude", () => {

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -78,7 +78,7 @@ export function useSyncEvents() {
       onClaudeMessageChanged((data) => {
         if (cancelled) return;
         useTerminalStore.getState().updateInstanceInfo(data.terminalId, {
-          claudeMessage: data.message,
+          activityMessage: data.message,
         });
       }),
     );

--- a/ui/src/lib/activity-handler.ts
+++ b/ui/src/lib/activity-handler.ts
@@ -1,5 +1,4 @@
 import type { TerminalActivityInfo } from "@/stores/terminal-store";
-import type { ClaudeStatusMessageMode } from "@/lib/tauri-api";
 import { ShellActivityHandler } from "./shell-activity-handler";
 import { ClaudeActivityHandler } from "./claude-activity-handler";
 
@@ -8,16 +7,18 @@ export interface StatusResult {
   color: string;
 }
 
+export type ActivityStatusMessageMode = "bullet" | "title" | "title-bullet" | "bullet-title";
+
 export interface RawTerminalState {
   exitCode: number | undefined;
   outputActive: boolean;
   lastCommand: string | undefined;
-  claudeMessage: string | undefined;
+  activityMessage: string | undefined;
   activity: TerminalActivityInfo | undefined;
   title: string | undefined;
-  /** Claude status message display mode (default: "bullet-title"). */
-  statusMessageMode?: ClaudeStatusMessageMode;
-  /** Delimiter between bullet and title (default: " · "). */
+  /** Activity status message display mode. */
+  statusMessageMode?: ActivityStatusMessageMode;
+  /** Delimiter between bullet and title. */
   statusMessageDelimiter?: string;
 }
 
@@ -27,11 +28,18 @@ export interface ActivityHandler {
   computeNotification(raw: RawTerminalState): { message: string; level: string } | null;
 }
 
-const handlers: Record<string, ActivityHandler> = {
-  default: new ShellActivityHandler(),
-  Claude: new ClaudeActivityHandler(),
-};
+const defaultHandler = new ShellActivityHandler();
+const interactiveAppHandlers = new Map<string, ActivityHandler>();
+
+export function registerActivityHandler(activityName: string, handler: ActivityHandler): void {
+  interactiveAppHandlers.set(activityName, handler);
+}
+
+registerActivityHandler("Claude", new ClaudeActivityHandler());
 
 export function getHandler(activity?: TerminalActivityInfo): ActivityHandler {
-  return (activity?.name ? handlers[activity.name] : undefined) ?? handlers.default;
+  if (activity?.type === "interactiveApp" && activity.name) {
+    return interactiveAppHandlers.get(activity.name) ?? defaultHandler;
+  }
+  return defaultHandler;
 }

--- a/ui/src/lib/claude-activity-handler.test.ts
+++ b/ui/src/lib/claude-activity-handler.test.ts
@@ -1,13 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ClaudeActivityHandler } from "./claude-activity-handler";
 import type { RawTerminalState } from "./activity-handler";
+
+const SEP = " \u00b7 ";
 
 function raw(overrides: Partial<RawTerminalState> = {}): RawTerminalState {
   return {
     exitCode: undefined,
     outputActive: false,
     lastCommand: undefined,
-    claudeMessage: undefined,
+    activityMessage: undefined,
     activity: { type: "interactiveApp", name: "Claude" },
     title: undefined,
     ...overrides,
@@ -18,253 +20,185 @@ describe("ClaudeActivityHandler", () => {
   const handler = new ClaudeActivityHandler();
 
   describe("computeStatus", () => {
-    it("returns ⏳ yellow when outputActive (working/responding)", () => {
-      const result = handler.computeStatus(raw({ outputActive: true }));
-      expect(result).toEqual({ icon: "⏳", color: "var(--yellow)" });
+    it("returns pending while output is active", () => {
+      expect(handler.computeStatus(raw({ outputActive: true }))).toEqual({
+        icon: "⏳",
+        color: "var(--yellow)",
+      });
     });
 
-    it("outputActive overrides exitCode", () => {
-      const result = handler.computeStatus(raw({ outputActive: true, exitCode: 0 }));
-      expect(result.icon).toBe("⏳");
+    it("prefers active output over exitCode and idle title", () => {
+      expect(
+        handler.computeStatus(raw({ outputActive: true, exitCode: 0, title: "✳ Claude Code" })),
+      ).toEqual({
+        icon: "⏳",
+        color: "var(--yellow)",
+      });
     });
 
-    it("outputActive overrides idle title", () => {
-      const result = handler.computeStatus(raw({ outputActive: true, title: "✳ Claude Code" }));
-      expect(result.icon).toBe("⏳");
+    it("returns success when exitCode is zero", () => {
+      expect(handler.computeStatus(raw({ exitCode: 0 }))).toEqual({
+        icon: "✓",
+        color: "var(--green)",
+      });
     });
 
-    it("returns ✓ green when task completed (synthetic exitCode=0)", () => {
-      const result = handler.computeStatus(raw({ exitCode: 0 }));
-      expect(result).toEqual({ icon: "✓", color: "var(--green)" });
+    it("returns failure when exitCode is non-zero", () => {
+      expect(handler.computeStatus(raw({ exitCode: 1 }))).toEqual({
+        icon: "✗",
+        color: "var(--red)",
+      });
     });
 
-    it("returns ✗ red when exitCode≠0", () => {
-      const result = handler.computeStatus(raw({ exitCode: 1 }));
-      expect(result).toEqual({ icon: "✗", color: "var(--red)" });
+    it("returns Claude idle status for idle title", () => {
+      expect(handler.computeStatus(raw({ title: "✳ Claude Code" }))).toEqual({
+        icon: "✳",
+        color: "var(--claude)",
+      });
     });
 
-    it("returns ✳ Claude accent when idle with ✳ title", () => {
-      const result = handler.computeStatus(raw({ title: "✳ Claude Code" }));
-      expect(result).toEqual({ icon: "✳", color: "var(--claude)" });
-    });
-
-    it("returns — gray when no title (fallback idle)", () => {
-      const result = handler.computeStatus(raw());
-      expect(result).toEqual({ icon: "—", color: "var(--text-secondary)" });
-    });
-
-    it("returns — gray when title has no Claude marker", () => {
-      const result = handler.computeStatus(raw({ title: "bash" }));
-      expect(result).toEqual({ icon: "—", color: "var(--text-secondary)" });
-    });
-
-    it("exitCode=0 overrides idle title (task just completed)", () => {
-      const result = handler.computeStatus(raw({ exitCode: 0, title: "✳ Claude Code" }));
-      expect(result).toEqual({ icon: "✓", color: "var(--green)" });
+    it("falls back to shell idle status", () => {
+      expect(handler.computeStatus(raw({ title: "bash" }))).toEqual({
+        icon: "—",
+        color: "var(--text-secondary)",
+      });
     });
   });
 
   describe("computeStatusMessage", () => {
-    it("returns claudeMessage when only bullet exists", () => {
-      expect(handler.computeStatusMessage(raw({ claudeMessage: "Reading file src/main.rs" }))).toBe(
-        "Reading file src/main.rs",
-      );
+    it("returns activityMessage when only bullet exists", () => {
+      expect(
+        handler.computeStatusMessage(raw({ activityMessage: "Reading file src/main.rs" })),
+      ).toBe("Reading file src/main.rs");
     });
 
-    it("returns title message when only title exists (spinner stripped)", () => {
+    it("returns title message when only spinner title exists", () => {
       expect(handler.computeStatusMessage(raw({ title: "✢ Working on task" }))).toBe(
         "Working on task",
       );
     });
 
-    it("returns title message with braille spinner stripped", () => {
+    it("strips braille spinner titles", () => {
       expect(handler.computeStatusMessage(raw({ title: "⠐ Analyzing code" }))).toBe(
         "Analyzing code",
       );
     });
 
-    it("combines bullet and title with · separator when both exist", () => {
+    it("combines bullet and title with default delimiter", () => {
       expect(
         handler.computeStatusMessage(
-          raw({ claudeMessage: "Reading file", title: "✢ Working on task" }),
+          raw({ activityMessage: "Reading file", title: "✢ Working on task" }),
         ),
-      ).toBe("Reading file · Working on task");
+      ).toBe(`Reading file${SEP}Working on task`);
     });
 
-    it("combines bullet and braille title", () => {
-      expect(
-        handler.computeStatusMessage(
-          raw({ claudeMessage: "Editing files", title: "⠐ Fix the bug" }),
-        ),
-      ).toBe("Editing files · Fix the bug");
-    });
-
-    it("returns undefined when no claudeMessage and no title", () => {
-      expect(handler.computeStatusMessage(raw())).toBeUndefined();
-    });
-
-    it("returns undefined for empty claudeMessage and no title", () => {
-      expect(handler.computeStatusMessage(raw({ claudeMessage: "" }))).toBeUndefined();
-    });
-
-    it("skips title when it has no spinner prefix (plain title)", () => {
-      expect(handler.computeStatusMessage(raw({ title: "bash" }))).toBeUndefined();
-    });
-
-    it("skips idle title (✳ prefix) — not useful as status message", () => {
+    it("ignores idle titles in status message output", () => {
       expect(handler.computeStatusMessage(raw({ title: "✳ Claude Code" }))).toBeUndefined();
-    });
-
-    it("bullet only when title is idle ✳", () => {
       expect(
         handler.computeStatusMessage(
-          raw({ claudeMessage: "Reading file", title: "✳ Claude Code" }),
+          raw({ activityMessage: "Reading file", title: "✳ Claude Code" }),
         ),
       ).toBe("Reading file");
     });
 
-    it("skips title when stripped text equals 'Claude Code'", () => {
-      expect(handler.computeStatusMessage(raw({ title: "✢ Claude Code" }))).toBeUndefined();
+    it("returns undefined when no message source exists", () => {
+      expect(handler.computeStatusMessage(raw())).toBeUndefined();
+      expect(handler.computeStatusMessage(raw({ activityMessage: "" }))).toBeUndefined();
     });
 
-    describe("statusMessageMode", () => {
-      const both = { claudeMessage: "Reading file", title: "✢ Working on task" };
+    it("supports bullet mode", () => {
+      expect(
+        handler.computeStatusMessage(
+          raw({
+            activityMessage: "Reading file",
+            title: "✢ Working on task",
+            statusMessageMode: "bullet",
+          }),
+        ),
+      ).toBe("Reading file");
+    });
 
-      it("bullet mode: only bullet", () => {
-        expect(handler.computeStatusMessage(raw({ ...both, statusMessageMode: "bullet" }))).toBe(
-          "Reading file",
-        );
-      });
+    it("supports title mode", () => {
+      expect(
+        handler.computeStatusMessage(
+          raw({
+            activityMessage: "Reading file",
+            title: "✢ Working on task",
+            statusMessageMode: "title",
+          }),
+        ),
+      ).toBe("Working on task");
+    });
 
-      it("bullet mode: undefined when no bullet", () => {
-        expect(
-          handler.computeStatusMessage(
-            raw({ title: "✢ Working on task", statusMessageMode: "bullet" }),
-          ),
-        ).toBeUndefined();
-      });
+    it("supports bullet-title mode", () => {
+      expect(
+        handler.computeStatusMessage(
+          raw({
+            activityMessage: "Reading file",
+            title: "✢ Working on task",
+            statusMessageMode: "bullet-title",
+          }),
+        ),
+      ).toBe(`Reading file${SEP}Working on task`);
+    });
 
-      it("title mode: only title", () => {
-        expect(handler.computeStatusMessage(raw({ ...both, statusMessageMode: "title" }))).toBe(
-          "Working on task",
-        );
-      });
+    it("supports title-bullet mode", () => {
+      expect(
+        handler.computeStatusMessage(
+          raw({
+            activityMessage: "Reading file",
+            title: "✢ Working on task",
+            statusMessageMode: "title-bullet",
+          }),
+        ),
+      ).toBe(`Working on task${SEP}Reading file`);
+    });
 
-      it("title mode: undefined when no spinner title", () => {
-        expect(
-          handler.computeStatusMessage(
-            raw({ claudeMessage: "Reading file", statusMessageMode: "title" }),
-          ),
-        ).toBeUndefined();
-      });
-
-      it("bullet-title mode (default): bullet · title", () => {
-        expect(
-          handler.computeStatusMessage(raw({ ...both, statusMessageMode: "bullet-title" })),
-        ).toBe("Reading file · Working on task");
-      });
-
-      it("title-bullet mode: title · bullet", () => {
-        expect(
-          handler.computeStatusMessage(raw({ ...both, statusMessageMode: "title-bullet" })),
-        ).toBe("Working on task · Reading file");
-      });
-
-      it("title-bullet mode: falls back to bullet when no title", () => {
-        expect(
-          handler.computeStatusMessage(
-            raw({ claudeMessage: "Reading file", statusMessageMode: "title-bullet" }),
-          ),
-        ).toBe("Reading file");
-      });
-
-      it("custom delimiter", () => {
-        expect(
-          handler.computeStatusMessage(
-            raw({ ...both, statusMessageMode: "bullet-title", statusMessageDelimiter: " | " }),
-          ),
-        ).toBe("Reading file | Working on task");
-      });
-
-      it("custom delimiter with title-bullet", () => {
-        expect(
-          handler.computeStatusMessage(
-            raw({ ...both, statusMessageMode: "title-bullet", statusMessageDelimiter: " — " }),
-          ),
-        ).toBe("Working on task — Reading file");
-      });
+    it("supports custom delimiter", () => {
+      expect(
+        handler.computeStatusMessage(
+          raw({
+            activityMessage: "Reading file",
+            title: "✢ Working on task",
+            statusMessageMode: "title-bullet",
+            statusMessageDelimiter: " | ",
+          }),
+        ),
+      ).toBe("Working on task | Reading file");
     });
   });
 
   describe("computeNotification", () => {
-    it("returns null (Rust handles notifications)", () => {
+    it("returns null because Rust emits notifications", () => {
       expect(handler.computeNotification(raw())).toBeNull();
-      expect(handler.computeNotification(raw({ exitCode: 0, claudeMessage: "Done" }))).toBeNull();
+      expect(handler.computeNotification(raw({ exitCode: 0, activityMessage: "Done" }))).toBeNull();
     });
   });
 
   describe("Claude lifecycle scenarios", () => {
-    it("initial entry: title=Claude Code, no exitCode → ✳ idle", () => {
-      const state = raw({ title: "✳ Claude Code" });
-      const s = handler.computeStatus(state);
-      expect(s).toEqual({ icon: "✳", color: "var(--claude)" });
+    it("shows idle status before a task starts", () => {
+      expect(handler.computeStatus(raw({ title: "✳ Claude Code" })).icon).toBe("✳");
     });
 
-    it("working state: outputActive=true → ⏳ with combined message", () => {
+    it("shows combined message while actively working", () => {
       const state = raw({
         outputActive: true,
-        claudeMessage: "Editing files",
+        activityMessage: "Editing files",
         title: "✢ Working on task",
       });
-      const s = handler.computeStatus(state);
-      const m = handler.computeStatusMessage(state);
-      expect(s.icon).toBe("⏳");
-      expect(m).toBe("Editing files · Working on task");
+      expect(handler.computeStatus(state).icon).toBe("⏳");
+      expect(handler.computeStatusMessage(state)).toBe(`Editing files${SEP}Working on task`);
     });
 
-    it("working state: bullet only when no spinner title", () => {
-      const state = raw({ outputActive: true, claudeMessage: "Editing files" });
-      const m = handler.computeStatusMessage(state);
-      expect(m).toBe("Editing files");
+    it("keeps bullet-only output when title is absent", () => {
+      const state = raw({ outputActive: true, activityMessage: "Editing files" });
+      expect(handler.computeStatusMessage(state)).toBe("Editing files");
     });
 
-    it("thinking with spinner title only → title message", () => {
-      const state = raw({ outputActive: true, title: "✢ Working on task" });
-      const s = handler.computeStatus(state);
-      const m = handler.computeStatusMessage(state);
-      expect(s.icon).toBe("⏳");
-      expect(m).toBe("Working on task");
-    });
-
-    it("thinking with braille spinner only → title message", () => {
-      const state = raw({ outputActive: true, title: "⠐ Analyzing code" });
-      const s = handler.computeStatus(state);
-      const m = handler.computeStatusMessage(state);
-      expect(s.icon).toBe("⏳");
-      expect(m).toBe("Analyzing code");
-    });
-
-    it("task completed: exitCode=0, claudeMessage → ✓ with message", () => {
-      const state = raw({ exitCode: 0, claudeMessage: "Fixed the bug" });
-      const s = handler.computeStatus(state);
-      const m = handler.computeStatusMessage(state);
-      expect(s.icon).toBe("✓");
-      expect(m).toBe("Fixed the bug");
-    });
-
-    it("idle after completion: exitCode=0, no message → ✓", () => {
-      const state = raw({ exitCode: 0 });
-      const s = handler.computeStatus(state);
-      const m = handler.computeStatusMessage(state);
-      expect(s.icon).toBe("✓");
-      expect(m).toBeUndefined();
-    });
-
-    it("back to idle after task: ✳ title, no exitCode → ✳", () => {
-      // After exitCode is cleared and Claude returns to idle prompt
-      const state = raw({ title: "✳ Claude Code" });
-      const s = handler.computeStatus(state);
-      expect(s).toEqual({ icon: "✳", color: "var(--claude)" });
+    it("keeps success message after completion", () => {
+      const state = raw({ exitCode: 0, activityMessage: "Fixed the bug" });
+      expect(handler.computeStatus(state).icon).toBe("✓");
+      expect(handler.computeStatusMessage(state)).toBe("Fixed the bug");
     });
   });
 });

--- a/ui/src/lib/claude-activity-handler.ts
+++ b/ui/src/lib/claude-activity-handler.ts
@@ -1,78 +1,43 @@
 import { ShellActivityHandler } from "./shell-activity-handler";
 import type { RawTerminalState, StatusResult } from "./activity-handler";
 
-/** U+2733 — Claude Code idle title prefix. */
 const CLAUDE_IDLE_PREFIX = "\u2733";
-
-/** Star-based working spinner prefixes (✶✻✽✢). */
 const WORKING_STAR_SPINNERS = ["\u2736", "\u273B", "\u273D", "\u2722"];
+const DEFAULT_STATUS_MESSAGE_DELIMITER = " \u00b7 ";
 
-/** Check if char is a Braille pattern (U+2800..U+28FF). */
 function isBraille(ch: string): boolean {
   const code = ch.codePointAt(0) ?? 0;
   return code >= 0x2800 && code <= 0x28ff;
 }
 
-/**
- * Extract a meaningful message from a Claude Code title by stripping spinner prefix.
- * Returns undefined for idle titles (✳), non-Claude titles, or "Claude Code" text.
- */
 function extractTitleMessage(title: string | undefined): string | undefined {
   if (!title) return undefined;
   const first = title.charAt(0);
-  // Must start with a working spinner (not idle ✳)
   if (!WORKING_STAR_SPINNERS.includes(first) && !isBraille(first)) return undefined;
+
   const stripped = title.slice(1).trim();
-  // Skip if the stripped text is just "Claude Code" — not informative
   if (!stripped || stripped === "Claude Code") return undefined;
   return stripped;
 }
 
-/**
- * Claude Code 전용 ActivityHandler.
- *
- * 셸 기본 4-state 규칙을 상속하되, Claude 전용 분기를 오버라이드한다:
- * - computeStatus: idle 상태(✳ 타이틀)에서 전용 아이콘/색상 표시
- * - computeStatusMessage: claudeMessage(white-● 상태 메시지) 반환
- */
 export class ClaudeActivityHandler extends ShellActivityHandler {
-  /**
-   * Claude 전용 status 계산.
-   *
-   * 우선순위:
-   * 1. outputActive → ⏳ yellow (working, 셸과 동일)
-   * 2. exitCode=0 → ✓ green (task completed)
-   * 3. exitCode≠0 → ✗ red (error)
-   * 4. title starts with ✳ → ✳ Claude accent (idle, waiting for input)
-   * 5. fallback → — gray
-   */
   computeStatus(raw: RawTerminalState): StatusResult {
-    // Priority 1-3: delegate to shell handler (outputActive, exitCode)
     if (raw.outputActive || raw.exitCode !== undefined) {
       return super.computeStatus(raw);
     }
 
-    // Priority 4: Claude idle — title starts with ✳
     if (raw.title?.startsWith(CLAUDE_IDLE_PREFIX)) {
       return { icon: "\u2733", color: "var(--claude)" };
     }
 
-    // Priority 5: fallback
     return super.computeStatus(raw);
   }
 
-  /**
-   * Claude 상태 메시지: statusMessageMode 설정에 따라 bullet/title을 조합.
-   * - "bullet": bullet만
-   * - "title": title만
-   * - "bullet-title": bullet + delimiter + title (기본)
-   * - "title-bullet": title + delimiter + bullet
-   */
   computeStatusMessage(raw: RawTerminalState): string | undefined {
-    const bullet = raw.claudeMessage || undefined;
+    const bullet = raw.activityMessage || undefined;
     const titleMsg = extractTitleMessage(raw.title);
     const mode = raw.statusMessageMode ?? "bullet-title";
-    const delimiter = raw.statusMessageDelimiter ?? " · ";
+    const delimiter = raw.statusMessageDelimiter ?? DEFAULT_STATUS_MESSAGE_DELIMITER;
 
     switch (mode) {
       case "bullet":

--- a/ui/src/lib/shell-activity-handler.test.ts
+++ b/ui/src/lib/shell-activity-handler.test.ts
@@ -7,7 +7,7 @@ function raw(overrides: Partial<RawTerminalState> = {}): RawTerminalState {
     exitCode: undefined,
     outputActive: false,
     lastCommand: undefined,
-    claudeMessage: undefined,
+    activityMessage: undefined,
     activity: undefined,
     title: undefined,
     ...overrides,
@@ -57,7 +57,7 @@ describe("ShellActivityHandler", () => {
   describe("computeStatusMessage", () => {
     it("always returns undefined (shell uses command text directly)", () => {
       expect(handler.computeStatusMessage(raw())).toBeUndefined();
-      expect(handler.computeStatusMessage(raw({ claudeMessage: "Building..." }))).toBeUndefined();
+      expect(handler.computeStatusMessage(raw({ activityMessage: "Building..." }))).toBeUndefined();
       expect(handler.computeStatusMessage(raw({ lastCommand: "npm test" }))).toBeUndefined();
     });
   });

--- a/ui/src/lib/workspace-summary.test.ts
+++ b/ui/src/lib/workspace-summary.test.ts
@@ -322,14 +322,14 @@ describe("getLastCommandForWorkspace — interactiveApp without lastCommand", ()
         activity: { type: "interactiveApp", name: "Claude" },
         outputActive: true,
         lastCommandAt: 300,
-        claudeMessage: "Working on task",
+        activityMessage: "Working on task",
         title: "✢ Working on task",
       }),
     ];
     const result = getLastCommandForWorkspace(terminals);
     expect(result).not.toBeNull();
     expect(result?.outputActive).toBe(true);
-    expect(result?.claudeMessage).toBe("Working on task");
+    expect(result?.activityMessage).toBe("Working on task");
     expect(result?.activity?.name).toBe("Claude");
   });
 
@@ -340,7 +340,7 @@ describe("getLastCommandForWorkspace — interactiveApp without lastCommand", ()
         activity: { type: "interactiveApp", name: "Claude" },
         lastExitCode: 0,
         lastCommandAt: 300,
-        claudeMessage: "Task completed",
+        activityMessage: "Task completed",
         title: "✳ Claude Code",
       }),
     ];
@@ -657,33 +657,33 @@ describe("computeCommandStatus", () => {
     expect(s.color).toBe("var(--text-secondary)");
   });
 
-  // claudeMessage → text field (only with Claude activity)
-  it("returns claudeMessage as text when Claude activity + outputActive", () => {
+  // activityMessage -> text field (only with Claude activity)
+  it("returns activityMessage as text when Claude activity + outputActive", () => {
     const claude = { type: "interactiveApp" as const, name: "Claude" };
     const s = computeCommandStatus(undefined, true, "모든 테스트 통과했습니다.", claude);
     expect(s.icon).toBe("⏳");
     expect(s.text).toBe("모든 테스트 통과했습니다.");
   });
 
-  it("returns claudeMessage as text for Claude success", () => {
+  it("returns activityMessage as text for Claude success", () => {
     const claude = { type: "interactiveApp" as const, name: "Claude" };
     const s = computeCommandStatus(0, false, "1235개 테스트 모두 통과했습니다.", claude);
     expect(s.icon).toBe("✓");
     expect(s.text).toBe("1235개 테스트 모두 통과했습니다.");
   });
 
-  it("shell ignores claudeMessage (uses command text directly)", () => {
-    // Shell handler does not return claudeMessage as text override
+  it("shell ignores activityMessage (uses command text directly)", () => {
+    // Shell handler does not return activityMessage as text override
     const s = computeCommandStatus(0, false, "some message");
     expect(s.text).toBeUndefined();
   });
 
-  it("returns undefined text when no claudeMessage", () => {
+  it("returns undefined text when no activityMessage", () => {
     const s = computeCommandStatus(0, false);
     expect(s.text).toBeUndefined();
   });
 
-  it("returns undefined text for empty string claudeMessage", () => {
+  it("returns undefined text for empty string activityMessage", () => {
     const claude = { type: "interactiveApp" as const, name: "Claude" };
     const s = computeCommandStatus(0, false, "", claude);
     expect(s.text).toBeUndefined();

--- a/ui/src/lib/workspace-summary.ts
+++ b/ui/src/lib/workspace-summary.ts
@@ -1,15 +1,18 @@
 import type { TerminalInstance, TerminalActivityInfo } from "@/stores/terminal-store";
 import type { Notification } from "@/stores/notification-store";
 import type { TerminalSummaryResponse } from "@/lib/tauri-api";
-import type { ClaudeStatusMessageMode } from "@/lib/tauri-api";
-import { getHandler, type RawTerminalState } from "./activity-handler";
+import {
+  getHandler,
+  type ActivityStatusMessageMode,
+  type RawTerminalState,
+} from "./activity-handler";
 
 export interface LastCommandInfo {
   command: string;
   exitCode: number | undefined; // undefined = still running
   timestamp: number;
   outputActive?: boolean; // true = terminal still producing output (e.g. subprocess running)
-  claudeMessage?: string; // latest white-● status message from Claude Code output
+  activityMessage?: string; // latest provider-specific activity status message
   activity?: TerminalActivityInfo;
   title?: string; // terminal title (used for Claude idle detection via ✳ prefix)
 }
@@ -27,7 +30,7 @@ export interface TerminalSummaryInfo {
   activity: TerminalActivityInfo | undefined;
   outputActive: boolean;
   hasUnreadNotification: boolean;
-  claudeMessage: string | undefined;
+  activityMessage: string | undefined;
 }
 
 export interface WorkspaceSummary {
@@ -79,7 +82,7 @@ export function getLastCommandForWorkspace(terminals: TerminalInstance[]): LastC
     exitCode: t.lastExitCode,
     timestamp: t.lastCommandAt ?? t.lastActivityAt,
     outputActive: t.outputActive,
-    claudeMessage: t.claudeMessage,
+    activityMessage: t.activityMessage,
     activity: t.activity,
     title: t.title,
   };
@@ -87,8 +90,8 @@ export function getLastCommandForWorkspace(terminals: TerminalInstance[]): LastC
 
 /** Max display length for shell commands in workspace summary. */
 export const CMD_TRUNCATE_LEN = 30;
-/** Max display length for Claude status messages (longer than shell commands). */
-export const CLAUDE_MSG_TRUNCATE_LEN = 50;
+/** Max display length for activity status messages (longer than shell commands). */
+export const ACTIVITY_MSG_TRUNCATE_LEN = 50;
 
 export function formatCommand(cmd: string, maxLen = CMD_TRUNCATE_LEN): string {
   const trimmed = cmd.trim();
@@ -132,7 +135,7 @@ export function computeWorkspaceSummary(
       activity: t.activity,
       outputActive: t.outputActive ?? false,
       hasUnreadNotification: notifications.some((n) => n.terminalId === t.id && n.readAt === null),
-      claudeMessage: t.claudeMessage,
+      activityMessage: t.activityMessage,
     })),
   };
 }
@@ -160,7 +163,7 @@ export function computeWorkspaceSummaryFromBackend(
     activity: s.activity as TerminalActivityInfo,
     outputActive: false, // outputActive is driven by frontend DEC 2026 events, not backend
     hasUnreadNotification: s.unreadNotificationCount > 0,
-    claudeMessage: s.claudeMessage ?? undefined,
+    activityMessage: s.claudeMessage ?? undefined,
   }));
 
   // Workspace-level aggregation
@@ -177,7 +180,7 @@ export function computeWorkspaceSummaryFromBackend(
           exitCode: s.lastExitCode ?? undefined,
           timestamp: s.lastCommandAt,
           outputActive: false, // outputActive is driven by frontend DEC 2026 events
-          claudeMessage: s.claudeMessage ?? undefined,
+          activityMessage: s.claudeMessage ?? undefined,
           activity: s.activity as TerminalActivityInfo,
           title: s.title ?? undefined,
         };
@@ -242,25 +245,25 @@ export function abbreviatePath(cwd: string, ellipsis: "start" | "end" = "start")
     path = fileMatch[1];
   }
 
-  // Strip WSL UNC prefix: //wsl.localhost/Distro/... → /...
+  // Strip WSL UNC prefix: //wsl.localhost/Distro/... -> /...
   const wslMatch = path.match(/^\/\/wsl\.localhost\/[^/]+(\/.*)/);
   if (wslMatch) {
     path = wslMatch[1];
   }
 
-  // Normalize forward slashes for Windows drive paths: C:/Users → C:\Users
+  // Normalize forward slashes for Windows drive paths: C:/Users -> C:\Users
   if (/^[A-Za-z]:\//.test(path)) {
     path = path.replace(/\//g, "\\");
   }
 
-  // Abbreviate Unix/WSL home directory: /home/user/... → ~/...
+  // Abbreviate Unix/WSL home directory: /home/user/... -> ~/...
   const unixHome = path.match(/^\/home\/[^/]+(\/.*)?$/);
   if (unixHome) {
     const rest = unixHome[1] ?? "";
     return rest ? "~" + rest : "~";
   }
 
-  // Abbreviate Windows home directory: C:\Users\name\... → ~/...
+  // Abbreviate Windows home directory: C:\Users\name\... -> ~/...
   const winHome = path.match(/^[A-Za-z]:\\Users\\[^\\]+(\\.*)?$/);
   if (winHome) {
     const rest = winHome[1] ?? "";
@@ -327,29 +330,29 @@ export function formatActivity(activity: TerminalActivityInfo | undefined): {
 export interface CommandStatus {
   icon: string; // "⏳" | "✓" | "✗" | "—"
   color: string; // CSS color value
-  text?: string; // display text override (e.g., Claude ● message)
+  text?: string; // display text override (e.g., Claude activity message)
 }
 
 /**
  * Compute final command status display via ActivityHandler delegation.
  *
- * Delegates to the appropriate handler based on activity type (§15.5).
+ * Delegates to the appropriate handler based on activity type.
  * Default (no activity) uses ShellActivityHandler with the 4-state rule.
  */
 export function computeCommandStatus(
   exitCode: number | undefined,
   outputActive: boolean | undefined,
-  claudeMessage?: string,
+  activityMessage?: string,
   activity?: TerminalActivityInfo,
   title?: string,
-  statusMessageMode?: ClaudeStatusMessageMode,
+  statusMessageMode?: ActivityStatusMessageMode,
   statusMessageDelimiter?: string,
 ): CommandStatus {
   const raw: RawTerminalState = {
     exitCode,
     outputActive: outputActive ?? false,
     lastCommand: undefined,
-    claudeMessage,
+    activityMessage,
     activity,
     title,
     statusMessageMode,

--- a/ui/src/stores/terminal-store.ts
+++ b/ui/src/stores/terminal-store.ts
@@ -25,8 +25,8 @@ export interface TerminalInstance {
   activity?: TerminalActivityInfo;
   /** True if terminal is actively producing output. */
   outputActive?: boolean;
-  /** Latest white-● status message from Claude Code output. */
-  claudeMessage?: string;
+  /** Latest provider-specific activity status message. */
+  activityMessage?: string;
 }
 
 interface TerminalStoreState {
@@ -56,7 +56,7 @@ interface TerminalStoreState {
         | "activity"
         | "outputActive"
         | "syncGroup"
-        | "claudeMessage"
+        | "activityMessage"
       >
     >,
   ) => void;


### PR DESCRIPTION
## Summary
- generalize UI activity state from Claude-specific naming to provider-agnostic activityMessage
- introduce an interactive app handler registry so provider-specific handlers can be added without expanding ad hoc branching
- keep Claude as a concrete handler implementation while preserving existing workspace summary and sync behavior

## Details
- added ActivityStatusMessageMode and a registry-based getHandler() flow in ui/src/lib/activity-handler.ts
- updated terminal store, workspace summary, selector rendering, and sync event handling to use generic activity message fields
- kept backend/Tauri contracts unchanged for now and mapped claudeMessage into the new UI-internal shape at the boundary
- refreshed Claude and shell handler tests around the new abstraction layer

## Verification
- npx tsc --noEmit
- npm test -- src/lib/shell-activity-handler.test.ts src/lib/claude-activity-handler.test.ts src/lib/workspace-summary.test.ts src/hooks/useSyncEvents.test.ts

## Follow-up
- add CodexActivityHandler on top of the new registry and generic activity state contract
- later, consider generalizing the remaining Claude-specific backend event names and payload schema