### PR TITLE
fix: 동적 생성 PowerShell 터미널의 커서 안정화

### DIFF
--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -282,8 +282,10 @@ impl SyncGroup {
 
 /// PowerShell shell integration script.
 /// Overrides `prompt` to emit:
+/// - OSC 133;A (prompt start) — enables shadow cursor prompt boundary detection
 /// - OSC 133;D (command exit code) — enables notify-on-fail
 /// - OSC 7 (current working directory) — enables sync-cwd
+/// - OSC 133;B (input start) — marks where user input begins (shadow cursor anchor)
 ///   Uses single quotes and concatenation to avoid double-quote escaping issues
 ///   with PowerShell's -Command parameter.
 fn shell_integration_powershell() -> String {
@@ -300,12 +302,13 @@ function prompt {
     $e = $global:__lmx_e; $b = $global:__lmx_b
     $loc = (Get-Location).ProviderPath
     $cwd = $loc.Replace([char]92, '/')
-    if ($cwd.StartsWith('//')) { $r = $e + ']7;' + $cwd + $b }
-    else { $r = $e + ']7;file://localhost/' + $cwd + $b }
+    $r = $e + ']133;A' + $b
+    if ($cwd.StartsWith('//')) { $r += $e + ']7;' + $cwd + $b }
+    else { $r += $e + ']7;file://localhost/' + $cwd + $b }
     if (-not $global:__lmx_f) { $r = $e + ']133;D;' + $ec + $b + $r }
     $global:__lmx_f = $false
     $global:LASTEXITCODE = $ec
-    return $r + 'PS ' + $loc + '> '
+    return $r + 'PS ' + $loc + '> ' + $e + ']133;B' + $b
 }
 "#
     .trim()

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -1781,6 +1781,76 @@ describe("TerminalView", () => {
       vi.useRealTimers();
     });
   });
+
+  describe("cursor warmup", () => {
+    it("hides cursor during warmup and reveals after first OSC 133", async () => {
+      render(<TerminalView instanceId="t-warmup" profile="PowerShell" syncGroup="" isFocused />);
+
+      // During warmup, cursor should be hidden (cursor color matches background)
+      const term = createdTerminals.at(-1)!;
+      const bgColor = (term.options.theme as { background?: string })?.background ?? "#0C0C0C";
+      await vi.waitFor(() => {
+        const cursorColor = (term.options.theme as { cursor?: string })?.cursor;
+        expect(cursorColor).toBe(bgColor);
+      });
+
+      // Receive first OSC 133 (prompt boundary) — cursor should be revealed
+      await act(async () => {
+        await oscHandlers.get("133")?.("D;0");
+      });
+
+      await vi.waitFor(() => {
+        const cursorColor = (term.options.theme as { cursor?: string })?.cursor;
+        expect(cursorColor).not.toBe(bgColor);
+      });
+    });
+
+    it("skips warmup when stabilizeInteractiveCursor is disabled", async () => {
+      useSettingsStore.getState().updateProfile(0, { stabilizeInteractiveCursor: false });
+
+      render(
+        <TerminalView instanceId="t-warmup-disabled" profile="PowerShell" syncGroup="" isFocused />,
+      );
+
+      const term = createdTerminals.at(-1)!;
+      const bgColor = (term.options.theme as { background?: string })?.background ?? "#0C0C0C";
+
+      // Cursor should NOT be hidden (normal cursor color, not matching background)
+      await vi.waitFor(() => {
+        const cursorColor = (term.options.theme as { cursor?: string })?.cursor;
+        expect(cursorColor).not.toBe(bgColor);
+      });
+    });
+
+    it("reveals cursor after warmup timeout even without OSC 133", async () => {
+      vi.useFakeTimers();
+
+      render(
+        <TerminalView instanceId="t-warmup-timeout" profile="PowerShell" syncGroup="" isFocused />,
+      );
+
+      const term = createdTerminals.at(-1)!;
+      const bgColor = (term.options.theme as { background?: string })?.background ?? "#0C0C0C";
+
+      // During warmup, cursor matches background
+      await vi.waitFor(() => {
+        const cursorColor = (term.options.theme as { cursor?: string })?.cursor;
+        expect(cursorColor).toBe(bgColor);
+      });
+
+      // Advance past warmup timeout (3 seconds)
+      await act(async () => {
+        vi.advanceTimersByTime(3100);
+      });
+
+      await vi.waitFor(() => {
+        const cursorColor = (term.options.theme as { cursor?: string })?.cursor;
+        expect(cursorColor).not.toBe(bgColor);
+      });
+
+      vi.useRealTimers();
+    });
+  });
 });
 
 describe("shouldEnableTerminalWebgl", () => {

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { FitAddon } from "@xterm/addon-fit";
@@ -69,6 +69,10 @@ function shouldBlockLargePaste(content: string, enabled: boolean): boolean {
 
 /** Notify gate fallback timeout — only used for output idle detector gating. */
 const NOTIFY_GATE_FALLBACK_MS = 3000;
+
+/** Cursor warmup timeout — hides cursor during shell initialization to prevent
+ * visible cursor jumping. Revealed on first OSC 133 or after this timeout. */
+const CURSOR_WARMUP_MS = 3000;
 
 // Stagger WebGL context creation to prevent WebView2 GPU process crash.
 // Multiple simultaneous WebGL inits can trigger ACCESS_VIOLATION in msedge.dll.
@@ -198,6 +202,8 @@ export function TerminalView({
   const registerInstance = useTerminalStore((s) => s.registerInstance);
   const unregisterInstance = useTerminalStore((s) => s.unregisterInstance);
   const syncOutputActiveRef = useRef(false);
+  const [cursorWarmup, setCursorWarmup] = useState(true);
+  const cursorWarmupRef = useRef(true);
   const shadowCursorRef = useRef<ShadowCursorState>({
     commandStartLine: 0,
     commandStartX: 0,
@@ -231,12 +237,25 @@ export function TerminalView({
       selectionBackground: "#232042",
     };
 
-    const theme = colorScheme
+    const resolvedThemeBase = colorScheme
       ? {
           ...defaultTheme,
           ...colorSchemeToXtermTheme(colorScheme as unknown as WTColorScheme),
         }
       : defaultTheme;
+
+    // Cursor warmup: when stabilizeInteractiveCursor is enabled, hide the cursor
+    // during initialization to prevent visible cursor jumping during shell startup.
+    // The cursor is revealed when the first prompt boundary (OSC 133) is detected.
+    const initStabilize =
+      profileConfig?.stabilizeInteractiveCursor ??
+      settingsState.profileDefaults?.stabilizeInteractiveCursor ??
+      defaultProfileDefaults.stabilizeInteractiveCursor;
+    cursorWarmupRef.current = initStabilize;
+    const warmupBg = resolvedThemeBase.background ?? defaultTheme.background;
+    const theme = initStabilize
+      ? { ...resolvedThemeBase, cursor: warmupBg, cursorAccent: warmupBg }
+      : resolvedThemeBase;
 
     // Scrollbar overlay mode: set overviewRuler width to 0 so FitAddon
     // does not reserve space for the scrollbar — it renders on top of content.
@@ -422,7 +441,13 @@ export function TerminalView({
         scheduleOverlayCaretUpdate();
       });
     };
+    const completeCursorWarmup = () => {
+      if (!cursorWarmupRef.current) return;
+      cursorWarmupRef.current = false;
+      setCursorWarmup(false);
+    };
     const handlePromptOsc = (data: string) => {
+      completeCursorWarmup();
       const shadowCursor = shadowCursorRef.current;
       shadowCursor.hasPromptBoundary = true;
       switch (data.split(";")[0]) {
@@ -729,6 +754,12 @@ export function TerminalView({
     const notifyGateTimer = setTimeout(() => {
       notifyGate.armed = true;
     }, NOTIFY_GATE_FALLBACK_MS);
+
+    // Cursor warmup timeout — reveal cursor even if no OSC 133 is received
+    // (e.g., shells without shell integration).
+    const cursorWarmupTimer = cursorWarmupRef.current
+      ? setTimeout(() => completeCursorWarmup(), CURSOR_WARMUP_MS)
+      : undefined;
 
     // Output idle detector (monitor-silence): fires when terminal output
     // stops for OUTPUT_IDLE_TIMEOUT_MS while activity is "running".
@@ -1071,6 +1102,7 @@ export function TerminalView({
       cancelled = true;
       if (webglTimer !== undefined) clearTimeout(webglTimer);
       clearTimeout(notifyGateTimer);
+      if (cursorWarmupTimer !== undefined) clearTimeout(cursorWarmupTimer);
       idleDetector.dispose();
       resizeObserver.disconnect();
       outerContainer?.removeEventListener("contextmenu", handleContextMenu);
@@ -1201,7 +1233,8 @@ export function TerminalView({
       // so rgba(0,0,0,0) renders as opaque black. Hide the native cursor by
       // matching it to the background color instead.
       const hiddenCursorColor = resolvedTheme.background ?? defaultTheme.background;
-      term.options.theme = nativeCursorHidden
+      const hideCursor = nativeCursorHidden || cursorWarmupRef.current;
+      term.options.theme = hideCursor
         ? {
             ...resolvedTheme,
             cursor: hiddenCursorColor,
@@ -1241,6 +1274,7 @@ export function TerminalView({
     effectiveNativeCursorBlink,
     nativeCursorHidden,
     stabilizeInteractiveCursor,
+    cursorWarmup,
   ]);
 
   // Reactively update xterm overviewRuler width when scrollbarStyle changes

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -151,7 +151,10 @@
  * CSS classes (scrollbar-overlay / scrollbar-separate) applied for test hooks only.
  */
 
-.terminal-sync-output-active .xterm-cursor-layer,
+/* xterm.js v6: cursor is drawn on canvas (WebGL or built-in renderer),
+ * so CSS cannot hide it. Cursor hiding during DEC 2026 frames and Codex
+ * overlay mode is handled via xterm theme options (cursor color = background).
+ * These selectors target the DOM renderer fallback only. */
 .terminal-sync-output-active .xterm-cursor {
   opacity: 0 !important;
 }
@@ -160,7 +163,6 @@
   caret-color: transparent !important;
 }
 
-.terminal-native-cursor-hidden .xterm-cursor-layer,
 .terminal-native-cursor-hidden .xterm-cursor {
   opacity: 0 !important;
 }


### PR DESCRIPTION
## Summary

- xterm.js v6에서 `.xterm-cursor-layer` CSS 클래스가 제거되어 WebGL 렌더러에서 CSS 기반 커서 숨김이 무효화되는 문제 수정
- PowerShell shell integration에 OSC 133;A/B 프롬프트 경계 마커 추가로 shadow cursor 시스템 활성화
- 커서 워밍업 메커니즘 추가: 셸 초기화 중 커서를 배경색으로 숨기고 첫 프롬프트 수신 후 복원

## 근본 원인

1. **xterm.js v6 CSS 호환성**: `.xterm-cursor-layer` 클래스가 v6에서 완전히 제거됨. WebGL 렌더러는 커서를 캔버스에 직접 그리므로 CSS `opacity: 0`이 작동하지 않음
2. **PowerShell OSC 마커 부재**: shell integration이 OSC 133;D만 emit하고 A/B를 emit하지 않아 shadow cursor가 프롬프트 입력 경계를 감지 불가
3. **초기화 중 커서 노출**: 시작 시 로드된 터미널은 캐시 복원으로 초기화가 가려지지만, 동적 생성 터미널은 셸 부팅 과정의 커서 점프가 그대로 보임

## 변경 사항

| 파일 | 변경 |
|------|------|
| `TerminalView.tsx` | 커서 워밍업 state/ref 추가, theme 기반 커서 숨김 (WebGL 호환), OSC 133 수신 시 워밍업 완료 |
| `TerminalView.test.tsx` | 워밍업 테스트 3개 추가 (숨김→복원, 비활성 시 스킵, 타임아웃 폴백) |
| `terminal/mod.rs` | PowerShell prompt에 OSC 133;A (프롬프트 시작) + OSC 133;B (입력 시작) 추가 |
| `index.css` | `.xterm-cursor-layer` 셀렉터 제거 (v6에 없음), 설명 주석 추가 |

## Test plan

- [x] 기존 TerminalView 테스트 76개 전체 통과
- [x] 새 워밍업 테스트 3개 통과
- [ ] 수동 테스트: Pane 분할 → EmptyView → PowerShell 선택 → 커서 안정성 확인
- [ ] 수동 테스트: 앱 시작 시 기존 터미널 커서 정상 동작 확인
- [ ] 수동 테스트: Codex 실행 시 overlay caret 정상 동작 확인

Fixes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)