### PR TITLE
feat: settings 구조 검증 및 복구 로직 추가

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -99,6 +99,23 @@ pub fn load_settings() -> Result<crate::settings::Settings, String> {
 }
 
 #[tauri::command]
+pub fn load_settings_validated() -> Result<crate::settings::SettingsLoadResult, String> {
+    Ok(crate::settings::load_settings_validated())
+}
+
+#[tauri::command]
+pub fn reset_settings() -> Result<crate::settings::Settings, String> {
+    let default_settings = crate::settings::Settings::default();
+    crate::settings::save_settings(&default_settings)?;
+    Ok(default_settings)
+}
+
+#[tauri::command]
+pub fn get_settings_path() -> Result<String, String> {
+    Ok(crate::settings::settings_path().display().to_string())
+}
+
+#[tauri::command]
 pub fn save_settings(settings: crate::settings::Settings) -> Result<(), String> {
     crate::settings::save_settings(&settings)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -142,6 +142,9 @@ pub fn run() {
             commands::read_file_for_viewer,
             commands::list_directory,
             commands::get_automation_info,
+            commands::load_settings_validated,
+            commands::reset_settings,
+            commands::get_settings_path,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -1,5 +1,7 @@
 pub mod models;
+pub mod validation;
 pub use models::*;
+pub use validation::{SettingsLoadResult, ValidationWarning};
 
 use std::fs;
 use std::path::PathBuf;
@@ -35,13 +37,66 @@ pub(crate) fn dirs_config_path() -> Option<PathBuf> {
 
 /// Load settings from disk. Returns default settings if file doesn't exist.
 pub fn load_settings() -> Settings {
+    let result = load_settings_validated();
+    match result {
+        SettingsLoadResult::Ok { settings, .. } => settings,
+        SettingsLoadResult::Repaired { settings, .. } => settings,
+        SettingsLoadResult::ParseError { settings, .. } => settings,
+    }
+}
+
+/// Load settings from disk with full validation result.
+/// Returns a `SettingsLoadResult` that the frontend can use to show recovery UI.
+pub fn load_settings_validated() -> SettingsLoadResult {
     let path = settings_path();
-    let mut settings = match fs::read_to_string(&path) {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
-        Err(_) => Settings::default(),
+    let path_str = path.display().to_string();
+
+    let raw_content = match fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(_) => {
+            // File doesn't exist — return default (no error, no warnings)
+            return SettingsLoadResult::Ok {
+                settings: Settings::default(),
+                warnings: vec![],
+            };
+        }
     };
+
+    // Try to parse JSON
+    let mut settings: Settings = match serde_json::from_str(&raw_content) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path_str, "Settings JSON 파싱 실패, 기본 설정 사용");
+            return SettingsLoadResult::ParseError {
+                settings: Settings::default(),
+                error: e.to_string(),
+                settings_path: path_str,
+            };
+        }
+    };
+
+    // Apply migrations
     migrate_settings(&mut settings);
-    settings
+
+    // Validate and repair
+    let warnings = validation::validate_and_repair(&mut settings);
+
+    if warnings.is_empty() {
+        SettingsLoadResult::Ok {
+            settings,
+            warnings: vec![],
+        }
+    } else {
+        let has_repairs = warnings.iter().any(|w| w.repaired);
+        if has_repairs {
+            tracing::info!(
+                warning_count = warnings.len(),
+                "Settings 검증 완료: {}개 항목 자동 수정",
+                warnings.iter().filter(|w| w.repaired).count()
+            );
+        }
+        SettingsLoadResult::Repaired { settings, warnings }
+    }
 }
 
 /// Apply settings migrations.

--- a/src-tauri/src/settings/validation.rs
+++ b/src-tauri/src/settings/validation.rs
@@ -303,6 +303,86 @@ fn validate_docks(settings: &mut Settings, warnings: &mut Vec<ValidationWarning>
                 repaired: true,
             });
         }
+
+        // Validate dock pane coordinates
+        let mut to_remove = Vec::new();
+        for (i, pane) in dock.panes.iter_mut().enumerate() {
+            let pane_path = format!("{dock_path}.panes[{i}]");
+
+            if pane.x.is_nan()
+                || pane.y.is_nan()
+                || pane.w.is_nan()
+                || pane.h.is_nan()
+                || pane.x.is_infinite()
+                || pane.y.is_infinite()
+                || pane.w.is_infinite()
+                || pane.h.is_infinite()
+            {
+                to_remove.push(i);
+                warnings.push(ValidationWarning {
+                    path: pane_path,
+                    message: "독 Pane 좌표에 NaN/Infinity 값이 있어 제거했습니다.".into(),
+                    repaired: true,
+                });
+                continue;
+            }
+
+            if !is_valid_ratio(pane.x) {
+                let old = pane.x;
+                pane.x = clamp_ratio(pane.x);
+                warnings.push(ValidationWarning {
+                    path: format!("{pane_path}.x"),
+                    message: format!(
+                        "독 Pane x 좌표 {old}이(가) 유효 범위(0.0~1.0)를 벗어나 {:.2}로 수정했습니다.",
+                        pane.x
+                    ),
+                    repaired: true,
+                });
+            }
+
+            if !is_valid_ratio(pane.y) {
+                let old = pane.y;
+                pane.y = clamp_ratio(pane.y);
+                warnings.push(ValidationWarning {
+                    path: format!("{pane_path}.y"),
+                    message: format!(
+                        "독 Pane y 좌표 {old}이(가) 유효 범위(0.0~1.0)를 벗어나 {:.2}로 수정했습니다.",
+                        pane.y
+                    ),
+                    repaired: true,
+                });
+            }
+
+            if !is_valid_dimension(pane.w) {
+                let old = pane.w;
+                pane.w = clamp_dimension(pane.w);
+                warnings.push(ValidationWarning {
+                    path: format!("{pane_path}.w"),
+                    message: format!(
+                        "독 Pane w 크기 {old}이(가) 유효 범위(0.0~1.0, >0)를 벗어나 {:.2}로 수정했습니다.",
+                        pane.w
+                    ),
+                    repaired: true,
+                });
+            }
+
+            if !is_valid_dimension(pane.h) {
+                let old = pane.h;
+                pane.h = clamp_dimension(pane.h);
+                warnings.push(ValidationWarning {
+                    path: format!("{pane_path}.h"),
+                    message: format!(
+                        "독 Pane h 크기 {old}이(가) 유효 범위(0.0~1.0, >0)를 벗어나 {:.2}로 수정했습니다.",
+                        pane.h
+                    ),
+                    repaired: true,
+                });
+            }
+        }
+
+        for i in to_remove.into_iter().rev() {
+            dock.panes.remove(i);
+        }
     }
 }
 
@@ -579,6 +659,69 @@ mod tests {
         assert!(warnings
             .iter()
             .any(|w| w.path.contains("size") && w.repaired));
+    }
+
+    #[test]
+    fn dock_pane_nan_coordinates_removed() {
+        let mut settings = Settings::default();
+        settings.docks[0].panes = vec![DockPaneSetting {
+            id: "dp-bad".into(),
+            view: serde_json::json!({"type": "TerminalView"}),
+            x: f64::NAN,
+            y: 0.0,
+            w: 1.0,
+            h: 1.0,
+        }];
+        let warnings = validate_and_repair(&mut settings);
+        assert!(settings.docks[0].panes.is_empty());
+        assert!(warnings.iter().any(|w| w.message.contains("NaN/Infinity")));
+    }
+
+    #[test]
+    fn dock_pane_out_of_range_is_clamped() {
+        let mut settings = Settings::default();
+        settings.docks[0].panes = vec![DockPaneSetting {
+            id: "dp-test".into(),
+            view: serde_json::json!({"type": "TerminalView"}),
+            x: 1.5,
+            y: -0.5,
+            w: 0.0,
+            h: 2.0,
+        }];
+        let warnings = validate_and_repair(&mut settings);
+        let pane = &settings.docks[0].panes[0];
+        assert_eq!(pane.x, 1.0);
+        assert_eq!(pane.y, 0.0);
+        assert!(pane.w > 0.0);
+        assert_eq!(pane.h, 1.0);
+        assert!(warnings.len() >= 4);
+    }
+
+    #[test]
+    fn dock_pane_infinity_removed() {
+        let mut settings = Settings::default();
+        settings.docks[0].panes = vec![
+            DockPaneSetting {
+                id: "dp-good".into(),
+                view: serde_json::json!({"type": "TerminalView"}),
+                x: 0.0,
+                y: 0.0,
+                w: 1.0,
+                h: 1.0,
+            },
+            DockPaneSetting {
+                id: "dp-inf".into(),
+                view: serde_json::json!({"type": "TerminalView"}),
+                x: 0.0,
+                y: 0.0,
+                w: f64::INFINITY,
+                h: 1.0,
+            },
+        ];
+        let warnings = validate_and_repair(&mut settings);
+        assert_eq!(settings.docks[0].panes.len(), 1);
+        assert_eq!(settings.docks[0].panes[0].id, "dp-good");
+        assert!(warnings.iter().any(|w| w.message.contains("NaN/Infinity")));
     }
 
     // ── 레이아웃 검증 ──

--- a/src-tauri/src/settings/validation.rs
+++ b/src-tauri/src/settings/validation.rs
@@ -44,23 +44,7 @@ pub enum SettingsLoadResult {
 pub fn validate_and_repair(settings: &mut Settings) -> Vec<ValidationWarning> {
     let mut warnings = Vec::new();
 
-    validate_workspaces(settings, &mut warnings);
-    validate_layouts(settings, &mut warnings);
-    validate_docks(settings, &mut warnings);
-    validate_profile_references(settings, &mut warnings);
-
-    // Ensure at least one workspace exists
-    if settings.workspaces.is_empty() {
-        let default = Settings::default();
-        settings.workspaces = default.workspaces;
-        warnings.push(ValidationWarning {
-            path: "workspaces".into(),
-            message: "워크스페이스가 비어 있어 기본 워크스페이스를 생성했습니다.".into(),
-            repaired: true,
-        });
-    }
-
-    // Ensure at least one profile exists
+    // Ensure at least one profile exists FIRST — workspace repair needs a valid profile name.
     if settings.profiles.is_empty() {
         let default = Settings::default();
         settings.profiles = default.profiles;
@@ -71,10 +55,33 @@ pub fn validate_and_repair(settings: &mut Settings) -> Vec<ValidationWarning> {
         });
     }
 
+    validate_workspaces(settings, &mut warnings);
+    validate_layouts(settings, &mut warnings);
+    validate_docks(settings, &mut warnings);
+    validate_profile_references(settings, &mut warnings);
+
+    // Ensure at least one workspace exists
+    if settings.workspaces.is_empty() {
+        let fallback_profile = resolve_fallback_profile(settings);
+        settings.workspaces = vec![super::models::Workspace {
+            id: format!("ws-{}", &uuid::Uuid::new_v4().to_string()[..8]),
+            name: "Workspace 1".into(),
+            layout_id: None,
+            panes: vec![default_workspace_pane(&fallback_profile)],
+        }];
+        warnings.push(ValidationWarning {
+            path: "workspaces".into(),
+            message: "워크스페이스가 비어 있어 기본 워크스페이스를 생성했습니다.".into(),
+            repaired: true,
+        });
+    }
+
     warnings
 }
 
 fn validate_workspaces(settings: &mut Settings, warnings: &mut Vec<ValidationWarning>) {
+    let fallback_profile = resolve_fallback_profile(settings);
+
     for (ws_idx, ws) in settings.workspaces.iter_mut().enumerate() {
         let ws_path = format!("workspaces[{ws_idx}]");
 
@@ -103,7 +110,7 @@ fn validate_workspaces(settings: &mut Settings, warnings: &mut Vec<ValidationWar
 
         // If all panes were removed, add a default pane
         if ws.panes.is_empty() {
-            ws.panes.push(default_workspace_pane());
+            ws.panes.push(default_workspace_pane(&fallback_profile));
             warnings.push(ValidationWarning {
                 path: format!("{ws_path}.panes"),
                 message: "유효한 Pane이 없어 기본 Pane을 추가했습니다.".into(),
@@ -359,7 +366,27 @@ fn clamp_dimension(v: f64) -> f64 {
     v.clamp(0.01, 1.0)
 }
 
-fn default_workspace_pane() -> WorkspacePane {
+/// Pick the best profile name for fallback panes:
+/// 1. settings.default_profile if non-empty and present in profiles
+/// 2. First profile in the list
+/// 3. "PowerShell" as absolute last resort
+fn resolve_fallback_profile(settings: &Settings) -> String {
+    let profile_names: Vec<&str> = settings.profiles.iter().map(|p| p.name.as_str()).collect();
+
+    if !settings.default_profile.is_empty()
+        && profile_names.contains(&settings.default_profile.as_str())
+    {
+        return settings.default_profile.clone();
+    }
+
+    if let Some(first) = settings.profiles.first() {
+        return first.name.clone();
+    }
+
+    "PowerShell".into()
+}
+
+fn default_workspace_pane(profile_name: &str) -> WorkspacePane {
     WorkspacePane {
         id: format!("pane-{}", &uuid::Uuid::new_v4().to_string()[..8]),
         x: 0.0,
@@ -368,7 +395,7 @@ fn default_workspace_pane() -> WorkspacePane {
         h: 1.0,
         view: super::models::WorkspacePaneView {
             view_type: "TerminalView".into(),
-            extra: serde_json::json!({"profile": "PowerShell"}),
+            extra: serde_json::json!({"profile": profile_name}),
         },
     }
 }
@@ -634,6 +661,64 @@ mod tests {
         let json = r#"{"unknownField": true, "profiles": []}"#;
         let settings: Settings = serde_json::from_str(json).unwrap();
         assert!(settings.profiles.is_empty());
+    }
+
+    // ── 폴백 프로파일 선택 ──
+
+    #[test]
+    fn default_pane_uses_default_profile_when_valid() {
+        let mut settings = Settings::default();
+        settings.default_profile = "WSL".into();
+        // Remove all panes to trigger default_workspace_pane
+        settings.workspaces[0].panes.clear();
+        let _warnings = validate_and_repair(&mut settings);
+        let profile = settings.workspaces[0].panes[0]
+            .view
+            .extra
+            .get("profile")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert_eq!(profile, "WSL");
+    }
+
+    #[test]
+    fn default_pane_uses_first_profile_when_default_invalid() {
+        let mut settings = Settings::default();
+        settings.default_profile = "NonExistent".into();
+        settings.profiles = vec![Profile {
+            name: "GitBash".into(),
+            command_line: "bash.exe".into(),
+            ..Profile::default()
+        }];
+        settings.workspaces[0].panes.clear();
+        let _warnings = validate_and_repair(&mut settings);
+        let profile = settings.workspaces[0].panes[0]
+            .view
+            .extra
+            .get("profile")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert_eq!(profile, "GitBash");
+    }
+
+    #[test]
+    fn default_pane_uses_first_profile_when_no_default_set() {
+        let mut settings = Settings::default();
+        settings.default_profile = "".into();
+        settings.profiles = vec![Profile {
+            name: "WSL".into(),
+            command_line: "wsl.exe".into(),
+            ..Profile::default()
+        }];
+        settings.workspaces[0].panes.clear();
+        let _warnings = validate_and_repair(&mut settings);
+        let profile = settings.workspaces[0].panes[0]
+            .view
+            .extra
+            .get("profile")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert_eq!(profile, "WSL");
     }
 
     // ── Multiple panes: valid + invalid mix ──

--- a/src-tauri/src/settings/validation.rs
+++ b/src-tauri/src/settings/validation.rs
@@ -1,0 +1,662 @@
+use serde::{Deserialize, Serialize};
+
+use super::models::{Settings, WorkspacePane};
+
+/// A single validation warning describing an issue found in settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationWarning {
+    /// Dot-separated path to the problematic field (e.g. "workspaces[0].panes[1].x").
+    pub path: String,
+    /// Human-readable description of the issue.
+    pub message: String,
+    /// Whether the issue was auto-repaired.
+    pub repaired: bool,
+}
+
+/// Result of loading and validating settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum SettingsLoadResult {
+    /// Settings loaded and validated successfully (possibly with auto-repaired warnings).
+    #[serde(rename = "ok")]
+    Ok {
+        settings: Settings,
+        warnings: Vec<ValidationWarning>,
+    },
+    /// JSON was parseable but had structural issues that were auto-repaired.
+    #[serde(rename = "repaired")]
+    Repaired {
+        settings: Settings,
+        warnings: Vec<ValidationWarning>,
+    },
+    /// JSON could not be parsed at all. Default settings are provided.
+    #[serde(rename = "parse_error")]
+    ParseError {
+        settings: Settings,
+        error: String,
+        settings_path: String,
+    },
+}
+
+/// Validate settings and auto-repair where possible.
+/// Returns the (possibly modified) settings and a list of warnings.
+pub fn validate_and_repair(settings: &mut Settings) -> Vec<ValidationWarning> {
+    let mut warnings = Vec::new();
+
+    validate_workspaces(settings, &mut warnings);
+    validate_layouts(settings, &mut warnings);
+    validate_docks(settings, &mut warnings);
+    validate_profile_references(settings, &mut warnings);
+
+    // Ensure at least one workspace exists
+    if settings.workspaces.is_empty() {
+        let default = Settings::default();
+        settings.workspaces = default.workspaces;
+        warnings.push(ValidationWarning {
+            path: "workspaces".into(),
+            message: "워크스페이스가 비어 있어 기본 워크스페이스를 생성했습니다.".into(),
+            repaired: true,
+        });
+    }
+
+    // Ensure at least one profile exists
+    if settings.profiles.is_empty() {
+        let default = Settings::default();
+        settings.profiles = default.profiles;
+        warnings.push(ValidationWarning {
+            path: "profiles".into(),
+            message: "프로파일이 비어 있어 기본 프로파일을 생성했습니다.".into(),
+            repaired: true,
+        });
+    }
+
+    warnings
+}
+
+fn validate_workspaces(settings: &mut Settings, warnings: &mut Vec<ValidationWarning>) {
+    for (ws_idx, ws) in settings.workspaces.iter_mut().enumerate() {
+        let ws_path = format!("workspaces[{ws_idx}]");
+
+        // Workspace must have an id
+        if ws.id.is_empty() {
+            ws.id = format!("ws-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+            warnings.push(ValidationWarning {
+                path: format!("{ws_path}.id"),
+                message: "워크스페이스 ID가 비어 있어 새로 생성했습니다.".into(),
+                repaired: true,
+            });
+        }
+
+        // Workspace must have a name
+        if ws.name.is_empty() {
+            ws.name = format!("Workspace {}", ws_idx + 1);
+            warnings.push(ValidationWarning {
+                path: format!("{ws_path}.name"),
+                message: "워크스페이스 이름이 비어 있어 기본 이름을 설정했습니다.".into(),
+                repaired: true,
+            });
+        }
+
+        // Validate panes
+        validate_workspace_panes(&mut ws.panes, &ws_path, warnings);
+
+        // If all panes were removed, add a default pane
+        if ws.panes.is_empty() {
+            ws.panes.push(default_workspace_pane());
+            warnings.push(ValidationWarning {
+                path: format!("{ws_path}.panes"),
+                message: "유효한 Pane이 없어 기본 Pane을 추가했습니다.".into(),
+                repaired: true,
+            });
+        }
+    }
+}
+
+fn validate_workspace_panes(
+    panes: &mut Vec<WorkspacePane>,
+    parent_path: &str,
+    warnings: &mut Vec<ValidationWarning>,
+) {
+    let mut to_remove = Vec::new();
+
+    for (i, pane) in panes.iter_mut().enumerate() {
+        let pane_path = format!("{parent_path}.panes[{i}]");
+
+        // Check for NaN/Infinity coordinates first — not repairable, remove pane
+        if pane.x.is_nan()
+            || pane.y.is_nan()
+            || pane.w.is_nan()
+            || pane.h.is_nan()
+            || pane.x.is_infinite()
+            || pane.y.is_infinite()
+            || pane.w.is_infinite()
+            || pane.h.is_infinite()
+        {
+            to_remove.push(i);
+            warnings.push(ValidationWarning {
+                path: pane_path.clone(),
+                message: "Pane 좌표에 NaN/Infinity 값이 있어 제거했습니다.".into(),
+                repaired: true,
+            });
+            continue;
+        }
+
+        // Clamp coordinates to 0.0~1.0
+        if !is_valid_ratio(pane.x) {
+            let old = pane.x;
+            pane.x = clamp_ratio(pane.x);
+            warnings.push(ValidationWarning {
+                path: format!("{pane_path}.x"),
+                message: format!(
+                    "x 좌표 {old}이(가) 유효 범위(0.0~1.0)를 벗어나 {:.2}로 수정했습니다.",
+                    pane.x
+                ),
+                repaired: true,
+            });
+        }
+
+        if !is_valid_ratio(pane.y) {
+            let old = pane.y;
+            pane.y = clamp_ratio(pane.y);
+            warnings.push(ValidationWarning {
+                path: format!("{pane_path}.y"),
+                message: format!(
+                    "y 좌표 {old}이(가) 유효 범위(0.0~1.0)를 벗어나 {:.2}로 수정했습니다.",
+                    pane.y
+                ),
+                repaired: true,
+            });
+        }
+
+        if !is_valid_dimension(pane.w) {
+            let old = pane.w;
+            pane.w = clamp_dimension(pane.w);
+            warnings.push(ValidationWarning {
+                path: format!("{pane_path}.w"),
+                message: format!(
+                    "w 크기 {old}이(가) 유효 범위(0.0~1.0, >0)를 벗어나 {:.2}로 수정했습니다.",
+                    pane.w
+                ),
+                repaired: true,
+            });
+        }
+
+        if !is_valid_dimension(pane.h) {
+            let old = pane.h;
+            pane.h = clamp_dimension(pane.h);
+            warnings.push(ValidationWarning {
+                path: format!("{pane_path}.h"),
+                message: format!(
+                    "h 크기 {old}이(가) 유효 범위(0.0~1.0, >0)를 벗어나 {:.2}로 수정했습니다.",
+                    pane.h
+                ),
+                repaired: true,
+            });
+        }
+
+        // View type must not be empty
+        if pane.view.view_type.is_empty() {
+            pane.view.view_type = "EmptyView".into();
+            warnings.push(ValidationWarning {
+                path: format!("{pane_path}.view.type"),
+                message: "View 타입이 비어 있어 EmptyView로 설정했습니다.".into(),
+                repaired: true,
+            });
+        }
+    }
+
+    // Remove invalid panes in reverse order to maintain indices
+    for i in to_remove.into_iter().rev() {
+        panes.remove(i);
+    }
+}
+
+fn validate_layouts(settings: &mut Settings, warnings: &mut Vec<ValidationWarning>) {
+    for (layout_idx, layout) in settings.layouts.iter_mut().enumerate() {
+        let layout_path = format!("layouts[{layout_idx}]");
+
+        if layout.id.is_empty() {
+            layout.id = format!("layout-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+            warnings.push(ValidationWarning {
+                path: format!("{layout_path}.id"),
+                message: "레이아웃 ID가 비어 있어 새로 생성했습니다.".into(),
+                repaired: true,
+            });
+        }
+
+        for (i, pane) in layout.panes.iter_mut().enumerate() {
+            let pane_path = format!("{layout_path}.panes[{i}]");
+            if !is_valid_ratio(pane.x) {
+                pane.x = clamp_ratio(pane.x);
+                warnings.push(ValidationWarning {
+                    path: format!("{pane_path}.x"),
+                    message: "레이아웃 Pane x 좌표를 유효 범위로 수정했습니다.".into(),
+                    repaired: true,
+                });
+            }
+            if !is_valid_ratio(pane.y) {
+                pane.y = clamp_ratio(pane.y);
+                warnings.push(ValidationWarning {
+                    path: format!("{pane_path}.y"),
+                    message: "레이아웃 Pane y 좌표를 유효 범위로 수정했습니다.".into(),
+                    repaired: true,
+                });
+            }
+            if !is_valid_dimension(pane.w) {
+                pane.w = clamp_dimension(pane.w);
+                warnings.push(ValidationWarning {
+                    path: format!("{pane_path}.w"),
+                    message: "레이아웃 Pane w 크기를 유효 범위로 수정했습니다.".into(),
+                    repaired: true,
+                });
+            }
+            if !is_valid_dimension(pane.h) {
+                pane.h = clamp_dimension(pane.h);
+                warnings.push(ValidationWarning {
+                    path: format!("{pane_path}.h"),
+                    message: "레이아웃 Pane h 크기를 유효 범위로 수정했습니다.".into(),
+                    repaired: true,
+                });
+            }
+            if pane.view_type.is_empty() {
+                pane.view_type = "TerminalView".into();
+                warnings.push(ValidationWarning {
+                    path: format!("{pane_path}.viewType"),
+                    message: "레이아웃 Pane viewType이 비어 있어 TerminalView로 설정했습니다."
+                        .into(),
+                    repaired: true,
+                });
+            }
+        }
+    }
+}
+
+fn validate_docks(settings: &mut Settings, warnings: &mut Vec<ValidationWarning>) {
+    let valid_positions = ["top", "bottom", "left", "right"];
+    for (dock_idx, dock) in settings.docks.iter_mut().enumerate() {
+        let dock_path = format!("docks[{dock_idx}]");
+
+        if !valid_positions.contains(&dock.position.as_str()) {
+            warnings.push(ValidationWarning {
+                path: format!("{dock_path}.position"),
+                message: format!(
+                    "독 위치 '{}'이(가) 유효하지 않습니다. 유효 값: top, bottom, left, right.",
+                    dock.position
+                ),
+                repaired: false,
+            });
+        }
+
+        if dock.size < 0.0 {
+            dock.size = 240.0;
+            warnings.push(ValidationWarning {
+                path: format!("{dock_path}.size"),
+                message: "독 크기가 음수여서 기본값(240)으로 수정했습니다.".into(),
+                repaired: true,
+            });
+        }
+    }
+}
+
+fn validate_profile_references(settings: &mut Settings, warnings: &mut Vec<ValidationWarning>) {
+    let profile_names: Vec<String> = settings.profiles.iter().map(|p| p.name.clone()).collect();
+
+    // Check workspace pane profile references
+    for (ws_idx, ws) in settings.workspaces.iter().enumerate() {
+        for (pane_idx, pane) in ws.panes.iter().enumerate() {
+            if pane.view.view_type == "TerminalView" {
+                if let Some(profile_name) = pane.view.extra.get("profile").and_then(|v| v.as_str())
+                {
+                    if !profile_name.is_empty()
+                        && !profile_names.contains(&profile_name.to_string())
+                    {
+                        warnings.push(ValidationWarning {
+                            path: format!("workspaces[{ws_idx}].panes[{pane_idx}].view.profile"),
+                            message: format!(
+                                "프로파일 '{profile_name}'이(가) 정의된 프로파일 목록에 없습니다."
+                            ),
+                            repaired: false,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Check default profile reference
+    if !settings.default_profile.is_empty() && !profile_names.contains(&settings.default_profile) {
+        warnings.push(ValidationWarning {
+            path: "defaultProfile".into(),
+            message: format!(
+                "기본 프로파일 '{}'이(가) 정의된 프로파일 목록에 없습니다.",
+                settings.default_profile
+            ),
+            repaired: false,
+        });
+    }
+}
+
+fn is_valid_ratio(v: f64) -> bool {
+    v.is_finite() && (0.0..=1.0).contains(&v)
+}
+
+fn is_valid_dimension(v: f64) -> bool {
+    v.is_finite() && v > 0.0 && v <= 1.0
+}
+
+fn clamp_ratio(v: f64) -> f64 {
+    if !v.is_finite() {
+        return 0.0;
+    }
+    v.clamp(0.0, 1.0)
+}
+
+fn clamp_dimension(v: f64) -> f64 {
+    if !v.is_finite() || v <= 0.0 {
+        return 0.1;
+    }
+    v.clamp(0.01, 1.0)
+}
+
+fn default_workspace_pane() -> WorkspacePane {
+    WorkspacePane {
+        id: format!("pane-{}", &uuid::Uuid::new_v4().to_string()[..8]),
+        x: 0.0,
+        y: 0.0,
+        w: 1.0,
+        h: 1.0,
+        view: super::models::WorkspacePaneView {
+            view_type: "TerminalView".into(),
+            extra: serde_json::json!({"profile": "PowerShell"}),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::models::*;
+
+    // ── validate_and_repair: 정상 settings는 경고 없이 통과 ──
+
+    #[test]
+    fn valid_settings_produce_no_warnings() {
+        let mut settings = Settings::default();
+        let warnings = validate_and_repair(&mut settings);
+        assert!(warnings.is_empty(), "warnings: {warnings:?}");
+    }
+
+    // ── Pane 좌표 범위 검증 ──
+
+    #[test]
+    fn pane_x_out_of_range_is_clamped() {
+        let mut settings = Settings::default();
+        settings.workspaces[0].panes[0].x = 1.5;
+        let warnings = validate_and_repair(&mut settings);
+        assert_eq!(settings.workspaces[0].panes[0].x, 1.0);
+        assert!(warnings.iter().any(|w| w.path.contains(".x") && w.repaired));
+    }
+
+    #[test]
+    fn pane_negative_x_is_clamped() {
+        let mut settings = Settings::default();
+        settings.workspaces[0].panes[0].x = -0.5;
+        let warnings = validate_and_repair(&mut settings);
+        assert_eq!(settings.workspaces[0].panes[0].x, 0.0);
+        assert!(warnings.iter().any(|w| w.path.contains(".x") && w.repaired));
+    }
+
+    #[test]
+    fn pane_w_zero_is_repaired() {
+        let mut settings = Settings::default();
+        settings.workspaces[0].panes[0].w = 0.0;
+        let warnings = validate_and_repair(&mut settings);
+        assert!(settings.workspaces[0].panes[0].w > 0.0);
+        assert!(warnings.iter().any(|w| w.path.contains(".w") && w.repaired));
+    }
+
+    #[test]
+    fn pane_h_negative_is_repaired() {
+        let mut settings = Settings::default();
+        settings.workspaces[0].panes[0].h = -1.0;
+        let warnings = validate_and_repair(&mut settings);
+        assert!(settings.workspaces[0].panes[0].h > 0.0);
+        assert!(warnings.iter().any(|w| w.path.contains(".h") && w.repaired));
+    }
+
+    // ── View 타입 검증 ──
+
+    #[test]
+    fn empty_view_type_set_to_empty_view() {
+        let mut settings = Settings::default();
+        settings.workspaces[0].panes[0].view.view_type = "".into();
+        let warnings = validate_and_repair(&mut settings);
+        assert_eq!(settings.workspaces[0].panes[0].view.view_type, "EmptyView");
+        assert!(warnings.iter().any(|w| w.path.contains("view.type")));
+    }
+
+    // ── 빈 워크스페이스 복구 ──
+
+    #[test]
+    fn empty_workspaces_get_default() {
+        let mut settings = Settings::default();
+        settings.workspaces.clear();
+        let warnings = validate_and_repair(&mut settings);
+        assert!(!settings.workspaces.is_empty());
+        assert!(warnings.iter().any(|w| w.path == "workspaces"));
+    }
+
+    // ── 빈 프로파일 복구 ──
+
+    #[test]
+    fn empty_profiles_get_default() {
+        let mut settings = Settings::default();
+        settings.profiles.clear();
+        let warnings = validate_and_repair(&mut settings);
+        assert!(!settings.profiles.is_empty());
+        assert!(warnings.iter().any(|w| w.path == "profiles"));
+    }
+
+    // ── 워크스페이스 ID/이름 검증 ──
+
+    #[test]
+    fn workspace_empty_id_is_assigned() {
+        let mut settings = Settings::default();
+        settings.workspaces[0].id = "".into();
+        let warnings = validate_and_repair(&mut settings);
+        assert!(!settings.workspaces[0].id.is_empty());
+        assert!(warnings.iter().any(|w| w.path.contains(".id")));
+    }
+
+    #[test]
+    fn workspace_empty_name_gets_default() {
+        let mut settings = Settings::default();
+        settings.workspaces[0].name = "".into();
+        let warnings = validate_and_repair(&mut settings);
+        assert!(!settings.workspaces[0].name.is_empty());
+        assert!(warnings.iter().any(|w| w.path.contains(".name")));
+    }
+
+    // ── Pane이 전부 제거되면 기본 Pane 추가 ──
+
+    #[test]
+    fn workspace_with_all_nan_panes_gets_default_pane() {
+        let mut settings = Settings::default();
+        settings.workspaces[0].panes = vec![WorkspacePane {
+            id: "pane-bad".into(),
+            x: f64::NAN,
+            y: f64::NAN,
+            w: f64::NAN,
+            h: f64::NAN,
+            view: WorkspacePaneView {
+                view_type: "TerminalView".into(),
+                extra: serde_json::json!({}),
+            },
+        }];
+        let warnings = validate_and_repair(&mut settings);
+        assert_eq!(settings.workspaces[0].panes.len(), 1);
+        assert_eq!(settings.workspaces[0].panes[0].x, 0.0);
+        assert!(warnings.iter().any(|w| w.message.contains("NaN/Infinity")));
+    }
+
+    // ── 프로파일 참조 검증 ──
+
+    #[test]
+    fn nonexistent_profile_reference_warns() {
+        let mut settings = Settings::default();
+        settings.workspaces[0].panes[0].view.view_type = "TerminalView".into();
+        settings.workspaces[0].panes[0].view.extra =
+            serde_json::json!({"profile": "NonExistentProfile"});
+        let warnings = validate_and_repair(&mut settings);
+        assert!(warnings
+            .iter()
+            .any(|w| w.path.contains("profile") && !w.repaired));
+    }
+
+    #[test]
+    fn nonexistent_default_profile_warns() {
+        let mut settings = Settings::default();
+        settings.default_profile = "DoesNotExist".into();
+        let warnings = validate_and_repair(&mut settings);
+        assert!(warnings
+            .iter()
+            .any(|w| w.path == "defaultProfile" && !w.repaired));
+    }
+
+    // ── 독 검증 ──
+
+    #[test]
+    fn dock_invalid_position_warns() {
+        let mut settings = Settings::default();
+        settings.docks.push(DockSetting {
+            position: "diagonal".into(),
+            active_view: None,
+            views: vec![],
+            visible: true,
+            size: 240.0,
+            panes: vec![],
+        });
+        let warnings = validate_and_repair(&mut settings);
+        assert!(warnings
+            .iter()
+            .any(|w| w.path.contains("position") && !w.repaired));
+    }
+
+    #[test]
+    fn dock_negative_size_repaired() {
+        let mut settings = Settings::default();
+        settings.docks[0].size = -100.0;
+        let warnings = validate_and_repair(&mut settings);
+        assert_eq!(settings.docks[0].size, 240.0);
+        assert!(warnings
+            .iter()
+            .any(|w| w.path.contains("size") && w.repaired));
+    }
+
+    // ── 레이아웃 검증 ──
+
+    #[test]
+    fn layout_empty_id_is_assigned() {
+        let mut settings = Settings::default();
+        settings.layouts[0].id = "".into();
+        let warnings = validate_and_repair(&mut settings);
+        assert!(!settings.layouts[0].id.is_empty());
+        assert!(warnings.iter().any(|w| w.path.contains("layouts[0].id")));
+    }
+
+    #[test]
+    fn layout_pane_out_of_range_is_clamped() {
+        let mut settings = Settings::default();
+        settings.layouts[0].panes[0].x = 2.0;
+        settings.layouts[0].panes[0].w = -0.5;
+        let warnings = validate_and_repair(&mut settings);
+        assert_eq!(settings.layouts[0].panes[0].x, 1.0);
+        assert!(settings.layouts[0].panes[0].w > 0.0);
+        assert!(warnings.len() >= 2);
+    }
+
+    #[test]
+    fn layout_pane_empty_view_type_repaired() {
+        let mut settings = Settings::default();
+        settings.layouts[0].panes[0].view_type = "".into();
+        let warnings = validate_and_repair(&mut settings);
+        assert_eq!(settings.layouts[0].panes[0].view_type, "TerminalView");
+        assert!(warnings
+            .iter()
+            .any(|w| w.path.contains("viewType") && w.repaired));
+    }
+
+    // ── SettingsLoadResult serde ──
+
+    #[test]
+    fn settings_load_result_ok_serializes() {
+        let result = SettingsLoadResult::Ok {
+            settings: Settings::default(),
+            warnings: vec![],
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"status\":\"ok\""));
+    }
+
+    #[test]
+    fn settings_load_result_parse_error_serializes() {
+        let result = SettingsLoadResult::ParseError {
+            settings: Settings::default(),
+            error: "unexpected token".into(),
+            settings_path: "/path/to/settings.json".into(),
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"status\":\"parse_error\""));
+        assert!(json.contains("unexpected token"));
+    }
+
+    // ── JSON 파싱 실패 케이스 ──
+
+    #[test]
+    fn completely_invalid_json_yields_default() {
+        let raw = "this is not json at all {{{";
+        let result: Result<Settings, _> = serde_json::from_str(raw);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_required_fields_in_workspace_pane_view() {
+        // WorkspacePaneView requires "type" field
+        let json = r#"{"x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0, "view": {}}"#;
+        let result: Result<WorkspacePane, _> = serde_json::from_str(json);
+        // "type" is required in WorkspacePaneView (no default)
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn partial_json_with_extra_fields_still_parses() {
+        let json = r#"{"unknownField": true, "profiles": []}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert!(settings.profiles.is_empty());
+    }
+
+    // ── Multiple panes: valid + invalid mix ──
+
+    #[test]
+    fn mixed_valid_invalid_panes_keep_valid_ones() {
+        let mut settings = Settings::default();
+        let good_pane = settings.workspaces[0].panes[0].clone();
+        let bad_pane = WorkspacePane {
+            id: "pane-bad".into(),
+            x: f64::NAN,
+            y: 0.0,
+            w: 1.0,
+            h: 1.0,
+            view: WorkspacePaneView {
+                view_type: "TerminalView".into(),
+                extra: serde_json::json!({}),
+            },
+        };
+        settings.workspaces[0].panes = vec![good_pane.clone(), bad_pane];
+        let warnings = validate_and_repair(&mut settings);
+        assert_eq!(settings.workspaces[0].panes.len(), 1);
+        assert_eq!(settings.workspaces[0].panes[0].id, good_pane.id);
+        assert!(warnings.iter().any(|w| w.message.contains("NaN/Infinity")));
+    }
+}

--- a/src-tauri/tests/e2e_test.rs
+++ b/src-tauri/tests/e2e_test.rs
@@ -1,9 +1,10 @@
 use laymux_lib::cli::{LxMessage, LxResponse};
+use laymux_lib::settings::validation::validate_and_repair;
 use laymux_lib::settings::{
     ClaudeSettings, ColorScheme, ConvenienceSettings, DockSetting, FileExplorerSettings,
     FontSettings, IssueReporterSettings, Keybinding, Layout, LayoutPane, MemoSettings,
-    OutputActivityBurstSettings, Profile, ProfileDefaults, Settings, TerminalSettings, Workspace,
-    WorkspacePane, WorkspacePaneView,
+    OutputActivityBurstSettings, Profile, ProfileDefaults, Settings, SettingsLoadResult,
+    TerminalSettings, ValidationWarning, Workspace, WorkspacePane, WorkspacePaneView,
 };
 use laymux_lib::state::AppState;
 use laymux_lib::terminal::{SyncGroup, TerminalConfig, TerminalSession};
@@ -2041,4 +2042,135 @@ fn burst_settings_deserialize_with_invalid_values() {
     assert!(safe.window_ms >= 100);
     assert!(safe.threshold >= 2);
     assert!(safe.throttle_ms >= 100);
+}
+
+// ============================================================================
+// Settings Validation E2E Tests (#152)
+// ============================================================================
+
+#[test]
+fn validate_settings_with_missing_profile_in_pane() {
+    // Simulate API-created settings where pane references a non-existent profile
+    let json = r#"{
+        "profiles": [
+            {"name": "PowerShell", "commandLine": "powershell.exe"}
+        ],
+        "workspaces": [{
+            "id": "ws-1",
+            "name": "Test",
+            "panes": [{
+                "id": "pane-1",
+                "x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0,
+                "view": {"type": "TerminalView", "profile": "NonExistent"}
+            }]
+        }]
+    }"#;
+    let mut settings: Settings = serde_json::from_str(json).unwrap();
+    let warnings = validate_and_repair(&mut settings);
+    // Should warn about non-existent profile (not repaired, just warned)
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.path.contains("profile") && !w.repaired),
+        "Should warn about missing profile reference"
+    );
+}
+
+#[test]
+fn validate_settings_with_corrupted_pane_coordinates() {
+    let json = r#"{
+        "profiles": [{"name": "PowerShell", "commandLine": "powershell.exe"}],
+        "workspaces": [{
+            "id": "ws-1",
+            "name": "Test",
+            "panes": [
+                {"id": "pane-ok", "x": 0.0, "y": 0.0, "w": 0.5, "h": 1.0,
+                 "view": {"type": "TerminalView", "profile": "PowerShell"}},
+                {"id": "pane-bad", "x": 2.5, "y": -1.0, "w": 0.5, "h": 0.0,
+                 "view": {"type": "TerminalView", "profile": "PowerShell"}}
+            ]
+        }]
+    }"#;
+    let mut settings: Settings = serde_json::from_str(json).unwrap();
+    let warnings = validate_and_repair(&mut settings);
+    // bad pane coordinates should be clamped
+    assert!(!warnings.is_empty());
+    let bad_pane = &settings.workspaces[0].panes[1];
+    assert!(bad_pane.x <= 1.0 && bad_pane.x >= 0.0);
+    assert!(bad_pane.y <= 1.0 && bad_pane.y >= 0.0);
+    assert!(bad_pane.h > 0.0);
+}
+
+#[test]
+fn validate_settings_completely_empty_workspaces_gets_default() {
+    let json = r#"{"workspaces": [], "profiles": []}"#;
+    let mut settings: Settings = serde_json::from_str(json).unwrap();
+    let warnings = validate_and_repair(&mut settings);
+    // Should have added default workspace and profiles
+    assert!(!settings.workspaces.is_empty());
+    assert!(!settings.profiles.is_empty());
+    assert!(warnings
+        .iter()
+        .any(|w| w.path == "workspaces" && w.repaired));
+    assert!(warnings.iter().any(|w| w.path == "profiles" && w.repaired));
+}
+
+#[test]
+fn validate_settings_pane_without_view_type() {
+    let json = r#"{
+        "profiles": [{"name": "PowerShell", "commandLine": "powershell.exe"}],
+        "workspaces": [{
+            "id": "ws-1",
+            "name": "Test",
+            "panes": [{
+                "id": "pane-1",
+                "x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0,
+                "view": {"type": ""}
+            }]
+        }]
+    }"#;
+    let mut settings: Settings = serde_json::from_str(json).unwrap();
+    let warnings = validate_and_repair(&mut settings);
+    assert_eq!(settings.workspaces[0].panes[0].view.view_type, "EmptyView");
+    assert!(warnings
+        .iter()
+        .any(|w| w.path.contains("view.type") && w.repaired));
+}
+
+#[test]
+fn settings_load_result_round_trip_ok() {
+    let result = SettingsLoadResult::Ok {
+        settings: Settings::default(),
+        warnings: vec![],
+    };
+    let json = serde_json::to_string(&result).unwrap();
+    let parsed: SettingsLoadResult = serde_json::from_str(&json).unwrap();
+    assert_eq!(result, parsed);
+}
+
+#[test]
+fn settings_load_result_round_trip_repaired() {
+    let result = SettingsLoadResult::Repaired {
+        settings: Settings::default(),
+        warnings: vec![ValidationWarning {
+            path: "workspaces[0].panes[0].x".into(),
+            message: "x 좌표가 범위를 벗어남".into(),
+            repaired: true,
+        }],
+    };
+    let json = serde_json::to_string(&result).unwrap();
+    let parsed: SettingsLoadResult = serde_json::from_str(&json).unwrap();
+    assert_eq!(result, parsed);
+}
+
+#[test]
+fn settings_load_result_round_trip_parse_error() {
+    let result = SettingsLoadResult::ParseError {
+        settings: Settings::default(),
+        error: "expected value at line 1 column 1".into(),
+        settings_path: "C:\\Users\\test\\settings.json".into(),
+    };
+    let json = serde_json::to_string(&result).unwrap();
+    let parsed: SettingsLoadResult = serde_json::from_str(&json).unwrap();
+    assert_eq!(result, parsed);
 }

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -43,6 +43,12 @@ vi.mock("@tauri-apps/api/window", () => {
   };
 });
 
+vi.mock("@/lib/persist-session", () => ({
+  persistSession: vi.fn().mockResolvedValue(undefined),
+  saveBeforeClose: vi.fn().mockResolvedValue(undefined),
+  setBlockPersist: vi.fn(),
+}));
+
 // Mock tauri-api to prevent unhandled errors in test environment
 vi.mock("@/lib/tauri-api", () => {
   const unlisten = vi.fn();
@@ -65,6 +71,19 @@ vi.mock("@/lib/tauri-api", () => {
       layouts: [],
       workspaces: [],
       docks: [],
+    }),
+    loadSettingsValidated: vi.fn().mockResolvedValue({
+      status: "ok",
+      settings: {
+        defaultProfile: "PowerShell",
+        profiles: [],
+        colorSchemes: [],
+        keybindings: [],
+        layouts: [],
+        workspaces: [],
+        docks: [],
+      },
+      warnings: [],
     }),
     saveSettings: vi.fn().mockResolvedValue(undefined),
     getListeningPorts: vi.fn().mockResolvedValue([]),

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useSyncEvents } from "@/hooks/useSyncEvents";
@@ -8,14 +8,17 @@ import { saveBeforeClose } from "@/lib/persist-session";
 import { createCloseHandler } from "@/lib/window-close-handler";
 import { useWindowGeometry, captureWindowGeometry } from "@/hooks/useWindowGeometry";
 import { useAppFocus } from "@/hooks/useAppFocus";
+import { SettingsRecoveryModal } from "@/components/views/SettingsRecoveryModal";
 
 export function App() {
   useKeyboardShortcuts();
   useSyncEvents();
-  const { loaded } = useSessionPersistence();
+  const { loaded, loadStatus } = useSessionPersistence();
   useAutomationBridge();
   useWindowGeometry();
   useAppFocus();
+
+  const [recoveryDismissed, setRecoveryDismissed] = useState(false);
 
   // Save terminal state before window close (Alt+F4, OS close, etc.)
   const cleanupRef = useRef<(() => void) | null>(null);
@@ -75,9 +78,27 @@ export function App() {
     );
   }
 
+  // Show recovery modal when settings had issues
+  const showRecovery =
+    !recoveryDismissed &&
+    loaded &&
+    loadStatus.result != null &&
+    (loadStatus.result.status === "parse_error" || loadStatus.result.status === "repaired");
+
   return (
     <div className="h-screen" data-testid="app-root">
       <AppLayout />
+      {showRecovery && loadStatus.result && (
+        <SettingsRecoveryModal
+          loadResult={loadStatus.result}
+          onDismiss={() => setRecoveryDismissed(true)}
+          onReset={() => {
+            setRecoveryDismissed(true);
+            // Reload to apply fresh defaults
+            window.location.reload();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/ui/src/components/views/SettingsRecoveryModal.tsx
+++ b/ui/src/components/views/SettingsRecoveryModal.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import {
+  resetSettings,
+  getSettingsPath,
+  type SettingsLoadResult,
+  type ValidationWarning,
+} from "@/lib/tauri-api";
+
+interface SettingsRecoveryModalProps {
+  loadResult: SettingsLoadResult;
+  onDismiss: () => void;
+  onReset: () => void;
+}
+
+/**
+ * Modal shown when settings.json has issues (parse error or validation warnings).
+ * Offers the user choices: reset to defaults, view path for manual editing, or dismiss.
+ */
+export function SettingsRecoveryModal({
+  loadResult,
+  onDismiss,
+  onReset,
+}: SettingsRecoveryModalProps) {
+  const [settingsPath, setSettingsPath] = useState<string | null>(null);
+  const [resetting, setResetting] = useState(false);
+
+  const isParseError = loadResult.status === "parse_error";
+  const warnings: ValidationWarning[] = loadResult.status === "repaired" ? loadResult.warnings : [];
+  const parseError = isParseError ? loadResult.error : null;
+  const parseErrorPath = isParseError ? loadResult.settingsPath : null;
+
+  const handleShowPath = async () => {
+    try {
+      const path = parseErrorPath || (await getSettingsPath());
+      setSettingsPath(path);
+    } catch {
+      setSettingsPath("(경로를 가져올 수 없습니다)");
+    }
+  };
+
+  const handleReset = async () => {
+    setResetting(true);
+    try {
+      await resetSettings();
+      onReset();
+    } catch (err) {
+      console.error("[SettingsRecoveryModal] Reset failed:", err);
+      setResetting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center"
+      style={{ background: "rgba(0, 0, 0, 0.6)" }}
+      data-testid="settings-recovery-overlay"
+    >
+      <div
+        className="flex flex-col gap-4 rounded-lg p-6"
+        style={{
+          background: "var(--bg-surface, #313244)",
+          color: "var(--text-primary, #cdd6f4)",
+          border: "1px solid var(--border, #45475a)",
+          maxWidth: 520,
+          width: "90vw",
+          maxHeight: "80vh",
+          fontFamily: "system-ui, sans-serif",
+          fontSize: 14,
+        }}
+        data-testid="settings-recovery-modal"
+      >
+        {/* Title */}
+        <div className="flex items-center gap-2" style={{ fontSize: 16, fontWeight: 600 }}>
+          <span
+            style={{ color: isParseError ? "var(--error, #f38ba8)" : "var(--warning, #f9e2af)" }}
+          >
+            {isParseError ? "\u26A0" : "\u2139"}
+          </span>
+          <span>{isParseError ? "설정 파일을 읽을 수 없습니다" : "설정 파일 검증 결과"}</span>
+        </div>
+
+        {/* Parse error details */}
+        {isParseError && parseError && (
+          <div className="flex flex-col gap-2">
+            <div style={{ color: "var(--text-secondary, #a6adc8)" }}>
+              settings.json 파일의 JSON 구문이 올바르지 않아 기본 설정으로 시작합니다.
+            </div>
+            <pre
+              className="overflow-auto rounded p-3 text-xs"
+              style={{
+                background: "var(--bg-base, #1e1e2e)",
+                color: "var(--error, #f38ba8)",
+                maxHeight: 120,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-all",
+              }}
+            >
+              {parseError}
+            </pre>
+          </div>
+        )}
+
+        {/* Validation warnings */}
+        {warnings.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <div style={{ color: "var(--text-secondary, #a6adc8)" }}>
+              {warnings.filter((w) => w.repaired).length}개 항목이 자동 수정되었습니다.
+              {warnings.filter((w) => !w.repaired).length > 0 &&
+                ` ${warnings.filter((w) => !w.repaired).length}개 항목은 수동 확인이 필요합니다.`}
+            </div>
+            <div
+              className="overflow-auto rounded p-3 text-xs"
+              style={{
+                background: "var(--bg-base, #1e1e2e)",
+                maxHeight: 200,
+              }}
+            >
+              {warnings.map((w, i) => (
+                <div key={i} className="flex gap-2 py-0.5" style={{ lineHeight: 1.5 }}>
+                  <span
+                    style={{
+                      color: w.repaired ? "var(--success, #a6e3a1)" : "var(--warning, #f9e2af)",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {w.repaired ? "\u2713" : "\u26A0"}
+                  </span>
+                  <span style={{ color: "var(--text-secondary, #a6adc8)" }}>
+                    <span
+                      style={{ color: "var(--text-primary, #cdd6f4)", fontFamily: "monospace" }}
+                    >
+                      {w.path}
+                    </span>
+                    {" \u2014 "}
+                    {w.message}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Settings path */}
+        {settingsPath && (
+          <div
+            className="select-all overflow-auto rounded p-2 text-xs"
+            style={{
+              background: "var(--bg-base, #1e1e2e)",
+              color: "var(--accent, #89b4fa)",
+              fontFamily: "monospace",
+              wordBreak: "break-all",
+            }}
+          >
+            {settingsPath}
+          </div>
+        )}
+
+        {/* Buttons */}
+        <div className="flex justify-end gap-2 pt-2">
+          {!settingsPath && (
+            <button
+              onClick={handleShowPath}
+              className="rounded px-4 py-1.5 text-sm hover-bg"
+              style={{
+                background: "var(--bg-base, #1e1e2e)",
+                color: "var(--text-primary, #cdd6f4)",
+                border: "1px solid var(--border, #45475a)",
+              }}
+              data-testid="settings-recovery-show-path"
+            >
+              경로 확인
+            </button>
+          )}
+          <button
+            onClick={handleReset}
+            disabled={resetting}
+            className="rounded px-4 py-1.5 text-sm"
+            style={{
+              background: "var(--error, #f38ba8)",
+              color: "var(--bg-base, #1e1e2e)",
+              opacity: resetting ? 0.5 : 1,
+            }}
+            data-testid="settings-recovery-reset"
+          >
+            {resetting ? "초기화 중..." : "기본값으로 초기화"}
+          </button>
+          <button
+            onClick={onDismiss}
+            className="rounded px-4 py-1.5 text-sm"
+            style={{
+              background: "var(--accent, #89b4fa)",
+              color: "var(--bg-base, #1e1e2e)",
+            }}
+            data-testid="settings-recovery-dismiss"
+          >
+            {isParseError ? "기본 설정으로 계속" : "확인"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/views/SettingsRecoveryModal.tsx
+++ b/ui/src/components/views/SettingsRecoveryModal.tsx
@@ -5,6 +5,7 @@ import {
   type SettingsLoadResult,
   type ValidationWarning,
 } from "@/lib/tauri-api";
+import { setBlockPersist } from "@/lib/persist-session";
 
 interface SettingsRecoveryModalProps {
   loadResult: SettingsLoadResult;
@@ -40,11 +41,14 @@ export function SettingsRecoveryModal({
 
   const handleReset = async () => {
     setResetting(true);
+    // Block persistence so any in-flight persistSession() doesn't overwrite the fresh defaults
+    setBlockPersist(true);
     try {
       await resetSettings();
       onReset();
     } catch (err) {
       console.error("[SettingsRecoveryModal] Reset failed:", err);
+      setBlockPersist(false);
       setResetting(false);
     }
   };

--- a/ui/src/hooks/useSessionPersistence.test.ts
+++ b/ui/src/hooks/useSessionPersistence.test.ts
@@ -3,10 +3,11 @@ import { renderHook, act } from "@testing-library/react";
 
 vi.mock("@/lib/persist-session", () => ({
   persistSession: vi.fn().mockResolvedValue(undefined),
+  setBlockPersist: vi.fn(),
 }));
 
-vi.mock("@/lib/tauri-api", () => ({
-  loadSettings: vi.fn().mockResolvedValue({
+vi.mock("@/lib/tauri-api", () => {
+  const mockSettings = {
     font: { face: "Fira Code", size: 16 },
     defaultProfile: "WSL",
     profiles: [
@@ -34,7 +35,6 @@ vi.mock("@/lib/tauri-api", () => ({
       {
         id: "ws-1",
         name: "Saved WS",
-
         panes: [
           {
             x: 0,
@@ -62,30 +62,42 @@ vi.mock("@/lib/tauri-api", () => ({
       },
       { position: "right", activeView: null, views: [], visible: true },
     ],
-  }),
-  saveSettings: vi.fn().mockResolvedValue(undefined),
-  createTerminalSession: vi.fn().mockResolvedValue({}),
-  writeToTerminal: vi.fn().mockResolvedValue(undefined),
-  resizeTerminal: vi.fn().mockResolvedValue(undefined),
-  closeTerminalSession: vi.fn().mockResolvedValue(undefined),
-  getSyncGroupTerminals: vi.fn().mockResolvedValue([]),
-  handleLxMessage: vi.fn().mockResolvedValue({}),
-  onTerminalOutput: vi.fn().mockResolvedValue(() => {}),
-  onSyncCwd: vi.fn().mockResolvedValue(() => {}),
-  onSyncBranch: vi.fn().mockResolvedValue(() => {}),
-  onLxNotify: vi.fn().mockResolvedValue(() => {}),
-  onSetTabTitle: vi.fn().mockResolvedValue(() => {}),
-  getListeningPorts: vi.fn().mockResolvedValue([]),
-  getGitBranch: vi.fn().mockResolvedValue(null),
-  sendOsNotification: vi.fn().mockResolvedValue(undefined),
-}));
+  };
+  return {
+    loadSettings: vi.fn().mockResolvedValue(mockSettings),
+    loadSettingsValidated: vi
+      .fn()
+      .mockResolvedValue({ status: "ok", settings: mockSettings, warnings: [] }),
+    cleanTerminalOutputCache: vi.fn().mockResolvedValue(undefined),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+    createTerminalSession: vi.fn().mockResolvedValue({}),
+    writeToTerminal: vi.fn().mockResolvedValue(undefined),
+    resizeTerminal: vi.fn().mockResolvedValue(undefined),
+    closeTerminalSession: vi.fn().mockResolvedValue(undefined),
+    getSyncGroupTerminals: vi.fn().mockResolvedValue([]),
+    handleLxMessage: vi.fn().mockResolvedValue({}),
+    onTerminalOutput: vi.fn().mockResolvedValue(() => {}),
+    onSyncCwd: vi.fn().mockResolvedValue(() => {}),
+    onSyncBranch: vi.fn().mockResolvedValue(() => {}),
+    onLxNotify: vi.fn().mockResolvedValue(() => {}),
+    onSetTabTitle: vi.fn().mockResolvedValue(() => {}),
+    getListeningPorts: vi.fn().mockResolvedValue([]),
+    getGitBranch: vi.fn().mockResolvedValue(null),
+    sendOsNotification: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 import { useSessionPersistence } from "./useSessionPersistence";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useDockStore } from "@/stores/dock-store";
-import { loadSettings } from "@/lib/tauri-api";
+import { loadSettingsValidated } from "@/lib/tauri-api";
 import { persistSession } from "@/lib/persist-session";
+
+/** Wrap raw settings into a SettingsLoadResult with status "ok" for test mocks. */
+function wrapOk(settings: any) {
+  return { status: "ok", settings, warnings: [] };
+}
 
 describe("useSessionPersistence", () => {
   beforeEach(() => {
@@ -102,7 +114,7 @@ describe("useSessionPersistence", () => {
       await new Promise((r) => setTimeout(r, 10));
     });
 
-    expect(loadSettings).toHaveBeenCalledTimes(1);
+    expect(loadSettingsValidated).toHaveBeenCalledTimes(1);
     expect(result.current.loaded).toBe(true);
   });
 
@@ -162,51 +174,53 @@ describe("useSessionPersistence", () => {
 
   it("leaves cwdReceive/cwdSend undefined when not set in dock panes (resolved at render time via syncCwdDefaults)", async () => {
     // Override loadSettings to return dock panes without cwdReceive/cwdSend
-    vi.mocked(loadSettings).mockResolvedValueOnce({
-      defaultProfile: "WSL",
-      profiles: [
-        {
-          name: "WSL",
-          commandLine: "wsl.exe",
-          colorScheme: "",
-          startingDirectory: "",
-          hidden: false,
+    vi.mocked(loadSettingsValidated).mockResolvedValueOnce(
+      wrapOk({
+        defaultProfile: "WSL",
+        profiles: [
+          {
+            name: "WSL",
+            commandLine: "wsl.exe",
+            colorScheme: "",
+            startingDirectory: "",
+            hidden: false,
+          },
+        ],
+        colorSchemes: [],
+        keybindings: [],
+        layouts: [],
+        workspaces: [],
+        docks: [
+          {
+            position: "bottom",
+            activeView: "TerminalView",
+            views: ["TerminalView"],
+            visible: true,
+            size: 200,
+            panes: [
+              {
+                id: "dp-test1",
+                view: { type: "TerminalView", profile: "WSL" }, // no cwdReceive/cwdSend
+                x: 0,
+                y: 0,
+                w: 1,
+                h: 1,
+              },
+            ],
+          },
+        ],
+        convenience: {
+          smartPaste: true,
+          pasteImageDir: "",
+          hoverIdleSeconds: 2,
+          notificationDismiss: "workspace",
+          copyOnSelect: true,
+          pathEllipsis: "start",
+          scrollbarStyle: "overlay",
         },
-      ],
-      colorSchemes: [],
-      keybindings: [],
-      layouts: [],
-      workspaces: [],
-      docks: [
-        {
-          position: "bottom",
-          activeView: "TerminalView",
-          views: ["TerminalView"],
-          visible: true,
-          size: 200,
-          panes: [
-            {
-              id: "dp-test1",
-              view: { type: "TerminalView", profile: "WSL" }, // no cwdReceive/cwdSend
-              x: 0,
-              y: 0,
-              w: 1,
-              h: 1,
-            },
-          ],
-        },
-      ],
-      convenience: {
-        smartPaste: true,
-        pasteImageDir: "",
-        hoverIdleSeconds: 2,
-        notificationDismiss: "workspace",
-        copyOnSelect: true,
-        pathEllipsis: "start",
-        scrollbarStyle: "overlay",
-      },
-      claude: { syncCwd: "skip" },
-    } as any);
+        claude: { syncCwd: "skip" },
+      }) as any,
+    );
 
     renderHook(() => useSessionPersistence());
     await act(async () => {
@@ -222,51 +236,53 @@ describe("useSessionPersistence", () => {
   });
 
   it("preserves explicit cwdReceive=false from saved dock panes", async () => {
-    vi.mocked(loadSettings).mockResolvedValueOnce({
-      defaultProfile: "WSL",
-      profiles: [
-        {
-          name: "WSL",
-          commandLine: "wsl.exe",
-          colorScheme: "",
-          startingDirectory: "",
-          hidden: false,
+    vi.mocked(loadSettingsValidated).mockResolvedValueOnce(
+      wrapOk({
+        defaultProfile: "WSL",
+        profiles: [
+          {
+            name: "WSL",
+            commandLine: "wsl.exe",
+            colorScheme: "",
+            startingDirectory: "",
+            hidden: false,
+          },
+        ],
+        colorSchemes: [],
+        keybindings: [],
+        layouts: [],
+        workspaces: [],
+        docks: [
+          {
+            position: "bottom",
+            activeView: "TerminalView",
+            views: ["TerminalView"],
+            visible: true,
+            size: 200,
+            panes: [
+              {
+                id: "dp-test1",
+                view: { type: "TerminalView", profile: "WSL", cwdReceive: false, cwdSend: false },
+                x: 0,
+                y: 0,
+                w: 1,
+                h: 1,
+              },
+            ],
+          },
+        ],
+        convenience: {
+          smartPaste: true,
+          pasteImageDir: "",
+          hoverIdleSeconds: 2,
+          notificationDismiss: "workspace",
+          copyOnSelect: true,
+          pathEllipsis: "start",
+          scrollbarStyle: "overlay",
         },
-      ],
-      colorSchemes: [],
-      keybindings: [],
-      layouts: [],
-      workspaces: [],
-      docks: [
-        {
-          position: "bottom",
-          activeView: "TerminalView",
-          views: ["TerminalView"],
-          visible: true,
-          size: 200,
-          panes: [
-            {
-              id: "dp-test1",
-              view: { type: "TerminalView", profile: "WSL", cwdReceive: false, cwdSend: false },
-              x: 0,
-              y: 0,
-              w: 1,
-              h: 1,
-            },
-          ],
-        },
-      ],
-      convenience: {
-        smartPaste: true,
-        pasteImageDir: "",
-        hoverIdleSeconds: 2,
-        notificationDismiss: "workspace",
-        copyOnSelect: true,
-        pathEllipsis: "start",
-        scrollbarStyle: "overlay",
-      },
-      claude: { syncCwd: "skip" },
-    } as any);
+        claude: { syncCwd: "skip" },
+      }) as any,
+    );
 
     renderHook(() => useSessionPersistence());
     await act(async () => {
@@ -280,34 +296,36 @@ describe("useSessionPersistence", () => {
   });
 
   it("loads per-profile font override from backend settings", async () => {
-    vi.mocked(loadSettings).mockResolvedValueOnce({
-      defaultProfile: "WSL",
-      profiles: [
-        {
-          name: "WSL",
-          commandLine: "wsl.exe",
-          colorScheme: "",
-          startingDirectory: "",
-          hidden: false,
-          font: { face: "JetBrains Mono", size: 16, weight: "bold" },
+    vi.mocked(loadSettingsValidated).mockResolvedValueOnce(
+      wrapOk({
+        defaultProfile: "WSL",
+        profiles: [
+          {
+            name: "WSL",
+            commandLine: "wsl.exe",
+            colorScheme: "",
+            startingDirectory: "",
+            hidden: false,
+            font: { face: "JetBrains Mono", size: 16, weight: "bold" },
+          },
+        ],
+        colorSchemes: [],
+        keybindings: [],
+        layouts: [],
+        workspaces: [],
+        docks: [],
+        convenience: {
+          smartPaste: true,
+          pasteImageDir: "",
+          hoverIdleSeconds: 2,
+          notificationDismiss: "workspace",
+          copyOnSelect: true,
+          pathEllipsis: "start",
+          scrollbarStyle: "overlay",
         },
-      ],
-      colorSchemes: [],
-      keybindings: [],
-      layouts: [],
-      workspaces: [],
-      docks: [],
-      convenience: {
-        smartPaste: true,
-        pasteImageDir: "",
-        hoverIdleSeconds: 2,
-        notificationDismiss: "workspace",
-        copyOnSelect: true,
-        pathEllipsis: "start",
-        scrollbarStyle: "overlay",
-      },
-      claude: { syncCwd: "skip" },
-    } as any);
+        claude: { syncCwd: "skip" },
+      }) as any,
+    );
 
     renderHook(() => useSessionPersistence());
     await act(async () => {
@@ -332,33 +350,35 @@ describe("useSessionPersistence", () => {
   });
 
   it("loads convenience settings from backend", async () => {
-    vi.mocked(loadSettings).mockResolvedValueOnce({
-      defaultProfile: "WSL",
-      profiles: [
-        {
-          name: "WSL",
-          commandLine: "wsl.exe",
-          colorScheme: "",
-          startingDirectory: "",
-          hidden: false,
+    vi.mocked(loadSettingsValidated).mockResolvedValueOnce(
+      wrapOk({
+        defaultProfile: "WSL",
+        profiles: [
+          {
+            name: "WSL",
+            commandLine: "wsl.exe",
+            colorScheme: "",
+            startingDirectory: "",
+            hidden: false,
+          },
+        ],
+        colorSchemes: [],
+        keybindings: [],
+        layouts: [],
+        workspaces: [],
+        docks: [],
+        convenience: {
+          smartPaste: false,
+          pasteImageDir: "/images",
+          hoverIdleSeconds: 5,
+          notificationDismiss: "manual",
+          copyOnSelect: false,
+          pathEllipsis: "end",
+          scrollbarStyle: "separate",
         },
-      ],
-      colorSchemes: [],
-      keybindings: [],
-      layouts: [],
-      workspaces: [],
-      docks: [],
-      convenience: {
-        smartPaste: false,
-        pasteImageDir: "/images",
-        hoverIdleSeconds: 5,
-        notificationDismiss: "manual",
-        copyOnSelect: false,
-        pathEllipsis: "end",
-        scrollbarStyle: "separate",
-      },
-      claude: { syncCwd: "skip" },
-    } as any);
+        claude: { syncCwd: "skip" },
+      }) as any,
+    );
 
     renderHook(() => useSessionPersistence());
     await act(async () => {
@@ -376,62 +396,64 @@ describe("useSessionPersistence", () => {
   });
 
   it("restores layout viewConfig (overwritten layouts persist across restart)", async () => {
-    vi.mocked(loadSettings).mockResolvedValueOnce({
-      defaultProfile: "WSL",
-      profiles: [
-        {
-          name: "WSL",
-          commandLine: "wsl.exe",
-          colorScheme: "",
-          startingDirectory: "",
-          hidden: false,
+    vi.mocked(loadSettingsValidated).mockResolvedValueOnce(
+      wrapOk({
+        defaultProfile: "WSL",
+        profiles: [
+          {
+            name: "WSL",
+            commandLine: "wsl.exe",
+            colorScheme: "",
+            startingDirectory: "",
+            hidden: false,
+          },
+        ],
+        colorSchemes: [],
+        keybindings: [],
+        layouts: [
+          {
+            id: "layout-custom",
+            name: "Custom Layout",
+            panes: [
+              {
+                x: 0,
+                y: 0,
+                w: 0.5,
+                h: 1,
+                viewType: "TerminalView",
+                viewConfig: { type: "TerminalView", profile: "WSL" },
+              },
+              {
+                x: 0.5,
+                y: 0,
+                w: 0.5,
+                h: 1,
+                viewType: "MemoView",
+                viewConfig: { type: "MemoView" },
+              },
+            ],
+          },
+        ],
+        workspaces: [
+          {
+            id: "ws-1",
+            name: "WS",
+            panes: [{ x: 0, y: 0, w: 1, h: 1, view: { type: "TerminalView" } }],
+          },
+        ],
+        docks: [],
+        convenience: {
+          smartPaste: true,
+          pasteImageDir: "",
+          hoverIdleSeconds: 2,
+          notificationDismiss: "workspace",
+          copyOnSelect: true,
+          pathEllipsis: "start",
+          scrollbarStyle: "overlay",
         },
-      ],
-      colorSchemes: [],
-      keybindings: [],
-      layouts: [
-        {
-          id: "layout-custom",
-          name: "Custom Layout",
-          panes: [
-            {
-              x: 0,
-              y: 0,
-              w: 0.5,
-              h: 1,
-              viewType: "TerminalView",
-              viewConfig: { type: "TerminalView", profile: "WSL" },
-            },
-            {
-              x: 0.5,
-              y: 0,
-              w: 0.5,
-              h: 1,
-              viewType: "MemoView",
-              viewConfig: { type: "MemoView" },
-            },
-          ],
-        },
-      ],
-      workspaces: [
-        {
-          id: "ws-1",
-          name: "WS",
-          panes: [{ x: 0, y: 0, w: 1, h: 1, view: { type: "TerminalView" } }],
-        },
-      ],
-      docks: [],
-      convenience: {
-        smartPaste: true,
-        pasteImageDir: "",
-        hoverIdleSeconds: 2,
-        notificationDismiss: "workspace",
-        copyOnSelect: true,
-        pathEllipsis: "start",
-        scrollbarStyle: "overlay",
-      },
-      claude: { syncCwd: "skip" },
-    } as any);
+        claude: { syncCwd: "skip" },
+      }) as any,
+    );
 
     renderHook(() => useSessionPersistence());
     await act(async () => {
@@ -450,33 +472,35 @@ describe("useSessionPersistence", () => {
   });
 
   it("loads claude settings from backend", async () => {
-    vi.mocked(loadSettings).mockResolvedValueOnce({
-      defaultProfile: "WSL",
-      profiles: [
-        {
-          name: "WSL",
-          commandLine: "wsl.exe",
-          colorScheme: "",
-          startingDirectory: "",
-          hidden: false,
+    vi.mocked(loadSettingsValidated).mockResolvedValueOnce(
+      wrapOk({
+        defaultProfile: "WSL",
+        profiles: [
+          {
+            name: "WSL",
+            commandLine: "wsl.exe",
+            colorScheme: "",
+            startingDirectory: "",
+            hidden: false,
+          },
+        ],
+        colorSchemes: [],
+        keybindings: [],
+        layouts: [],
+        workspaces: [],
+        docks: [],
+        convenience: {
+          smartPaste: true,
+          pasteImageDir: "",
+          hoverIdleSeconds: 2,
+          notificationDismiss: "workspace",
+          copyOnSelect: true,
+          pathEllipsis: "start",
+          scrollbarStyle: "overlay",
         },
-      ],
-      colorSchemes: [],
-      keybindings: [],
-      layouts: [],
-      workspaces: [],
-      docks: [],
-      convenience: {
-        smartPaste: true,
-        pasteImageDir: "",
-        hoverIdleSeconds: 2,
-        notificationDismiss: "workspace",
-        copyOnSelect: true,
-        pathEllipsis: "start",
-        scrollbarStyle: "overlay",
-      },
-      claude: { syncCwd: "command" },
-    } as any);
+        claude: { syncCwd: "command" },
+      }) as any,
+    );
 
     renderHook(() => useSessionPersistence());
     await act(async () => {

--- a/ui/src/hooks/useSessionPersistence.test.ts
+++ b/ui/src/hooks/useSessionPersistence.test.ts
@@ -91,11 +91,11 @@ import { useSessionPersistence } from "./useSessionPersistence";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useDockStore } from "@/stores/dock-store";
-import { loadSettingsValidated } from "@/lib/tauri-api";
+import { loadSettingsValidated, type SettingsLoadResult } from "@/lib/tauri-api";
 import { persistSession } from "@/lib/persist-session";
 
 /** Wrap raw settings into a SettingsLoadResult with status "ok" for test mocks. */
-function wrapOk(settings: any) {
+function wrapOk(settings: any): SettingsLoadResult {
   return { status: "ok", settings, warnings: [] };
 }
 

--- a/ui/src/hooks/useSessionPersistence.ts
+++ b/ui/src/hooks/useSessionPersistence.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
-import { loadSettings, cleanTerminalOutputCache } from "@/lib/tauri-api";
+import {
+  loadSettingsValidated,
+  cleanTerminalOutputCache,
+  type SettingsLoadResult,
+  type ValidationWarning,
+} from "@/lib/tauri-api";
 import { persistSession } from "@/lib/persist-session";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import {
@@ -11,16 +16,37 @@ import {
 import { useDockStore } from "@/stores/dock-store";
 import type { ViewType, Layout, Workspace, DockPosition } from "@/stores/types";
 
+/** Settings load status exposed to App for recovery UI. */
+export interface SettingsLoadStatus {
+  /** Whether settings loaded with issues. */
+  result: SettingsLoadResult | null;
+  /** Warnings from validation (repaired items). */
+  warnings: ValidationWarning[];
+}
+
 /**
  * Hook that loads settings from disk on mount and provides a save function.
  * Bridges the gap between the Tauri backend settings.json and the frontend stores.
  */
 export function useSessionPersistence() {
   const [loaded, setLoaded] = useState(false);
+  const [loadStatus, setLoadStatus] = useState<SettingsLoadStatus>({
+    result: null,
+    warnings: [],
+  });
 
   useEffect(() => {
-    loadSettings()
-      .then((rawSettings) => {
+    loadSettingsValidated()
+      .then((loadResult) => {
+        setLoadStatus({
+          result: loadResult,
+          warnings:
+            loadResult.status === "repaired" || loadResult.status === "ok"
+              ? loadResult.warnings
+              : [],
+        });
+
+        const rawSettings = loadResult.settings;
         const sFont = rawSettings.font;
         const sProfiles = rawSettings.profiles;
         const sColorSchemes = rawSettings.colorSchemes;
@@ -243,5 +269,5 @@ export function useSessionPersistence() {
     await persistSession();
   }, []);
 
-  return { loaded, save };
+  return { loaded, save, loadStatus };
 }

--- a/ui/src/hooks/useSessionPersistence.ts
+++ b/ui/src/hooks/useSessionPersistence.ts
@@ -5,7 +5,7 @@ import {
   type SettingsLoadResult,
   type ValidationWarning,
 } from "@/lib/tauri-api";
-import { persistSession } from "@/lib/persist-session";
+import { persistSession, setBlockPersist } from "@/lib/persist-session";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import {
   useSettingsStore,
@@ -45,6 +45,14 @@ export function useSessionPersistence() {
               ? loadResult.warnings
               : [],
         });
+
+        // When settings.json couldn't be parsed, don't hydrate stores with defaults —
+        // this prevents saveBeforeClose from overwriting the user's original file.
+        if (loadResult.status === "parse_error") {
+          setBlockPersist(true);
+          setLoaded(true);
+          return;
+        }
 
         const rawSettings = loadResult.settings;
         const sFont = rawSettings.font;

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -39,6 +39,14 @@ export function truncateFromEnd(data: string, maxChars: number): string {
 /** True once saveBeforeClose() starts — prevents duplicate persistSession() calls during teardown. */
 let closingDown = false;
 
+/** When true, persistSession/saveBeforeClose skip writing settings.json (e.g. parse_error recovery). */
+let persistBlocked = false;
+
+/** Block settings persistence (e.g. when settings.json had a parse error and we don't want to overwrite it). */
+export function setBlockPersist(blocked: boolean): void {
+  persistBlocked = blocked;
+}
+
 /** Reset closingDown flag (for tests only). */
 export function _resetClosingDown(): void {
   closingDown = false;
@@ -203,7 +211,7 @@ async function persistSessionCore(): Promise<void> {
  * No-op if saveBeforeClose() is already in progress (prevents duplicate saves during teardown).
  */
 export async function persistSession(): Promise<void> {
-  if (closingDown) return;
+  if (closingDown || persistBlocked) return;
   await persistSessionCore();
 }
 
@@ -214,6 +222,11 @@ export async function persistSession(): Promise<void> {
  */
 export async function saveBeforeClose(): Promise<void> {
   closingDown = true;
+
+  // When settings had a parse error, don't overwrite the user's original file with defaults.
+  // Terminal output caching is still safe — only settings.json persistence is blocked.
+  if (persistBlocked) return;
+
   const wsState = useWorkspaceStore.getState();
   const dockState = useDockStore.getState();
 

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -70,6 +70,29 @@ export async function loadSettings(): Promise<Settings> {
   return invoke("load_settings");
 }
 
+export interface ValidationWarning {
+  path: string;
+  message: string;
+  repaired: boolean;
+}
+
+export type SettingsLoadResult =
+  | { status: "ok"; settings: Settings; warnings: ValidationWarning[] }
+  | { status: "repaired"; settings: Settings; warnings: ValidationWarning[] }
+  | { status: "parse_error"; settings: Settings; error: string; settingsPath: string };
+
+export async function loadSettingsValidated(): Promise<SettingsLoadResult> {
+  return invoke("load_settings_validated");
+}
+
+export async function resetSettings(): Promise<Settings> {
+  return invoke("reset_settings");
+}
+
+export async function getSettingsPath(): Promise<string> {
+  return invoke("get_settings_path");
+}
+
 export async function saveSettings(settings: Settings): Promise<void> {
   return invoke("save_settings", { settings });
 }


### PR DESCRIPTION
## Summary
- Settings 로드 시 구조 검증(serde 자동 감지 + 비즈니스 규칙 validate) 및 자동 복구 로직 추가
- JSON 파싱 실패 또는 검증 경고 시 사용자에게 선택지를 제공하는 SettingsRecoveryModal 추가
- Pane 좌표 범위 클램핑, NaN/Infinity 제거, 빈 워크스페이스/프로파일 복구, 프로파일 참조 유효성 검증 등 자동화된 validation 규칙 도출

## Changes
### Rust 백엔드
- `settings/validation.rs` (신규): `validate_and_repair()` 검증/복구 로직 + 24개 단위 테스트
- `settings/mod.rs`: `load_settings_validated()` 추가, validation 모듈 등록
- `commands/misc.rs`: `load_settings_validated`, `reset_settings`, `get_settings_path` 커맨드 추가
- `lib.rs`: 새 커맨드 3개 등록
- `tests/e2e_test.rs`: 7개 e2e 테스트 추가

### 프론트엔드
- `tauri-api.ts`: `SettingsLoadResult`, `ValidationWarning` 타입 + API 함수 3개
- `useSessionPersistence.ts`: `loadSettingsValidated()` 사용으로 전환
- `App.tsx`: SettingsRecoveryModal 조건부 렌더링
- `SettingsRecoveryModal.tsx` (신규): 복구 UI 모달 (초기화 / 경로 확인 / 계속 진행)

## Test plan
- [x] Rust 634 테스트 전체 통과 (단위 24개 + e2e 7개 신규 포함)
- [x] 프론트엔드 451 테스트 통과
- [ ] 수동 검증: settings.json을 의도적으로 손상시킨 후 앱 실행 → 복구 모달 확인

Fixes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)