### PR TITLE
fix: 윈도우 크기 복원 시 innerSize 사용하여 크기 불일치 해결

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@tauri-apps/api/window", () => {
     isMinimized: vi.fn().mockResolvedValue(false),
     toggleMaximize: vi.fn().mockResolvedValue(undefined),
     outerPosition: vi.fn().mockResolvedValue({ x: 0, y: 0 }),
+    innerSize: vi.fn().mockResolvedValue({ width: 1200, height: 770 }),
     outerSize: vi.fn().mockResolvedValue({ width: 1200, height: 800 }),
   };
   return {

--- a/ui/src/hooks/useWindowGeometry.test.ts
+++ b/ui/src/hooks/useWindowGeometry.test.ts
@@ -182,10 +182,11 @@ describe("useWindowGeometry", () => {
   });
 
   describe("captureWindowGeometry", () => {
-    it("captures current window state and saves", async () => {
+    it("captures inner size (not outer size) to match setSize restore", async () => {
       mockSaveWindowGeometry.mockResolvedValue(undefined);
       const mockWindow = {
         outerPosition: vi.fn().mockResolvedValue({ x: 50, y: 100 }),
+        innerSize: vi.fn().mockResolvedValue({ width: 1200, height: 770 }),
         outerSize: vi.fn().mockResolvedValue({ width: 1200, height: 800 }),
         isMaximized: vi.fn().mockResolvedValue(false),
         isMinimized: vi.fn().mockResolvedValue(false),
@@ -194,11 +195,14 @@ describe("useWindowGeometry", () => {
 
       await captureWindowGeometry();
 
+      // Must use innerSize, not outerSize, because restoreWindowGeometry
+      // calls setSize() which sets inner (content) size.
+      expect(mockWindow.innerSize).toHaveBeenCalled();
       expect(mockSaveWindowGeometry).toHaveBeenCalledWith({
         x: 50,
         y: 100,
         width: 1200,
-        height: 800,
+        height: 770,
         maximized: false,
       });
     });
@@ -207,6 +211,7 @@ describe("useWindowGeometry", () => {
       mockSaveWindowGeometry.mockResolvedValue(undefined);
       const mockWindow = {
         outerPosition: vi.fn().mockResolvedValue({ x: 200, y: 300 }),
+        innerSize: vi.fn().mockResolvedValue({ width: 1400, height: 870 }),
         outerSize: vi.fn().mockResolvedValue({ width: 1400, height: 900 }),
         isMaximized: vi.fn().mockResolvedValue(false),
         isMinimized: vi.fn().mockResolvedValue(false),
@@ -219,7 +224,7 @@ describe("useWindowGeometry", () => {
         x: 200,
         y: 300,
         width: 1400,
-        height: 900,
+        height: 870,
         maximized: false,
       });
     });
@@ -229,6 +234,7 @@ describe("useWindowGeometry", () => {
       mockSaveWindowGeometry.mockResolvedValue(undefined);
       const normalWindow = {
         outerPosition: vi.fn().mockResolvedValue({ x: 100, y: 200 }),
+        innerSize: vi.fn().mockResolvedValue({ width: 1200, height: 770 }),
         outerSize: vi.fn().mockResolvedValue({ width: 1200, height: 800 }),
         isMaximized: vi.fn().mockResolvedValue(false),
         isMinimized: vi.fn().mockResolvedValue(false),
@@ -252,7 +258,7 @@ describe("useWindowGeometry", () => {
         x: 100,
         y: 200,
         width: 1200,
-        height: 800,
+        height: 770,
         maximized: false,
       });
     });
@@ -260,6 +266,7 @@ describe("useWindowGeometry", () => {
     it("skips saving when minimized and no cached geometry", async () => {
       const mockWindow = {
         outerPosition: vi.fn().mockResolvedValue({ x: -32000, y: -32000 }),
+        innerSize: vi.fn().mockResolvedValue({ width: 160, height: 28 }),
         outerSize: vi.fn().mockResolvedValue({ width: 160, height: 28 }),
         isMaximized: vi.fn().mockResolvedValue(false),
         isMinimized: vi.fn().mockResolvedValue(true),

--- a/ui/src/hooks/useWindowGeometry.ts
+++ b/ui/src/hooks/useWindowGeometry.ts
@@ -65,7 +65,7 @@ async function snapshotGeometry(): Promise<void> {
   if (minimized) return;
 
   const pos = await appWindow.outerPosition();
-  const size = await appWindow.outerSize();
+  const size = await appWindow.innerSize();
   const maximized = await appWindow.isMaximized();
 
   cachedGeometry = {
@@ -80,6 +80,10 @@ async function snapshotGeometry(): Promise<void> {
 /**
  * Save window geometry to persistent cache.
  * If minimized, saves the last known good geometry instead of bogus values.
+ *
+ * NOTE: We save innerSize (content area), not outerSize (includes OS decorations),
+ * because restoreWindowGeometry uses setSize() which sets the inner size.
+ * Using outerSize would cause the window to grow by the decoration height on each restart.
  */
 export async function captureWindowGeometry(): Promise<void> {
   const { getCurrentWindow } = await import("@tauri-apps/api/window");
@@ -95,7 +99,7 @@ export async function captureWindowGeometry(): Promise<void> {
   }
 
   const pos = await appWindow.outerPosition();
-  const size = await appWindow.outerSize();
+  const size = await appWindow.innerSize();
   const maximized = await appWindow.isMaximized();
 
   const geo: WindowGeometry = {


### PR DESCRIPTION
## Summary
- 윈도우 크기 저장 시 `outerSize()`(OS 데코레이션 포함)를 사용했으나 복원 시 `setSize()`는 inner size를 설정하여, 매 시작마다 데코레이션 높이만큼 윈도우가 커지는 문제 수정
- `snapshotGeometry()`와 `captureWindowGeometry()`에서 `outerSize()` → `innerSize()`로 변경하여 저장/복원 기준 일치

Fixes #189

## Test plan
- [x] useWindowGeometry 테스트 10개 통과
- [x] App 테스트 2개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)