### PR TITLE
fix: 숨긴 워크스페이스 키보드 네비게이션 제외

### DIFF
--- a/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -1283,5 +1283,69 @@ describe("useKeyboardShortcuts", () => {
       fireKey("9", { ctrlKey: true, altKey: true });
       expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ids[1]);
     });
+
+    it("ArrowDown from hidden active workspace goes to next visible in sorted order", () => {
+      // [Default, WS2, WS3] — hide WS2, make WS2 active
+      useWorkspaceStore.getState().addWorkspace("WS2", "default-layout");
+      useWorkspaceStore.getState().addWorkspace("WS3", "default-layout");
+      const ids = useWorkspaceStore.getState().workspaces.map((ws) => ws.id);
+
+      useUiStore.getState().toggleWorkspaceHidden(ids[1]); // hide WS2
+      useWorkspaceStore.getState().setActiveWorkspace(ids[1]); // active = WS2 (hidden)
+
+      renderHook(() => useKeyboardShortcuts());
+
+      // ArrowDown from hidden WS2 should go to WS3 (next visible after WS2 in sorted order)
+      fireKey("ArrowDown", { ctrlKey: true, altKey: true });
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ids[2]);
+    });
+
+    it("ArrowUp from hidden active workspace goes to previous visible in sorted order", () => {
+      // [Default, WS2, WS3] — hide WS2, make WS2 active
+      useWorkspaceStore.getState().addWorkspace("WS2", "default-layout");
+      useWorkspaceStore.getState().addWorkspace("WS3", "default-layout");
+      const ids = useWorkspaceStore.getState().workspaces.map((ws) => ws.id);
+
+      useUiStore.getState().toggleWorkspaceHidden(ids[1]); // hide WS2
+      useWorkspaceStore.getState().setActiveWorkspace(ids[1]); // active = WS2 (hidden)
+
+      renderHook(() => useKeyboardShortcuts());
+
+      // ArrowUp from hidden WS2 should go to Default (previous visible before WS2)
+      fireKey("ArrowUp", { ctrlKey: true, altKey: true });
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ids[0]);
+    });
+
+    it("ArrowDown from hidden active at end wraps to first visible", () => {
+      // [Default, WS2, WS3] — hide WS3, make WS3 active
+      useWorkspaceStore.getState().addWorkspace("WS2", "default-layout");
+      useWorkspaceStore.getState().addWorkspace("WS3", "default-layout");
+      const ids = useWorkspaceStore.getState().workspaces.map((ws) => ws.id);
+
+      useUiStore.getState().toggleWorkspaceHidden(ids[2]); // hide WS3
+      useWorkspaceStore.getState().setActiveWorkspace(ids[2]); // active = WS3 (hidden)
+
+      renderHook(() => useKeyboardShortcuts());
+
+      // ArrowDown from hidden WS3 (end) should wrap to Default (first visible)
+      fireKey("ArrowDown", { ctrlKey: true, altKey: true });
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ids[0]);
+    });
+
+    it("ArrowUp from hidden active at start wraps to last visible", () => {
+      // [Default, WS2, WS3] — hide Default, make Default active
+      useWorkspaceStore.getState().addWorkspace("WS2", "default-layout");
+      useWorkspaceStore.getState().addWorkspace("WS3", "default-layout");
+      const ids = useWorkspaceStore.getState().workspaces.map((ws) => ws.id);
+
+      useUiStore.getState().toggleWorkspaceHidden(ids[0]); // hide Default
+      useWorkspaceStore.getState().setActiveWorkspace(ids[0]); // active = Default (hidden)
+
+      renderHook(() => useKeyboardShortcuts());
+
+      // ArrowUp from hidden Default (start) should wrap to WS3 (last visible)
+      fireKey("ArrowUp", { ctrlKey: true, altKey: true });
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ids[2]);
+    });
   });
 });

--- a/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -1214,4 +1214,74 @@ describe("useKeyboardShortcuts", () => {
 
     expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ws2.id);
   });
+
+  // --- Hidden workspace navigation ---
+  describe("hidden workspace navigation", () => {
+    it("Ctrl+Alt+ArrowDown skips hidden workspaces", () => {
+      useWorkspaceStore.getState().addWorkspace("WS2", "default-layout");
+      useWorkspaceStore.getState().addWorkspace("WS3", "default-layout");
+      const ids = useWorkspaceStore.getState().workspaces.map((ws) => ws.id);
+
+      // Hide WS2 (the middle one)
+      useUiStore.getState().toggleWorkspaceHidden(ids[1]);
+
+      renderHook(() => useKeyboardShortcuts());
+
+      // From Default (index 0), ArrowDown should skip WS2 and go to WS3
+      fireKey("ArrowDown", { ctrlKey: true, altKey: true });
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ids[2]);
+    });
+
+    it("Ctrl+Alt+ArrowUp skips hidden workspaces", () => {
+      useWorkspaceStore.getState().addWorkspace("WS2", "default-layout");
+      useWorkspaceStore.getState().addWorkspace("WS3", "default-layout");
+      const ids = useWorkspaceStore.getState().workspaces.map((ws) => ws.id);
+
+      // Hide WS2 (the middle one)
+      useUiStore.getState().toggleWorkspaceHidden(ids[1]);
+
+      // Set active to WS3
+      useWorkspaceStore.getState().setActiveWorkspace(ids[2]);
+
+      renderHook(() => useKeyboardShortcuts());
+
+      // From WS3, ArrowUp should skip WS2 and go to Default
+      fireKey("ArrowUp", { ctrlKey: true, altKey: true });
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ids[0]);
+    });
+
+    it("Ctrl+Alt+number skips hidden workspaces in index", () => {
+      useWorkspaceStore.getState().addWorkspace("WS2", "default-layout");
+      useWorkspaceStore.getState().addWorkspace("WS3", "default-layout");
+      const ids = useWorkspaceStore.getState().workspaces.map((ws) => ws.id);
+
+      // Hide Default (first workspace)
+      useUiStore.getState().toggleWorkspaceHidden(ids[0]);
+
+      renderHook(() => useKeyboardShortcuts());
+
+      // Ctrl+Alt+1 should go to WS2 (first visible), not Default
+      fireKey("1", { ctrlKey: true, altKey: true });
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ids[1]);
+
+      // Ctrl+Alt+2 should go to WS3 (second visible)
+      fireKey("2", { ctrlKey: true, altKey: true });
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ids[2]);
+    });
+
+    it("Ctrl+Alt+9 goes to last visible workspace", () => {
+      useWorkspaceStore.getState().addWorkspace("WS2", "default-layout");
+      useWorkspaceStore.getState().addWorkspace("WS3", "default-layout");
+      const ids = useWorkspaceStore.getState().workspaces.map((ws) => ws.id);
+
+      // Hide WS3 (last workspace)
+      useUiStore.getState().toggleWorkspaceHidden(ids[2]);
+
+      renderHook(() => useKeyboardShortcuts());
+
+      // Ctrl+Alt+9 should go to WS2 (last visible), not WS3
+      fireKey("9", { ctrlKey: true, altKey: true });
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(ids[1]);
+    });
+  });
 });

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -5,7 +5,7 @@ import { useGridStore } from "@/stores/grid-store";
 import { useNotificationStore } from "@/stores/notification-store";
 import { useUiStore } from "@/stores/ui-store";
 import { useSettingsStore } from "@/stores/settings-store";
-import { sortWorkspaces } from "@/lib/workspace-sort";
+import { sortWorkspaces, filterVisibleWorkspaces } from "@/lib/workspace-sort";
 import { findPaneInDirection, type Direction } from "@/lib/pane-navigation";
 import { findNotificationNavTarget } from "@/lib/notification-navigation";
 import { getDockForDirection, getDockExitDirection } from "@/lib/dock-navigation";
@@ -173,6 +173,8 @@ export function useKeyboardShortcuts() {
         workspaceDisplayOrder,
         notifications,
       );
+      const { hiddenWorkspaceIds } = useUiStore.getState();
+      const visibleWorkspaces = filterVisibleWorkspaces(workspaces, hiddenWorkspaceIds);
 
       // Ctrl+Shift shortcuts (non-workspace: sidebar, notifications)
       if (e.shiftKey && !e.altKey) {
@@ -258,20 +260,20 @@ export function useKeyboardShortcuts() {
           return;
         }
 
-        // Ctrl+Alt+1~8: switch workspace by index
+        // Ctrl+Alt+1~8: switch workspace by index (visible only)
         if (e.key >= "1" && e.key <= "8") {
           e.preventDefault();
           const idx = parseInt(e.key) - 1;
-          if (idx < workspaces.length) {
-            switchWorkspace(workspaces[idx].id);
+          if (idx < visibleWorkspaces.length) {
+            switchWorkspace(visibleWorkspaces[idx].id);
           }
           return;
         }
 
-        // Ctrl+Alt+9: last workspace
+        // Ctrl+Alt+9: last visible workspace
         if (e.key === "9") {
           e.preventDefault();
-          const last = workspaces.at(-1);
+          const last = visibleWorkspaces.at(-1);
           if (last) switchWorkspace(last.id);
           return;
         }
@@ -290,21 +292,23 @@ export function useKeyboardShortcuts() {
           return;
         }
 
-        // Ctrl+Alt+ArrowDown: next workspace
+        // Ctrl+Alt+ArrowDown: next visible workspace
         if (e.key === "ArrowDown") {
           e.preventDefault();
-          const currentIdx = workspaces.findIndex((ws) => ws.id === activeWorkspaceId);
-          const nextIdx = (currentIdx + 1) % workspaces.length;
-          switchWorkspace(workspaces[nextIdx].id);
+          if (visibleWorkspaces.length === 0) return;
+          const currentIdx = visibleWorkspaces.findIndex((ws) => ws.id === activeWorkspaceId);
+          const nextIdx = (currentIdx + 1) % visibleWorkspaces.length;
+          switchWorkspace(visibleWorkspaces[nextIdx].id);
           return;
         }
 
-        // Ctrl+Alt+ArrowUp: previous workspace
+        // Ctrl+Alt+ArrowUp: previous visible workspace
         if (e.key === "ArrowUp") {
           e.preventDefault();
-          const currentIdx = workspaces.findIndex((ws) => ws.id === activeWorkspaceId);
-          const prevIdx = (currentIdx - 1 + workspaces.length) % workspaces.length;
-          switchWorkspace(workspaces[prevIdx].id);
+          if (visibleWorkspaces.length === 0) return;
+          const currentIdx = visibleWorkspaces.findIndex((ws) => ws.id === activeWorkspaceId);
+          const prevIdx = (currentIdx - 1 + visibleWorkspaces.length) % visibleWorkspaces.length;
+          switchWorkspace(visibleWorkspaces[prevIdx].id);
           return;
         }
 

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -297,8 +297,18 @@ export function useKeyboardShortcuts() {
           e.preventDefault();
           if (visibleWorkspaces.length === 0) return;
           const currentIdx = visibleWorkspaces.findIndex((ws) => ws.id === activeWorkspaceId);
-          const nextIdx = (currentIdx + 1) % visibleWorkspaces.length;
-          switchWorkspace(visibleWorkspaces[nextIdx].id);
+          if (currentIdx >= 0) {
+            // Active workspace is visible — simple cyclic navigation
+            const nextIdx = (currentIdx + 1) % visibleWorkspaces.length;
+            switchWorkspace(visibleWorkspaces[nextIdx].id);
+          } else {
+            // Active workspace is hidden — find next visible after current position in full sorted order
+            const fullIdx = workspaces.findIndex((ws) => ws.id === activeWorkspaceId);
+            const next =
+              visibleWorkspaces.find((vws) => workspaces.indexOf(vws) > fullIdx) ??
+              visibleWorkspaces[0];
+            switchWorkspace(next.id);
+          }
           return;
         }
 
@@ -307,8 +317,18 @@ export function useKeyboardShortcuts() {
           e.preventDefault();
           if (visibleWorkspaces.length === 0) return;
           const currentIdx = visibleWorkspaces.findIndex((ws) => ws.id === activeWorkspaceId);
-          const prevIdx = (currentIdx - 1 + visibleWorkspaces.length) % visibleWorkspaces.length;
-          switchWorkspace(visibleWorkspaces[prevIdx].id);
+          if (currentIdx >= 0) {
+            // Active workspace is visible — simple cyclic navigation
+            const prevIdx = (currentIdx - 1 + visibleWorkspaces.length) % visibleWorkspaces.length;
+            switchWorkspace(visibleWorkspaces[prevIdx].id);
+          } else {
+            // Active workspace is hidden — find previous visible before current position in full sorted order
+            const fullIdx = workspaces.findIndex((ws) => ws.id === activeWorkspaceId);
+            const prev =
+              [...visibleWorkspaces].reverse().find((vws) => workspaces.indexOf(vws) < fullIdx) ??
+              visibleWorkspaces[visibleWorkspaces.length - 1];
+            switchWorkspace(prev.id);
+          }
           return;
         }
 

--- a/ui/src/lib/workspace-sort.test.ts
+++ b/ui/src/lib/workspace-sort.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sortWorkspaces } from "./workspace-sort";
+import { sortWorkspaces, filterVisibleWorkspaces } from "./workspace-sort";
 import type { Workspace } from "@/stores/types";
 
 function ws(id: string): Workspace {
@@ -54,5 +54,31 @@ describe("sortWorkspaces", () => {
       const result = sortWorkspaces(workspaces, "notification", ["c", "a", "b"], []);
       expect(result.map((w) => w.id)).toEqual(["a", "b", "c"]);
     });
+  });
+});
+
+describe("filterVisibleWorkspaces", () => {
+  const workspaces = [ws("a"), ws("b"), ws("c")];
+
+  it("returns all workspaces when hiddenIds is empty", () => {
+    const result = filterVisibleWorkspaces(workspaces, new Set());
+    expect(result).toHaveLength(3);
+    expect(result.map((w) => w.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("excludes hidden workspace", () => {
+    const result = filterVisibleWorkspaces(workspaces, new Set(["b"]));
+    expect(result.map((w) => w.id)).toEqual(["a", "c"]);
+  });
+
+  it("excludes multiple hidden workspaces", () => {
+    const result = filterVisibleWorkspaces(workspaces, new Set(["a", "c"]));
+    expect(result.map((w) => w.id)).toEqual(["b"]);
+  });
+
+  it("preserves sort order from input", () => {
+    const sorted = [ws("c"), ws("a"), ws("b")];
+    const result = filterVisibleWorkspaces(sorted, new Set(["a"]));
+    expect(result.map((w) => w.id)).toEqual(["c", "b"]);
   });
 });

--- a/ui/src/lib/workspace-sort.ts
+++ b/ui/src/lib/workspace-sort.ts
@@ -9,6 +9,18 @@ interface NotificationLike {
 }
 
 /**
+ * Filter out hidden workspaces from a (pre-sorted) list.
+ * Preserves the input order — apply after sortWorkspaces().
+ */
+export function filterVisibleWorkspaces(
+  workspaces: Workspace[],
+  hiddenIds: Set<string>,
+): Workspace[] {
+  if (hiddenIds.size === 0) return workspaces;
+  return workspaces.filter((ws) => !hiddenIds.has(ws.id));
+}
+
+/**
  * Sort workspaces to match the visual display order.
  * - "manual": follows workspaceDisplayOrder (DnD), falls back to natural array order.
  * - "notification": unread-notification recency first, then original array order.


### PR DESCRIPTION
## Summary
- 숨긴 워크스페이스가 `Ctrl+Alt+방향키` (이전/다음) 탐색에서 건너뛰어지도록 수정
- 숨긴 워크스페이스가 `Ctrl+Alt+1~8` 숫자 인덱싱에서 제외되도록 수정 (visible만 카운트)
- `filterVisibleWorkspaces()` 유틸 함수를 `workspace-sort.ts`에 추가하여 기존 정렬과 필터링 관심사를 분리

## Changed files
- `ui/src/lib/workspace-sort.ts` — `filterVisibleWorkspaces()` 추가
- `ui/src/lib/workspace-sort.test.ts` — 단위 테스트 4개
- `ui/src/hooks/useKeyboardShortcuts.ts` — visible 워크스페이스 기반 네비게이션
- `ui/src/hooks/useKeyboardShortcuts.test.ts` — hidden workspace 테스트 4개

## Test plan
- [x] `npx vitest run` — 66개 파일, 1481개 테스트 전체 통과
- [ ] 수동: 워크스페이스 숨기기 후 Ctrl+Alt+↓/↑로 건너뛰는지 확인
- [ ] 수동: 워크스페이스 숨기기 후 Ctrl+Alt+숫자가 visible 기준인지 확인

Fixes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)