### PR TITLE
Fix PowerShell stable cursor fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,8 @@ test-results/
 .claude/worktrees/
 .claude/*.local.*
 
+# Codex
+.codex
+
 # Temp files
 *~

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -141,11 +141,18 @@ else
     warn "curl이 없어 health check를 건너뜁니다."
 fi
 
-# --- 5. .mcp.json 생성 ---
+# --- 5. MCP 서버 이름 결정 (dev/release 키 분리) ---
+if [ "$USE_DEV" = true ]; then
+    MCP_NAME="laymux-dev"
+else
+    MCP_NAME="laymux"
+fi
+
+# --- 6. .mcp.json 생성 ---
 MCP_CONFIG=$(cat <<EOF
 {
   "mcpServers": {
-    "laymux": {
+    "$MCP_NAME": {
       "type": "http",
       "url": "$MCP_URL",
       "headers": {
@@ -163,33 +170,33 @@ if [ "$SCOPE" = "global" ]; then
     if [ -f "$TARGET" ]; then
         # Merge into existing file
         EXISTING=$(cat "$TARGET")
-        echo "$EXISTING" | jq --arg url "$MCP_URL" --arg key "Bearer $KEY" \
-            '.mcpServers.laymux = { "type": "http", "url": $url, "headers": { "Authorization": $key } }' \
+        echo "$EXISTING" | jq --arg name "$MCP_NAME" --arg url "$MCP_URL" --arg key "Bearer $KEY" \
+            '.mcpServers[$name] = { "type": "http", "url": $url, "headers": { "Authorization": $key } }' \
             > "$TARGET.tmp"
         mv "$TARGET.tmp" "$TARGET"
     else
         echo "$MCP_CONFIG" > "$TARGET"
     fi
-    info "전역 등록 완료: $TARGET"
+    info "전역 등록 완료: $TARGET ($MCP_NAME)"
 else
     PROJECT_DIR="$(realpath "$PROJECT_DIR")"
     [ -d "$PROJECT_DIR" ] || error "디렉토리가 존재하지 않습니다: $PROJECT_DIR"
     TARGET="$PROJECT_DIR/.mcp.json"
 
     if [ -f "$TARGET" ]; then
-        jq --arg url "$MCP_URL" --arg key "Bearer $KEY" \
-            '.mcpServers.laymux = { "type": "http", "url": $url, "headers": { "Authorization": $key } }' \
+        jq --arg name "$MCP_NAME" --arg url "$MCP_URL" --arg key "Bearer $KEY" \
+            '.mcpServers[$name] = { "type": "http", "url": $url, "headers": { "Authorization": $key } }' \
             "$TARGET" > "$TARGET.tmp"
         mv "$TARGET.tmp" "$TARGET"
     else
         echo "$MCP_CONFIG" > "$TARGET"
     fi
-    info "프로젝트 등록 완료: $TARGET"
+    info "프로젝트 등록 완료: $TARGET ($MCP_NAME)"
 fi
 
-# --- 6. 권한 설정 ---
+# --- 7. 권한 설정 ---
 SETTINGS="$HOME/.claude/settings.json"
-PERMISSION_RULE="mcp__laymux__*"
+PERMISSION_RULE="mcp__${MCP_NAME}__*"
 
 if [ -f "$SETTINGS" ]; then
     if jq -e --arg rule "$PERMISSION_RULE" '.permissions.allow | index($rule)' "$SETTINGS" >/dev/null 2>&1; then

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -513,6 +513,77 @@ describe("TerminalView", () => {
     expect(container).not.toHaveClass("terminal-sync-output-active");
   });
 
+  it("keeps DEC 2026 fallback cursor sync available after PowerShell-style OSC 133 D", async () => {
+    render(
+      <TerminalView
+        instanceId="t-powershell-dec-fallback"
+        profile="PowerShell"
+        syncGroup=""
+        isFocused
+      />,
+    );
+
+    act(() => {
+      useTerminalStore.getState().updateInstanceInfo("t-powershell-dec-fallback", {
+        activity: { type: "interactiveApp", name: "Codex" },
+      });
+    });
+
+    const container = screen.getByTestId("terminal-view-t-powershell-dec-fallback");
+    const overlay = screen.getByTestId("terminal-overlay-caret-t-powershell-dec-fallback");
+    const terminal = createdTerminals[0] as unknown as {
+      element: HTMLDivElement;
+      buffer: { active: { cursorX: number; cursorY: number; baseY?: number } };
+    };
+    const screenEl = document.createElement("div");
+    screenEl.className = "xterm-screen";
+    screenEl.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: 0,
+        width: 800,
+        height: 480,
+        right: 800,
+        bottom: 480,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    terminal.element.appendChild(screenEl);
+    container.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: 0,
+        width: 800,
+        height: 480,
+        right: 800,
+        bottom: 480,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    terminal.buffer.active.baseY = 0;
+    terminal.buffer.active.cursorX = 2;
+    terminal.buffer.active.cursorY = 4;
+
+    await act(async () => {
+      await oscHandlers.get("133")?.("D;0");
+    });
+
+    terminal.buffer.active.cursorX = 20;
+    terminal.buffer.active.cursorY = 10;
+
+    await act(async () => {
+      await csiHandlers.get("?:l")?.([2026]);
+    });
+
+    await vi.waitFor(() => {
+      expect(overlay.style.transform).toBe("translate(200px, 200px)");
+      expect(overlay.style.opacity).toBe("1");
+    });
+  });
+
   it("tracks xterm synchronizedOutputMode after terminal.write", async () => {
     render(<TerminalView instanceId="t-sync-write" profile="PowerShell" syncGroup="" />);
 

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -84,6 +84,10 @@ function hasDecModeParam(params: readonly (number | number[])[], mode: number): 
   return params.some((param) => (Array.isArray(param) ? param.includes(mode) : param === mode));
 }
 
+function isPromptBoundaryOscParam(param: string): boolean {
+  return param === "A" || param === "B" || param === "C";
+}
+
 export function shouldEnableTerminalWebgl(): boolean {
   return true;
 }
@@ -424,8 +428,11 @@ export function TerminalView({
     };
     const handlePromptOsc = (data: string) => {
       const shadowCursor = shadowCursorRef.current;
-      shadowCursor.hasPromptBoundary = true;
-      switch (data.split(";")[0]) {
+      const param = data.split(";")[0] ?? "";
+      if (isPromptBoundaryOscParam(param)) {
+        shadowCursor.hasPromptBoundary = true;
+      }
+      switch (param) {
         case "A":
           setInputPhase(false);
           break;
@@ -820,11 +827,12 @@ export function TerminalView({
       }
       if (
         text.includes("\x1b]133;C") ||
-        text.includes("\x1b]133;D") ||
-        text.includes("\x1b]633;C") ||
-        text.includes("\x1b]633;D")
+        text.includes("\x1b]633;C")
       ) {
         shadowCursorRef.current.hasPromptBoundary = true;
+        setInputPhase(false);
+      }
+      if (text.includes("\x1b]133;D") || text.includes("\x1b]633;D")) {
         setInputPhase(false);
       }
 


### PR DESCRIPTION
## Summary
- stop treating PowerShell-style OSC 133;D as a full prompt boundary for shadow cursor state
- keep Codex DEC 2026 fallback cursor sync available when PowerShell only emits completion markers
- add a regression test covering the new PowerShell pane path

## Test
- npm test -- src/components/views/TerminalView.test.tsx