### PR TITLE
Add Codex activity handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Rust
 /target/
 src-tauri/target/
+src-tauri/target-review/
 
 # Node
 node_modules/

--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -20,7 +20,6 @@ use crate::terminal::{TerminalActivity, TerminalStateInfo};
 pub const INTERACTIVE_APP_PATTERNS: &[(&str, &str)] = &[
     ("Claude Code", "Claude"),
     ("OpenAI Codex", "Codex"),
-    ("codex", "Codex"),
     ("nvim", "neovim"),
     ("vim", "vim"),
     ("vi", "vim"),
@@ -173,6 +172,11 @@ fn is_word_match(text: &str, pattern: &str) -> bool {
     false
 }
 
+pub(crate) fn is_codex_spinner_title(title: &str) -> bool {
+    let first = title.chars().next().unwrap_or_default() as u32;
+    (0x2800..=0x28ff).contains(&first)
+}
+
 /// Detect the activity state of a terminal from its output buffer.
 pub fn detect_terminal_activity(buffer: Option<&TerminalOutputBuffer>) -> TerminalActivity {
     let Some(buf) = buffer else {
@@ -196,8 +200,51 @@ pub fn detect_terminal_activity(buffer: Option<&TerminalOutputBuffer>) -> Termin
 }
 
 /// Detect full terminal state (activity) for a single terminal.
-pub fn detect_terminal_state(buffer: Option<&TerminalOutputBuffer>) -> TerminalStateInfo {
+pub fn detect_terminal_state(
+    state: &AppState,
+    terminal_id: &str,
+    buffer: Option<&TerminalOutputBuffer>,
+) -> TerminalStateInfo {
     let activity = detect_terminal_activity(buffer);
+
+    let Some(buf) = buffer else {
+        return TerminalStateInfo { activity };
+    };
+    let recent = buf.recent_bytes(ACTIVITY_SCAN_BYTES);
+    if recent.is_empty() {
+        return TerminalStateInfo { activity };
+    }
+
+    if osc::any_terminal_title_contains(&recent, "OpenAI Codex") {
+        if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
+            known.insert(terminal_id.to_string());
+        }
+    }
+
+    if let Some(title) = osc::extract_last_terminal_title(&recent) {
+        if detect_interactive_app_from_title(&title).is_some_and(|name| name == "Codex") {
+            if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
+                known.insert(terminal_id.to_string());
+            }
+            return TerminalStateInfo {
+                activity: TerminalActivity::InteractiveApp {
+                    name: "Codex".to_string(),
+                },
+            };
+        }
+        if is_codex_spinner_title(&title) {
+            if let Ok(known) = state.known_codex_terminals.lock_or_err() {
+                if known.contains(terminal_id) {
+                    return TerminalStateInfo {
+                        activity: TerminalActivity::InteractiveApp {
+                            name: "Codex".to_string(),
+                        },
+                    };
+                }
+            }
+        }
+    }
+
     TerminalStateInfo { activity }
 }
 
@@ -209,7 +256,7 @@ pub fn detect_all_terminal_states(
     if let Ok(buffers) = state.output_buffers.lock_or_err() {
         if let Ok(terminals) = state.terminals.lock_or_err() {
             for id in terminals.keys() {
-                let info = detect_terminal_state(buffers.get(id));
+                let info = detect_terminal_state(state, id, buffers.get(id));
                 result.insert(id.clone(), info);
             }
         }
@@ -420,9 +467,28 @@ mod tests {
             detect_interactive_app_from_title("OpenAI Codex"),
             Some("Codex".to_string())
         );
+        assert_eq!(detect_interactive_app_from_title("codex"), None);
+    }
+
+    #[test]
+    fn codex_spinner_title_preserved_after_explicit_detection() {
+        let state = AppState::new();
+        let mut explicit = TerminalOutputBuffer::default();
+        explicit.push(b"\x1b]0;OpenAI Codex\x07");
         assert_eq!(
-            detect_interactive_app_from_title("codex"),
-            Some("Codex".to_string())
+            detect_terminal_state(&state, "t1", Some(&explicit)).activity,
+            TerminalActivity::InteractiveApp {
+                name: "Codex".to_string()
+            }
+        );
+
+        let mut spinner = TerminalOutputBuffer::default();
+        spinner.push("\x1b]0;\u{280b} laymux\x07".as_bytes());
+        assert_eq!(
+            detect_terminal_state(&state, "t1", Some(&spinner)).activity,
+            TerminalActivity::InteractiveApp {
+                name: "Codex".to_string()
+            }
         );
     }
 

--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -177,6 +177,68 @@ pub(crate) fn is_codex_spinner_title(title: &str) -> bool {
     (0x2800..=0x28ff).contains(&first)
 }
 
+fn recent_buffer_contains(recent: &[u8], needle: &str) -> bool {
+    let needle = needle.as_bytes();
+    !needle.is_empty() && recent.windows(needle.len()).any(|window| window == needle)
+}
+
+pub fn is_codex_terminal_from_buffer(
+    state: &AppState,
+    terminal_id: &str,
+    buffer: Option<&TerminalOutputBuffer>,
+) -> bool {
+    if let Ok(known) = state.known_codex_terminals.lock_or_err() {
+        if known.contains(terminal_id) {
+            return true;
+        }
+    }
+
+    let Some(buf) = buffer else {
+        return false;
+    };
+    let recent = buf.recent_bytes(ACTIVITY_SCAN_BYTES);
+    if recent.is_empty() {
+        return false;
+    }
+
+    let detected = osc::any_terminal_title_contains(&recent, "OpenAI Codex")
+        || recent_buffer_contains(&recent, "OpenAI Codex");
+    if detected {
+        if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
+            known.insert(terminal_id.to_string());
+        }
+    }
+    detected
+}
+
+pub fn detect_interactive_app_from_live_title(
+    state: &AppState,
+    terminal_id: &str,
+    title: &str,
+    buffer: Option<&TerminalOutputBuffer>,
+) -> Option<String> {
+    if let Some(name) = detect_interactive_app_from_title(title) {
+        if name == "Codex" {
+            if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
+                known.insert(terminal_id.to_string());
+            }
+        }
+        return Some(name);
+    }
+
+    if let Ok(known) = state.known_claude_terminals.lock_or_err() {
+        if known.contains(terminal_id) {
+            return Some("Claude".to_string());
+        }
+    }
+
+    if is_codex_spinner_title(title) && is_codex_terminal_from_buffer(state, terminal_id, buffer) {
+        return Some("Codex".to_string());
+    }
+
+    None
+}
+
 /// Detect the activity state of a terminal from its output buffer.
 pub fn detect_terminal_activity(buffer: Option<&TerminalOutputBuffer>) -> TerminalActivity {
     let Some(buf) = buffer else {
@@ -215,33 +277,13 @@ pub fn detect_terminal_state(
         return TerminalStateInfo { activity };
     }
 
-    if osc::any_terminal_title_contains(&recent, "OpenAI Codex") {
-        if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
-            known.insert(terminal_id.to_string());
-        }
-    }
-
     if let Some(title) = osc::extract_last_terminal_title(&recent) {
-        if detect_interactive_app_from_title(&title).is_some_and(|name| name == "Codex") {
-            if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
-                known.insert(terminal_id.to_string());
-            }
+        if let Some(name) =
+            detect_interactive_app_from_live_title(state, terminal_id, &title, buffer)
+        {
             return TerminalStateInfo {
-                activity: TerminalActivity::InteractiveApp {
-                    name: "Codex".to_string(),
-                },
+                activity: TerminalActivity::InteractiveApp { name },
             };
-        }
-        if is_codex_spinner_title(&title) {
-            if let Ok(known) = state.known_codex_terminals.lock_or_err() {
-                if known.contains(terminal_id) {
-                    return TerminalStateInfo {
-                        activity: TerminalActivity::InteractiveApp {
-                            name: "Codex".to_string(),
-                        },
-                    };
-                }
-            }
         }
     }
 
@@ -484,6 +526,24 @@ mod tests {
 
         let mut spinner = TerminalOutputBuffer::default();
         spinner.push("\x1b]0;\u{280b} laymux\x07".as_bytes());
+        assert_eq!(
+            detect_terminal_state(&state, "t1", Some(&spinner)).activity,
+            TerminalActivity::InteractiveApp {
+                name: "Codex".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn codex_spinner_title_detected_from_banner_output() {
+        let state = AppState::new();
+        let mut spinner = TerminalOutputBuffer::default();
+        spinner.push(b">- OpenAI Codex (v0.118.0)\r\n");
+        spinner.push("\x1b]0;\u{280b} laymux\x07".as_bytes());
+        assert_eq!(
+            detect_interactive_app_from_live_title(&state, "t1", "\u{280b} laymux", Some(&spinner)),
+            Some("Codex".to_string())
+        );
         assert_eq!(
             detect_terminal_state(&state, "t1", Some(&spinner)).activity,
             TerminalActivity::InteractiveApp {

--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -19,6 +19,8 @@ use crate::terminal::{TerminalActivity, TerminalStateInfo};
 /// (e.g., "vim" should not match "environment").
 pub const INTERACTIVE_APP_PATTERNS: &[(&str, &str)] = &[
     ("Claude Code", "Claude"),
+    ("OpenAI Codex", "Codex"),
+    ("codex", "Codex"),
     ("nvim", "neovim"),
     ("vim", "vim"),
     ("vi", "vim"),
@@ -323,6 +325,12 @@ mod tests {
     }
 
     #[test]
+    fn detect_interactive_app_codex() {
+        let data = b"\x1b]0;OpenAI Codex\x07";
+        assert_eq!(detect_interactive_app(data), Some("Codex".to_string()));
+    }
+
+    #[test]
     fn detect_interactive_app_vim() {
         let data = b"\x1b]2;vim - main.rs\x07";
         assert_eq!(detect_interactive_app(data), Some("vim".to_string()));
@@ -407,6 +415,18 @@ mod tests {
     }
 
     #[test]
+    fn title_codex_detected() {
+        assert_eq!(
+            detect_interactive_app_from_title("OpenAI Codex"),
+            Some("Codex".to_string())
+        );
+        assert_eq!(
+            detect_interactive_app_from_title("codex"),
+            Some("Codex".to_string())
+        );
+    }
+
+    #[test]
     fn title_claude_with_prefix() {
         // ✳ Claude Code (idle indicator)
         assert_eq!(
@@ -445,11 +465,7 @@ mod tests {
         assert!(is_claude_terminal_from_buffer(&state, tid, None));
 
         // Remove (simulates Claude exit detection)
-        state
-            .known_claude_terminals
-            .lock()
-            .unwrap()
-            .remove(tid);
+        state.known_claude_terminals.lock().unwrap().remove(tid);
         assert!(!is_claude_terminal_from_buffer(&state, tid, None));
     }
 
@@ -486,7 +502,7 @@ mod tests {
     #[test]
     fn burst_window_expired_resets_count() {
         let detector = BurstDetector::new(0, 3, 0); // 0ms window → always expired
-        // Each hit resets the window, so count never accumulates past 1
+                                                    // Each hit resets the window, so count never accumulates past 1
         assert!(!detector.record_hit());
         assert!(!detector.record_hit());
         assert!(!detector.record_hit());

--- a/src-tauri/src/commands/ipc_dispatch.rs
+++ b/src-tauri/src/commands/ipc_dispatch.rs
@@ -1273,9 +1273,10 @@ mod tests {
     #[test]
     fn detect_state_activity_only() {
         use crate::terminal::TerminalActivity;
+        let state = AppState::new();
         let mut buf = crate::output_buffer::TerminalOutputBuffer::default();
         buf.push(b"\x1b]133;D;0\x07prompt$ ");
-        let state_info = activity::detect_terminal_state(Some(&buf));
+        let state_info = activity::detect_terminal_state(&state, "t1", Some(&buf));
         assert_eq!(state_info.activity, TerminalActivity::Shell);
     }
 

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -478,7 +478,8 @@ pub fn get_terminal_summaries_inner(
         let Some(session) = terminals.get(tid.as_str()) else {
             continue;
         };
-        let state_info = activity::detect_terminal_state(buffers.get(tid.as_str()));
+        let state_info =
+            activity::detect_terminal_state(state, tid.as_str(), buffers.get(tid.as_str()));
         let is_claude = known_claude.contains(tid.as_str());
         let term_notifs: Vec<&TerminalNotification> = notifications
             .iter()

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -318,7 +318,22 @@ pub fn create_terminal_session(
 
             // Emit structured title change event (OSC 0/2) for frontend activity detection
             if event.code == 0 || event.code == 2 {
-                let interactive_app = activity::detect_interactive_app_from_title(&event.data)
+                let interactive_app =
+                    if let Ok(buffers) = state_for_pty.output_buffers.lock_or_err() {
+                        activity::detect_interactive_app_from_live_title(
+                            &state_for_pty,
+                            &terminal_id,
+                            &event.data,
+                            buffers.get(&terminal_id),
+                        )
+                    } else {
+                        activity::detect_interactive_app_from_live_title(
+                            &state_for_pty,
+                            &terminal_id,
+                            &event.data,
+                            None,
+                        )
+                    }
                     .or_else(|| {
                         // Title may not contain "Claude Code" (e.g. spinner "✢ Working"),
                         // but if the terminal is in known_claude_terminals, preserve detection.

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -551,6 +551,11 @@ pub fn close_terminal_session(id: String, state: State<Arc<AppState>>) -> Result
         known.remove(&id);
     }
 
+    // Clean up Codex terminal tracking
+    if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
+        known.remove(&id);
+    }
+
     // Clean up notifications for this terminal
     if let Ok(mut notifs) = state.notifications.lock_or_err() {
         notifs.retain(|n| n.terminal_id != id);

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -201,6 +201,26 @@ mod tests {
     }
 
     #[test]
+    fn codex_settings_round_trip() {
+        let json = r#"{
+          "codex": {
+            "statusMessageMode": "title-bullet",
+            "statusMessageDelimiter": " | "
+          }
+        }"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            settings.codex.status_message_mode,
+            CodexStatusMessageMode::TitleBullet
+        );
+        assert_eq!(settings.codex.status_message_delimiter, " | ");
+
+        let serialized = serde_json::to_string(&settings).unwrap();
+        assert!(serialized.contains("\"codex\""));
+        assert!(serialized.contains("\"statusMessageMode\":\"title-bullet\""));
+    }
+
+    #[test]
     fn migrate_cmd_profile_to_powershell_in_workspace_panes() {
         let mut settings = Settings::default();
         settings.workspaces = vec![Workspace {

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -401,6 +401,47 @@ fn default_session_max_age_hours() -> u64 {
     24
 }
 
+/// Status message display mode for Codex in WorkspaceSelectorView.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+#[derive(Default)]
+pub enum CodexStatusMessageMode {
+    /// Show only bullet/assistant message.
+    Bullet,
+    /// Show only title/spinner text.
+    Title,
+    /// Show title first, then bullet.
+    TitleBullet,
+    /// Show bullet first, then title (default).
+    #[default]
+    BulletTitle,
+}
+
+/// Codex integration settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexSettings {
+    /// Status message display mode (default: "bullet-title").
+    #[serde(default)]
+    pub status_message_mode: CodexStatusMessageMode,
+    /// Delimiter between bullet and title when both are shown (default: " · ").
+    #[serde(default = "default_codex_status_message_delimiter")]
+    pub status_message_delimiter: String,
+}
+
+impl Default for CodexSettings {
+    fn default() -> Self {
+        Self {
+            status_message_mode: CodexStatusMessageMode::default(),
+            status_message_delimiter: default_codex_status_message_delimiter(),
+        }
+    }
+}
+
+fn default_codex_status_message_delimiter() -> String {
+    " · ".to_string()
+}
+
 /// Path ellipsis direction: "start" truncates the beginning, "end" truncates the end.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -787,6 +828,8 @@ pub struct Settings {
     #[serde(default)]
     pub claude: ClaudeSettings,
     #[serde(default)]
+    pub codex: CodexSettings,
+    #[serde(default)]
     pub memo: MemoSettings,
     #[serde(default)]
     pub issue_reporter: IssueReporterSettings,
@@ -876,6 +919,7 @@ impl Default for Settings {
             terminal: TerminalSettings::default(),
             convenience: ConvenienceSettings::default(),
             claude: ClaudeSettings::default(),
+            codex: CodexSettings::default(),
             memo: MemoSettings::default(),
             issue_reporter: IssueReporterSettings::default(),
             file_explorer: FileExplorerSettings::default(),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -16,6 +16,7 @@ use crate::terminal::{SyncGroup, TerminalNotification, TerminalSession};
 /// 1. `terminals`
 /// 2. `output_buffers`
 /// 3. `known_claude_terminals`
+/// 4. `known_codex_terminals`
 /// 4. `notifications`
 /// 5. `sync_groups`
 /// 6. `propagated_terminals`
@@ -44,6 +45,10 @@ pub struct AppState {
     /// or when the terminal session closes.
     /// Both backend (CWD skip) and frontend (activity display) consume this state.
     pub known_claude_terminals: Arc<Mutex<HashSet<String>>>,
+    /// Single source of truth for Codex terminal detection.
+    /// Populated proactively by the PTY output callback and frontend command detection.
+    /// Removed when the terminal session closes.
+    pub known_codex_terminals: Arc<Mutex<HashSet<String>>>,
     /// Single source of truth for terminal notifications.
     /// Stored in backend so `get_terminal_summaries` can return unread counts.
     pub notifications: Arc<Mutex<Vec<TerminalNotification>>>,
@@ -64,6 +69,7 @@ impl AppState {
             automation_key: Mutex::new(None),
             propagated_terminals: Mutex::new(HashMap::new()),
             known_claude_terminals: Arc::new(Mutex::new(HashSet::new())),
+            known_codex_terminals: Arc::new(Mutex::new(HashSet::new())),
             notifications: Arc::new(Mutex::new(Vec::new())),
             notification_counter: AtomicU64::new(1),
         }
@@ -109,6 +115,13 @@ mod tests {
     fn known_claude_terminals_starts_empty() {
         let state = AppState::new();
         let known = state.known_claude_terminals.lock().unwrap();
+        assert!(known.is_empty());
+    }
+
+    #[test]
+    fn known_codex_terminals_starts_empty() {
+        let state = AppState::new();
+        let known = state.known_codex_terminals.lock().unwrap();
         assert!(known.is_empty());
     }
 

--- a/src-tauri/tests/e2e_test.rs
+++ b/src-tauri/tests/e2e_test.rs
@@ -171,6 +171,7 @@ fn settings_round_trip_with_full_config() {
         terminal: TerminalSettings::default(),
         convenience: ConvenienceSettings::default(),
         claude: ClaudeSettings::default(),
+        codex: Default::default(),
         memo: MemoSettings::default(),
         issue_reporter: IssueReporterSettings::default(),
         file_explorer: FileExplorerSettings::default(),
@@ -1991,7 +1992,10 @@ fn burst_settings_sanitize_clamps_zero_threshold() {
         throttle_ms: 1000,
     };
     let safe = bad.sanitized();
-    assert!(safe.threshold >= 2, "threshold must be ≥2 to filter false positives");
+    assert!(
+        safe.threshold >= 2,
+        "threshold must be ≥2 to filter false positives"
+    );
 }
 
 #[test]

--- a/ui/src/components/views/SettingsView.test.tsx
+++ b/ui/src/components/views/SettingsView.test.tsx
@@ -831,6 +831,33 @@ describe("SettingsView", () => {
     expect(useSettingsStore.getState().claude.syncCwd).toBe("command");
   });
 
+  it("shows Codex nav button", () => {
+    render(<SettingsView />);
+    expect(screen.getByTestId("nav-codex")).toBeInTheDocument();
+  });
+
+  it("renders Codex section with status message mode", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+
+    await user.click(screen.getByTestId("nav-codex"));
+    expect(screen.getAllByText("Codex").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByTestId("codex-status-message-mode-select")).toBeInTheDocument();
+  });
+
+  it("changing codex status message mode updates store after Save", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+
+    await user.click(screen.getByTestId("nav-codex"));
+    const select = screen.getByTestId("codex-status-message-mode-select");
+    await user.selectOptions(select, "bullet-title");
+
+    await user.click(screen.getByTestId("save-settings-btn"));
+
+    expect(useSettingsStore.getState().codex.statusMessageMode).toBe("bullet-title");
+  });
+
   // -- Discard --
 
   it("has a discard button", () => {

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1724,6 +1724,100 @@ function ClaudeSection() {
   );
 }
 
+function CodexSection() {
+  const storeCodex = useSettingsStore((s) => s.codex);
+  const setCodex = useSettingsStore((s) => s.setCodex);
+  const [codex, setDraftCodex] = useDraft("codex", storeCodex, (v) => setCodex(v));
+  const updateCodex = (partial: Partial<typeof codex>) =>
+    setDraftCodex((prev) => ({ ...prev, ...partial }));
+
+  return (
+    <div>
+      <SectionTitle>Codex</SectionTitle>
+
+      <div style={cardStyle} className="p-4">
+        <div className="flex items-start gap-3 py-1.5">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+              상태 메시지 모드
+            </span>
+            <p
+              className="mt-0.5 text-[11px] leading-tight"
+              style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+            >
+              워크스페이스 목록에서 Codex 상태 텍스트 표시 방식
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <FocusSelect
+              data-testid="codex-status-message-mode-select"
+              className={inputCls}
+              value={codex.statusMessageMode}
+              onChange={(e) =>
+                updateCodex({
+                  statusMessageMode: e.target.value as
+                    | "bullet"
+                    | "title"
+                    | "bullet-title"
+                    | "title-bullet",
+                })
+              }
+            >
+              <option value="title">Title만 (기본)</option>
+              <option value="bullet-title">Bullet · Title</option>
+              <option value="title-bullet">Title · Bullet</option>
+              <option value="bullet">Bullet만</option>
+            </FocusSelect>
+          </div>
+        </div>
+
+        {(codex.statusMessageMode === "bullet-title" ||
+          codex.statusMessageMode === "title-bullet") && (
+          <div className="flex items-start gap-3 py-1.5">
+            <div className="w-36 shrink-0 pt-1">
+              <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+                구분자
+              </span>
+              <p
+                className="mt-0.5 text-[11px] leading-tight"
+                style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+              >
+                두 텍스트 사이 구분 문자열
+              </p>
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <FocusInput
+                  data-testid="codex-status-message-delimiter-input"
+                  className={inputCls}
+                  type="text"
+                  style={{ width: 100 }}
+                  value={codex.statusMessageDelimiter}
+                  onChange={(e) => updateCodex({ statusMessageDelimiter: e.target.value })}
+                />
+                {codex.statusMessageDelimiter !== DEFAULT_STATUS_MESSAGE_DELIMITER && (
+                  <button
+                    data-testid="codex-status-message-delimiter-reset"
+                    className="hover-bg rounded px-1.5 py-0.5 text-[11px]"
+                    style={{ color: "var(--text-secondary)" }}
+                    onClick={() =>
+                      updateCodex({
+                        statusMessageDelimiter: DEFAULT_STATUS_MESSAGE_DELIMITER,
+                      })
+                    }
+                  >
+                    기본값
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // -- Section: Issue Reporter --
 
 function FileExplorerSection() {
@@ -2890,6 +2984,16 @@ export function SettingsView() {
             Claude Code
           </button>
           <button
+            data-testid="nav-codex"
+            className="w-full px-4 py-2 text-left text-[13px]"
+            style={navBtnStyle("codex")}
+            onClick={() => setActiveNav("codex")}
+            onMouseEnter={() => setNavHover("codex")}
+            onMouseLeave={() => setNavHover(null)}
+          >
+            Codex
+          </button>
+          <button
             data-testid="nav-memo"
             className="w-full px-4 py-2 text-left text-[13px]"
             style={navBtnStyle("memo")}
@@ -3008,6 +3112,7 @@ export function SettingsView() {
             {activeNav === "convenience" && <ConvenienceSection />}
             {activeNav === "workspaceDisplay" && <WorkspacesSection />}
             {activeNav === "claude" && <ClaudeSection />}
+            {activeNav === "codex" && <CodexSection />}
             {activeNav === "memo" && <MemoSection />}
             {activeNav === "fileExplorer" && <FileExplorerSection />}
             {activeNav === "issueReporter" && <IssueReporterSection />}

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -183,6 +183,26 @@ describe("TerminalView", () => {
     });
   });
 
+  it("detects Codex from banner output without command-status", async () => {
+    render(<TerminalView instanceId="t-codex" profile="PowerShell" syncGroup="" />);
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    act(() => {
+      onOutput?.(new TextEncoder().encode(">- OpenAI Codex (v0.118.0)\r\n"));
+    });
+
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === "t-codex");
+    expect(instance?.activity).toEqual({ type: "interactiveApp", name: "Codex" });
+  });
+
   it("registers onData handler to write to terminal", () => {
     render(<TerminalView instanceId="t5" profile="PowerShell" syncGroup="" />);
 

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -240,6 +240,32 @@ describe("TerminalView", () => {
     ).toBeUndefined();
   });
 
+  it("detects Codex approval prompts split across output chunks", async () => {
+    render(<TerminalView instanceId="t-codex-split" profile="PowerShell" syncGroup="" />);
+    useTerminalStore.getState().updateInstanceInfo("t-codex-split", {
+      activity: { type: "interactiveApp", name: "Codex" },
+    });
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    act(() => {
+      onOutput?.(new TextEncoder().encode("Would you like to run the fol"));
+      onOutput?.(new TextEncoder().encode("lowing command?\r\nPress enter to con"));
+      onOutput?.(new TextEncoder().encode("firm or esc to cancel\r\n"));
+    });
+
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-codex-split")?.activityMessage,
+    ).toBe(CODEX_INPUT_PENDING_MARKER);
+  });
+
   it("registers onData handler to write to terminal", () => {
     render(<TerminalView instanceId="t5" profile="PowerShell" syncGroup="" />);
 

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -4,6 +4,7 @@ import { TerminalView, _resetWebglStagger } from "./TerminalView";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { useSettingsStore } from "@/stores/settings-store";
+import { CODEX_INPUT_PENDING_MARKER } from "@/lib/activity-detection";
 
 // Mock xterm since it requires a real DOM with canvas
 const mockOnData = vi.fn();
@@ -201,6 +202,42 @@ describe("TerminalView", () => {
 
     const instance = useTerminalStore.getState().instances.find((i) => i.id === "t-codex");
     expect(instance?.activity).toEqual({ type: "interactiveApp", name: "Codex" });
+  });
+
+  it("marks Codex approval prompts as input pending", async () => {
+    render(<TerminalView instanceId="t-codex-prompt" profile="PowerShell" syncGroup="" />);
+    useTerminalStore.getState().updateInstanceInfo("t-codex-prompt", {
+      activity: { type: "interactiveApp", name: "Codex" },
+    });
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    act(() => {
+      onOutput?.(
+        new TextEncoder().encode(
+          "Would you like to run the following command?\r\nPress enter to confirm or esc to cancel\r\n",
+        ),
+      );
+    });
+
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-codex-prompt")?.activityMessage,
+    ).toBe(CODEX_INPUT_PENDING_MARKER);
+
+    act(() => {
+      onOutput?.(new TextEncoder().encode("• continuing after approval\r\n"));
+    });
+
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-codex-prompt")?.activityMessage,
+    ).toBeUndefined();
   });
 
   it("registers onData handler to write to terminal", () => {

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -237,7 +237,7 @@ describe("TerminalView", () => {
 
     expect(
       useTerminalStore.getState().instances.find((i) => i.id === "t-codex-prompt")?.activityMessage,
-    ).toBeUndefined();
+    ).toBe("continuing after approval");
   });
 
   it("detects Codex approval prompts split across output chunks", async () => {
@@ -264,6 +264,94 @@ describe("TerminalView", () => {
     expect(
       useTerminalStore.getState().instances.find((i) => i.id === "t-codex-split")?.activityMessage,
     ).toBe(CODEX_INPUT_PENDING_MARKER);
+  });
+
+  it("parses Codex footer status messages from output", async () => {
+    render(<TerminalView instanceId="t-codex-footer" profile="PowerShell" syncGroup="" />);
+    useTerminalStore.getState().updateInstanceInfo("t-codex-footer", {
+      activity: { type: "interactiveApp", name: "Codex" },
+    });
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    act(() => {
+      onOutput?.(new TextEncoder().encode("gpt-5.4 medium · 93% left · C:\\Users\r\n"));
+    });
+
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-codex-footer")?.activityMessage,
+    ).toBe("gpt-5.4 medium · 93% left · C:\\Users");
+  });
+
+  it("prefers Codex assistant replies over footer status lines", async () => {
+    render(<TerminalView instanceId="t-codex-reply" profile="PowerShell" syncGroup="" />);
+    useTerminalStore.getState().updateInstanceInfo("t-codex-reply", {
+      activity: { type: "interactiveApp", name: "Codex" },
+    });
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    act(() => {
+      onOutput?.(
+        new TextEncoder().encode(
+          "> hello\r\n• Hello.\r\n> Improve documentation in @filename\r\ngpt-5.4 medium · 93% left · C:\\Users\r\n",
+        ),
+      );
+    });
+
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-codex-reply")?.activityMessage,
+    ).toBe("Hello.");
+  });
+
+  it("does not let Codex footer overwrite the last assistant reply", async () => {
+    render(<TerminalView instanceId="t-codex-sticky-reply" profile="PowerShell" syncGroup="" />);
+    useTerminalStore.getState().updateInstanceInfo("t-codex-sticky-reply", {
+      activity: { type: "interactiveApp", name: "Codex" },
+    });
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    act(() => {
+      onOutput?.(new TextEncoder().encode("> hello\r\n• Hello.\r\n"));
+    });
+
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-codex-sticky-reply")
+        ?.activityMessage,
+    ).toBe("Hello.");
+
+    act(() => {
+      onOutput?.(
+        new TextEncoder().encode("> what did you say\r\ngpt-5.4 medium · 93% left · C:\\Users\r\n"),
+      );
+    });
+
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-codex-sticky-reply")
+        ?.activityMessage,
+    ).toBe("Hello.");
   });
 
   it("registers onData handler to write to terminal", () => {

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -25,7 +25,11 @@ import { colorSchemeToXtermTheme, type WTColorScheme } from "@/lib/color-scheme"
 import { transformPasteContent, trimSelectionTrailingWhitespace } from "@/lib/smart-text";
 import { isLxShortcut } from "@/lib/lx-shortcuts";
 
-import { detectActivityFromTitle, detectActivityFromCommand } from "@/lib/activity-detection";
+import {
+  detectActivityFromTitle,
+  detectActivityFromCommand,
+  detectActivityFromOutput,
+} from "@/lib/activity-detection";
 import { useNotificationStore } from "@/stores/notification-store";
 import { resolveWorkspaceId } from "@/lib/workspace-utils";
 import { OutputIdleDetector } from "@/lib/output-idle-detector";
@@ -332,6 +336,17 @@ export function TerminalView({
       const inst = useTerminalStore.getState().instances.find((i) => i.id === instanceId);
       if (inst?.activity?.type === "running") {
         idleDetector.recordOutput();
+      }
+
+      const outputActivity = detectActivityFromOutput(text);
+      if (outputActivity) {
+        const current = useTerminalStore.getState().instances.find((i) => i.id === instanceId);
+        if (
+          current?.activity?.type !== "interactiveApp" ||
+          current.activity.name !== outputActivity.name
+        ) {
+          useTerminalStore.getState().updateInstanceInfo(instanceId, { activity: outputActivity });
+        }
       }
 
       // Detect alt screen buffer switch (vim, nano, htop, less, etc.)

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -325,10 +325,13 @@ export function TerminalView({
     let cancelled = false;
     let unlistenOutput: (() => void) | undefined;
     let inAltScreen = false;
+    let recentOutputTail = "";
     onTerminalOutput(instanceId, (data) => {
       if (cancelled) return;
       terminal.write(data);
       const text = streamDecoder.decode(data, { stream: true });
+      const combinedText = (recentOutputTail + text).slice(-1024);
+      recentOutputTail = combinedText;
 
       // OSC parsing and hook dispatch are now handled entirely in the Rust
       // PTY callback (iter_osc_events + match_hooks + dispatch_osc_action).
@@ -340,7 +343,7 @@ export function TerminalView({
         idleDetector.recordOutput();
       }
 
-      const outputActivity = detectActivityFromOutput(text);
+      const outputActivity = detectActivityFromOutput(combinedText);
       if (outputActivity) {
         const current = useTerminalStore.getState().instances.find((i) => i.id === instanceId);
         if (
@@ -353,13 +356,17 @@ export function TerminalView({
 
       const current = useTerminalStore.getState().instances.find((i) => i.id === instanceId);
       if (current?.activity?.type === "interactiveApp" && current.activity.name === "Codex") {
-        if (detectCodexInputPendingFromOutput(text)) {
-          useTerminalStore.getState().updateInstanceInfo(instanceId, {
-            activityMessage: CODEX_INPUT_PENDING_MARKER,
-          });
-        } else if (current.activityMessage === CODEX_INPUT_PENDING_MARKER && text.trim()) {
+        if (
+          current.activityMessage === CODEX_INPUT_PENDING_MARKER &&
+          text.trim() &&
+          !detectCodexInputPendingFromOutput(text)
+        ) {
           useTerminalStore.getState().updateInstanceInfo(instanceId, {
             activityMessage: undefined,
+          });
+        } else if (detectCodexInputPendingFromOutput(combinedText)) {
+          useTerminalStore.getState().updateInstanceInfo(instanceId, {
+            activityMessage: CODEX_INPUT_PENDING_MARKER,
           });
         }
       }

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -27,7 +27,10 @@ import { isLxShortcut } from "@/lib/lx-shortcuts";
 
 import {
   CODEX_INPUT_PENDING_MARKER,
+  detectCodexConversationMessageFromOutput,
   detectCodexInputPendingFromOutput,
+  detectCodexStatusMessageFromOutput,
+  isCodexFooterStatusLine,
   detectActivityFromTitle,
   detectActivityFromCommand,
   detectActivityFromOutput,
@@ -356,17 +359,31 @@ export function TerminalView({
 
       const current = useTerminalStore.getState().instances.find((i) => i.id === instanceId);
       if (current?.activity?.type === "interactiveApp" && current.activity.name === "Codex") {
+        const codexConversationMessage = detectCodexConversationMessageFromOutput(combinedText);
+        const codexStatusMessage = detectCodexStatusMessageFromOutput(combinedText);
+        const currentMessage = current.activityMessage;
+        const currentIsFooter =
+          !!currentMessage &&
+          currentMessage !== CODEX_INPUT_PENDING_MARKER &&
+          isCodexFooterStatusLine(currentMessage);
+        const nextCodexMessage =
+          codexConversationMessage ??
+          (currentIsFooter || !currentMessage ? codexStatusMessage : undefined);
         if (
           current.activityMessage === CODEX_INPUT_PENDING_MARKER &&
           text.trim() &&
           !detectCodexInputPendingFromOutput(text)
         ) {
           useTerminalStore.getState().updateInstanceInfo(instanceId, {
-            activityMessage: undefined,
+            activityMessage: nextCodexMessage,
           });
         } else if (detectCodexInputPendingFromOutput(combinedText)) {
           useTerminalStore.getState().updateInstanceInfo(instanceId, {
             activityMessage: CODEX_INPUT_PENDING_MARKER,
+          });
+        } else if (nextCodexMessage && current.activityMessage !== nextCodexMessage) {
+          useTerminalStore.getState().updateInstanceInfo(instanceId, {
+            activityMessage: nextCodexMessage,
           });
         }
       }
@@ -505,6 +522,7 @@ export function TerminalView({
         if (paneId) {
           registerTerminalSerializer(paneId, () => serializeAddon.serialize());
         }
+        registerTerminalSerializer(instanceId, () => serializeAddon.serialize());
 
         fitAddon.fit();
         openedRef.current = true;
@@ -591,6 +609,7 @@ export function TerminalView({
       if (paneId) {
         unregisterTerminalSerializer(paneId);
       }
+      unregisterTerminalSerializer(instanceId);
       unlistenOutput?.();
       closeTerminalSession(instanceId).catch(() => {});
       terminal.dispose();

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -26,6 +26,8 @@ import { transformPasteContent, trimSelectionTrailingWhitespace } from "@/lib/sm
 import { isLxShortcut } from "@/lib/lx-shortcuts";
 
 import {
+  CODEX_INPUT_PENDING_MARKER,
+  detectCodexInputPendingFromOutput,
   detectActivityFromTitle,
   detectActivityFromCommand,
   detectActivityFromOutput,
@@ -346,6 +348,19 @@ export function TerminalView({
           current.activity.name !== outputActivity.name
         ) {
           useTerminalStore.getState().updateInstanceInfo(instanceId, { activity: outputActivity });
+        }
+      }
+
+      const current = useTerminalStore.getState().instances.find((i) => i.id === instanceId);
+      if (current?.activity?.type === "interactiveApp" && current.activity.name === "Codex") {
+        if (detectCodexInputPendingFromOutput(text)) {
+          useTerminalStore.getState().updateInstanceInfo(instanceId, {
+            activityMessage: CODEX_INPUT_PENDING_MARKER,
+          });
+        } else if (current.activityMessage === CODEX_INPUT_PENDING_MARKER && text.trim()) {
+          useTerminalStore.getState().updateInstanceInfo(instanceId, {
+            activityMessage: undefined,
+          });
         }
       }
 

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -20,6 +20,7 @@ import { NotificationPanel } from "./NotificationPanel";
 import { PaneMinimap } from "./PaneMinimap";
 import { ViewHeader } from "@/components/ui/ViewHeader";
 import type { WorkspacePane } from "@/stores/types";
+import type { TerminalActivityInfo } from "@/stores/terminal-store";
 import { persistSession } from "@/lib/persist-session";
 
 /** Abbreviate profile/view labels to max 3 characters. */
@@ -36,6 +37,32 @@ const LABEL_ABBREV: Record<string, string> = {
 function isWindowsProfile(profile: string): boolean {
   const lower = profile.toLowerCase();
   return lower.includes("powershell") || lower === "cmd" || lower === "command prompt";
+}
+
+function getStatusDisplaySettings(
+  activity: TerminalActivityInfo | undefined,
+  claudeSettings: ReturnType<typeof useSettingsStore.getState>["claude"],
+  codexSettings: ReturnType<typeof useSettingsStore.getState>["codex"],
+): {
+  mode: "bullet" | "title" | "title-bullet" | "bullet-title" | undefined;
+  delimiter: string | undefined;
+} {
+  if (activity?.type !== "interactiveApp") {
+    return { mode: undefined, delimiter: undefined };
+  }
+  if (activity.name === "Claude") {
+    return {
+      mode: claudeSettings.statusMessageMode,
+      delimiter: claudeSettings.statusMessageDelimiter,
+    };
+  }
+  if (activity.name === "Codex") {
+    return {
+      mode: codexSettings.statusMessageMode,
+      delimiter: codexSettings.statusMessageDelimiter,
+    };
+  }
+  return { mode: undefined, delimiter: undefined };
 }
 
 function shortLabel(label: string): string {
@@ -123,8 +150,14 @@ function WorkspaceItem({
   const [hovered, setHovered] = useState(false);
   const wsDisplay = useSettingsStore((s) => s.workspaceDisplay);
   const claudeSettings = useSettingsStore((s) => s.claude);
+  const codexSettings = useSettingsStore((s) => s.codex);
 
   const cmdInfo = summary.lastCommand;
+  const cmdStatusSettings = getStatusDisplaySettings(
+    cmdInfo?.activity,
+    claudeSettings,
+    codexSettings,
+  );
   const cmdStatus = cmdInfo
     ? computeCommandStatus(
         cmdInfo.exitCode,
@@ -132,8 +165,8 @@ function WorkspaceItem({
         cmdInfo.activityMessage,
         cmdInfo.activity,
         cmdInfo.title,
-        claudeSettings.statusMessageMode,
-        claudeSettings.statusMessageDelimiter,
+        cmdStatusSettings.mode,
+        cmdStatusSettings.delimiter,
       )
     : null;
 
@@ -315,6 +348,11 @@ function WorkspaceItem({
                 const termId = `terminal-${pane.id}`;
                 const ts = summary.terminalSummaries.find((t) => t.id === termId);
                 if (!ts) return null;
+                const paneStatusSettings = getStatusDisplaySettings(
+                  ts.activity,
+                  claudeSettings,
+                  codexSettings,
+                );
                 const tCmdStatus =
                   ts.lastCommand || ts.activity?.type === "interactiveApp"
                     ? computeCommandStatus(
@@ -323,6 +361,8 @@ function WorkspaceItem({
                         ts.activityMessage,
                         ts.activity,
                         ts.title,
+                        paneStatusSettings.mode,
+                        paneStatusSettings.delimiter,
                       )
                     : null;
                 const actInfo = formatActivity(ts.activity);

--- a/ui/src/hooks/useSessionPersistence.ts
+++ b/ui/src/hooks/useSessionPersistence.ts
@@ -97,6 +97,9 @@ export function useSessionPersistence() {
           ...(rawSettings.claude
             ? { claude: rawSettings.claude as import("@/lib/tauri-api").ClaudeSettings }
             : {}),
+          ...(rawSettings.codex
+            ? { codex: rawSettings.codex as import("@/lib/tauri-api").CodexSettings }
+            : {}),
           ...(rawSettings.issueReporter
             ? {
                 issueReporter:

--- a/ui/src/hooks/useSyncEvents.test.ts
+++ b/ui/src/hooks/useSyncEvents.test.ts
@@ -24,6 +24,7 @@ const mockOnTerminalOutputActivity = vi.fn();
 const mockMarkClaudeTerminal = vi.fn().mockResolvedValue(true);
 
 const mockSendDesktopNotification = vi.fn().mockResolvedValue(undefined);
+const mockGetTerminalSerializeMap = vi.fn();
 
 vi.mock("@/lib/tauri-api", () => ({
   onSyncCwd: (...args: unknown[]) => mockOnSyncCwd(...args),
@@ -44,6 +45,10 @@ vi.mock("./useOsNotification", () => ({
   sendDesktopNotification: (...args: unknown[]) => mockSendDesktopNotification(...args),
 }));
 
+vi.mock("@/lib/terminal-serialize-registry", () => ({
+  getTerminalSerializeMap: () => mockGetTerminalSerializeMap(),
+}));
+
 describe("useSyncEvents", () => {
   beforeEach(() => {
     useTerminalStore.setState(useTerminalStore.getInitialState());
@@ -62,6 +67,7 @@ describe("useSyncEvents", () => {
     mockOnTerminalCwdChanged.mockResolvedValue(unlisten);
     mockOnTerminalTitleChanged.mockResolvedValue(unlisten);
     mockOnTerminalOutputActivity.mockResolvedValue(unlisten);
+    mockGetTerminalSerializeMap.mockReturnValue(new Map());
   });
 
   it("registers sync-cwd listener on mount", () => {
@@ -542,6 +548,31 @@ describe("useSyncEvents", () => {
     expect(instance?.activityMessage).toBe("planning changes");
   });
 
+  it("does not clear an existing Codex activityMessage on plain title changes", () => {
+    useTerminalStore.getState().registerInstance({
+      id: "t1",
+      profile: "PowerShell",
+      syncGroup: "g1",
+      workspaceId: "ws-1",
+    });
+    useTerminalStore.getState().updateInstanceInfo("t1", {
+      activity: { type: "interactiveApp", name: "Codex" },
+      activityMessage: "gpt-5.4 medium · 93% left · C:\\Users",
+    });
+
+    renderHook(() => useSyncEvents());
+
+    const callback = mockOnTerminalTitleChanged.mock.calls[0][0];
+    callback({
+      terminalId: "t1",
+      title: "C:\\Users",
+      interactiveApp: "Codex",
+    });
+
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+    expect(instance?.activityMessage).toBe("gpt-5.4 medium · 93% left · C:\\Users");
+  });
+
   it("returns Codex terminal to shell on exitCode", () => {
     useTerminalStore.getState().registerInstance({
       id: "t1",
@@ -837,6 +868,38 @@ describe("useSyncEvents", () => {
       expect(notifications[0].terminalId).toBe("t1");
       expect(notifications[0].level).toBe("success");
       expect(notifications[0].message).toBe("Codex task completed");
+    });
+
+    it("reparses the Codex screen snapshot when success is detected", () => {
+      useTerminalStore.getState().registerInstance({
+        id: "t1",
+        profile: "PowerShell",
+        syncGroup: "g1",
+        workspaceId: "ws-1",
+      });
+      useTerminalStore.getState().updateInstanceInfo("t1", {
+        activity: { type: "interactiveApp", name: "Codex" },
+        outputActive: true,
+        activityMessage: "Working (1s · esc to interrupt)",
+      });
+      mockGetTerminalSerializeMap.mockReturnValue(
+        new Map([
+          [
+            "t1",
+            () =>
+              "> hello\r\n• Hello.\r\n> good!!\r\n• Yes.\r\n> Summarize recent commits\r\ngpt-5.4 medium · 93% left · C:\\Users\r\n",
+          ],
+        ]),
+      );
+
+      renderHook(() => useSyncEvents());
+
+      const activityCb = mockOnTerminalOutputActivity.mock.calls[0][0];
+      activityCb({ terminalId: "t1", active: false });
+
+      const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+      expect(instance?.activityMessage).toBe("Yes.");
+      expect(instance?.lastExitCode).toBe(0);
     });
 
     it("marks Codex success when outputActive times out", () => {

--- a/ui/src/hooks/useSyncEvents.test.ts
+++ b/ui/src/hooks/useSyncEvents.test.ts
@@ -808,6 +808,11 @@ describe("useSyncEvents", () => {
       expect(instance?.outputActive).toBe(false);
       expect(instance?.lastExitCode).toBe(0);
       expect(instance?.activity).toEqual({ type: "interactiveApp", name: "Codex" });
+      const notifications = useNotificationStore.getState().notifications;
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0].terminalId).toBe("t1");
+      expect(notifications[0].level).toBe("success");
+      expect(notifications[0].message).toBe("Codex task completed");
     });
 
     it("marks Codex success when outputActive times out", () => {
@@ -834,8 +839,35 @@ describe("useSyncEvents", () => {
       const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
       expect(instance?.outputActive).toBe(false);
       expect(instance?.lastExitCode).toBe(0);
+      const notifications = useNotificationStore.getState().notifications;
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0].message).toBe("Codex task completed");
 
       vi.useRealTimers();
+    });
+
+    it("uses awaiting-input notification message for Codex approval prompts", () => {
+      useTerminalStore.getState().registerInstance({
+        id: "t1",
+        profile: "PowerShell",
+        syncGroup: "g1",
+        workspaceId: "ws-1",
+      });
+      useTerminalStore.getState().updateInstanceInfo("t1", {
+        activity: { type: "interactiveApp", name: "Codex" },
+        outputActive: true,
+        activityMessage: "__codex_input_pending__",
+      });
+
+      renderHook(() => useSyncEvents());
+
+      const activityCb = mockOnTerminalOutputActivity.mock.calls[0][0];
+      activityCb({ terminalId: "t1", active: false });
+
+      const notifications = useNotificationStore.getState().notifications;
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0].message).toBe("Codex is awaiting input");
+      expect(notifications[0].level).toBe("success");
     });
   });
 });

--- a/ui/src/hooks/useSyncEvents.test.ts
+++ b/ui/src/hooks/useSyncEvents.test.ts
@@ -624,6 +624,7 @@ describe("useSyncEvents", () => {
       // Step 1: Rust emits active:false (task_completed)
       activityCb({ terminalId: "t1", active: false });
       expect(getInst()?.outputActive).toBe(false);
+      expect(getInst()?.lastExitCode).toBe(0);
 
       // Step 2: Rust emits command-status with exitCode=0 (synthetic)
       cmdStatusCb({ terminalId: "t1", exitCode: 0 });
@@ -672,6 +673,7 @@ describe("useSyncEvents", () => {
       // 2s passes with no new events → auto-reset
       vi.advanceTimersByTime(2100);
       expect(getInst()?.outputActive).toBe(false);
+      expect(getInst()?.lastExitCode).toBe(0);
 
       vi.useRealTimers();
     });
@@ -700,6 +702,7 @@ describe("useSyncEvents", () => {
       // 0.6s later: timer expires (2.1s since last burst)
       vi.advanceTimersByTime(600);
       expect(getInst()?.outputActive).toBe(false);
+      expect(getInst()?.lastExitCode).toBe(0);
 
       vi.useRealTimers();
     });
@@ -719,6 +722,7 @@ describe("useSyncEvents", () => {
       // active:false arrives → immediate deactivation + timer cancelled
       activityCb({ terminalId: "t1", active: false });
       expect(getInst()?.outputActive).toBe(false);
+      expect(getInst()?.lastExitCode).toBe(0);
 
       // Original timer would have fired here, but was cancelled
       vi.advanceTimersByTime(3000);
@@ -781,6 +785,57 @@ describe("useSyncEvents", () => {
       // Activity MUST remain interactiveApp, NOT shell
       expect(getInst()?.activity).toEqual({ type: "interactiveApp", name: "Claude" });
       expect(getInst()?.lastExitCode).toBe(0);
+    });
+
+    it("marks Codex success when outputActive transitions to false", () => {
+      useTerminalStore.getState().registerInstance({
+        id: "t1",
+        profile: "PowerShell",
+        syncGroup: "g1",
+        workspaceId: "ws-1",
+      });
+      useTerminalStore.getState().updateInstanceInfo("t1", {
+        activity: { type: "interactiveApp", name: "Codex" },
+        outputActive: true,
+      });
+
+      renderHook(() => useSyncEvents());
+
+      const activityCb = mockOnTerminalOutputActivity.mock.calls[0][0];
+      activityCb({ terminalId: "t1", active: false });
+
+      const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+      expect(instance?.outputActive).toBe(false);
+      expect(instance?.lastExitCode).toBe(0);
+      expect(instance?.activity).toEqual({ type: "interactiveApp", name: "Codex" });
+    });
+
+    it("marks Codex success when outputActive times out", () => {
+      vi.useFakeTimers();
+      useTerminalStore.getState().registerInstance({
+        id: "t1",
+        profile: "PowerShell",
+        syncGroup: "g1",
+        workspaceId: "ws-1",
+      });
+      useTerminalStore.getState().updateInstanceInfo("t1", {
+        activity: { type: "interactiveApp", name: "Codex" },
+      });
+
+      renderHook(() => useSyncEvents());
+
+      const activityCb = mockOnTerminalOutputActivity.mock.calls[0][0];
+      activityCb({ terminalId: "t1" });
+      expect(useTerminalStore.getState().instances.find((i) => i.id === "t1")?.outputActive).toBe(
+        true,
+      );
+
+      vi.advanceTimersByTime(2100);
+      const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+      expect(instance?.outputActive).toBe(false);
+      expect(instance?.lastExitCode).toBe(0);
+
+      vi.useRealTimers();
     });
   });
 });

--- a/ui/src/hooks/useSyncEvents.test.ts
+++ b/ui/src/hooks/useSyncEvents.test.ts
@@ -474,6 +474,72 @@ describe("useSyncEvents", () => {
     expect(mockMarkClaudeTerminal).not.toHaveBeenCalled();
   });
 
+  it("detects Codex from command text without calling Claude marker", () => {
+    useTerminalStore.getState().registerInstance({
+      id: "t1",
+      profile: "WSL",
+      syncGroup: "g1",
+      workspaceId: "ws-1",
+    });
+
+    renderHook(() => useSyncEvents());
+
+    const callback = mockOnCommandStatus.mock.calls[0][0];
+    callback({ terminalId: "t1", command: "codex" });
+
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+    expect(instance?.activity).toEqual({ type: "interactiveApp", name: "Codex" });
+    expect(mockMarkClaudeTerminal).not.toHaveBeenCalled();
+  });
+
+  it("preserves Codex activity when title no longer contains app name", () => {
+    useTerminalStore.getState().registerInstance({
+      id: "t1",
+      profile: "WSL",
+      syncGroup: "g1",
+      workspaceId: "ws-1",
+    });
+    useTerminalStore.getState().updateInstanceInfo("t1", {
+      activity: { type: "interactiveApp", name: "Codex" },
+    });
+
+    renderHook(() => useSyncEvents());
+
+    const callback = mockOnTerminalTitleChanged.mock.calls[0][0];
+    callback({
+      terminalId: "t1",
+      title: "⠋ laymux",
+      interactiveApp: null,
+      notifyGateArmed: false,
+    });
+
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+    expect(instance?.activity).toEqual({ type: "interactiveApp", name: "Codex" });
+    expect(instance?.outputActive).toBe(true);
+  });
+
+  it("returns Codex terminal to shell on exitCode", () => {
+    useTerminalStore.getState().registerInstance({
+      id: "t1",
+      profile: "WSL",
+      syncGroup: "g1",
+      workspaceId: "ws-1",
+    });
+    useTerminalStore.getState().updateInstanceInfo("t1", {
+      activity: { type: "interactiveApp", name: "Codex" },
+      lastCommand: "codex",
+    });
+
+    renderHook(() => useSyncEvents());
+
+    const callback = mockOnCommandStatus.mock.calls[0][0];
+    callback({ terminalId: "t1", exitCode: 0 });
+
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+    expect(instance?.activity).toEqual({ type: "shell" });
+    expect(instance?.lastExitCode).toBe(0);
+  });
+
   it("clears outputActive immediately on active:false event (app-agnostic)", () => {
     useTerminalStore.getState().registerInstance({
       id: "t1",

--- a/ui/src/hooks/useSyncEvents.test.ts
+++ b/ui/src/hooks/useSyncEvents.test.ts
@@ -518,6 +518,30 @@ describe("useSyncEvents", () => {
     expect(instance?.outputActive).toBe(true);
   });
 
+  it("stores Codex spinner title text as activityMessage", () => {
+    useTerminalStore.getState().registerInstance({
+      id: "t1",
+      profile: "PowerShell",
+      syncGroup: "g1",
+      workspaceId: "ws-1",
+    });
+    useTerminalStore.getState().updateInstanceInfo("t1", {
+      activity: { type: "interactiveApp", name: "Codex" },
+    });
+
+    renderHook(() => useSyncEvents());
+
+    const callback = mockOnTerminalTitleChanged.mock.calls[0][0];
+    callback({
+      terminalId: "t1",
+      title: "⠋ planning changes",
+      interactiveApp: "Codex",
+    });
+
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+    expect(instance?.activityMessage).toBe("planning changes");
+  });
+
   it("returns Codex terminal to shell on exitCode", () => {
     useTerminalStore.getState().registerInstance({
       id: "t1",

--- a/ui/src/hooks/useSyncEvents.test.ts
+++ b/ui/src/hooks/useSyncEvents.test.ts
@@ -624,7 +624,7 @@ describe("useSyncEvents", () => {
       // Step 1: Rust emits active:false (task_completed)
       activityCb({ terminalId: "t1", active: false });
       expect(getInst()?.outputActive).toBe(false);
-      expect(getInst()?.lastExitCode).toBe(0);
+      expect(getInst()?.lastExitCode).toBeUndefined();
 
       // Step 2: Rust emits command-status with exitCode=0 (synthetic)
       cmdStatusCb({ terminalId: "t1", exitCode: 0 });
@@ -673,7 +673,7 @@ describe("useSyncEvents", () => {
       // 2s passes with no new events → auto-reset
       vi.advanceTimersByTime(2100);
       expect(getInst()?.outputActive).toBe(false);
-      expect(getInst()?.lastExitCode).toBe(0);
+      expect(getInst()?.lastExitCode).toBeUndefined();
 
       vi.useRealTimers();
     });
@@ -702,7 +702,7 @@ describe("useSyncEvents", () => {
       // 0.6s later: timer expires (2.1s since last burst)
       vi.advanceTimersByTime(600);
       expect(getInst()?.outputActive).toBe(false);
-      expect(getInst()?.lastExitCode).toBe(0);
+      expect(getInst()?.lastExitCode).toBeUndefined();
 
       vi.useRealTimers();
     });
@@ -722,7 +722,7 @@ describe("useSyncEvents", () => {
       // active:false arrives → immediate deactivation + timer cancelled
       activityCb({ terminalId: "t1", active: false });
       expect(getInst()?.outputActive).toBe(false);
-      expect(getInst()?.lastExitCode).toBe(0);
+      expect(getInst()?.lastExitCode).toBeUndefined();
 
       // Original timer would have fired here, but was cancelled
       vi.advanceTimersByTime(3000);

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -19,6 +19,7 @@ import { persistSession } from "@/lib/persist-session";
 import { sendDesktopNotification } from "./useOsNotification";
 import { CODEX_INPUT_PENDING_MARKER, detectActivityFromCommand } from "@/lib/activity-detection";
 import { getHandler, type RawTerminalState } from "@/lib/activity-handler";
+import { extractCodexTitleMessage } from "@/lib/codex-activity-handler";
 import { resolveWorkspaceId } from "@/lib/workspace-utils";
 
 const CWD_PERSIST_DEBOUNCE_MS = 2000;
@@ -186,6 +187,13 @@ export function useSyncEvents() {
           !handler.shouldPreserveActivityOnTitleReset?.(raw)
         ) {
           updates.activity = { type: "shell" };
+        }
+
+        const codexActivity =
+          (detectedActivity ?? currentActivity)?.type === "interactiveApp" &&
+          (detectedActivity ?? currentActivity).name === "Codex";
+        if (codexActivity && instance?.activityMessage !== CODEX_INPUT_PENDING_MARKER) {
+          updates.activityMessage = extractCodexTitleMessage(data.title);
         }
 
         updateInstanceInfo(data.terminalId, updates as Parameters<typeof updateInstanceInfo>[1]);

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -18,19 +18,9 @@ import {
 import { persistSession } from "@/lib/persist-session";
 import { sendDesktopNotification } from "./useOsNotification";
 import { detectActivityFromCommand } from "@/lib/activity-detection";
+import { getHandler, type RawTerminalState } from "@/lib/activity-handler";
 
-/**
- * Hook that listens for sync events from the Tauri backend
- * and updates the appropriate stores.
- */
-/** Debounce delay for persisting CWD changes to settings.json (ms). */
 const CWD_PERSIST_DEBOUNCE_MS = 2000;
-
-/** Delay before resetting outputActive to false after last DEC 2026 event (ms).
- *
- * **Coupled with backend**: must match `DEC2026_BURST_WINDOW_MS` in `constants.rs`.
- * If shorter, outputActive flickers between DEC 2026 events.
- * If longer, ⏳ persists after TUI stops rendering. */
 const OUTPUT_ACTIVE_RESET_MS = 2000;
 
 export function useSyncEvents() {
@@ -43,6 +33,35 @@ export function useSyncEvents() {
       persistSession();
     }, CWD_PERSIST_DEBOUNCE_MS);
   }, []);
+
+  const resetOutputActiveSoon = useCallback((terminalId: string) => {
+    const prev = outputActiveTimers.current.get(terminalId);
+    if (prev) clearTimeout(prev);
+    outputActiveTimers.current.set(
+      terminalId,
+      setTimeout(() => {
+        useTerminalStore.getState().updateInstanceInfo(terminalId, { outputActive: false });
+        outputActiveTimers.current.delete(terminalId);
+      }, OUTPUT_ACTIVE_RESET_MS),
+    );
+  }, []);
+
+  const clearOutputActive = useCallback((terminalId: string) => {
+    useTerminalStore.getState().updateInstanceInfo(terminalId, { outputActive: false });
+    const timer = outputActiveTimers.current.get(terminalId);
+    if (timer) {
+      clearTimeout(timer);
+      outputActiveTimers.current.delete(terminalId);
+    }
+  }, []);
+
+  const markOutputActive = useCallback(
+    (terminalId: string) => {
+      useTerminalStore.getState().updateInstanceInfo(terminalId, { outputActive: true });
+      resetOutputActiveSoon(terminalId);
+    },
+    [resetOutputActiveSoon],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -58,14 +77,11 @@ export function useSyncEvents() {
       });
     }
 
-    // claude-terminal-detected: backend PTY callback detected Claude Code in terminal title.
-    // This is the single source of truth — set activity so frontend display matches.
     trackListener(
       onClaudeTerminalDetected((terminalId) => {
         if (cancelled) return;
         const { updateInstanceInfo, instances } = useTerminalStore.getState();
-        const instance = instances.find((i) => i.id === terminalId);
-        if (instance) {
+        if (instances.some((i) => i.id === terminalId)) {
           updateInstanceInfo(terminalId, {
             activity: { type: "interactiveApp", name: "Claude" },
           });
@@ -73,7 +89,6 @@ export function useSyncEvents() {
       }),
     );
 
-    // claude-message-changed: backend PTY callback extracted white-● status message.
     trackListener(
       onClaudeMessageChanged((data) => {
         if (cancelled) return;
@@ -83,75 +98,54 @@ export function useSyncEvents() {
       }),
     );
 
-    // terminal-output-activity: Two modes of operation:
-    //   1. active=true (default, omitted): DEC 2026 burst detected → TUI is rendering frames.
-    //      Sets outputActive=true + starts 2s auto-reset timer.
-    //   2. active=false: Rust detected TUI working→idle transition (e.g., Claude task completion).
-    //      Immediately clears outputActive — no 2s lag. This is app-agnostic: the frontend
-    //      doesn't check which app triggered it. Rust's state machine decides when to emit.
     trackListener(
       onTerminalOutputActivity((data) => {
         if (cancelled) return;
-        const { updateInstanceInfo } = useTerminalStore.getState();
-
         if (data.active === false) {
-          // Immediate deactivation from Rust state machine (TUI working→idle).
-          // Arrives BEFORE terminal-title-changed for the same title update,
-          // so ⏳→✓ transition happens without the DEC 2026 timeout lag.
-          updateInstanceInfo(data.terminalId, { outputActive: false });
-          const timer = outputActiveTimers.current.get(data.terminalId);
-          if (timer) {
-            clearTimeout(timer);
-            outputActiveTimers.current.delete(data.terminalId);
-          }
+          clearOutputActive(data.terminalId);
           return;
         }
-
-        updateInstanceInfo(data.terminalId, { outputActive: true });
-
-        // Reset timer: clear outputActive after 2s of no activity
-        const prev = outputActiveTimers.current.get(data.terminalId);
-        if (prev) clearTimeout(prev);
-        outputActiveTimers.current.set(
-          data.terminalId,
-          setTimeout(() => {
-            if (cancelled) return;
-            useTerminalStore.getState().updateInstanceInfo(data.terminalId, {
-              outputActive: false,
-            });
-            outputActiveTimers.current.delete(data.terminalId);
-          }, OUTPUT_ACTIVE_RESET_MS),
-        );
+        markOutputActive(data.terminalId);
       }),
     );
 
-    // terminal-title-changed: backend PTY callback extracted OSC 0/2 title.
-    // Handles activity detection and title updates.
     trackListener(
       onTerminalTitleChanged((data) => {
         if (cancelled) return;
         const { updateInstanceInfo, instances } = useTerminalStore.getState();
         const instance = instances.find((i) => i.id === data.terminalId);
+        const detectedActivity = data.interactiveApp
+          ? ({ type: "interactiveApp", name: data.interactiveApp } as const)
+          : undefined;
+        const currentActivity = instance?.activity;
+        const handler = getHandler(detectedActivity ?? currentActivity);
+        const raw: RawTerminalState = {
+          exitCode: instance?.lastExitCode,
+          outputActive: instance?.outputActive ?? false,
+          lastCommand: instance?.lastCommand,
+          activityMessage: instance?.activityMessage,
+          activity: detectedActivity ?? currentActivity,
+          title: data.title,
+        };
 
-        // Update title in store
         const updates: Record<string, unknown> = { title: data.title };
-
-        // Activity detection from interactive app (Rust already detected this,
-        // including known_claude_terminals fallback for spinner titles like "✢ Working").
-        if (data.interactiveApp) {
-          updates.activity = { type: "interactiveApp", name: data.interactiveApp };
-        } else if (instance?.activity?.type === "interactiveApp") {
-          // Interactive app exited — title no longer matches any app pattern.
-          // Reset to shell so stale Claude/vim indicators don't persist.
+        if (detectedActivity) {
+          updates.activity = detectedActivity;
+        } else if (
+          currentActivity?.type === "interactiveApp" &&
+          !handler.shouldPreserveActivityOnTitleReset?.(raw)
+        ) {
           updates.activity = { type: "shell" };
         }
 
         updateInstanceInfo(data.terminalId, updates as Parameters<typeof updateInstanceInfo>[1]);
+
+        if (handler.isActiveTitle?.(data.title)) {
+          markOutputActive(data.terminalId);
+        }
       }),
     );
 
-    // terminal-cwd-changed: backend PTY callback detected CWD from OSC 7/9;9.
-    // This is the single source of truth — update frontend store to match.
     trackListener(
       onTerminalCwdChanged((data) => {
         if (cancelled) return;
@@ -162,13 +156,11 @@ export function useSyncEvents() {
       }),
     );
 
-    // sync-cwd: update CWD for all targeted terminals + source
     trackListener(
       onSyncCwd((data) => {
         if (cancelled) return;
         const { updateInstanceInfo, instances } = useTerminalStore.getState();
         const targetSet = new Set(data.targets);
-        // Always include the source terminal
         if (instances.find((i) => i.id === data.terminalId)) {
           targetSet.add(data.terminalId);
         }
@@ -179,7 +171,6 @@ export function useSyncEvents() {
       }),
     );
 
-    // sync-branch: update branch for all terminals in the group
     trackListener(
       onSyncBranch((data) => {
         if (cancelled) return;
@@ -191,11 +182,9 @@ export function useSyncEvents() {
       }),
     );
 
-    // lx-notify: add notification to the workspace that owns the terminal
     trackListener(
       onLxNotify((data) => {
         if (cancelled) return;
-        // Find which workspace the terminal belongs to via its syncGroup
         const instance = useTerminalStore
           .getState()
           .instances.find((i) => i.id === data.terminalId);
@@ -213,7 +202,6 @@ export function useSyncEvents() {
           message: data.message,
           level: data.level as "info" | "error" | "warning" | "success" | undefined,
         });
-        // Only send OS notification when IDE is not focused or the workspace is not active
         const ideFocused = document.hasFocus();
         if (!ideFocused || activeWorkspaceId !== targetWsId) {
           sendDesktopNotification("Laymux", data.message);
@@ -221,7 +209,6 @@ export function useSyncEvents() {
       }),
     );
 
-    // set-tab-title: update terminal title
     trackListener(
       onSetTabTitle((data) => {
         if (cancelled) return;
@@ -231,22 +218,17 @@ export function useSyncEvents() {
       }),
     );
 
-    // command-status: track last command and exit code per terminal + activity state
     trackListener(
       onCommandStatus((data) => {
         if (cancelled) return;
         const update: Record<string, unknown> = {};
+
         if (data.command !== undefined && data.command !== "__preexec__") {
-          // Real command text from OSC 133 E
           update.lastCommand = data.command;
           update.lastCommandAt = Date.now();
-          // Detect interactive app from command text (e.g. "vim file.txt" → vim)
           const appActivity = detectActivityFromCommand(data.command);
           if (appActivity) {
             update.activity = appActivity;
-            // Notify backend so known_claude_terminals (single source of truth) is updated.
-            // This covers the case where the user typed "claude" but the title
-            // hasn't been set yet (PTY callback hasn't seen "Claude Code" title).
             if (appActivity.name === "Claude") {
               markClaudeTerminal(data.terminalId).catch(() => {});
             }
@@ -259,7 +241,6 @@ export function useSyncEvents() {
             }
           }
         } else if (data.command === "__preexec__") {
-          // Preexec marker from OSC 133 C — don't overwrite lastCommand
           update.lastCommandAt = Date.now();
           const instance = useTerminalStore
             .getState()
@@ -268,18 +249,31 @@ export function useSyncEvents() {
             update.activity = { type: "running" };
           }
         }
+
         if (data.exitCode !== undefined) {
           update.lastExitCode = data.exitCode;
           update.lastCommandAt = Date.now();
-          // Command finished → shell prompt (but preserve interactiveApp state
-          // so sub-command exit codes don't override Claude/vim/etc. activity)
           const instance = useTerminalStore
             .getState()
             .instances.find((i) => i.id === data.terminalId);
           if (!instance?.activity || instance.activity.type !== "interactiveApp") {
             update.activity = { type: "shell" };
+          } else {
+            const handler = getHandler(instance.activity);
+            const raw: RawTerminalState = {
+              exitCode: data.exitCode,
+              outputActive: instance.outputActive ?? false,
+              lastCommand: instance.lastCommand,
+              activityMessage: instance.activityMessage,
+              activity: instance.activity,
+              title: instance.title,
+            };
+            if (!handler.shouldPreserveActivityOnExitCode?.(raw)) {
+              update.activity = { type: "shell" };
+            }
           }
         }
+
         useTerminalStore.getState().updateInstanceInfo(
           data.terminalId,
           update as {
@@ -292,7 +286,6 @@ export function useSyncEvents() {
       }),
     );
 
-    // Clean up outputActive timers when terminals are removed from the store
     const unsubStore = useTerminalStore.subscribe((state, prevState) => {
       if (state.instances.length < prevState.instances.length) {
         const currentIds = new Set(state.instances.map((i) => i.id));
@@ -317,5 +310,5 @@ export function useSyncEvents() {
         unlisten();
       }
     };
-  }, []);
+  }, [clearOutputActive, debouncedPersistCwd, markOutputActive]);
 }

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -27,6 +27,21 @@ export function useSyncEvents() {
   const cwdPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const outputActiveTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
 
+  const markInteractiveAppSuccessOnIdle = useCallback((terminalId: string) => {
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === terminalId);
+    if (
+      !instance?.outputActive ||
+      instance.activity?.type !== "interactiveApp" ||
+      !["Claude", "Codex"].includes(instance.activity.name ?? "")
+    ) {
+      return;
+    }
+    useTerminalStore.getState().updateInstanceInfo(terminalId, {
+      lastExitCode: 0,
+      lastCommandAt: Date.now(),
+    });
+  }, []);
+
   const debouncedPersistCwd = useCallback(() => {
     if (cwdPersistTimerRef.current) clearTimeout(cwdPersistTimerRef.current);
     cwdPersistTimerRef.current = setTimeout(() => {
@@ -34,26 +49,34 @@ export function useSyncEvents() {
     }, CWD_PERSIST_DEBOUNCE_MS);
   }, []);
 
-  const resetOutputActiveSoon = useCallback((terminalId: string) => {
-    const prev = outputActiveTimers.current.get(terminalId);
-    if (prev) clearTimeout(prev);
-    outputActiveTimers.current.set(
-      terminalId,
-      setTimeout(() => {
-        useTerminalStore.getState().updateInstanceInfo(terminalId, { outputActive: false });
-        outputActiveTimers.current.delete(terminalId);
-      }, OUTPUT_ACTIVE_RESET_MS),
-    );
-  }, []);
+  const resetOutputActiveSoon = useCallback(
+    (terminalId: string) => {
+      const prev = outputActiveTimers.current.get(terminalId);
+      if (prev) clearTimeout(prev);
+      outputActiveTimers.current.set(
+        terminalId,
+        setTimeout(() => {
+          markInteractiveAppSuccessOnIdle(terminalId);
+          useTerminalStore.getState().updateInstanceInfo(terminalId, { outputActive: false });
+          outputActiveTimers.current.delete(terminalId);
+        }, OUTPUT_ACTIVE_RESET_MS),
+      );
+    },
+    [markInteractiveAppSuccessOnIdle],
+  );
 
-  const clearOutputActive = useCallback((terminalId: string) => {
-    useTerminalStore.getState().updateInstanceInfo(terminalId, { outputActive: false });
-    const timer = outputActiveTimers.current.get(terminalId);
-    if (timer) {
-      clearTimeout(timer);
-      outputActiveTimers.current.delete(terminalId);
-    }
-  }, []);
+  const clearOutputActive = useCallback(
+    (terminalId: string) => {
+      markInteractiveAppSuccessOnIdle(terminalId);
+      useTerminalStore.getState().updateInstanceInfo(terminalId, { outputActive: false });
+      const timer = outputActiveTimers.current.get(terminalId);
+      if (timer) {
+        clearTimeout(timer);
+        outputActiveTimers.current.delete(terminalId);
+      }
+    },
+    [markInteractiveAppSuccessOnIdle],
+  );
 
   const markOutputActive = useCallback(
     (terminalId: string) => {

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -17,8 +17,9 @@ import {
 } from "@/lib/tauri-api";
 import { persistSession } from "@/lib/persist-session";
 import { sendDesktopNotification } from "./useOsNotification";
-import { detectActivityFromCommand } from "@/lib/activity-detection";
+import { CODEX_INPUT_PENDING_MARKER, detectActivityFromCommand } from "@/lib/activity-detection";
 import { getHandler, type RawTerminalState } from "@/lib/activity-handler";
+import { resolveWorkspaceId } from "@/lib/workspace-utils";
 
 const CWD_PERSIST_DEBOUNCE_MS = 2000;
 const OUTPUT_ACTIVE_RESET_MS = 2000;
@@ -27,20 +28,46 @@ export function useSyncEvents() {
   const cwdPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const outputActiveTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
 
-  const markInteractiveAppSuccessOnIdle = useCallback((terminalId: string) => {
-    const instance = useTerminalStore.getState().instances.find((i) => i.id === terminalId);
-    if (
-      !instance?.outputActive ||
-      instance.activity?.type !== "interactiveApp" ||
-      instance.activity.name !== "Codex"
-    ) {
-      return;
-    }
-    useTerminalStore.getState().updateInstanceInfo(terminalId, {
-      lastExitCode: 0,
-      lastCommandAt: Date.now(),
+  const notifyInteractiveAppSuccessOnIdle = useCallback((terminalId: string, message: string) => {
+    const workspaceId = resolveWorkspaceId(terminalId);
+    useNotificationStore.getState().addNotification({
+      terminalId,
+      workspaceId,
+      message,
+      level: "success",
     });
+
+    const { activeWorkspaceId } = useWorkspaceStore.getState();
+    const ideFocused = document.hasFocus();
+    if (!ideFocused || activeWorkspaceId !== workspaceId) {
+      sendDesktopNotification("Laymux", message);
+    }
   }, []);
+
+  const markInteractiveAppSuccessOnIdle = useCallback(
+    (terminalId: string) => {
+      const instance = useTerminalStore.getState().instances.find((i) => i.id === terminalId);
+      if (
+        !instance?.outputActive ||
+        instance.activity?.type !== "interactiveApp" ||
+        instance.activity.name !== "Codex"
+      ) {
+        return;
+      }
+
+      const message =
+        instance.activityMessage === CODEX_INPUT_PENDING_MARKER
+          ? "Codex is awaiting input"
+          : "Codex task completed";
+
+      useTerminalStore.getState().updateInstanceInfo(terminalId, {
+        lastExitCode: 0,
+        lastCommandAt: Date.now(),
+      });
+      notifyInteractiveAppSuccessOnIdle(terminalId, message);
+    },
+    [notifyInteractiveAppSuccessOnIdle],
+  );
 
   const debouncedPersistCwd = useCallback(() => {
     if (cwdPersistTimerRef.current) clearTimeout(cwdPersistTimerRef.current);

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -32,7 +32,7 @@ export function useSyncEvents() {
     if (
       !instance?.outputActive ||
       instance.activity?.type !== "interactiveApp" ||
-      !["Claude", "Codex"].includes(instance.activity.name ?? "")
+      instance.activity.name !== "Codex"
     ) {
       return;
     }

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -17,10 +17,16 @@ import {
 } from "@/lib/tauri-api";
 import { persistSession } from "@/lib/persist-session";
 import { sendDesktopNotification } from "./useOsNotification";
-import { CODEX_INPUT_PENDING_MARKER, detectActivityFromCommand } from "@/lib/activity-detection";
+import {
+  CODEX_INPUT_PENDING_MARKER,
+  detectActivityFromCommand,
+  detectCodexConversationMessageFromOutput,
+  detectCodexStatusMessageFromOutput,
+} from "@/lib/activity-detection";
 import { getHandler, type RawTerminalState } from "@/lib/activity-handler";
 import { extractCodexTitleMessage } from "@/lib/codex-activity-handler";
 import { resolveWorkspaceId } from "@/lib/workspace-utils";
+import { getTerminalSerializeMap } from "@/lib/terminal-serialize-registry";
 
 const CWD_PERSIST_DEBOUNCE_MS = 2000;
 const OUTPUT_ACTIVE_RESET_MS = 2000;
@@ -28,6 +34,16 @@ const OUTPUT_ACTIVE_RESET_MS = 2000;
 export function useSyncEvents() {
   const cwdPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const outputActiveTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+
+  const parseCodexSnapshotMessage = useCallback((terminalId: string): string | undefined => {
+    const snapshot = getTerminalSerializeMap().get(terminalId)?.();
+    if (!snapshot) return undefined;
+    return (
+      detectCodexConversationMessageFromOutput(snapshot) ??
+      detectCodexStatusMessageFromOutput(snapshot) ??
+      undefined
+    );
+  }, []);
 
   const notifyInteractiveAppSuccessOnIdle = useCallback((terminalId: string, message: string) => {
     const workspaceId = resolveWorkspaceId(terminalId);
@@ -61,13 +77,19 @@ export function useSyncEvents() {
           ? "Codex is awaiting input"
           : "Codex task completed";
 
+      const snapshotMessage =
+        instance.activityMessage === CODEX_INPUT_PENDING_MARKER
+          ? undefined
+          : parseCodexSnapshotMessage(terminalId);
+
       useTerminalStore.getState().updateInstanceInfo(terminalId, {
         lastExitCode: 0,
         lastCommandAt: Date.now(),
+        activityMessage: snapshotMessage ?? instance.activityMessage,
       });
       notifyInteractiveAppSuccessOnIdle(terminalId, message);
     },
-    [notifyInteractiveAppSuccessOnIdle],
+    [notifyInteractiveAppSuccessOnIdle, parseCodexSnapshotMessage],
   );
 
   const debouncedPersistCwd = useCallback(() => {
@@ -189,11 +211,14 @@ export function useSyncEvents() {
           updates.activity = { type: "shell" };
         }
 
+        const resolvedActivity = detectedActivity ?? currentActivity;
         const codexActivity =
-          (detectedActivity ?? currentActivity)?.type === "interactiveApp" &&
-          (detectedActivity ?? currentActivity).name === "Codex";
+          resolvedActivity?.type === "interactiveApp" && resolvedActivity.name === "Codex";
         if (codexActivity && instance?.activityMessage !== CODEX_INPUT_PENDING_MARKER) {
-          updates.activityMessage = extractCodexTitleMessage(data.title);
+          const titleMessage = extractCodexTitleMessage(data.title);
+          if (titleMessage !== undefined || !instance?.activityMessage) {
+            updates.activityMessage = titleMessage;
+          }
         }
 
         updateInstanceInfo(data.terminalId, updates as Parameters<typeof updateInstanceInfo>[1]);

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -20,6 +20,17 @@ describe("detectActivityFromTitle", () => {
     });
   });
 
+  it("detects Codex title variants", () => {
+    expect(detectActivityFromTitle("OpenAI Codex")).toEqual({
+      type: "interactiveApp",
+      name: "Codex",
+    });
+    expect(detectActivityFromTitle("codex")).toEqual({
+      type: "interactiveApp",
+      name: "Codex",
+    });
+  });
+
   it("detects nvim as neovim", () => {
     expect(detectActivityFromTitle("nvim")).toEqual({ type: "interactiveApp", name: "neovim" });
   });
@@ -125,6 +136,14 @@ describe("detectActivityFromCommand", () => {
 
   it("detects claude as Claude", () => {
     expect(detectActivityFromCommand("claude")).toEqual({ type: "interactiveApp", name: "Claude" });
+  });
+
+  it("detects codex as Codex", () => {
+    expect(detectActivityFromCommand("codex")).toEqual({ type: "interactiveApp", name: "Codex" });
+    expect(detectActivityFromCommand("sudo codex --full-auto")).toEqual({
+      type: "interactiveApp",
+      name: "Codex",
+    });
   });
 
   it("returns undefined for empty command", () => {

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { detectActivityFromTitle, detectActivityFromCommand } from "./activity-detection";
+import {
+  detectActivityFromTitle,
+  detectActivityFromCommand,
+  detectActivityFromOutput,
+} from "./activity-detection";
 
 describe("detectActivityFromTitle", () => {
   it("detects vim from title", () => {
@@ -141,6 +145,14 @@ describe("detectActivityFromCommand", () => {
       type: "interactiveApp",
       name: "Codex",
     });
+    expect(detectActivityFromCommand("node /opt/codex/bin/codex.js")).toEqual({
+      type: "interactiveApp",
+      name: "Codex",
+    });
+    expect(detectActivityFromCommand("npx @openai/codex --model gpt-5")).toEqual({
+      type: "interactiveApp",
+      name: "Codex",
+    });
     expect(detectActivityFromCommand("sudo codex --full-auto")).toEqual({
       type: "interactiveApp",
       name: "Codex",
@@ -149,5 +161,18 @@ describe("detectActivityFromCommand", () => {
 
   it("returns undefined for empty command", () => {
     expect(detectActivityFromCommand("")).toBeUndefined();
+  });
+});
+
+describe("detectActivityFromOutput", () => {
+  it("detects Codex banner text", () => {
+    expect(detectActivityFromOutput(">- OpenAI Codex (v0.118.0)\r\n")).toEqual({
+      type: "interactiveApp",
+      name: "Codex",
+    });
+  });
+
+  it("ignores unrelated output", () => {
+    expect(detectActivityFromOutput("PS C:\\Users\\kochul> dir")).toBeUndefined();
   });
 });

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -137,6 +137,10 @@ describe("detectActivityFromCommand", () => {
 
   it("detects codex as Codex", () => {
     expect(detectActivityFromCommand("codex")).toEqual({ type: "interactiveApp", name: "Codex" });
+    expect(detectActivityFromCommand("codex.exe")).toEqual({
+      type: "interactiveApp",
+      name: "Codex",
+    });
     expect(detectActivityFromCommand("sudo codex --full-auto")).toEqual({
       type: "interactiveApp",
       name: "Codex",

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -167,14 +167,21 @@ describe("detectActivityFromCommand", () => {
 
 describe("detectActivityFromOutput", () => {
   it("detects Codex banner text", () => {
-    expect(detectActivityFromOutput(">- OpenAI Codex (v0.118.0)\r\n")).toEqual({
-      type: "interactiveApp",
-      name: "Codex",
-    });
+    expect(
+      detectActivityFromOutput(
+        ">- OpenAI Codex (v0.118.0)\r\nmodel: gpt-5.4 medium\r\ndirectory: C:\\Users\r\n",
+      ),
+    ).toEqual({ type: "interactiveApp", name: "Codex" });
   });
 
   it("ignores unrelated output", () => {
     expect(detectActivityFromOutput("PS C:\\Users\\kochul> dir")).toBeUndefined();
+  });
+
+  it("does not misclassify plain output mentions of OpenAI Codex", () => {
+    expect(
+      detectActivityFromOutput("README.md: OpenAI Codex is available in this repository\r\n"),
+    ).toBeUndefined();
   });
 });
 

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -25,10 +25,7 @@ describe("detectActivityFromTitle", () => {
       type: "interactiveApp",
       name: "Codex",
     });
-    expect(detectActivityFromTitle("codex")).toEqual({
-      type: "interactiveApp",
-      name: "Codex",
-    });
+    expect(detectActivityFromTitle("codex")).toBeUndefined();
   });
 
   it("detects nvim as neovim", () => {

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -3,6 +3,8 @@ import {
   detectActivityFromTitle,
   detectActivityFromCommand,
   detectActivityFromOutput,
+  detectCodexConversationMessageFromOutput,
+  detectCodexStatusMessageFromOutput,
 } from "./activity-detection";
 
 describe("detectActivityFromTitle", () => {
@@ -46,7 +48,7 @@ describe("detectActivityFromTitle", () => {
 
   it("does not false-positive on app names embedded in words", () => {
     expect(detectActivityFromTitle("Review current directory structure")).toBeUndefined();
-    expect(detectActivityFromTitle("✳ Review code changes")).toBeUndefined();
+    expect(detectActivityFromTitle("⠋Review code changes")).toBeUndefined();
     expect(detectActivityFromTitle("navigation helper")).toBeUndefined();
     expect(detectActivityFromTitle("environment variables")).toBeUndefined();
   });
@@ -107,7 +109,6 @@ describe("detectActivityFromCommand", () => {
   });
 
   it("detects python (not python3 script.py style)", () => {
-    // 'python' bare is interactive REPL
     expect(detectActivityFromCommand("python")).toEqual({ type: "interactiveApp", name: "python" });
   });
 
@@ -174,5 +175,37 @@ describe("detectActivityFromOutput", () => {
 
   it("ignores unrelated output", () => {
     expect(detectActivityFromOutput("PS C:\\Users\\kochul> dir")).toBeUndefined();
+  });
+});
+
+describe("detectCodexStatusMessageFromOutput", () => {
+  it("parses the Codex footer status line", () => {
+    expect(
+      detectCodexStatusMessageFromOutput(
+        "Use /skills to list available skills\r\ngpt-5.4 medium · 93% left · C:\\Users\r\n",
+      ),
+    ).toBe("gpt-5.4 medium · 93% left · C:\\Users");
+  });
+
+  it("ignores unrelated footer lines", () => {
+    expect(detectCodexStatusMessageFromOutput("PS C:\\Users> codex\r\n")).toBeUndefined();
+  });
+});
+
+describe("detectCodexConversationMessageFromOutput", () => {
+  it("prefers the latest assistant bullet reply", () => {
+    expect(
+      detectCodexConversationMessageFromOutput(
+        "> hello\r\n• Hello.\r\n> Improve documentation\r\ngpt-5.4 medium · 93% left · C:\\Users\r\n",
+      ),
+    ).toBe("Hello.");
+  });
+
+  it("ignores tool execution bullets", () => {
+    expect(
+      detectCodexConversationMessageFromOutput(
+        "• Ran Get-ChildItem\r\ngpt-5.4 medium · 93% left · C:\\Users\r\n",
+      ),
+    ).toBeUndefined();
   });
 });

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -55,8 +55,15 @@ export function detectCodexInputPendingFromOutput(text: string): boolean {
   return (
     text.includes("Would you like to run the following command?") ||
     text.includes("Press enter to confirm or esc to cancel") ||
+    text.includes("command?") ||
+    text.includes("confirm or esc to cancel") ||
+    text.includes("esc to cancel") ||
+    text.includes("to cancel") ||
+    text.includes("Reason:") ||
+    text.includes("Would you like to run") ||
     text.includes("Yes, proceed") ||
-    text.includes("No, and tell Codex what to do differently")
+    text.includes("No, and tell Codex what to do differently") ||
+    text.includes("tell Codex what to do differently")
   );
 }
 

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -80,7 +80,12 @@ export function detectActivityFromTitle(title: string): TerminalActivityInfo | u
 
 /** Detect interactive app from raw output text when command/title signals are unavailable. */
 export function detectActivityFromOutput(text: string): TerminalActivityInfo | undefined {
-  if (text.includes("OpenAI Codex")) {
+  const lines = normalizeOutputLines(text);
+  const hasCodexBanner = lines.some((line) => /^>[-\s]*OpenAI Codex \(v[^\s)]+\)$/i.test(line));
+  const hasCodexSessionMetadata = lines.some(
+    (line) => /^model:\s+/i.test(line) || /^directory:\s+/i.test(line),
+  );
+  if (hasCodexBanner && hasCodexSessionMetadata) {
     return { type: "interactiveApp", name: "Codex" };
   }
   return undefined;

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -5,6 +5,8 @@ import {
 } from "./activity-handler";
 
 export const CODEX_INPUT_PENDING_MARKER = "__codex_input_pending__";
+const MIDDLE_DOT = "\u00b7";
+const ASSISTANT_BULLET = "\u2022";
 
 /** Known interactive apps without dedicated provider handlers. */
 const STATIC_INTERACTIVE_APPS: { title: string; command: string; name: string }[] = [
@@ -21,18 +23,51 @@ const STATIC_INTERACTIVE_APPS: { title: string; command: string; name: string }[
   { title: "ipython", command: "ipython", name: "ipython" },
 ];
 
+function normalizeOutputLines(text: string): string[] {
+  return text
+    .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export function isCodexFooterStatusLine(line: string): boolean {
+  const parts = line.split(new RegExp(`\\s+${MIDDLE_DOT}\\s+`));
+  return (
+    parts.length >= 3 &&
+    /\b\d+% left\b/i.test(parts[1] ?? "") &&
+    /(^gpt-|^o[134]\b|^codex\b)/i.test(parts[0] ?? "") &&
+    Boolean(parts[2])
+  );
+}
+
+export function isCodexAssistantMessage(line: string): boolean {
+  if (!line.startsWith(`${ASSISTANT_BULLET} `)) return false;
+  const message = line.slice(2).trim();
+  if (!message) return false;
+  if (
+    message.startsWith("Ran ") ||
+    message.startsWith("Running ") ||
+    message.startsWith("Reason:") ||
+    message.startsWith("Would you like to run") ||
+    message.startsWith("Press enter to confirm") ||
+    message.startsWith("Yes, proceed") ||
+    message.startsWith("No, and tell Codex") ||
+    message.startsWith("Tip:")
+  ) {
+    return false;
+  }
+  return true;
+}
+
 /** Detect interactive app from terminal title (OSC 0/2). */
 export function detectActivityFromTitle(title: string): TerminalActivityInfo | undefined {
   const registered = detectRegisteredActivityFromTitle(title);
   if (registered) return registered;
 
-  // Skip path-like titles (e.g. "//wsl.localhost/.../python_projects")
-  // These can false-positive on app names embedded in directory names
   if (title.includes("/") || title.includes("\\")) return undefined;
 
   for (const app of STATIC_INTERACTIVE_APPS) {
-    // Use word boundary matching to avoid false positives
-    // e.g. "vi" should not match "Review", "vim" should not match "environment"
     const pattern = new RegExp(
       `(?:^|[\\s\\-:])${app.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:$|[\\s\\-:])`,
     );
@@ -67,6 +102,27 @@ export function detectCodexInputPendingFromOutput(text: string): boolean {
   );
 }
 
+export function detectCodexConversationMessageFromOutput(text: string): string | undefined {
+  const lines = normalizeOutputLines(text);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (!isCodexAssistantMessage(line)) continue;
+    return line.slice(2).trim();
+  }
+  return undefined;
+}
+
+export function detectCodexStatusMessageFromOutput(text: string): string | undefined {
+  const lines = normalizeOutputLines(text);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (isCodexFooterStatusLine(line)) {
+      return line;
+    }
+  }
+  return undefined;
+}
+
 /** Detect interactive app from command text (OSC 133 E). */
 export function detectActivityFromCommand(command: string): TerminalActivityInfo | undefined {
   const registered = detectRegisteredActivityFromCommand(command);
@@ -75,12 +131,10 @@ export function detectActivityFromCommand(command: string): TerminalActivityInfo
   const trimmed = command.trim();
   if (!trimmed) return undefined;
 
-  // Extract the binary name: strip sudo prefix, take basename of first token
   let first = trimmed.split(/\s+/)[0];
   if (first === "sudo" && trimmed.split(/\s+/).length > 1) {
     first = trimmed.split(/\s+/)[1];
   }
-  // Strip path prefix: /usr/bin/vim -> vim
   const basename = first.split("/").pop() ?? first;
 
   for (const app of STATIC_INTERACTIVE_APPS) {

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -41,6 +41,14 @@ export function detectActivityFromTitle(title: string): TerminalActivityInfo | u
   return undefined;
 }
 
+/** Detect interactive app from raw output text when command/title signals are unavailable. */
+export function detectActivityFromOutput(text: string): TerminalActivityInfo | undefined {
+  if (text.includes("OpenAI Codex")) {
+    return { type: "interactiveApp", name: "Codex" };
+  }
+  return undefined;
+}
+
 /** Detect interactive app from command text (OSC 133 E). */
 export function detectActivityFromCommand(command: string): TerminalActivityInfo | undefined {
   const registered = detectRegisteredActivityFromCommand(command);

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -4,6 +4,8 @@ import {
   detectRegisteredActivityFromTitle,
 } from "./activity-handler";
 
+export const CODEX_INPUT_PENDING_MARKER = "__codex_input_pending__";
+
 /** Known interactive apps without dedicated provider handlers. */
 const STATIC_INTERACTIVE_APPS: { title: string; command: string; name: string }[] = [
   { title: "nvim", command: "nvim", name: "neovim" },
@@ -47,6 +49,15 @@ export function detectActivityFromOutput(text: string): TerminalActivityInfo | u
     return { type: "interactiveApp", name: "Codex" };
   }
   return undefined;
+}
+
+export function detectCodexInputPendingFromOutput(text: string): boolean {
+  return (
+    text.includes("Would you like to run the following command?") ||
+    text.includes("Press enter to confirm or esc to cancel") ||
+    text.includes("Yes, proceed") ||
+    text.includes("No, and tell Codex what to do differently")
+  );
 }
 
 /** Detect interactive app from command text (OSC 133 E). */

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -1,8 +1,11 @@
 import type { TerminalActivityInfo } from "@/stores/terminal-store";
+import {
+  detectRegisteredActivityFromCommand,
+  detectRegisteredActivityFromTitle,
+} from "./activity-handler";
 
-/** Known interactive apps: [titlePattern, displayName, commandName?] */
-const INTERACTIVE_APPS: { title: string; command: string; name: string }[] = [
-  { title: "Claude Code", command: "claude", name: "Claude" },
+/** Known interactive apps without dedicated provider handlers. */
+const STATIC_INTERACTIVE_APPS: { title: string; command: string; name: string }[] = [
   { title: "nvim", command: "nvim", name: "neovim" },
   { title: "vim", command: "vim", name: "vim" },
   { title: "vi", command: "vi", name: "vim" },
@@ -18,11 +21,14 @@ const INTERACTIVE_APPS: { title: string; command: string; name: string }[] = [
 
 /** Detect interactive app from terminal title (OSC 0/2). */
 export function detectActivityFromTitle(title: string): TerminalActivityInfo | undefined {
+  const registered = detectRegisteredActivityFromTitle(title);
+  if (registered) return registered;
+
   // Skip path-like titles (e.g. "//wsl.localhost/.../python_projects")
   // These can false-positive on app names embedded in directory names
   if (title.includes("/") || title.includes("\\")) return undefined;
 
-  for (const app of INTERACTIVE_APPS) {
+  for (const app of STATIC_INTERACTIVE_APPS) {
     // Use word boundary matching to avoid false positives
     // e.g. "vi" should not match "Review", "vim" should not match "environment"
     const pattern = new RegExp(
@@ -37,6 +43,9 @@ export function detectActivityFromTitle(title: string): TerminalActivityInfo | u
 
 /** Detect interactive app from command text (OSC 133 E). */
 export function detectActivityFromCommand(command: string): TerminalActivityInfo | undefined {
+  const registered = detectRegisteredActivityFromCommand(command);
+  if (registered) return registered;
+
   const trimmed = command.trim();
   if (!trimmed) return undefined;
 
@@ -45,10 +54,10 @@ export function detectActivityFromCommand(command: string): TerminalActivityInfo
   if (first === "sudo" && trimmed.split(/\s+/).length > 1) {
     first = trimmed.split(/\s+/)[1];
   }
-  // Strip path prefix: /usr/bin/vim → vim
+  // Strip path prefix: /usr/bin/vim -> vim
   const basename = first.split("/").pop() ?? first;
 
-  for (const app of INTERACTIVE_APPS) {
+  for (const app of STATIC_INTERACTIVE_APPS) {
     if (basename === app.command) {
       return { type: "interactiveApp", name: app.name };
     }

--- a/ui/src/lib/activity-handler.test.ts
+++ b/ui/src/lib/activity-handler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { getHandler } from "./activity-handler";
 import { ShellActivityHandler } from "./shell-activity-handler";
 import { ClaudeActivityHandler } from "./claude-activity-handler";
+import { CodexActivityHandler } from "./codex-activity-handler";
 
 describe("getHandler", () => {
   it("returns ShellActivityHandler for undefined activity", () => {
@@ -25,6 +26,12 @@ describe("getHandler", () => {
   it("returns ShellActivityHandler for unknown app name", () => {
     expect(getHandler({ type: "interactiveApp", name: "vim" })).toBeInstanceOf(
       ShellActivityHandler,
+    );
+  });
+
+  it("returns CodexActivityHandler for Codex interactiveApp", () => {
+    expect(getHandler({ type: "interactiveApp", name: "Codex" })).toBeInstanceOf(
+      CodexActivityHandler,
     );
   });
 });

--- a/ui/src/lib/activity-handler.ts
+++ b/ui/src/lib/activity-handler.ts
@@ -35,6 +35,7 @@ export interface ActivityHandler {
 type InteractiveAppRegistration = {
   handler: ActivityHandler;
   commands?: string[];
+  commandPatterns?: RegExp[];
   titlePatterns?: string[];
 };
 
@@ -59,6 +60,11 @@ registerInteractiveApp("Claude", {
 registerInteractiveApp("Codex", {
   handler: new CodexActivityHandler(),
   commands: ["codex"],
+  commandPatterns: [
+    /@openai\/codex/i,
+    /(?:^|[\\/])codex(?:\.js)?$/i,
+    /\bcodex\s+(?:exec|resume)\b/i,
+  ],
   titlePatterns: ["OpenAI Codex"],
 });
 
@@ -104,11 +110,15 @@ export function detectRegisteredActivityFromTitle(title: string): TerminalActivi
 export function detectRegisteredActivityFromCommand(
   command: string,
 ): TerminalActivityInfo | undefined {
-  const basename = getBasename(command);
-  if (!basename) return undefined;
+  const trimmed = command.trim();
+  if (!trimmed) return undefined;
 
+  const basename = getBasename(command);
   for (const [name, registration] of interactiveApps) {
-    if (registration.commands?.includes(basename)) {
+    if (basename && registration.commands?.includes(basename)) {
+      return { type: "interactiveApp", name };
+    }
+    if (registration.commandPatterns?.some((pattern) => pattern.test(trimmed))) {
       return { type: "interactiveApp", name };
     }
   }

--- a/ui/src/lib/activity-handler.ts
+++ b/ui/src/lib/activity-handler.ts
@@ -1,6 +1,7 @@
 import type { TerminalActivityInfo } from "@/stores/terminal-store";
 import { ShellActivityHandler } from "./shell-activity-handler";
 import { ClaudeActivityHandler } from "./claude-activity-handler";
+import { CodexActivityHandler } from "./codex-activity-handler";
 
 export interface StatusResult {
   icon: string;
@@ -26,20 +27,89 @@ export interface ActivityHandler {
   computeStatus(raw: RawTerminalState): StatusResult;
   computeStatusMessage(raw: RawTerminalState): string | undefined;
   computeNotification(raw: RawTerminalState): { message: string; level: string } | null;
+  shouldPreserveActivityOnTitleReset?(raw: RawTerminalState): boolean;
+  shouldPreserveActivityOnExitCode?(raw: RawTerminalState): boolean;
+  isActiveTitle?(title: string | undefined): boolean;
 }
+
+type InteractiveAppRegistration = {
+  handler: ActivityHandler;
+  commands?: string[];
+  titlePatterns?: string[];
+};
 
 const defaultHandler = new ShellActivityHandler();
-const interactiveAppHandlers = new Map<string, ActivityHandler>();
+const interactiveApps = new Map<string, InteractiveAppRegistration>();
 
-export function registerActivityHandler(activityName: string, handler: ActivityHandler): void {
-  interactiveAppHandlers.set(activityName, handler);
+function registerInteractiveApp(
+  activityName: string,
+  registration: ActivityHandler | InteractiveAppRegistration,
+): void {
+  interactiveApps.set(
+    activityName,
+    "computeStatus" in registration ? { handler: registration } : registration,
+  );
 }
 
-registerActivityHandler("Claude", new ClaudeActivityHandler());
+registerInteractiveApp("Claude", {
+  handler: new ClaudeActivityHandler(),
+  commands: ["claude"],
+  titlePatterns: ["Claude Code"],
+});
+registerInteractiveApp("Codex", {
+  handler: new CodexActivityHandler(),
+  commands: ["codex"],
+  titlePatterns: ["OpenAI Codex", "codex"],
+});
 
 export function getHandler(activity?: TerminalActivityInfo): ActivityHandler {
   if (activity?.type === "interactiveApp" && activity.name) {
-    return interactiveAppHandlers.get(activity.name) ?? defaultHandler;
+    return interactiveApps.get(activity.name)?.handler ?? defaultHandler;
   }
   return defaultHandler;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function matchTitlePattern(title: string, pattern: string): boolean {
+  if (title === pattern) return true;
+  return new RegExp(`(?:^|[\\s\\-:])${escapeRegExp(pattern)}(?:$|[\\s\\-:])`).test(title);
+}
+
+function getBasename(command: string): string | undefined {
+  const trimmed = command.trim();
+  if (!trimmed) return undefined;
+
+  let first = trimmed.split(/\s+/)[0];
+  if (first === "sudo" && trimmed.split(/\s+/).length > 1) {
+    first = trimmed.split(/\s+/)[1];
+  }
+  return first.split("/").pop() ?? first;
+}
+
+export function detectRegisteredActivityFromTitle(title: string): TerminalActivityInfo | undefined {
+  if (!title || title.includes("/") || title.includes("\\")) return undefined;
+
+  for (const [name, registration] of interactiveApps) {
+    if (registration.titlePatterns?.some((pattern) => matchTitlePattern(title, pattern))) {
+      return { type: "interactiveApp", name };
+    }
+  }
+  return undefined;
+}
+
+export function detectRegisteredActivityFromCommand(
+  command: string,
+): TerminalActivityInfo | undefined {
+  const basename = getBasename(command);
+  if (!basename) return undefined;
+
+  for (const [name, registration] of interactiveApps) {
+    if (registration.commands?.includes(basename)) {
+      return { type: "interactiveApp", name };
+    }
+  }
+  return undefined;
 }

--- a/ui/src/lib/activity-handler.ts
+++ b/ui/src/lib/activity-handler.ts
@@ -86,7 +86,8 @@ function getBasename(command: string): string | undefined {
   if (first === "sudo" && trimmed.split(/\s+/).length > 1) {
     first = trimmed.split(/\s+/)[1];
   }
-  return first.split("/").pop() ?? first;
+  const basename = first.split("/").pop() ?? first;
+  return basename.replace(/\.(exe|cmd|bat)$/i, "");
 }
 
 export function detectRegisteredActivityFromTitle(title: string): TerminalActivityInfo | undefined {

--- a/ui/src/lib/activity-handler.ts
+++ b/ui/src/lib/activity-handler.ts
@@ -59,7 +59,7 @@ registerInteractiveApp("Claude", {
 registerInteractiveApp("Codex", {
   handler: new CodexActivityHandler(),
   commands: ["codex"],
-  titlePatterns: ["OpenAI Codex", "codex"],
+  titlePatterns: ["OpenAI Codex"],
 });
 
 export function getHandler(activity?: TerminalActivityInfo): ActivityHandler {

--- a/ui/src/lib/claude-activity-handler.test.ts
+++ b/ui/src/lib/claude-activity-handler.test.ts
@@ -19,6 +19,10 @@ function raw(overrides: Partial<RawTerminalState> = {}): RawTerminalState {
 describe("ClaudeActivityHandler", () => {
   const handler = new ClaudeActivityHandler();
 
+  it("preserves activity on exitCode for Claude sub-commands", () => {
+    expect(handler.shouldPreserveActivityOnExitCode(raw({ exitCode: 0 }))).toBe(true);
+  });
+
   describe("computeStatus", () => {
     it("returns pending while output is active", () => {
       expect(handler.computeStatus(raw({ outputActive: true }))).toEqual({

--- a/ui/src/lib/claude-activity-handler.ts
+++ b/ui/src/lib/claude-activity-handler.ts
@@ -21,6 +21,10 @@ function extractTitleMessage(title: string | undefined): string | undefined {
 }
 
 export class ClaudeActivityHandler extends ShellActivityHandler {
+  shouldPreserveActivityOnExitCode(): boolean {
+    return true;
+  }
+
   computeStatus(raw: RawTerminalState): StatusResult {
     if (raw.outputActive || raw.exitCode !== undefined) {
       return super.computeStatus(raw);

--- a/ui/src/lib/codex-activity-handler.test.ts
+++ b/ui/src/lib/codex-activity-handler.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { CodexActivityHandler } from "./codex-activity-handler";
+import type { RawTerminalState } from "./activity-handler";
+
+function raw(overrides: Partial<RawTerminalState> = {}): RawTerminalState {
+  return {
+    exitCode: undefined,
+    outputActive: false,
+    lastCommand: undefined,
+    activityMessage: undefined,
+    activity: { type: "interactiveApp", name: "Codex" },
+    title: undefined,
+    ...overrides,
+  };
+}
+
+describe("CodexActivityHandler", () => {
+  const handler = new CodexActivityHandler();
+
+  it("preserves activity when title stops matching explicit Codex name", () => {
+    expect(handler.shouldPreserveActivityOnTitleReset(raw({ title: "⠋ laymux" }))).toBe(true);
+  });
+
+  it("returns to shell on exitCode", () => {
+    expect(handler.shouldPreserveActivityOnExitCode(raw({ exitCode: 0 }))).toBe(false);
+  });
+
+  it("treats braille title spinner as active", () => {
+    expect(handler.isActiveTitle("⠋ laymux")).toBe(true);
+    expect(handler.isActiveTitle("laymux")).toBe(false);
+  });
+
+  it("uses running status for braille spinner title without outputActive event", () => {
+    expect(handler.computeStatus(raw({ title: "⠋ laymux" }))).toEqual({
+      icon: "⏳",
+      color: "var(--yellow)",
+    });
+  });
+});

--- a/ui/src/lib/codex-activity-handler.test.ts
+++ b/ui/src/lib/codex-activity-handler.test.ts
@@ -19,7 +19,7 @@ describe("CodexActivityHandler", () => {
   const handler = new CodexActivityHandler();
 
   it("preserves activity when title stops matching explicit Codex name", () => {
-    expect(handler.shouldPreserveActivityOnTitleReset(raw({ title: "⠋ laymux" }))).toBe(true);
+    expect(handler.shouldPreserveActivityOnTitleReset(raw({ title: "⠋laymux" }))).toBe(true);
   });
 
   it("returns to shell on exitCode", () => {
@@ -27,12 +27,12 @@ describe("CodexActivityHandler", () => {
   });
 
   it("treats braille title spinner as active", () => {
-    expect(handler.isActiveTitle("⠋ laymux")).toBe(true);
+    expect(handler.isActiveTitle("⠋laymux")).toBe(true);
     expect(handler.isActiveTitle("laymux")).toBe(false);
   });
 
   it("uses running status for braille spinner title without outputActive event", () => {
-    expect(handler.computeStatus(raw({ title: "⠋ laymux" }))).toEqual({
+    expect(handler.computeStatus(raw({ title: "⠋laymux" }))).toEqual({
       icon: "⏳",
       color: "var(--yellow)",
     });
@@ -44,7 +44,7 @@ describe("CodexActivityHandler", () => {
         raw({
           outputActive: true,
           activityMessage: CODEX_INPUT_PENDING_MARKER,
-          title: "⠋ laymux",
+          title: "⠋laymux",
         }),
       ),
     ).toEqual({
@@ -54,14 +54,25 @@ describe("CodexActivityHandler", () => {
   });
 
   it("returns spinner title text by default", () => {
-    expect(handler.computeStatusMessage(raw({ title: "⠋ laymux" }))).toBe("laymux");
+    expect(handler.computeStatusMessage(raw({ title: "⠋laymux" }))).toBe("laymux");
+  });
+
+  it("falls back to activity message when title mode has no spinner title", () => {
+    expect(
+      handler.computeStatusMessage(
+        raw({
+          activityMessage: "gpt-5.4 medium · 93% left · C:\\Users",
+          statusMessageMode: "title",
+        }),
+      ),
+    ).toBe("gpt-5.4 medium · 93% left · C:\\Users");
   });
 
   it("supports configurable title-bullet formatting", () => {
     expect(
       handler.computeStatusMessage(
         raw({
-          title: "⠋ laymux",
+          title: "⠋laymux",
           activityMessage: "Planning",
           statusMessageMode: "title-bullet",
           statusMessageDelimiter: " | ",
@@ -74,7 +85,7 @@ describe("CodexActivityHandler", () => {
     expect(
       handler.computeStatusMessage(
         raw({
-          title: "⠋ laymux",
+          title: "⠋laymux",
           activityMessage: "laymux",
           statusMessageMode: "bullet-title",
         }),

--- a/ui/src/lib/codex-activity-handler.test.ts
+++ b/ui/src/lib/codex-activity-handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { CodexActivityHandler } from "./codex-activity-handler";
 import type { RawTerminalState } from "./activity-handler";
+import { CODEX_INPUT_PENDING_MARKER } from "./activity-detection";
+import { CodexActivityHandler } from "./codex-activity-handler";
 
 function raw(overrides: Partial<RawTerminalState> = {}): RawTerminalState {
   return {
@@ -34,6 +35,21 @@ describe("CodexActivityHandler", () => {
     expect(handler.computeStatus(raw({ title: "⠋ laymux" }))).toEqual({
       icon: "⏳",
       color: "var(--yellow)",
+    });
+  });
+
+  it("treats input pending as success even while output is active", () => {
+    expect(
+      handler.computeStatus(
+        raw({
+          outputActive: true,
+          activityMessage: CODEX_INPUT_PENDING_MARKER,
+          title: "⠋ laymux",
+        }),
+      ),
+    ).toEqual({
+      icon: "✓",
+      color: "var(--green)",
     });
   });
 });

--- a/ui/src/lib/codex-activity-handler.test.ts
+++ b/ui/src/lib/codex-activity-handler.test.ts
@@ -69,4 +69,16 @@ describe("CodexActivityHandler", () => {
       ),
     ).toBe("laymux | Planning");
   });
+
+  it("deduplicates identical bullet and title messages", () => {
+    expect(
+      handler.computeStatusMessage(
+        raw({
+          title: "⠋ laymux",
+          activityMessage: "laymux",
+          statusMessageMode: "bullet-title",
+        }),
+      ),
+    ).toBe("laymux");
+  });
 });

--- a/ui/src/lib/codex-activity-handler.test.ts
+++ b/ui/src/lib/codex-activity-handler.test.ts
@@ -57,7 +57,7 @@ describe("CodexActivityHandler", () => {
     expect(handler.computeStatusMessage(raw({ title: "⠋laymux" }))).toBe("laymux");
   });
 
-  it("falls back to activity message when title mode has no spinner title", () => {
+  it("keeps title mode strict when no spinner title is present", () => {
     expect(
       handler.computeStatusMessage(
         raw({
@@ -65,7 +65,7 @@ describe("CodexActivityHandler", () => {
           statusMessageMode: "title",
         }),
       ),
-    ).toBe("gpt-5.4 medium · 93% left · C:\\Users");
+    ).toBeUndefined();
   });
 
   it("supports configurable title-bullet formatting", () => {

--- a/ui/src/lib/codex-activity-handler.test.ts
+++ b/ui/src/lib/codex-activity-handler.test.ts
@@ -52,4 +52,21 @@ describe("CodexActivityHandler", () => {
       color: "var(--green)",
     });
   });
+
+  it("returns spinner title text by default", () => {
+    expect(handler.computeStatusMessage(raw({ title: "⠋ laymux" }))).toBe("laymux");
+  });
+
+  it("supports configurable title-bullet formatting", () => {
+    expect(
+      handler.computeStatusMessage(
+        raw({
+          title: "⠋ laymux",
+          activityMessage: "Planning",
+          statusMessageMode: "title-bullet",
+          statusMessageDelimiter: " | ",
+        }),
+      ),
+    ).toBe("laymux | Planning");
+  });
 });

--- a/ui/src/lib/codex-activity-handler.ts
+++ b/ui/src/lib/codex-activity-handler.ts
@@ -1,5 +1,6 @@
-import { ShellActivityHandler } from "./shell-activity-handler";
 import type { RawTerminalState } from "./activity-handler";
+import { CODEX_INPUT_PENDING_MARKER } from "./activity-detection";
+import { ShellActivityHandler } from "./shell-activity-handler";
 
 const BRAILLE_SPINNER_RANGE_START = 0x2800;
 const BRAILLE_SPINNER_RANGE_END = 0x28ff;
@@ -8,6 +9,10 @@ function startsWithBrailleSpinner(title: string | undefined): boolean {
   if (!title) return false;
   const first = title.codePointAt(0) ?? 0;
   return first >= BRAILLE_SPINNER_RANGE_START && first <= BRAILLE_SPINNER_RANGE_END;
+}
+
+function isInputPending(activityMessage: string | undefined): boolean {
+  return activityMessage === CODEX_INPUT_PENDING_MARKER;
 }
 
 export class CodexActivityHandler extends ShellActivityHandler {
@@ -24,9 +29,19 @@ export class CodexActivityHandler extends ShellActivityHandler {
   }
 
   computeStatus(raw: RawTerminalState) {
+    if (isInputPending(raw.activityMessage)) {
+      return { icon: "✓", color: "var(--green)" };
+    }
     if (!raw.outputActive && startsWithBrailleSpinner(raw.title)) {
       return { icon: "⏳", color: "var(--yellow)" };
     }
     return super.computeStatus(raw);
+  }
+
+  computeStatusMessage(raw: RawTerminalState): string | undefined {
+    if (isInputPending(raw.activityMessage)) {
+      return undefined;
+    }
+    return super.computeStatusMessage(raw);
   }
 }

--- a/ui/src/lib/codex-activity-handler.ts
+++ b/ui/src/lib/codex-activity-handler.ts
@@ -4,6 +4,7 @@ import { ShellActivityHandler } from "./shell-activity-handler";
 
 const BRAILLE_SPINNER_RANGE_START = 0x2800;
 const BRAILLE_SPINNER_RANGE_END = 0x28ff;
+const DEFAULT_STATUS_MESSAGE_DELIMITER = " · ";
 
 function startsWithBrailleSpinner(title: string | undefined): boolean {
   if (!title) return false;
@@ -13,6 +14,12 @@ function startsWithBrailleSpinner(title: string | undefined): boolean {
 
 function isInputPending(activityMessage: string | undefined): boolean {
   return activityMessage === CODEX_INPUT_PENDING_MARKER;
+}
+
+function extractTitleMessage(title: string | undefined): string | undefined {
+  if (!startsWithBrailleSpinner(title) || !title) return undefined;
+  const stripped = title.slice(1).trim();
+  return stripped || undefined;
 }
 
 export class CodexActivityHandler extends ShellActivityHandler {
@@ -42,6 +49,24 @@ export class CodexActivityHandler extends ShellActivityHandler {
     if (isInputPending(raw.activityMessage)) {
       return undefined;
     }
-    return super.computeStatusMessage(raw);
+    const bullet = raw.activityMessage || undefined;
+    const titleMsg = extractTitleMessage(raw.title);
+    const mode = raw.statusMessageMode ?? "title";
+    const delimiter = raw.statusMessageDelimiter ?? DEFAULT_STATUS_MESSAGE_DELIMITER;
+
+    switch (mode) {
+      case "bullet":
+        return bullet;
+      case "title":
+        return titleMsg;
+      case "bullet-title":
+        if (bullet && titleMsg) return `${bullet}${delimiter}${titleMsg}`;
+        return bullet || titleMsg || undefined;
+      case "title-bullet":
+        if (bullet && titleMsg) return `${titleMsg}${delimiter}${bullet}`;
+        return titleMsg || bullet || undefined;
+      default:
+        return titleMsg || bullet || undefined;
+    }
   }
 }

--- a/ui/src/lib/codex-activity-handler.ts
+++ b/ui/src/lib/codex-activity-handler.ts
@@ -62,7 +62,7 @@ export class CodexActivityHandler extends ShellActivityHandler {
       case "bullet":
         return bullet;
       case "title":
-        return titleMsg;
+        return titleMsg || bullet || undefined;
       case "bullet-title":
         if (bullet && titleMsg) return `${bullet}${delimiter}${titleMsg}`;
         return bullet || titleMsg || undefined;

--- a/ui/src/lib/codex-activity-handler.ts
+++ b/ui/src/lib/codex-activity-handler.ts
@@ -62,7 +62,7 @@ export class CodexActivityHandler extends ShellActivityHandler {
       case "bullet":
         return bullet;
       case "title":
-        return titleMsg || bullet || undefined;
+        return titleMsg;
       case "bullet-title":
         if (bullet && titleMsg) return `${bullet}${delimiter}${titleMsg}`;
         return bullet || titleMsg || undefined;

--- a/ui/src/lib/codex-activity-handler.ts
+++ b/ui/src/lib/codex-activity-handler.ts
@@ -16,7 +16,7 @@ function isInputPending(activityMessage: string | undefined): boolean {
   return activityMessage === CODEX_INPUT_PENDING_MARKER;
 }
 
-function extractTitleMessage(title: string | undefined): string | undefined {
+export function extractCodexTitleMessage(title: string | undefined): string | undefined {
   if (!startsWithBrailleSpinner(title) || !title) return undefined;
   const stripped = title.slice(1).trim();
   return stripped || undefined;
@@ -50,9 +50,13 @@ export class CodexActivityHandler extends ShellActivityHandler {
       return undefined;
     }
     const bullet = raw.activityMessage || undefined;
-    const titleMsg = extractTitleMessage(raw.title);
+    const titleMsg = extractCodexTitleMessage(raw.title);
     const mode = raw.statusMessageMode ?? "title";
     const delimiter = raw.statusMessageDelimiter ?? DEFAULT_STATUS_MESSAGE_DELIMITER;
+
+    if (bullet && titleMsg && bullet === titleMsg) {
+      return bullet;
+    }
 
     switch (mode) {
       case "bullet":

--- a/ui/src/lib/codex-activity-handler.ts
+++ b/ui/src/lib/codex-activity-handler.ts
@@ -1,0 +1,32 @@
+import { ShellActivityHandler } from "./shell-activity-handler";
+import type { RawTerminalState } from "./activity-handler";
+
+const BRAILLE_SPINNER_RANGE_START = 0x2800;
+const BRAILLE_SPINNER_RANGE_END = 0x28ff;
+
+function startsWithBrailleSpinner(title: string | undefined): boolean {
+  if (!title) return false;
+  const first = title.codePointAt(0) ?? 0;
+  return first >= BRAILLE_SPINNER_RANGE_START && first <= BRAILLE_SPINNER_RANGE_END;
+}
+
+export class CodexActivityHandler extends ShellActivityHandler {
+  shouldPreserveActivityOnTitleReset(): boolean {
+    return true;
+  }
+
+  shouldPreserveActivityOnExitCode(): boolean {
+    return false;
+  }
+
+  isActiveTitle(title: string | undefined): boolean {
+    return startsWithBrailleSpinner(title);
+  }
+
+  computeStatus(raw: RawTerminalState) {
+    if (!raw.outputActive && startsWithBrailleSpinner(raw.title)) {
+      return { icon: "⏳", color: "var(--yellow)" };
+    }
+    return super.computeStatus(raw);
+  }
+}

--- a/ui/src/lib/persist-session.test.ts
+++ b/ui/src/lib/persist-session.test.ts
@@ -253,6 +253,22 @@ describe("persistSession", () => {
 
       expect(useSettingsStore.getState().claude.syncCwd).toBe("command");
     });
+
+    it("codex settings survive round-trip", async () => {
+      useSettingsStore.getState().setCodex({
+        statusMessageMode: "title-bullet",
+        statusMessageDelimiter: " | ",
+      });
+
+      await persistSession();
+
+      const saved = (saveSettings as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      useSettingsStore.setState(useSettingsStore.getInitialState());
+      useSettingsStore.getState().loadFromSettings(saved);
+
+      expect(useSettingsStore.getState().codex.statusMessageMode).toBe("title-bullet");
+      expect(useSettingsStore.getState().codex.statusMessageDelimiter).toBe(" | ");
+    });
   });
 
   it("preserves dock panes with view config through save", async () => {

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -159,6 +159,7 @@ async function persistSessionCore(): Promise<void> {
     convenience: { ...settingsState.convenience },
     workspaceDisplay: { ...settingsState.workspaceDisplay },
     claude: { ...settingsState.claude },
+    codex: { ...settingsState.codex },
     memo: { ...settingsState.memo },
     issueReporter: { ...settingsState.issueReporter },
     fileExplorer: { ...settingsState.fileExplorer },

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -121,6 +121,7 @@ export interface ConvenienceSettings {
 
 export type ClaudeSyncCwdMode = "skip" | "command";
 export type ClaudeStatusMessageMode = "bullet" | "title" | "title-bullet" | "bullet-title";
+export type CodexStatusMessageMode = ClaudeStatusMessageMode;
 
 export interface ClaudeSettings {
   syncCwd: ClaudeSyncCwdMode;
@@ -130,6 +131,13 @@ export interface ClaudeSettings {
   sessionMaxAgeHours: number;
   /** Status message display mode (default: "bullet-title"). */
   statusMessageMode: ClaudeStatusMessageMode;
+  /** Delimiter between bullet and title when both shown (default: " · "). */
+  statusMessageDelimiter: string;
+}
+
+export interface CodexSettings {
+  /** Status message display mode (default: "title"). */
+  statusMessageMode: CodexStatusMessageMode;
   /** Delimiter between bullet and title when both shown (default: " · "). */
   statusMessageDelimiter: string;
 }
@@ -232,6 +240,7 @@ export interface Settings {
   convenience: ConvenienceSettings;
   workspaceDisplay?: WorkspaceDisplaySettings;
   claude: ClaudeSettings;
+  codex?: CodexSettings;
   memo: MemoSettings;
   issueReporter: IssueReporterSettings;
   fileExplorer: FileExplorerSettings;

--- a/ui/src/lib/workspace-summary.test.ts
+++ b/ui/src/lib/workspace-summary.test.ts
@@ -689,6 +689,13 @@ describe("computeCommandStatus", () => {
     expect(s.text).toBeUndefined();
   });
 
+  it("returns running status for Codex braille spinner title", () => {
+    const codex = { type: "interactiveApp" as const, name: "Codex" };
+    const s = computeCommandStatus(undefined, false, undefined, codex, "⠋ laymux");
+    expect(s.icon).toBe("⏳");
+    expect(s.color).toBe("var(--yellow)");
+  });
+
   // ── Claude state transition scenarios ──
   // These test the 4-state rule across all Claude lifecycle phases.
   // computeCommandStatus itself is app-agnostic; these scenarios verify that

--- a/ui/src/stores/settings-store.test.ts
+++ b/ui/src/stores/settings-store.test.ts
@@ -419,7 +419,7 @@ describe("settings-store", () => {
 
   it("has default codex settings", () => {
     const { codex } = useSettingsStore.getState();
-    expect(codex.statusMessageMode).toBe("title");
+    expect(codex.statusMessageMode).toBe("bullet-title");
     expect(codex.statusMessageDelimiter).toBe(" · ");
   });
 
@@ -442,7 +442,7 @@ describe("settings-store", () => {
       codex: {} as any,
     });
     const { codex } = useSettingsStore.getState();
-    expect(codex.statusMessageMode).toBe("title");
+    expect(codex.statusMessageMode).toBe("bullet-title");
     expect(codex.statusMessageDelimiter).toBe(" · ");
   });
 

--- a/ui/src/stores/settings-store.test.ts
+++ b/ui/src/stores/settings-store.test.ts
@@ -417,6 +417,35 @@ describe("settings-store", () => {
     expect(claude.syncCwd).toBe("skip");
   });
 
+  it("has default codex settings", () => {
+    const { codex } = useSettingsStore.getState();
+    expect(codex.statusMessageMode).toBe("title");
+    expect(codex.statusMessageDelimiter).toBe(" · ");
+  });
+
+  it("setCodex updates status message mode", () => {
+    useSettingsStore.getState().setCodex({ statusMessageMode: "bullet-title" });
+    expect(useSettingsStore.getState().codex.statusMessageMode).toBe("bullet-title");
+  });
+
+  it("loadFromSettings loads codex settings", () => {
+    useSettingsStore.getState().loadFromSettings({
+      codex: { statusMessageMode: "bullet", statusMessageDelimiter: " | " },
+    });
+    const { codex } = useSettingsStore.getState();
+    expect(codex.statusMessageMode).toBe("bullet");
+    expect(codex.statusMessageDelimiter).toBe(" | ");
+  });
+
+  it("loadFromSettings fills missing codex fields with defaults", () => {
+    useSettingsStore.getState().loadFromSettings({
+      codex: {} as any,
+    });
+    const { codex } = useSettingsStore.getState();
+    expect(codex.statusMessageMode).toBe("title");
+    expect(codex.statusMessageDelimiter).toBe(" · ");
+  });
+
   // -- Scrollbar style settings --
 
   it("has default scrollbarStyle as overlay", () => {

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type {
   ClaudeSyncCwdMode,
   ClaudeSettings,
+  CodexSettings,
   FileExplorerSettings,
   IssueReporterSettings,
   MemoSettings,
@@ -280,6 +281,7 @@ interface SettingsState {
   convenience: ConvenienceSettings;
   workspaceDisplay: WorkspaceDisplaySettings;
   claude: ClaudeSettings;
+  codex: CodexSettings;
   memo: MemoSettings;
   issueReporter: IssueReporterSettings;
   fileExplorer: FileExplorerSettings;
@@ -293,6 +295,7 @@ interface SettingsState {
   setConvenience: (data: Partial<ConvenienceSettings>) => void;
   setWorkspaceDisplay: (data: Partial<WorkspaceDisplaySettings>) => void;
   setClaude: (data: Partial<ClaudeSettings>) => void;
+  setCodex: (data: Partial<CodexSettings>) => void;
   setMemo: (data: Partial<MemoSettings>) => void;
   setIssueReporter: (data: Partial<IssueReporterSettings>) => void;
   setFileExplorer: (data: Partial<FileExplorerSettings>) => void;
@@ -329,6 +332,7 @@ interface SettingsState {
         | "convenience"
         | "workspaceDisplay"
         | "claude"
+        | "codex"
         | "memo"
         | "issueReporter"
         | "fileExplorer"
@@ -728,6 +732,10 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     statusMessageMode: "bullet-title" as const,
     statusMessageDelimiter: " · ",
   },
+  codex: {
+    statusMessageMode: "title" as const,
+    statusMessageDelimiter: " · ",
+  },
   memo: { ...DEFAULT_MEMO },
   issueReporter: { ...DEFAULT_ISSUE_REPORTER },
   fileExplorer: { ...DEFAULT_FILE_EXPLORER },
@@ -750,6 +758,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setClaude: (data) =>
     set((state) => ({
       claude: { ...state.claude, ...data },
+    })),
+
+  setCodex: (data) =>
+    set((state) => ({
+      codex: { ...state.codex, ...data },
     })),
 
   setMemo: (data) =>
@@ -937,6 +950,13 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
           ...(data.claude as Partial<ClaudeSettings>),
         }
       : undefined;
+    const codex = data.codex
+      ? {
+          statusMessageMode: "title" as const,
+          statusMessageDelimiter: " · ",
+          ...(data.codex as Partial<CodexSettings>),
+        }
+      : undefined;
     // Ensure appFont has all fields (backwards compat)
     const appFont = data.appFont
       ? { ...DEFAULT_APP_FONT, ...data.appFont, weight: data.appFont.weight ?? "normal" }
@@ -980,6 +1000,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       ...(convenience ? { convenience } : {}),
       ...(workspaceDisplay ? { workspaceDisplay } : {}),
       ...(claude ? { claude } : {}),
+      ...(codex ? { codex } : {}),
       ...(issueReporter ? { issueReporter } : {}),
       ...(memo ? { memo } : {}),
       ...(fileExplorer ? { fileExplorer } : {}),

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -733,7 +733,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     statusMessageDelimiter: " · ",
   },
   codex: {
-    statusMessageMode: "title" as const,
+    statusMessageMode: "bullet-title" as const,
     statusMessageDelimiter: " · ",
   },
   memo: { ...DEFAULT_MEMO },
@@ -952,7 +952,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       : undefined;
     const codex = data.codex
       ? {
-          statusMessageMode: "title" as const,
+          statusMessageMode: "bullet-title" as const,
           statusMessageDelimiter: " · ",
           ...(data.codex as Partial<CodexSettings>),
         }


### PR DESCRIPTION
## Summary
- add a dedicated CodexActivityHandler and register provider-aware command/title detection
- let interactive app handlers control title-reset and exit-code lifecycle so Claude and Codex can diverge safely
- preserve Codex activity across dynamic terminal titles, treat braille spinner titles as active work, and add backend title detection for explicit Codex titles

## Testing
- cd ui && npm test -- src/lib/activity-handler.test.ts src/lib/activity-detection.test.ts src/lib/claude-activity-handler.test.ts src/lib/codex-activity-handler.test.ts src/lib/workspace-summary.test.ts src/hooks/useSyncEvents.test.ts
- cd ui && npx tsc --noEmit
- cargo test
- cd ui && npm test
