### PR TITLE
Claude 전용 상태 아이콘 제거

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -14,7 +14,6 @@
   --accent-08: rgba(137, 180, 250, 0.08);
   --accent-06: rgba(137, 180, 250, 0.06);
   --orange-15: rgba(217, 119, 87, 0.15);
-  --claude: #d97757;
   --green: #a6e3a1;
   --red: #f38ba8;
   --border: #313244;

--- a/ui/src/lib/claude-activity-handler.test.ts
+++ b/ui/src/lib/claude-activity-handler.test.ts
@@ -54,10 +54,10 @@ describe("ClaudeActivityHandler", () => {
       });
     });
 
-    it("returns Claude idle status for idle title", () => {
+    it("returns shell idle status for idle title (no Claude-specific icon)", () => {
       expect(handler.computeStatus(raw({ title: "✳ Claude Code" }))).toEqual({
-        icon: "✳",
-        color: "var(--claude)",
+        icon: "—",
+        color: "var(--text-secondary)",
       });
     });
 
@@ -180,8 +180,8 @@ describe("ClaudeActivityHandler", () => {
   });
 
   describe("Claude lifecycle scenarios", () => {
-    it("shows idle status before a task starts", () => {
-      expect(handler.computeStatus(raw({ title: "✳ Claude Code" })).icon).toBe("✳");
+    it("shows shell idle status before a task starts", () => {
+      expect(handler.computeStatus(raw({ title: "✳ Claude Code" })).icon).toBe("—");
     });
 
     it("shows combined message while actively working", () => {

--- a/ui/src/lib/claude-activity-handler.ts
+++ b/ui/src/lib/claude-activity-handler.ts
@@ -1,7 +1,6 @@
 import { ShellActivityHandler } from "./shell-activity-handler";
-import type { RawTerminalState, StatusResult } from "./activity-handler";
+import type { RawTerminalState } from "./activity-handler";
 
-const CLAUDE_IDLE_PREFIX = "\u2733";
 const WORKING_STAR_SPINNERS = ["\u2736", "\u273B", "\u273D", "\u2722"];
 const DEFAULT_STATUS_MESSAGE_DELIMITER = " \u00b7 ";
 
@@ -23,18 +22,6 @@ function extractTitleMessage(title: string | undefined): string | undefined {
 export class ClaudeActivityHandler extends ShellActivityHandler {
   shouldPreserveActivityOnExitCode(): boolean {
     return true;
-  }
-
-  computeStatus(raw: RawTerminalState): StatusResult {
-    if (raw.outputActive || raw.exitCode !== undefined) {
-      return super.computeStatus(raw);
-    }
-
-    if (raw.title?.startsWith(CLAUDE_IDLE_PREFIX)) {
-      return { icon: "\u2733", color: "var(--claude)" };
-    }
-
-    return super.computeStatus(raw);
   }
 
   computeStatusMessage(raw: RawTerminalState): string | undefined {

--- a/ui/src/lib/workspace-summary.test.ts
+++ b/ui/src/lib/workspace-summary.test.ts
@@ -557,10 +557,10 @@ describe("formatActivity", () => {
     expect(result.color).toBe("var(--accent)");
   });
 
-  it("returns Claude brand color for Claude app", () => {
+  it("returns accent color for Claude app", () => {
     const result = formatActivity({ type: "interactiveApp", name: "Claude" });
     expect(result.label).toBe("Claude");
-    expect(result.color).toBe("var(--claude)");
+    expect(result.color).toBe("var(--accent)");
   });
 });
 
@@ -718,10 +718,10 @@ describe("computeCommandStatus", () => {
       expect(s.icon).toBe("⏳");
     });
 
-    it("Claude interactiveApp without lastCommand: idle with ✳ → ✳", () => {
+    it("Claude interactiveApp without lastCommand: idle with ✳ → — (shell default)", () => {
       const s = computeCommandStatus(undefined, false, undefined, claudeActivity, "✳ Claude Code");
-      expect(s.icon).toBe("✳");
-      expect(s.color).toBe("var(--claude)");
+      expect(s.icon).toBe("—");
+      expect(s.color).toBe("var(--text-secondary)");
     });
 
     it("Claude interactiveApp without lastCommand: exitCode=0 → ✓", () => {
@@ -760,11 +760,11 @@ describe("computeCommandStatus", () => {
       expect(s.text).toBe("Task completed successfully");
     });
 
-    it("Claude idle with ✳ title: no exitCode → ✳ Claude accent", () => {
+    it("Claude idle with ✳ title: no exitCode → — (shell default)", () => {
       // Claude entered but no task completed yet. Title shows ✳ (idle prefix).
       const s = computeCommandStatus(undefined, false, undefined, claudeActivity, "✳ Claude Code");
-      expect(s.icon).toBe("✳");
-      expect(s.color).toBe("var(--claude)");
+      expect(s.icon).toBe("—");
+      expect(s.color).toBe("var(--text-secondary)");
     });
 
     it("Claude idle without title: no exitCode → — (fallback)", () => {

--- a/ui/src/lib/workspace-summary.ts
+++ b/ui/src/lib/workspace-summary.ts
@@ -321,7 +321,7 @@ export function formatActivity(activity: TerminalActivityInfo | undefined): {
     case "running":
       return { label: "running", color: "var(--yellow)" };
     case "interactiveApp": {
-      if (activity.name === "Claude") return { label: "Claude", color: "var(--claude)" };
+      if (activity.name === "Claude") return { label: "Claude", color: "var(--accent)" };
       return { label: activity.name ?? "app", color: "var(--accent)" };
     }
   }


### PR DESCRIPTION
## Summary
- Claude idle 전용 `✳` 아이콘/`var(--claude)` 색상 제거 → 셸 기본 `—` 아이콘 사용
- `computeStatus` 메서드 제거 (ShellActivityHandler 상속)
- `--claude` CSS 변수 제거, `formatActivity`에서 `var(--accent)` 사용

## Test plan
- [x] 전체 1457개 테스트 통과

Fixes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)