### PR TITLE
Stabilize terminal cursor rendering for Codex and Claude

### DIFF
--- a/ui/src/components/views/SettingsView.test.tsx
+++ b/ui/src/components/views/SettingsView.test.tsx
@@ -254,7 +254,7 @@ describe("SettingsView", () => {
     expect(screen.getByText("Hidden")).toBeInTheDocument();
   });
 
-  it("profile Additional Settings tab shows Font, Appearance and Advanced fields", async () => {
+  it("profile Additional Settings tab shows Font, Appearance, Cursor and Advanced fields", async () => {
     const user = userEvent.setup();
     render(<SettingsView />);
     await navigateToProfile(user, "PowerShell");
@@ -266,11 +266,16 @@ describe("SettingsView", () => {
     expect(screen.getAllByText("Font").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByTestId("font-face-input")).toBeInTheDocument();
     // Appearance fields
-    expect(screen.getByText("Cursor Shape")).toBeInTheDocument();
-    expect(screen.getByText("Cursor Blink")).toBeInTheDocument();
-    expect(screen.getByText("Cursor changes apply to new terminals.")).toBeInTheDocument();
+    expect(screen.getByText("Appearance")).toBeInTheDocument();
+    expect(screen.getByText("Color Scheme")).toBeInTheDocument();
     expect(screen.getByText("Opacity")).toBeInTheDocument();
     expect(screen.getByText("Padding")).toBeInTheDocument();
+    // Cursor fields
+    expect(screen.getByText("Cursor")).toBeInTheDocument();
+    expect(screen.getByText("Cursor Shape")).toBeInTheDocument();
+    expect(screen.getByText("Cursor Blink")).toBeInTheDocument();
+    expect(screen.getByText("Interactive Cursor Stability")).toBeInTheDocument();
+    expect(screen.getByText("Cursor changes apply to new terminals.")).toBeInTheDocument();
     // Advanced fields
     expect(screen.getByText("Scrollback Lines")).toBeInTheDocument();
     expect(screen.getByText("Bell Style")).toBeInTheDocument();
@@ -548,13 +553,14 @@ describe("SettingsView", () => {
 
   // -- Defaults page --
 
-  it("shows Defaults page with Appearance and Advanced sections", async () => {
+  it("shows Defaults page with Appearance, Cursor and Advanced sections", async () => {
     const user = userEvent.setup();
     render(<SettingsView />);
 
     await user.click(screen.getByTestId("nav-profile-defaults"));
     expect(screen.getByText("Profile Defaults")).toBeInTheDocument();
-    // Content area has Appearance heading (h4) and Advanced heading (h4)
+    expect(screen.getByText("Appearance")).toBeInTheDocument();
+    expect(screen.getByText("Cursor")).toBeInTheDocument();
     expect(screen.getByText("Cursor Shape")).toBeInTheDocument();
     expect(screen.getByText("Scrollback Lines")).toBeInTheDocument();
   });
@@ -646,6 +652,20 @@ describe("SettingsView", () => {
     await user.click(screen.getByTestId("save-settings-btn"));
 
     expect(useSettingsStore.getState().profileDefaults.cursorBlink).toBe(false);
+  });
+
+  it("updates profileDefaults interactive cursor stability after Save", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+
+    await user.click(screen.getByTestId("nav-profile-defaults"));
+    const toggle = screen.getByTestId("stabilize-interactive-cursor-toggle") as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+    await user.click(toggle);
+
+    await user.click(screen.getByTestId("save-settings-btn"));
+
+    expect(useSettingsStore.getState().profileDefaults.stabilizeInteractiveCursor).toBe(false);
   });
 
   it("shows settings.json shortcut in sidebar", () => {

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -338,13 +338,12 @@ function AppearanceFields({
   defaults,
   showReset,
 }: {
-  data: Pick<Profile, "colorScheme" | "cursorShape" | "cursorBlink" | "opacity" | "padding">;
+  data: Pick<Profile, "colorScheme" | "opacity" | "padding">;
   onChange: (d: Partial<Profile>) => void;
   colorSchemes: { name: string }[];
   defaults?: ProfileDefaults;
   showReset?: boolean;
 }) {
-  const supportedCursorShape = toSupportedCursorShape(data.cursorShape);
   const isDefault = (key: keyof ProfileDefaults) =>
     defaults && JSON.stringify(data[key as keyof typeof data]) === JSON.stringify(defaults[key]);
   const resetBtn = (key: keyof ProfileDefaults) =>
@@ -391,41 +390,6 @@ function AppearanceFields({
               {resetBtn("colorScheme")}
             </div>
           </SettingRow>
-          <SettingRow label="Cursor Shape">
-            <div className="flex items-center">
-              <select
-                data-testid="cursor-shape-select"
-                value={supportedCursorShape}
-                onChange={(e) => onChange({ cursorShape: e.target.value as CursorShape })}
-                className={inputCls}
-                style={inputStyle}
-              >
-                <option value="bar">Bar |</option>
-                <option value="underscore">Underscore _</option>
-                <option value="filledBox">Filled Box &#9608;</option>
-              </select>
-              {resetBtn("cursorShape")}
-            </div>
-          </SettingRow>
-          <SettingRow label="Cursor Blink">
-            <div className="flex items-center gap-2">
-              <label className="flex cursor-pointer items-center gap-2">
-                <input
-                  data-testid="cursor-blink-toggle"
-                  type="checkbox"
-                  checked={data.cursorBlink}
-                  onChange={(e) => onChange({ cursorBlink: e.target.checked })}
-                />
-                <span className="text-[12px]" style={{ color: "var(--text-secondary)" }}>
-                  Enable blinking cursor
-                </span>
-              </label>
-              {resetBtn("cursorBlink")}
-            </div>
-          </SettingRow>
-          <p className="mt-1 text-[11px]" style={{ color: "var(--text-secondary)", opacity: 0.7 }}>
-            Cursor changes apply to new terminals.
-          </p>
           <SettingRow label="Opacity">
             <div className="flex items-center gap-2">
               <input
@@ -479,6 +443,102 @@ function AppearanceFields({
         </div>
       </div>
     </>
+  );
+}
+
+function CursorFields({
+  data,
+  onChange,
+  defaults,
+  showReset,
+}: {
+  data: Pick<Profile, "cursorShape" | "cursorBlink" | "stabilizeInteractiveCursor">;
+  onChange: (d: Partial<Profile>) => void;
+  defaults?: ProfileDefaults;
+  showReset?: boolean;
+}) {
+  const supportedCursorShape = toSupportedCursorShape(data.cursorShape);
+  const isDefault = (key: keyof ProfileDefaults) =>
+    defaults && JSON.stringify(data[key as keyof typeof data]) === JSON.stringify(defaults[key]);
+  const resetBtn = (key: keyof ProfileDefaults) =>
+    showReset && defaults && !isDefault(key) ? (
+      <button
+        onClick={() => onChange({ [key]: defaults[key] })}
+        className="ml-1 shrink-0 rounded px-1.5 py-0.5 text-[9px]"
+        style={{
+          color: "var(--accent)",
+          background: "var(--accent-10)",
+          border: "none",
+          cursor: "pointer",
+        }}
+        title="Reset to default"
+      >
+        Reset
+      </button>
+    ) : null;
+
+  return (
+    <div style={cardStyle} className="mb-3">
+      <div className="px-4 py-2">
+        <h4 className="mb-2 text-xs font-semibold" style={{ color: "var(--text-primary)" }}>
+          Cursor
+        </h4>
+        <SettingRow label="Cursor Shape">
+          <div className="flex items-center">
+            <select
+              data-testid="cursor-shape-select"
+              value={supportedCursorShape}
+              onChange={(e) => onChange({ cursorShape: e.target.value as CursorShape })}
+              className={inputCls}
+              style={inputStyle}
+            >
+              <option value="bar">Bar |</option>
+              <option value="underscore">Underscore _</option>
+              <option value="filledBox">Filled Box &#9608;</option>
+            </select>
+            {resetBtn("cursorShape")}
+          </div>
+        </SettingRow>
+        <SettingRow label="Cursor Blink">
+          <div className="flex items-center gap-2">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                data-testid="cursor-blink-toggle"
+                type="checkbox"
+                checked={data.cursorBlink}
+                onChange={(e) => onChange({ cursorBlink: e.target.checked })}
+              />
+              <span className="text-[12px]" style={{ color: "var(--text-secondary)" }}>
+                Enable blinking cursor
+              </span>
+            </label>
+            {resetBtn("cursorBlink")}
+          </div>
+        </SettingRow>
+        <SettingRow
+          label="Interactive Cursor Stability"
+          desc="Use the stabilized cursor path for redraw-heavy interactive apps like Codex and Claude."
+        >
+          <div className="flex items-center gap-2">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                data-testid="stabilize-interactive-cursor-toggle"
+                type="checkbox"
+                checked={data.stabilizeInteractiveCursor}
+                onChange={(e) => onChange({ stabilizeInteractiveCursor: e.target.checked })}
+              />
+              <span className="text-[12px]" style={{ color: "var(--text-secondary)" }}>
+                Enable stable interactive cursor
+              </span>
+            </label>
+            {resetBtn("stabilizeInteractiveCursor")}
+          </div>
+        </SettingRow>
+        <p className="mt-1 text-[11px]" style={{ color: "var(--text-secondary)", opacity: 0.7 }}>
+          Cursor changes apply to new terminals.
+        </p>
+      </div>
+    </div>
   );
 }
 
@@ -703,6 +763,7 @@ function DefaultsSection() {
         onChange={updateDefaults}
         colorSchemes={colorSchemes}
       />
+      <CursorFields data={draftDefaults} onChange={updateDefaults} />
 
       <AdvancedFields data={draftDefaults} onChange={updateDefaults} />
     </div>
@@ -857,6 +918,7 @@ function ProfileSection({ profileIndex }: { profileIndex: number }) {
             defaults={profileDefaults}
             showReset
           />
+          <CursorFields data={profile} onChange={update} defaults={profileDefaults} showReset />
           <AdvancedFields data={profile} onChange={update} defaults={profileDefaults} showReset />
         </>
       )}

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, act } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { TerminalView, _resetWebglStagger } from "./TerminalView";
+import { TerminalView, _resetWebglStagger, shouldEnableTerminalWebgl } from "./TerminalView";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -18,13 +18,24 @@ const mockPaste = vi.fn();
 const mockHasSelection = vi.fn().mockReturnValue(false);
 const mockGetSelection = vi.fn().mockReturnValue("");
 const mockClearSelection = vi.fn();
+const mockOnCursorMove = vi.fn().mockReturnValue({ dispose: vi.fn() });
+const mockOnWriteParsed = vi.fn().mockReturnValue({ dispose: vi.fn() });
+const mockOnRender = vi.fn().mockReturnValue({ dispose: vi.fn() });
 const createdTerminals: Array<{ options: Record<string, unknown> }> = [];
+const mockModes = { synchronizedOutputMode: false };
 let capturedKeyHandler: ((e: KeyboardEvent) => boolean) | null = null;
 const mockAttachCustomKeyEventHandler = vi.fn((handler: (e: KeyboardEvent) => boolean) => {
   capturedKeyHandler = handler;
 });
-const mockWrite = vi.fn();
+const mockWrite = vi.fn((_: string | Uint8Array, callback?: () => void) => {
+  callback?.();
+});
 const mockRefresh = vi.fn();
+const mockRegisterCsiHandler = vi.fn();
+const csiHandlers = new Map<
+  string,
+  (params: readonly (number | number[])[]) => boolean | Promise<boolean>
+>();
 vi.mock("@xterm/xterm", () => ({
   Terminal: class MockTerminal {
     constructor(options: Record<string, unknown> = {}) {
@@ -38,6 +49,9 @@ vi.mock("@xterm/xterm", () => ({
     onTitleChange = mockOnTitleChange;
     onSelectionChange = mockOnSelectionChange;
     onKey = mockOnKey;
+    onCursorMove = mockOnCursorMove;
+    onWriteParsed = mockOnWriteParsed;
+    onRender = mockOnRender;
     attachCustomKeyEventHandler = mockAttachCustomKeyEventHandler;
     focus = mockFocus;
     blur = mockBlur;
@@ -49,6 +63,20 @@ vi.mock("@xterm/xterm", () => ({
     dispose = vi.fn();
     loadAddon = vi.fn();
     registerLinkProvider = vi.fn().mockReturnValue({ dispose: vi.fn() });
+    element = document.createElement("div");
+    buffer = { active: { cursorX: 0, cursorY: 0 } };
+    modes = mockModes;
+    parser = {
+      registerCsiHandler: mockRegisterCsiHandler.mockImplementation(
+        (
+          id: { prefix?: string; final: string },
+          callback: (params: readonly (number | number[])[]) => boolean | Promise<boolean>,
+        ) => {
+          csiHandlers.set(`${id.prefix ?? ""}:${id.final}`, callback);
+          return { dispose: vi.fn() };
+        },
+      ),
+    };
     cols = 80;
     rows = 24;
     options: Record<string, unknown>;
@@ -147,6 +175,8 @@ describe("TerminalView", () => {
     capturedLinkHandler = null;
     capturedIndentedLinkHandler = null;
     createdTerminals.length = 0;
+    csiHandlers.clear();
+    mockModes.synchronizedOutputMode = false;
     _resetWebglStagger();
     vi.clearAllMocks();
   });
@@ -235,6 +265,82 @@ describe("TerminalView", () => {
 
     await vi.waitFor(() => {
       expect(createdTerminals[0].options.cursorBlink).toBe(false);
+    });
+  });
+
+  it("uses overlay caret mode for Codex and Claude", async () => {
+    const { rerender } = render(
+      <TerminalView instanceId="t-overlay-mode" profile="PowerShell" syncGroup="" />,
+    );
+
+    const container = screen.getByTestId("terminal-view-t-overlay-mode");
+    expect(container).not.toHaveClass("terminal-native-cursor-hidden");
+
+    act(() => {
+      useTerminalStore.getState().updateInstanceInfo("t-overlay-mode", {
+        activity: { type: "interactiveApp", name: "Codex" },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(container).toHaveClass("terminal-native-cursor-hidden");
+    });
+
+    rerender(<TerminalView instanceId="t-overlay-mode" profile="PowerShell" syncGroup="" />);
+    act(() => {
+      useTerminalStore.getState().updateInstanceInfo("t-overlay-mode", {
+        activity: { type: "interactiveApp", name: "Claude" },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(container).toHaveClass("terminal-native-cursor-hidden");
+    });
+  });
+
+  it("hides the xterm cursor only during synchronized output frames", async () => {
+    render(<TerminalView instanceId="t-sync-cursor" profile="PowerShell" syncGroup="" />);
+
+    const container = screen.getByTestId("terminal-view-t-sync-cursor");
+    expect(container).not.toHaveClass("terminal-sync-output-active");
+
+    await act(async () => {
+      await csiHandlers.get("?:h")?.([2026]);
+    });
+    expect(container).toHaveClass("terminal-sync-output-active");
+
+    await act(async () => {
+      await csiHandlers.get("?:l")?.([2026]);
+    });
+    expect(container).not.toHaveClass("terminal-sync-output-active");
+  });
+
+  it("tracks xterm synchronizedOutputMode after terminal.write", async () => {
+    render(<TerminalView instanceId="t-sync-write" profile="PowerShell" syncGroup="" />);
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    const container = screen.getByTestId("terminal-view-t-sync-write");
+    mockModes.synchronizedOutputMode = true;
+
+    act(() => {
+      onOutput?.(new TextEncoder().encode("\x1b[?2026hframe"));
+    });
+
+    await vi.waitFor(() => {
+      expect(container).toHaveClass("terminal-sync-output-active");
+    });
+
+    mockModes.synchronizedOutputMode = false;
+    await vi.waitFor(() => {
+      expect(container).not.toHaveClass("terminal-sync-output-active");
     });
   });
 
@@ -1472,5 +1578,11 @@ describe("TerminalView", () => {
 
       vi.useRealTimers();
     });
+  });
+});
+
+describe("shouldEnableTerminalWebgl", () => {
+  it("keeps WebGL enabled", () => {
+    expect(shouldEnableTerminalWebgl()).toBe(true);
   });
 });

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -285,6 +285,9 @@ describe("TerminalView", () => {
     await vi.waitFor(() => {
       expect(container).toHaveClass("terminal-native-cursor-hidden");
     });
+    expect(createdTerminals[0].options.cursorStyle).toBe("bar");
+    expect(createdTerminals[0].options.cursorWidth).toBe(1);
+    expect(createdTerminals[0].options.cursorBlink).toBe(false);
 
     rerender(<TerminalView instanceId="t-overlay-mode" profile="PowerShell" syncGroup="" />);
     act(() => {
@@ -296,6 +299,9 @@ describe("TerminalView", () => {
     await vi.waitFor(() => {
       expect(container).toHaveClass("terminal-native-cursor-hidden");
     });
+    expect(createdTerminals[0].options.cursorStyle).toBe("bar");
+    expect(createdTerminals[0].options.cursorWidth).toBe(1);
+    expect(createdTerminals[0].options.cursorBlink).toBe(false);
   });
 
   it("hides the xterm cursor only during synchronized output frames", async () => {
@@ -344,7 +350,7 @@ describe("TerminalView", () => {
     });
   });
 
-  it("keeps profile cursor blink while Codex is active when codex override is disabled", async () => {
+  it("keeps native xterm cursor blink disabled in overlay mode even when codex override is disabled", async () => {
     useSettingsStore.getState().setCodex({ disableCursorBlink: false });
 
     render(<TerminalView instanceId="t-codex-blink-disabled" profile="PowerShell" syncGroup="" />);
@@ -356,7 +362,8 @@ describe("TerminalView", () => {
     });
 
     await vi.waitFor(() => {
-      expect(createdTerminals[0].options.cursorBlink).toBe(true);
+      expect(createdTerminals[0].options.cursorBlink).toBe(false);
+      expect(createdTerminals[0].options.cursorStyle).toBe("bar");
     });
   });
 

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -367,6 +367,25 @@ describe("TerminalView", () => {
     });
   });
 
+  it("falls back to native xterm cursor when interactive cursor stability is disabled", async () => {
+    useSettingsStore.getState().updateProfile(0, { stabilizeInteractiveCursor: false });
+
+    render(<TerminalView instanceId="t-native-cursor-mode" profile="PowerShell" syncGroup="" />);
+
+    const container = screen.getByTestId("terminal-view-t-native-cursor-mode");
+    act(() => {
+      useTerminalStore.getState().updateInstanceInfo("t-native-cursor-mode", {
+        activity: { type: "interactiveApp", name: "Codex" },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(container).not.toHaveClass("terminal-native-cursor-hidden");
+      expect(createdTerminals[0].options.cursorBlink).toBe(false);
+      expect(createdTerminals[0].options.cursorStyle).toBe("bar");
+    });
+  });
+
   it("registers terminal instance in store on mount", () => {
     render(<TerminalView instanceId="t2" profile="WSL" syncGroup="project-a" />);
     const instances = useTerminalStore.getState().instances;

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -36,6 +36,12 @@ const csiHandlers = new Map<
   string,
   (params: readonly (number | number[])[]) => boolean | Promise<boolean>
 >();
+const mockRequestAnimationFrame = vi.fn((callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0),
+);
+const mockCancelAnimationFrame = vi.fn((handle: number) => window.clearTimeout(handle));
+vi.stubGlobal("requestAnimationFrame", mockRequestAnimationFrame);
+vi.stubGlobal("cancelAnimationFrame", mockCancelAnimationFrame);
 vi.mock("@xterm/xterm", () => ({
   Terminal: class MockTerminal {
     constructor(options: Record<string, unknown> = {}) {
@@ -304,6 +310,23 @@ describe("TerminalView", () => {
     expect(createdTerminals[0].options.cursorBlink).toBe(false);
   });
 
+  it("uses the configured cursor color for the overlay caret", async () => {
+    useSettingsStore.getState().updateProfile(0, { colorScheme: "One Half Light" });
+
+    render(<TerminalView instanceId="t-overlay-color" profile="PowerShell" syncGroup="" />);
+
+    const container = screen.getByTestId("terminal-view-t-overlay-color");
+    act(() => {
+      useTerminalStore.getState().updateInstanceInfo("t-overlay-color", {
+        activity: { type: "interactiveApp", name: "Codex" },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(container).toHaveStyle({ "--terminal-overlay-caret-color": "#4F525D" });
+    });
+  });
+
   it("hides the xterm cursor only during synchronized output frames", async () => {
     render(<TerminalView instanceId="t-sync-cursor" profile="PowerShell" syncGroup="" />);
 
@@ -348,6 +371,7 @@ describe("TerminalView", () => {
     await vi.waitFor(() => {
       expect(container).not.toHaveClass("terminal-sync-output-active");
     });
+    expect(mockRequestAnimationFrame).toHaveBeenCalled();
   });
 
   it("keeps native xterm cursor blink disabled in overlay mode even when codex override is disabled", async () => {

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -862,6 +862,7 @@ export function TerminalView({
       ? false
       : cursorBlink;
   const nativeCursorHidden = isOverlayCaretActivity(activity);
+  const effectiveNativeCursorBlink = nativeCursorHidden ? false : effectiveCursorBlink;
   useEffect(() => {
     overlayCaretUpdaterRef.current?.();
   }, [activity, isFocused, font, cursorShape]);
@@ -895,14 +896,23 @@ export function TerminalView({
         : resolvedTheme;
       term.options.fontSize = font.size;
       term.options.fontFamily = fontFamily;
-      const cursorOptions = toXtermCursorOptions(cursorShape);
-      term.options.cursorBlink = effectiveCursorBlink;
-      term.options.cursorStyle = cursorOptions.cursorStyle;
-      if (cursorOptions.cursorWidth !== undefined) {
-        term.options.cursorWidth = cursorOptions.cursorWidth;
-      }
-      if (cursorOptions.cursorWidth === undefined) {
-        delete (term.options as { cursorWidth?: number }).cursorWidth;
+      if (nativeCursorHidden) {
+        // Keep xterm's internal cursor renderer on its least disruptive path.
+        // The visible caret is provided by the overlay, so block/invert rendering
+        // only creates repaint artifacts on the active text cell.
+        term.options.cursorBlink = false;
+        term.options.cursorStyle = "bar";
+        term.options.cursorWidth = 1;
+      } else {
+        const cursorOptions = toXtermCursorOptions(cursorShape);
+        term.options.cursorBlink = effectiveNativeCursorBlink;
+        term.options.cursorStyle = cursorOptions.cursorStyle;
+        if (cursorOptions.cursorWidth !== undefined) {
+          term.options.cursorWidth = cursorOptions.cursorWidth;
+        }
+        if (cursorOptions.cursorWidth === undefined) {
+          delete (term.options as { cursorWidth?: number }).cursorWidth;
+        }
       }
       fitAddonRef.current?.fit();
       term.refresh(0, term.rows - 1);
@@ -914,7 +924,7 @@ export function TerminalView({
     colorSchemes,
     font,
     cursorShape,
-    effectiveCursorBlink,
+    effectiveNativeCursorBlink,
     nativeCursorHidden,
   ]);
 

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -136,6 +136,7 @@ export function TerminalView({
   const openedRef = useRef(false);
   const isFocusedRef = useRef(isFocused);
   const activityRef = useRef<TerminalActivityInfo | undefined>(undefined);
+  const stabilizeInteractiveCursorRef = useRef(true);
   const onKeyboardActivityRef = useRef(onKeyboardActivity);
   onKeyboardActivityRef.current = onKeyboardActivity;
   isFocusedRef.current = isFocused;
@@ -243,6 +244,7 @@ export function TerminalView({
       if (
         !openedRef.current ||
         !isFocusedRef.current ||
+        !stabilizeInteractiveCursorRef.current ||
         !isOverlayCaretActivity(activityRef.current)
       ) {
         overlay.style.opacity = "0";
@@ -855,17 +857,26 @@ export function TerminalView({
       prof?.cursorBlink ?? s.profileDefaults?.cursorBlink ?? defaultProfileDefaults.cursorBlink
     );
   });
+  const stabilizeInteractiveCursor = useSettingsStore((s) => {
+    const prof = s.profiles?.find((p) => p.name === profile);
+    return (
+      prof?.stabilizeInteractiveCursor ??
+      s.profileDefaults?.stabilizeInteractiveCursor ??
+      defaultProfileDefaults.stabilizeInteractiveCursor
+    );
+  });
+  stabilizeInteractiveCursorRef.current = stabilizeInteractiveCursor;
   const effectiveCursorBlink =
     codexSettings.disableCursorBlink &&
     activity?.type === "interactiveApp" &&
     activity.name === "Codex"
       ? false
       : cursorBlink;
-  const nativeCursorHidden = isOverlayCaretActivity(activity);
+  const nativeCursorHidden = stabilizeInteractiveCursor && isOverlayCaretActivity(activity);
   const effectiveNativeCursorBlink = nativeCursorHidden ? false : effectiveCursorBlink;
   useEffect(() => {
     overlayCaretUpdaterRef.current?.();
-  }, [activity, isFocused, font, cursorShape]);
+  }, [activity, isFocused, font, cursorShape, stabilizeInteractiveCursor]);
   useEffect(() => {
     const term = terminalRef.current;
     if (!term?.options) return;
@@ -926,6 +937,7 @@ export function TerminalView({
     cursorShape,
     effectiveNativeCursorBlink,
     nativeCursorHidden,
+    stabilizeInteractiveCursor,
   ]);
 
   // Reactively update xterm overviewRuler width when scrollbarStyle changes

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -291,11 +291,11 @@ export function TerminalView({
       });
     };
     overlayCaretUpdaterRef.current = scheduleOverlayCaretUpdate;
-    let syncOutputMonitorTimer: ReturnType<typeof setTimeout> | undefined;
+    let syncOutputMonitorFrame: number | undefined;
     const stopSyncOutputMonitor = () => {
-      if (syncOutputMonitorTimer !== undefined) {
-        clearTimeout(syncOutputMonitorTimer);
-        syncOutputMonitorTimer = undefined;
+      if (syncOutputMonitorFrame !== undefined) {
+        cancelAnimationFrame(syncOutputMonitorFrame);
+        syncOutputMonitorFrame = undefined;
       }
     };
     const monitorSyncOutputMode = () => {
@@ -305,9 +305,9 @@ export function TerminalView({
       );
       setSyncOutputCursorVisibility(active);
       if (active && !cancelled) {
-        syncOutputMonitorTimer = setTimeout(monitorSyncOutputMode, 0);
+        syncOutputMonitorFrame = requestAnimationFrame(monitorSyncOutputMode);
       } else {
-        syncOutputMonitorTimer = undefined;
+        syncOutputMonitorFrame = undefined;
       }
     };
     const startSyncOutputMonitor = () => {
@@ -320,9 +320,9 @@ export function TerminalView({
         stopSyncOutputMonitor();
         return;
       }
-      if (syncOutputMonitorTimer === undefined) {
+      if (syncOutputMonitorFrame === undefined) {
         setSyncOutputCursorVisibility(true);
-        syncOutputMonitorTimer = setTimeout(monitorSyncOutputMode, 0);
+        syncOutputMonitorFrame = requestAnimationFrame(monitorSyncOutputMode);
       }
     };
 
@@ -956,6 +956,13 @@ export function TerminalView({
     }
   }, [scrollbarStyleForEffect]);
 
+  const overlayCaretColor = (() => {
+    const scheme = currentSchemeName
+      ? colorSchemes.find((cs) => cs.name === currentSchemeName)
+      : undefined;
+    return scheme?.cursorColor || "#FFFFFF";
+  })();
+
   // Resolve terminal background for padding area
   const termBg = (() => {
     const scheme = currentSchemeName
@@ -982,6 +989,7 @@ export function TerminalView({
       data-testid={`terminal-view-${instanceId}`}
       className={`relative h-full w-full ${scrollbarClass} ${nativeCursorHidden ? "terminal-native-cursor-hidden" : ""}`}
       style={{
+        ["--terminal-overlay-caret-color" as const]: overlayCaretColor,
         background: termBg,
         padding: `${pt}px ${pr}px ${pb}px ${pl}px`,
       }}

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -5,7 +5,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { createIndentedLinkProvider } from "@/lib/indented-link-provider";
 import { WebglAddon } from "@xterm/addon-webgl";
-import { useTerminalStore } from "@/stores/terminal-store";
+import { useTerminalStore, type TerminalActivityInfo } from "@/stores/terminal-store";
 import { useSettingsStore, defaultProfileDefaults } from "@/stores/settings-store";
 import { toXtermCursorOptions } from "@/lib/cursor-settings";
 import {
@@ -80,6 +80,20 @@ export function _resetWebglStagger(): void {
   webglInitCount = 0;
 }
 
+function hasDecModeParam(params: readonly (number | number[])[], mode: number): boolean {
+  return params.some((param) => (Array.isArray(param) ? param.includes(mode) : param === mode));
+}
+
+export function shouldEnableTerminalWebgl(): boolean {
+  return true;
+}
+
+function isOverlayCaretActivity(activity: TerminalActivityInfo | undefined): boolean {
+  return (
+    activity?.type === "interactiveApp" && (activity.name === "Codex" || activity.name === "Claude")
+  );
+}
+
 interface TerminalViewProps {
   instanceId: string;
   paneId?: string;
@@ -113,11 +127,15 @@ export function TerminalView({
   lastClaudeSession,
   startupCommandOverride,
 }: TerminalViewProps) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const overlayCaretRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const overlayCaretUpdaterRef = useRef<(() => void) | null>(null);
   const openedRef = useRef(false);
   const isFocusedRef = useRef(isFocused);
+  const activityRef = useRef<TerminalActivityInfo | undefined>(undefined);
   const onKeyboardActivityRef = useRef(onKeyboardActivity);
   onKeyboardActivityRef.current = onKeyboardActivity;
   isFocusedRef.current = isFocused;
@@ -129,6 +147,8 @@ export function TerminalView({
   cwdReceiveRef.current = cwdReceive;
   const registerInstance = useTerminalStore((s) => s.registerInstance);
   const unregisterInstance = useTerminalStore((s) => s.unregisterInstance);
+  const syncOutputActiveRef = useRef(false);
+  const shouldUseWebgl = shouldEnableTerminalWebgl();
 
   useEffect(() => {
     registerInstance({ id: instanceId, profile, syncGroup, workspaceId });
@@ -205,6 +225,143 @@ export function TerminalView({
     );
 
     terminalRef.current = terminal;
+
+    const setSyncOutputCursorVisibility = (active: boolean) => {
+      syncOutputActiveRef.current = active;
+      const host = wrapperRef.current;
+      if (host) {
+        host.classList.toggle("terminal-sync-output-active", active);
+      }
+    };
+    let overlayCaretFrame: number | undefined;
+    const updateOverlayCaret = () => {
+      const overlay = overlayCaretRef.current;
+      const host = wrapperRef.current;
+      const term = terminalRef.current;
+      if (!overlay || !host || !term) return;
+
+      if (
+        !openedRef.current ||
+        !isFocusedRef.current ||
+        !isOverlayCaretActivity(activityRef.current)
+      ) {
+        overlay.style.opacity = "0";
+        return;
+      }
+
+      const screen = term.element?.querySelector(".xterm-screen") as HTMLElement | null;
+      const canvas = term.element?.querySelector(
+        ".xterm-screen canvas",
+      ) as HTMLCanvasElement | null;
+      const targetRect = canvas?.getBoundingClientRect() ?? screen?.getBoundingClientRect();
+      const hostRect = host.getBoundingClientRect();
+      if (!targetRect || term.cols <= 0 || term.rows <= 0) {
+        overlay.style.opacity = "0";
+        return;
+      }
+
+      const cellWidth = targetRect.width / term.cols;
+      const cellHeight = targetRect.height / term.rows;
+      if (
+        !Number.isFinite(cellWidth) ||
+        !Number.isFinite(cellHeight) ||
+        cellWidth <= 0 ||
+        cellHeight <= 0
+      ) {
+        overlay.style.opacity = "0";
+        return;
+      }
+
+      const cursorX = term.buffer.active.cursorX;
+      const cursorY = term.buffer.active.cursorY;
+      overlay.style.opacity = "1";
+      overlay.style.width = `${Math.max(2, Math.round(cellWidth * 0.1))}px`;
+      overlay.style.height = `${Math.max(1, Math.round(cellHeight))}px`;
+      overlay.style.transform = `translate(${Math.round(targetRect.left - hostRect.left + cursorX * cellWidth)}px, ${Math.round(
+        targetRect.top - hostRect.top + cursorY * cellHeight,
+      )}px)`;
+    };
+    const scheduleOverlayCaretUpdate = () => {
+      if (overlayCaretFrame !== undefined) cancelAnimationFrame(overlayCaretFrame);
+      overlayCaretFrame = requestAnimationFrame(() => {
+        overlayCaretFrame = undefined;
+        updateOverlayCaret();
+      });
+    };
+    overlayCaretUpdaterRef.current = scheduleOverlayCaretUpdate;
+    let syncOutputMonitorTimer: ReturnType<typeof setTimeout> | undefined;
+    const stopSyncOutputMonitor = () => {
+      if (syncOutputMonitorTimer !== undefined) {
+        clearTimeout(syncOutputMonitorTimer);
+        syncOutputMonitorTimer = undefined;
+      }
+    };
+    const monitorSyncOutputMode = () => {
+      const active = Boolean(
+        (terminal as Terminal & { modes?: { synchronizedOutputMode?: boolean } }).modes
+          ?.synchronizedOutputMode,
+      );
+      setSyncOutputCursorVisibility(active);
+      if (active && !cancelled) {
+        syncOutputMonitorTimer = setTimeout(monitorSyncOutputMode, 0);
+      } else {
+        syncOutputMonitorTimer = undefined;
+      }
+    };
+    const startSyncOutputMonitor = () => {
+      const active = Boolean(
+        (terminal as Terminal & { modes?: { synchronizedOutputMode?: boolean } }).modes
+          ?.synchronizedOutputMode,
+      );
+      if (!active) {
+        setSyncOutputCursorVisibility(false);
+        stopSyncOutputMonitor();
+        return;
+      }
+      if (syncOutputMonitorTimer === undefined) {
+        setSyncOutputCursorVisibility(true);
+        syncOutputMonitorTimer = setTimeout(monitorSyncOutputMode, 0);
+      }
+    };
+
+    const parser = (
+      terminal as Terminal & {
+        parser?: {
+          registerCsiHandler?: (
+            id: { prefix?: string; final: string },
+            callback: (params: readonly (number | number[])[]) => boolean | Promise<boolean>,
+          ) => { dispose(): void };
+        };
+      }
+    ).parser;
+
+    const syncOutputSetDisposable = parser?.registerCsiHandler?.(
+      { prefix: "?", final: "h" },
+      (params) => {
+        if (hasDecModeParam(params, 2026)) {
+          setSyncOutputCursorVisibility(true);
+        }
+        return false;
+      },
+    );
+    const syncOutputResetDisposable = parser?.registerCsiHandler?.(
+      { prefix: "?", final: "l" },
+      (params) => {
+        if (hasDecModeParam(params, 2026)) {
+          setSyncOutputCursorVisibility(false);
+        }
+        return false;
+      },
+    );
+    const cursorMoveDisposable = terminal.onCursorMove(() => {
+      scheduleOverlayCaretUpdate();
+    });
+    const writeParsedDisposable = terminal.onWriteParsed(() => {
+      scheduleOverlayCaretUpdate();
+    });
+    const renderDisposable = terminal.onRender(() => {
+      scheduleOverlayCaretUpdate();
+    });
 
     // Custom key event handler: IDE shortcuts + smart paste interception.
     // Returning false prevents xterm from consuming the event.
@@ -343,7 +500,9 @@ export function TerminalView({
     let recentOutputTail = "";
     onTerminalOutput(instanceId, (data) => {
       if (cancelled) return;
-      terminal.write(data);
+      terminal.write(data, () => {
+        startSyncOutputMonitor();
+      });
       const text = streamDecoder.decode(data, { stream: true });
       const combinedText = (recentOutputTail + text).slice(-1024);
       recentOutputTail = combinedText;
@@ -514,18 +673,20 @@ export function TerminalView({
         // WebGL renderer required for custom glyph drawing (box-drawing, block
         // elements). xterm.js v6 built-in renderer does not support customGlyphs.
         // Stagger creation to prevent simultaneous GPU context init crash.
-        const delay = webglInitCount * WEBGL_STAGGER_MS;
-        webglInitCount++;
-        webglTimer = setTimeout(() => {
-          if (cancelled) return;
-          try {
-            const webgl = new WebglAddon(true); // preserveDrawingBuffer for screenshots
-            terminal.loadAddon(webgl);
-            webgl.onContextLoss(() => webgl.dispose());
-          } catch {
-            // WebGL not available — fall back to default renderer
-          }
-        }, delay);
+        if (shouldUseWebgl) {
+          const delay = webglInitCount * WEBGL_STAGGER_MS;
+          webglInitCount++;
+          webglTimer = setTimeout(() => {
+            if (cancelled) return;
+            try {
+              const webgl = new WebglAddon(true); // preserveDrawingBuffer for screenshots
+              terminal.loadAddon(webgl);
+              webgl.onContextLoss(() => webgl.dispose());
+            } catch {
+              // WebGL not available — fall back to default renderer
+            }
+          }, delay);
+        }
         // Load SerializeAddon for session persistence
         const serializeAddon = new SerializeAddon();
         terminal.loadAddon(serializeAddon);
@@ -538,6 +699,7 @@ export function TerminalView({
 
         fitAddon.fit();
         openedRef.current = true;
+        scheduleOverlayCaretUpdate();
         if (isFocusedRef.current) {
           terminal.focus();
         }
@@ -602,6 +764,7 @@ export function TerminalView({
         }
       } else if (sessionCreated && width > 0 && height > 0) {
         fitAddon.fit();
+        scheduleOverlayCaretUpdate();
       }
     });
     if (containerRef.current) {
@@ -618,6 +781,15 @@ export function TerminalView({
       outerContainer?.removeEventListener("wheel", handleWheel);
       outerEl?.removeEventListener("keydown", handleKeyDown);
       outerEl?.removeEventListener("mousemove", handleMouseMove);
+      if (overlayCaretFrame !== undefined) cancelAnimationFrame(overlayCaretFrame);
+      overlayCaretUpdaterRef.current = null;
+      stopSyncOutputMonitor();
+      syncOutputSetDisposable?.dispose();
+      syncOutputResetDisposable?.dispose();
+      cursorMoveDisposable?.dispose();
+      writeParsedDisposable?.dispose();
+      renderDisposable?.dispose();
+      setSyncOutputCursorVisibility(false);
       if (paneId) {
         unregisterTerminalSerializer(paneId);
       }
@@ -657,6 +829,7 @@ export function TerminalView({
       } else {
         terminalRef.current?.blur();
       }
+      overlayCaretUpdaterRef.current?.();
     }
   }, [isFocused]);
 
@@ -669,6 +842,7 @@ export function TerminalView({
   const font = useSettingsStore((s) => s.resolveFont(profile));
   const codexSettings = useSettingsStore((s) => s.codex);
   const activity = useTerminalStore((s) => s.instances.find((i) => i.id === instanceId)?.activity);
+  activityRef.current = activity;
   const cursorShape = useSettingsStore((s) => {
     const prof = s.profiles?.find((p) => p.name === profile);
     return (
@@ -687,7 +861,10 @@ export function TerminalView({
     activity.name === "Codex"
       ? false
       : cursorBlink;
-
+  const nativeCursorHidden = isOverlayCaretActivity(activity);
+  useEffect(() => {
+    overlayCaretUpdaterRef.current?.();
+  }, [activity, isFocused, font, cursorShape]);
   useEffect(() => {
     const term = terminalRef.current;
     if (!term?.options) return;
@@ -700,14 +877,22 @@ export function TerminalView({
       background: "#0C0C0C",
       foreground: "#F0F0F0",
       cursor: "#FFFFFF",
+      cursorAccent: "#0C0C0C",
       selectionBackground: "#232042",
     };
 
     const fontFamily = `'${font.face}', 'Cascadia Mono', 'Consolas', monospace`;
     try {
-      term.options.theme = scheme
+      const resolvedTheme = scheme
         ? { ...defaultTheme, ...colorSchemeToXtermTheme(scheme as unknown as WTColorScheme) }
         : defaultTheme;
+      term.options.theme = nativeCursorHidden
+        ? {
+            ...resolvedTheme,
+            cursor: "rgba(0, 0, 0, 0)",
+            cursorAccent: "rgba(0, 0, 0, 0)",
+          }
+        : resolvedTheme;
       term.options.fontSize = font.size;
       term.options.fontFamily = fontFamily;
       const cursorOptions = toXtermCursorOptions(cursorShape);
@@ -724,7 +909,14 @@ export function TerminalView({
     } catch {
       /* xterm mock may not support options setter */
     }
-  }, [currentSchemeName, colorSchemes, font, cursorShape, effectiveCursorBlink]);
+  }, [
+    currentSchemeName,
+    colorSchemes,
+    font,
+    cursorShape,
+    effectiveCursorBlink,
+    nativeCursorHidden,
+  ]);
 
   // Reactively update xterm overviewRuler width when scrollbarStyle changes
   const scrollbarStyleForEffect = useSettingsStore(
@@ -764,14 +956,21 @@ export function TerminalView({
 
   return (
     <div
+      ref={wrapperRef}
       data-testid={`terminal-view-${instanceId}`}
-      className={`h-full w-full ${scrollbarClass}`}
+      className={`relative h-full w-full ${scrollbarClass} ${nativeCursorHidden ? "terminal-native-cursor-hidden" : ""}`}
       style={{
         background: termBg,
         padding: `${pt}px ${pr}px ${pb}px ${pl}px`,
       }}
     >
       <div ref={containerRef} className="h-full w-full" />
+      <div
+        ref={overlayCaretRef}
+        data-testid={`terminal-overlay-caret-${instanceId}`}
+        className="terminal-overlay-caret pointer-events-none absolute"
+        style={{ opacity: 0 }}
+      />
     </div>
   );
 }

--- a/ui/src/hooks/useSessionPersistence.ts
+++ b/ui/src/hooks/useSessionPersistence.ts
@@ -51,6 +51,8 @@ export function useSessionPersistence() {
               cursorShape: (p.cursorShape ??
                 "bar") as import("@/stores/settings-store").CursorShape,
               cursorBlink: p.cursorBlink ?? defaultProfileDefaults.cursorBlink,
+              stabilizeInteractiveCursor:
+                p.stabilizeInteractiveCursor ?? defaultProfileDefaults.stabilizeInteractiveCursor,
               padding: p.padding ?? { top: 8, right: 8, bottom: 8, left: 8 },
               scrollbackLines: p.scrollbackLines ?? 9001,
               opacity: p.opacity ?? 100,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -149,3 +149,30 @@
  *   - separate: width = 14, FitAddon reserves scrollbar space
  * CSS classes (scrollbar-overlay / scrollbar-separate) applied for test hooks only.
  */
+
+.terminal-sync-output-active .xterm-cursor-layer,
+.terminal-sync-output-active .xterm-cursor {
+  opacity: 0 !important;
+}
+
+.terminal-sync-output-active .xterm-helper-textarea {
+  caret-color: transparent !important;
+}
+
+.terminal-native-cursor-hidden .xterm-cursor-layer,
+.terminal-native-cursor-hidden .xterm-cursor {
+  opacity: 0 !important;
+}
+
+.terminal-native-cursor-hidden .xterm-helper-textarea {
+  caret-color: transparent !important;
+}
+
+.terminal-overlay-caret {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: #ffffff;
+  will-change: transform;
+  z-index: 3;
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -172,7 +172,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  background: #ffffff;
+  background: var(--terminal-overlay-caret-color, #ffffff);
   will-change: transform;
   z-index: 3;
 }

--- a/ui/src/lib/persist-session.test.ts
+++ b/ui/src/lib/persist-session.test.ts
@@ -159,6 +159,7 @@ describe("persistSession", () => {
         hidden: true,
         cursorShape: "filledBox",
         cursorBlink: false,
+        stabilizeInteractiveCursor: false,
         padding: { top: 4, right: 4, bottom: 4, left: 4 },
         scrollbackLines: 5000,
         opacity: 80,

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -80,6 +80,7 @@ async function persistSessionCore(): Promise<void> {
       hidden: p.hidden,
       cursorShape: p.cursorShape,
       cursorBlink: p.cursorBlink,
+      stabilizeInteractiveCursor: p.stabilizeInteractiveCursor,
       padding: p.padding,
       scrollbackLines: p.scrollbackLines,
       opacity: p.opacity,

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -209,6 +209,7 @@ export interface ProfileDefaults {
   colorScheme?: string;
   cursorShape?: string;
   cursorBlink?: boolean;
+  stabilizeInteractiveCursor?: boolean;
   padding?: PaddingSettings;
   scrollbackLines?: number;
   opacity?: number;
@@ -289,6 +290,7 @@ export interface Profile {
   hidden: boolean;
   cursorShape?: string;
   cursorBlink?: boolean;
+  stabilizeInteractiveCursor?: boolean;
   padding?: PaddingSettings;
   scrollbackLines?: number;
   opacity?: number;

--- a/ui/src/stores/settings-store.test.ts
+++ b/ui/src/stores/settings-store.test.ts
@@ -11,6 +11,7 @@ describe("settings-store", () => {
     expect(profileDefaults.font.face).toBe("Cascadia Mono");
     expect(profileDefaults.font.size).toBe(14);
     expect(profileDefaults.font.weight).toBe("normal");
+    expect(profileDefaults.stabilizeInteractiveCursor).toBe(true);
   });
 
   it("has default profiles", () => {
@@ -39,11 +40,13 @@ describe("settings-store", () => {
     useSettingsStore.getState().setProfileDefaults({
       cursorBlink: false,
       cursorShape: "filledBox",
+      stabilizeInteractiveCursor: false,
     });
 
     const profile = useSettingsStore.getState().profiles[0];
     expect(profile.cursorBlink).toBe(false);
     expect(profile.cursorShape).toBe("filledBox");
+    expect(profile.stabilizeInteractiveCursor).toBe(false);
   });
 
   it("does not overwrite profile values that differ from previous defaults", () => {
@@ -114,6 +117,7 @@ describe("settings-store", () => {
       hidden: false,
       cursorShape: "bar",
       cursorBlink: true,
+      stabilizeInteractiveCursor: true,
       padding: { top: 8, right: 8, bottom: 8, left: 8 },
       scrollbackLines: 9001,
       opacity: 100,
@@ -152,6 +156,7 @@ describe("settings-store", () => {
           hidden: false,
           cursorShape: "bar",
           cursorBlink: true,
+          stabilizeInteractiveCursor: true,
           padding: { top: 8, right: 8, bottom: 8, left: 8 },
           scrollbackLines: 9001,
           opacity: 100,
@@ -325,6 +330,7 @@ describe("settings-store", () => {
           hidden: false,
           cursorShape: "bar",
           cursorBlink: true,
+          stabilizeInteractiveCursor: true,
           padding: { top: 8, right: 8, bottom: 8, left: 8 },
           scrollbackLines: 9001,
           opacity: 100,

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -134,6 +134,7 @@ export interface ProfileDefaults {
   colorScheme: string;
   cursorShape: CursorShape;
   cursorBlink: boolean;
+  stabilizeInteractiveCursor: boolean;
   padding: PaddingSettings;
   scrollbackLines: number;
   opacity: number;
@@ -159,6 +160,7 @@ export interface Profile {
   hidden: boolean;
   cursorShape: CursorShape;
   cursorBlink: boolean;
+  stabilizeInteractiveCursor: boolean;
   padding: PaddingSettings;
   scrollbackLines: number;
   opacity: number;
@@ -188,6 +190,7 @@ export const INHERITABLE_KEYS: (keyof ProfileDefaults)[] = [
   "colorScheme",
   "cursorShape",
   "cursorBlink",
+  "stabilizeInteractiveCursor",
   "padding",
   "scrollbackLines",
   "opacity",
@@ -401,6 +404,7 @@ export const defaultProfileDefaults: ProfileDefaults = {
   colorScheme: "CampbellClear",
   cursorShape: "bar",
   cursorBlink: true,
+  stabilizeInteractiveCursor: true,
   padding: { ...defaultPadding },
   scrollbackLines: 9001,
   opacity: 100,

--- a/ui/src/test/e2e.test.ts
+++ b/ui/src/test/e2e.test.ts
@@ -606,6 +606,7 @@ function makeTestProfile(overrides: {
     startupCommand: "",
     cursorShape: "bar",
     cursorBlink: true,
+    stabilizeInteractiveCursor: true,
     padding: { top: 8, right: 8, bottom: 8, left: 8 },
     scrollbackLines: 9001,
     opacity: 100,


### PR DESCRIPTION
## Summary
- stabilize terminal cursor rendering for Codex and Claude sessions in Laymux
- add an overlay caret for interactive app sessions while suppressing xterm's native cursor rendering path
- track synchronized output state and harden TerminalView tests around interactive cursor behavior

## What changed
- keep the visible caret in app-managed overlay mode for Codex and Claude
- force xterm's internal cursor onto a minimal non-blinking bar path during overlay mode to avoid active-cell repaint artifacts
- preserve synchronized output tracking and cursor visibility handling for frame-based redraws

## Verification
- reproduced the issue in Laymux PowerShell with Codex
- verified the cursor no longer jumps between draw positions and no longer causes character-cell flicker at the active caret location
- passed `npm test -- src/components/views/TerminalView.test.tsx`