### PR TITLE
feat: Bearer 인증 제거 → IP allowlist로 교체

### DIFF
--- a/.claude/commands/screenshot.md
+++ b/.claude/commands/screenshot.md
@@ -6,7 +6,7 @@ Laymux IDE의 dev 인스턴스에서 스크린샷을 캡처하여 확인한다.
 
 - **Dev 인스턴스**: 고정 포트 `19281`
 - **Release 인스턴스 (19280)**: 절대 건드리지 않는다
-- **인증 불필요**: IP allowlist로 로컬 접근만 허용 (loopback, RFC 1918 사설 대역)
+- **인증 불필요**: IP allowlist로 로컬 접근만 허용 (loopback, WSL2/Hyper-V, link-local)
 
 ## 절차
 

--- a/.claude/commands/screenshot.md
+++ b/.claude/commands/screenshot.md
@@ -2,23 +2,21 @@
 
 Laymux IDE의 dev 인스턴스에서 스크린샷을 캡처하여 확인한다.
 
-## 포트 및 인증 규칙
+## 포트 규칙
 
-- **Dev 인스턴스**: `%APPDATA%\laymux-dev\automation.json`에서 `port`와 `key`를 읽는다
+- **Dev 인스턴스**: 고정 포트 `19281`
 - **Release 인스턴스 (19280)**: 절대 건드리지 않는다
-- **모든 API 호출**에 `Authorization: Bearer {KEY}` 헤더를 포함해야 한다 (health 제외)
+- **인증 불필요**: IP allowlist로 로컬 접근만 허용 (loopback, RFC 1918 사설 대역)
 
 ## 절차
 
-### 1. dev discovery 파일 읽기
+### 1. health check
 
 ```bash
-cat "$APPDATA/laymux-dev/automation.json"
+curl -s http://127.0.0.1:19281/api/v1/health
 ```
 
-- `port` 필드 값을 이후 모든 요청의 `{PORT}`로 사용한다
-- `key` 필드 값을 이후 모든 요청의 `{KEY}`로 사용한다
-- 파일이 없으면 → 2단계 실행
+- 응답이 없으면 → 2단계 실행
 
 ### 2. 앱 실행 (dev 인스턴스가 없는 경우만)
 
@@ -28,15 +26,13 @@ cd D:/PycharmProjects/laymux && cargo tauri dev
 
 - 반드시 **백그라운드**로 실행한다
 - health 엔드포인트가 응답할 때까지 10초 간격으로 폴링한다 (최대 2분)
-- 실행 후 1단계를 다시 수행하여 `port`와 `key`를 읽는다
 
 ### 3. 스크린샷 캡처
 
 ```bash
-curl -s -X POST http://127.0.0.1:{PORT}/api/v1/screenshot -H "Authorization: Bearer {KEY}"
+curl -s -X POST http://127.0.0.1:19281/api/v1/screenshot
 ```
 
-- `{PORT}`와 `{KEY}`는 1단계에서 읽은 값으로 대체한다
 - 응답에서 `path` 필드를 확인한다
 - 해당 경로의 PNG 파일을 `Read` 도구로 열어서 시각적으로 확인한다
 
@@ -49,24 +45,21 @@ curl -s -X POST http://127.0.0.1:{PORT}/api/v1/screenshot -H "Authorization: Bea
 
 ## 추가 명령어 (필요시)
 
-모든 URL에서 `{PORT}`는 dev 인스턴스 포트로, `{KEY}`는 API 키로 대체한다.
-인증 헤더: `-H "Authorization: Bearer {KEY}"`
-
 | 용도 | 명령 |
 |------|------|
-| 헬스체크 (인증 불필요) | `curl -s http://127.0.0.1:{PORT}/api/v1/health` |
-| 워크스페이스 목록 | `curl -s http://127.0.0.1:{PORT}/api/v1/workspaces -H "Authorization: Bearer {KEY}"` |
-| 터미널 출력 읽기 | `curl -s http://127.0.0.1:{PORT}/api/v1/terminals/{id}/output?lines=50 -H "Authorization: Bearer {KEY}"` |
-| 터미널에 입력 | `curl -s -X POST http://127.0.0.1:{PORT}/api/v1/terminals/{id}/write -H "Authorization: Bearer {KEY}" -H "Content-Type: application/json" -d '{"data":"ls\n"}'` |
-| 그리드 상태 | `curl -s http://127.0.0.1:{PORT}/api/v1/grid -H "Authorization: Bearer {KEY}"` |
-| 편집모드 ON | `curl -s -X POST http://127.0.0.1:{PORT}/api/v1/grid/edit-mode -H "Authorization: Bearer {KEY}" -H "Content-Type: application/json" -d '{"enabled":true}'` |
-| Pane 분할 | `curl -s -X POST http://127.0.0.1:{PORT}/api/v1/panes/split -H "Authorization: Bearer {KEY}" -H "Content-Type: application/json" -d '{"paneIndex":0,"direction":"vertical"}'` |
-| 독 토글 | `curl -s -X POST http://127.0.0.1:{PORT}/api/v1/docks/left/toggle -H "Authorization: Bearer {KEY}"` |
-| 독 View 변경 | `curl -s -X PUT http://127.0.0.1:{PORT}/api/v1/docks/left/active-view -H "Authorization: Bearer {KEY}" -H "Content-Type: application/json" -d '{"view":"SettingsView"}'` |
-| 워크스페이스 전환 | `curl -s -X POST http://127.0.0.1:{PORT}/api/v1/workspaces/active -H "Authorization: Bearer {KEY}" -H "Content-Type: application/json" -d '{"id":"ws-1"}'` |
+| 헬스체크 | `curl -s http://127.0.0.1:19281/api/v1/health` |
+| 워크스페이스 목록 | `curl -s http://127.0.0.1:19281/api/v1/workspaces` |
+| 터미널 출력 읽기 | `curl -s http://127.0.0.1:19281/api/v1/terminals/{id}/output?lines=50` |
+| 터미널에 입력 | `curl -s -X POST http://127.0.0.1:19281/api/v1/terminals/{id}/write -H "Content-Type: application/json" -d '{"data":"ls\n"}'` |
+| 그리드 상태 | `curl -s http://127.0.0.1:19281/api/v1/grid` |
+| 편집모드 ON | `curl -s -X POST http://127.0.0.1:19281/api/v1/grid/edit-mode -H "Content-Type: application/json" -d '{"enabled":true}'` |
+| Pane 분할 | `curl -s -X POST http://127.0.0.1:19281/api/v1/panes/split -H "Content-Type: application/json" -d '{"paneIndex":0,"direction":"vertical"}'` |
+| 독 토글 | `curl -s -X POST http://127.0.0.1:19281/api/v1/docks/left/toggle` |
+| 독 View 변경 | `curl -s -X PUT http://127.0.0.1:19281/api/v1/docks/left/active-view -H "Content-Type: application/json" -d '{"view":"SettingsView"}'` |
+| 워크스페이스 전환 | `curl -s -X POST http://127.0.0.1:19281/api/v1/workspaces/active -H "Content-Type: application/json" -d '{"id":"ws-1"}'` |
 
 ## 주의사항
 
 - 스크린샷 파일은 `.screenshots/` 디렉터리에 저장되며 `.gitignore`로 제외됨
 - 터미널 내용은 html2canvas 한계로 canvas 렌더링이 깨질 수 있음
-- 앱 종료: `taskkill //F //IM laymux.exe` (Windows)
+- 앱 종료: `bash scripts/kill-dev.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 * 모든 개발 시 자율 검증 루프(API 조작→스크린샷→평가→수정)를 구성하여 스스로 결과를 확인하고 품질을 높인다. 필요한 API 엔드포인트가 없으면 먼저 추가한다. Automation API는 AI가 IDE를 자율 제어할 수 있는 핵심 인터페이스이므로, 기능 추가 시 항상 API 확장과 자율 루프 구성 가능 여부를 고려한다.
 * **컴파일 에러 수정 시 테스트 우선**: 새 필드/기능 추가로 인해 기존 테스트가 컴파일 에러를 일으키면, 단순히 기본값(`None`, `0` 등)을 채워 넣어 컴파일만 통과시키지 말고, 해당 기능을 실제로 검증하는 e2e 테스트를 추가한다.
 * **마이그레이션 불필요**: 현재 내부 개발 단계이므로 설정 파일 경로 변경 등에 대한 마이그레이션 로직은 구현하지 않는다. 기존 데이터는 수동으로 처리한다.
-* **Automation API 포트 규칙**: 고정 포트 — release=19280, dev=19281. 각 빌드 타입은 하나의 인스턴스만 실행 가능. 개발 중 스크린샷/API 호출은 반드시 dev 인스턴스(포트 19281)를 사용한다. Release 빌드(포트 19280)는 사용자가 직접 사용하므로 절대 건드리지 않는다. **Bearer 인증 필수**: dev discovery 파일(`%APPDATA%\laymux-dev\automation.json`)에서 `port`와 `key`를 읽어 모든 API 호출에 `Authorization: Bearer <key>` 헤더를 포함한다. Health 엔드포인트만 인증 없이 접근 가능.
+* **Automation API 포트 규칙**: 고정 포트 — release=19280, dev=19281. 각 빌드 타입은 하나의 인스턴스만 실행 가능. 개발 중 스크린샷/API 호출은 반드시 dev 인스턴스(포트 19281)를 사용한다. Release 빌드(포트 19280)는 사용자가 직접 사용하므로 절대 건드리지 않는다. **인증 불필요**: IP allowlist로 로컬 접근만 허용 (loopback, WSL2/Hyper-V 172.16.0.0/12, link-local). 별도 인증 헤더 없이 API 호출 가능.
 * **dev 프로세스 종료 시 반드시 `scripts/kill-dev.sh` 사용**: dev 인스턴스를 종료해야 할 때(포트 충돌, exe 잠금, 재시작 등) **절대로 `tasklist | grep laymux`로 PID를 찾아 수동 kill하지 않는다.** release와 dev가 동일한 `laymux.exe` 이름을 사용하므로 구분이 불가능하여 release를 잘못 죽일 수 있다. 반드시 `bash scripts/kill-dev.sh`를 실행하여 `automation.json` PID 기반으로 dev만 안전하게 종료한다.
 * **외부 프로세스 실행 시 headless_command 사용**: Rust에서 `std::process::Command::new()` 대신 반드시 `crate::process::headless_command()`를 사용한다. Windows에서 콘솔 창이 깜빡이는 것을 방지하기 위해 `CREATE_NO_WINDOW` 플래그를 자동 적용한다.
 * **Rust 코드 설계 원칙 준수**: ARCHITECTURE.md §14에 정의된 Rust 설계 원칙을 따른다. 핵심 규칙:

--- a/scripts/setup-mcp.ps1
+++ b/scripts/setup-mcp.ps1
@@ -1,0 +1,172 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    laymux 내장 MCP 서버 설정 스크립트 (Streamable HTTP) — Windows PowerShell 버전
+
+.DESCRIPTION
+    laymux가 실행 중이면 discovery 파일에서 port를 읽어
+    Claude Code MCP 설정을 자동 등록한다. 별도 빌드 불필요.
+    인증 불필요 — IP allowlist로 로컬 접근만 허용.
+    JSON 처리에 Python을 사용한다 (PowerShell 5.1의 대용량 JSON 파싱 제한 회피).
+
+.EXAMPLE
+    .\setup-mcp.ps1                          # 전역 (~/.claude.json)
+    .\setup-mcp.ps1 -Project C:\dev\myapp    # 프로젝트 (.mcp.json)
+    .\setup-mcp.ps1 -Dev                     # dev 인스턴스 (포트 19281)
+    .\setup-mcp.ps1 -Force                   # health check 실패해도 계속 진행
+#>
+
+param(
+    [string]$Project,
+    [switch]$Dev,
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# --- 색상 헬퍼 ---
+function Write-Ok    { param([string]$Msg) Write-Host "[OK] $Msg" -ForegroundColor Green }
+function Write-Warn  { param([string]$Msg) Write-Host "[WARN] $Msg" -ForegroundColor Yellow }
+function Write-Err   { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red; exit 1 }
+
+# --- Python 확인 ---
+$PythonCmd = $null
+foreach ($cmd in @("python", "python3", "py")) {
+    if (Get-Command $cmd -ErrorAction SilentlyContinue) {
+        $PythonCmd = $cmd
+        break
+    }
+}
+if (-not $PythonCmd) {
+    Write-Err "Python이 설치되어 있지 않습니다. JSON 처리에 Python이 필요합니다."
+}
+
+# --- 1. Port 결정 ---
+Write-Host "=== laymux MCP 설정 (내장 HTTP) ==="
+Write-Host ""
+
+$McpName = if ($Dev) { "laymux-dev" } else { "laymux" }
+$Port = if ($Dev) { 19281 } else { 19280 }
+$Gateway = "127.0.0.1"
+$McpUrl = "http://${Gateway}:${Port}/mcp"
+
+Write-Ok "서버: $McpName"
+Write-Ok "Port: $Port"
+Write-Ok "Gateway: $Gateway"
+
+# --- 2. Health check ---
+$HealthUrl = "http://${Gateway}:${Port}/api/v1/health"
+
+try {
+    $null = Invoke-RestMethod -Uri $HealthUrl -Method Get -TimeoutSec 3
+    Write-Ok "Health check 통과"
+} catch {
+    if ($Force) {
+        Write-Warn "Health check 실패 (-Force로 계속 진행)"
+    } else {
+        Write-Err "Health check 실패. laymux가 실행 중인지 확인하세요.`n       -Force로 무시할 수 있습니다."
+    }
+}
+
+# --- 3. MCP 설정 등록 (Python으로 JSON 안전 처리) ---
+$Scope = if ($Project) { "project" } else { "global" }
+
+if ($Scope -eq "global") {
+    $Target = Join-Path $env:USERPROFILE ".claude.json"
+} else {
+    $ProjectDir = Resolve-Path $Project -ErrorAction Stop
+    if (-not (Test-Path $ProjectDir -PathType Container)) {
+        Write-Err "디렉토리가 존재하지 않습니다: $Project"
+    }
+    $Target = Join-Path $ProjectDir ".mcp.json"
+}
+
+$pyScript = @"
+import json, sys, os
+
+target = sys.argv[1]
+name = sys.argv[2]
+url = sys.argv[3]
+
+if os.path.exists(target):
+    with open(target, encoding='utf-8-sig') as f:
+        data = json.load(f)
+else:
+    data = {}
+
+if 'mcpServers' not in data:
+    data['mcpServers'] = {}
+
+data['mcpServers'][name] = {
+    'type': 'http',
+    'url': url,
+}
+
+with open(target, 'w', encoding='utf-8', newline='\n') as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+
+print('ok')
+"@
+
+$result = & $PythonCmd -c $pyScript $Target $McpName $McpUrl 2>&1
+if ($result -ne "ok") {
+    Write-Err "MCP 설정 등록 실패: $result"
+}
+
+$scopeLabel = if ($Scope -eq "global") { "전역" } else { "프로젝트" }
+Write-Ok "$scopeLabel 등록 완료: $Target ($McpName)"
+
+# --- 4. 권한 설정 (Python으로 JSON 안전 처리) ---
+$SettingsPath = Join-Path (Join-Path $env:USERPROFILE ".claude") "settings.json"
+$PermissionRule = "mcp__${McpName}__*"
+
+$pyPermScript = @"
+import json, sys, os
+
+target = sys.argv[1]
+rule = sys.argv[2]
+
+if not os.path.exists(target):
+    print('no_file')
+    sys.exit(0)
+
+with open(target, encoding='utf-8-sig') as f:
+    data = json.load(f)
+
+perms = data.setdefault('permissions', {})
+allow = perms.setdefault('allow', [])
+
+if rule in allow:
+    print('already')
+    sys.exit(0)
+
+allow.append(rule)
+
+with open(target, 'w', encoding='utf-8', newline='\n') as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+
+print('added')
+"@
+
+$permResult = & $PythonCmd -c $pyPermScript $SettingsPath $PermissionRule 2>&1
+
+switch ($permResult) {
+    "already" { Write-Ok "권한이 이미 설정되어 있습니다." }
+    "added"   { Write-Ok "권한 추가 완료: $PermissionRule" }
+    "no_file" {
+        Write-Warn "$SettingsPath 파일이 없습니다. 수동으로 권한을 추가하세요:"
+        Write-Host "  `"$PermissionRule`""
+    }
+    default {
+        Write-Warn "권한 설정 실패: $permResult"
+    }
+}
+
+# --- 완료 ---
+Write-Host ""
+Write-Host "=== 설정 완료 ==="
+Write-Host "MCP URL: $McpUrl"
+Write-Host "Claude Code를 재시작한 후 /mcp 명령으로 $McpName 이 보이는지 확인하세요."
+Write-Host ""
+Write-Host "인증이 필요 없으므로 laymux를 재시작해도 이 설정은 유효합니다."

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # laymux 내장 MCP 서버 설정 스크립트 (Streamable HTTP)
 #
-# laymux가 실행 중이면 discovery 파일에서 port/key를 읽어
-# Claude Code MCP 설정을 자동 등록한다. 별도 빌드 불필요.
+# laymux의 고정 포트를 사용하여 Claude Code MCP 설정을 자동 등록한다.
+# 인증 불필요 — IP allowlist로 로컬 접근만 허용.
 # 기본: 전역 등록 (~/.claude.json), --project: 프로젝트별 (.mcp.json)
 #
 # 사용법:
@@ -22,6 +22,9 @@ NC='\033[0m'
 info()  { echo -e "${GREEN}[OK]${NC} $1"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
 error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+
+# --- jq 확인 ---
+command -v jq >/dev/null 2>&1 || error "jq가 설치되어 있지 않습니다. (sudo apt install jq)"
 
 # --- 인자 파싱 ---
 SCOPE="global"
@@ -51,63 +54,22 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# --- 1. Discovery 파일 찾기 ---
+# --- 1. Port 결정 ---
 echo "=== laymux MCP 설정 (내장 HTTP) ==="
 echo
 
-# Determine discovery file path
 if [ "$USE_DEV" = true ]; then
-    APP_DIR="laymux-dev"
+    MCP_NAME="laymux-dev"
+    PORT=19281
 else
-    APP_DIR="laymux"
+    MCP_NAME="laymux"
+    PORT=19280
 fi
 
-# Try WSL path first (Windows %APPDATA% via /mnt/c)
-DISCOVERY=""
-
-if [ -d "/mnt/c" ]; then
-    # WSL: resolve current Windows user via cmd.exe, not glob
-    WIN_USER=$(cmd.exe /C "echo %USERNAME%" 2>/dev/null | tr -d '\r\n' || echo "")
-    if [ -n "$WIN_USER" ]; then
-        candidate="/mnt/c/Users/$WIN_USER/AppData/Roaming/$APP_DIR/automation.json"
-        if [ -f "$candidate" ]; then
-            DISCOVERY="$candidate"
-        fi
-    fi
-
-    # Fallback: glob (single-user machines)
-    if [ -z "$DISCOVERY" ]; then
-        for user_dir in /mnt/c/Users/*/AppData/Roaming; do
-            candidate="$user_dir/$APP_DIR/automation.json"
-            if [ -f "$candidate" ]; then
-                DISCOVERY="$candidate"
-                break
-            fi
-        done
-    fi
-fi
-
-# Fallback: Linux native
-if [ -z "$DISCOVERY" ] && [ -f "$HOME/.config/$APP_DIR/automation.json" ]; then
-    DISCOVERY="$HOME/.config/$APP_DIR/automation.json"
-fi
-
-[ -z "$DISCOVERY" ] && error "automation.json을 찾을 수 없습니다. laymux가 실행 중인지 확인하세요."
-info "Discovery 파일: $DISCOVERY"
-
-# --- 2. Port / Key 읽기 ---
-command -v jq >/dev/null 2>&1 || error "jq가 설치되어 있지 않습니다. (sudo apt install jq)"
-
-PORT=$(jq -r '.port' "$DISCOVERY")
-KEY=$(jq -r '.key' "$DISCOVERY")
-
-[ -z "$PORT" ] || [ "$PORT" = "null" ] && error "discovery 파일에서 port를 읽을 수 없습니다."
-[ -z "$KEY" ] || [ "$KEY" = "null" ] && error "discovery 파일에서 key를 읽을 수 없습니다."
-
+info "서버: $MCP_NAME"
 info "Port: $PORT"
-info "Key: ${KEY:0:8}...${KEY: -4}"
 
-# --- 3. Gateway IP 결정 ---
+# --- 2. Gateway IP 결정 ---
 if [ -d "/mnt/c" ]; then
     # WSL: Windows host IP
     GATEWAY=$(ip route show default 2>/dev/null | awk '{print $3}' || echo "")
@@ -121,36 +83,31 @@ fi
 
 info "Gateway: $GATEWAY"
 
-# --- 4. Health check ---
+# --- 3. Health check ---
 MCP_URL="http://$GATEWAY:$PORT/mcp"
 HEALTH_URL="http://$GATEWAY:$PORT/api/v1/health"
 
-HEALTH_OK=false
 if command -v curl >/dev/null 2>&1; then
     if curl -sf --max-time 3 "$HEALTH_URL" >/dev/null 2>&1; then
         info "Health check 통과"
-        HEALTH_OK=true
     else
         if [ "$FORCE" = true ]; then
             warn "Health check 실패 (--force로 계속 진행)"
         else
-            error "Health check 실패. laymux가 실행 중인지 확인하세요.\n       stale automation.json일 수 있습니다. --force로 무시할 수 있습니다."
+            error "Health check 실패. laymux가 실행 중인지 확인하세요.\n       --force로 무시할 수 있습니다."
         fi
     fi
 else
     warn "curl이 없어 health check를 건너뜁니다."
 fi
 
-# --- 5. .mcp.json 생성 ---
+# --- 4. .mcp.json 생성 ---
 MCP_CONFIG=$(cat <<EOF
 {
   "mcpServers": {
-    "laymux": {
+    "$MCP_NAME": {
       "type": "http",
-      "url": "$MCP_URL",
-      "headers": {
-        "Authorization": "Bearer $KEY"
-      }
+      "url": "$MCP_URL"
     }
   }
 }
@@ -163,33 +120,33 @@ if [ "$SCOPE" = "global" ]; then
     if [ -f "$TARGET" ]; then
         # Merge into existing file
         EXISTING=$(cat "$TARGET")
-        echo "$EXISTING" | jq --arg url "$MCP_URL" --arg key "Bearer $KEY" \
-            '.mcpServers.laymux = { "type": "http", "url": $url, "headers": { "Authorization": $key } }' \
+        echo "$EXISTING" | jq --arg name "$MCP_NAME" --arg url "$MCP_URL" \
+            '.mcpServers[$name] = { "type": "http", "url": $url }' \
             > "$TARGET.tmp"
         mv "$TARGET.tmp" "$TARGET"
     else
         echo "$MCP_CONFIG" > "$TARGET"
     fi
-    info "전역 등록 완료: $TARGET"
+    info "전역 등록 완료: $TARGET ($MCP_NAME)"
 else
     PROJECT_DIR="$(realpath "$PROJECT_DIR")"
     [ -d "$PROJECT_DIR" ] || error "디렉토리가 존재하지 않습니다: $PROJECT_DIR"
     TARGET="$PROJECT_DIR/.mcp.json"
 
     if [ -f "$TARGET" ]; then
-        jq --arg url "$MCP_URL" --arg key "Bearer $KEY" \
-            '.mcpServers.laymux = { "type": "http", "url": $url, "headers": { "Authorization": $key } }' \
+        jq --arg name "$MCP_NAME" --arg url "$MCP_URL" \
+            '.mcpServers[$name] = { "type": "http", "url": $url }' \
             "$TARGET" > "$TARGET.tmp"
         mv "$TARGET.tmp" "$TARGET"
     else
         echo "$MCP_CONFIG" > "$TARGET"
     fi
-    info "프로젝트 등록 완료: $TARGET"
+    info "프로젝트 등록 완료: $TARGET ($MCP_NAME)"
 fi
 
-# --- 6. 권한 설정 ---
+# --- 5. 권한 설정 ---
 SETTINGS="$HOME/.claude/settings.json"
-PERMISSION_RULE="mcp__laymux__*"
+PERMISSION_RULE="mcp__${MCP_NAME}__*"
 
 if [ -f "$SETTINGS" ]; then
     if jq -e --arg rule "$PERMISSION_RULE" '.permissions.allow | index($rule)' "$SETTINGS" >/dev/null 2>&1; then
@@ -208,7 +165,6 @@ fi
 echo
 echo "=== 설정 완료 ==="
 echo "MCP URL: $MCP_URL"
-echo "Claude Code를 재시작한 후 /mcp 명령으로 laymux가 보이는지 확인하세요."
+echo "Claude Code를 재시작한 후 /mcp 명령으로 $MCP_NAME 이 보이는지 확인하세요."
 echo
-echo "참고: laymux를 재시작하면 Bearer key가 변경됩니다."
-echo "      그 때 이 스크립트를 다시 실행하세요."
+echo "인증이 필요 없으므로 laymux를 재시작해도 이 설정은 유효합니다."

--- a/src-tauri/src/automation_server/handlers_backend.rs
+++ b/src-tauri/src/automation_server/handlers_backend.rs
@@ -15,10 +15,10 @@ pub async fn api_docs() -> impl IntoResponse {
     Json(serde_json::json!({
         "name": "Laymux IDE Automation API",
         "version": "v1",
-        "description": "Programmatic control of Laymux IDE. Binds to 0.0.0.0 (WSL2 access). Requires Bearer token from discovery file.",
+        "description": "Programmatic control of Laymux IDE. Binds to 0.0.0.0 (WSL2 access). Access restricted to local/private networks (loopback, RFC 1918).",
         "base_url": format!("http://127.0.0.1:{}/api/v1", super::automation_port()),
-        "auth": "Bearer token required. Read 'key' from discovery file and send as: Authorization: Bearer <key>. GET /api/v1/health is exempt.",
-        "discovery": format!("Fixed port: release={}, dev={}. Discovery file: %APPDATA%/laymux/automation.json (release) or %APPDATA%/laymux-dev/automation.json (dev) on Windows, ~/.config/laymux/ or ~/.config/laymux-dev/ on Linux. Contains port, key, pid. Also LX_AUTOMATION_PORT env var in spawned terminals.", super::RELEASE_PORT, super::DEV_PORT),
+        "auth": "No authentication required. Access is restricted by IP allowlist (localhost, RFC 1918 private networks, link-local).",
+        "discovery": format!("Fixed port: release={}, dev={}. Discovery file: %APPDATA%/laymux/automation.json (release) or %APPDATA%/laymux-dev/automation.json (dev) on Windows, ~/.config/laymux/ or ~/.config/laymux-dev/ on Linux. Contains port and pid. Also LX_AUTOMATION_PORT env var in spawned terminals.", super::RELEASE_PORT, super::DEV_PORT),
         "endpoints": [
             {
                 "method": "GET", "path": "/api/v1/health",

--- a/src-tauri/src/automation_server/handlers_backend.rs
+++ b/src-tauri/src/automation_server/handlers_backend.rs
@@ -15,9 +15,9 @@ pub async fn api_docs() -> impl IntoResponse {
     Json(serde_json::json!({
         "name": "Laymux IDE Automation API",
         "version": "v1",
-        "description": "Programmatic control of Laymux IDE. Binds to 0.0.0.0 (WSL2 access). Access restricted to local/private networks (loopback, RFC 1918).",
+        "description": "Programmatic control of Laymux IDE. Binds to 0.0.0.0 (WSL2 access). Access restricted to loopback, WSL2/Hyper-V bridge (172.16.0.0/12), and link-local.",
         "base_url": format!("http://127.0.0.1:{}/api/v1", super::automation_port()),
-        "auth": "No authentication required. Access is restricted by IP allowlist (localhost, RFC 1918 private networks, link-local).",
+        "auth": "No authentication required. Access is restricted by IP allowlist: loopback (127.x, ::1), WSL2/Hyper-V (172.16.0.0/12), link-local (169.254.x, fe80::).",
         "discovery": format!("Fixed port: release={}, dev={}. Discovery file: %APPDATA%/laymux/automation.json (release) or %APPDATA%/laymux-dev/automation.json (dev) on Windows, ~/.config/laymux/ or ~/.config/laymux-dev/ on Linux. Contains port and pid. Also LX_AUTOMATION_PORT env var in spawned terminals.", super::RELEASE_PORT, super::DEV_PORT),
         "endpoints": [
             {

--- a/src-tauri/src/automation_server/mod.rs
+++ b/src-tauri/src/automation_server/mod.rs
@@ -120,19 +120,22 @@ pub async fn start(app_state: Arc<AppState>, app_handle: AppHandle) -> Result<u1
     Ok(port)
 }
 
-/// Check if an IP address is a local/private address.
-/// Allows: loopback (127.x, ::1), RFC 1918 private (10.x, 172.16-31.x, 192.168.x),
-/// and link-local (169.254.x, fe80::).
+/// Check if an IP address is allowed to access the automation API.
+/// Allows only loopback, link-local, and Hyper-V/WSL2 bridge (172.16.0.0/12).
+/// Broader RFC 1918 ranges (10.0.0.0/8, 192.168.0.0/16) are excluded to prevent
+/// LAN/VPN peers from accessing the API without authentication.
 fn is_local_ip(ip: &IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => {
             v4.is_loopback()            // 127.0.0.0/8
-                || v4.octets()[0] == 10  // 10.0.0.0/8
-                || (v4.octets()[0] == 172 && (16..=31).contains(&v4.octets()[1])) // 172.16.0.0/12
-                || (v4.octets()[0] == 192 && v4.octets()[1] == 168) // 192.168.0.0/16
+                || (v4.octets()[0] == 172 && (16..=31).contains(&v4.octets()[1])) // 172.16.0.0/12 (WSL2/Hyper-V)
                 || (v4.octets()[0] == 169 && v4.octets()[1] == 254) // 169.254.0.0/16 link-local
         }
         IpAddr::V6(v6) => {
+            // Handle IPv4-mapped IPv6 (::ffff:x.x.x.x) — OS may use these when bound to 0.0.0.0
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return is_local_ip(&IpAddr::V4(mapped));
+            }
             v6.is_loopback()  // ::1
                 || (v6.segments()[0] & 0xffc0) == 0xfe80 // fe80::/10 link-local
         }
@@ -265,17 +268,22 @@ mod tests {
     }
 
     #[test]
-    fn is_local_ip_allows_private_ranges() {
-        // 10.0.0.0/8
-        assert!(is_local_ip(&"10.0.0.1".parse().unwrap()));
-        assert!(is_local_ip(&"10.255.255.255".parse().unwrap()));
-        // 172.16.0.0/12
+    fn is_local_ip_allows_wsl2_and_link_local() {
+        // 172.16.0.0/12 (WSL2/Hyper-V bridge)
         assert!(is_local_ip(&"172.16.0.1".parse().unwrap()));
         assert!(is_local_ip(&"172.31.255.255".parse().unwrap()));
-        // 192.168.0.0/16
-        assert!(is_local_ip(&"192.168.1.1".parse().unwrap()));
         // link-local
         assert!(is_local_ip(&"169.254.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn is_local_ip_rejects_lan_and_vpn_ranges() {
+        // 10.0.0.0/8 (corporate VPN)
+        assert!(!is_local_ip(&"10.0.0.1".parse().unwrap()));
+        assert!(!is_local_ip(&"10.255.255.255".parse().unwrap()));
+        // 192.168.0.0/16 (home LAN)
+        assert!(!is_local_ip(&"192.168.1.1".parse().unwrap()));
+        assert!(!is_local_ip(&"192.168.0.1".parse().unwrap()));
     }
 
     #[test]
@@ -284,6 +292,18 @@ mod tests {
         assert!(!is_local_ip(&"172.32.0.1".parse().unwrap()));
         assert!(!is_local_ip(&"172.15.255.255".parse().unwrap()));
         assert!(!is_local_ip(&"192.169.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn is_local_ip_handles_ipv4_mapped_ipv6() {
+        // ::ffff:127.0.0.1 → loopback
+        assert!(is_local_ip(&"::ffff:127.0.0.1".parse().unwrap()));
+        // ::ffff:172.20.0.1 → WSL2 range
+        assert!(is_local_ip(&"::ffff:172.20.0.1".parse().unwrap()));
+        // ::ffff:192.168.1.1 → rejected (LAN)
+        assert!(!is_local_ip(&"::ffff:192.168.1.1".parse().unwrap()));
+        // ::ffff:8.8.8.8 → rejected (public)
+        assert!(!is_local_ip(&"::ffff:8.8.8.8".parse().unwrap()));
     }
 
     #[test]

--- a/src-tauri/src/automation_server/mod.rs
+++ b/src-tauri/src/automation_server/mod.rs
@@ -11,7 +11,10 @@ pub use types::{AutomationRequest, AutomationResponse};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use axum::extract::{Request, State as AxumState};
+use std::net::IpAddr;
+
+use axum::extract::ConnectInfo;
+use axum::extract::Request;
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
@@ -49,13 +52,8 @@ pub fn automation_port() -> u16 {
     }
 }
 
-/// Generate a random bearer token for API authentication.
-pub fn generate_automation_key() -> String {
-    uuid::Uuid::new_v4().to_string()
-}
-
-/// Write discovery file so external tools can find the automation port and key.
-pub fn write_discovery_file(port: u16, key: &str) {
+/// Write discovery file so external tools can find the automation port.
+pub fn write_discovery_file(port: u16) {
     let path = discovery_file_path();
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -64,7 +62,6 @@ pub fn write_discovery_file(port: u16, key: &str) {
         "port": port,
         "pid": std::process::id(),
         "version": env!("CARGO_PKG_VERSION"),
-        "key": key,
     });
     let _ = std::fs::write(
         &path,
@@ -88,14 +85,12 @@ fn discovery_file_path() -> std::path::PathBuf {
 /// Start the automation HTTP server on a fixed port.
 /// Release = 19280, Dev = 19281. No fallback — fails if port is occupied.
 pub async fn start(app_state: Arc<AppState>, app_handle: AppHandle) -> Result<u16, String> {
-    let key = generate_automation_key();
-
     let server_state = ServerState {
         app_state: app_state.clone(),
         app_handle,
     };
 
-    let app = build_router(server_state, &key);
+    let app = build_router(server_state);
 
     let port = automation_port();
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -103,32 +98,21 @@ pub async fn start(app_state: Arc<AppState>, app_handle: AppHandle) -> Result<u1
         .await
         .map_err(|e| format!("Failed to bind automation server on port {port}: {e}. Is another instance already running?"))?;
 
-    // Store port and key in AppState
+    // Store port in AppState
     if let Ok(mut p) = app_state.automation_port.lock_or_err() {
         *p = Some(port);
     } else {
         tracing::error!("Failed to store automation port in AppState (lock poisoned)");
     }
-    if let Ok(mut k) = app_state.automation_key.lock_or_err() {
-        *k = Some(key.clone());
-    } else {
-        tracing::error!("Failed to store automation key in AppState (lock poisoned)");
-    }
 
-    // Write discovery file (includes key)
-    write_discovery_file(port, &key);
+    write_discovery_file(port);
 
     tracing::info!(port, "Automation server listening on 0.0.0.0:{port}");
-    tracing::info!(
-        key_prefix = &key[..8],
-        key_suffix = &key[key.len() - 4..],
-        "Automation API key: {}...{}",
-        &key[..8],
-        &key[key.len() - 4..]
-    );
 
     tokio::spawn(async move {
-        if let Err(e) = axum::serve(listener, app).await {
+        if let Err(e) =
+            axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await
+        {
             tracing::error!(error = %e, "Automation server error");
         }
     });
@@ -136,48 +120,45 @@ pub async fn start(app_state: Arc<AppState>, app_handle: AppHandle) -> Result<u1
     Ok(port)
 }
 
-/// Bearer token authentication middleware.
-/// Skips auth for GET /api/v1/health and CORS preflight (OPTIONS).
-async fn auth_middleware(
-    AxumState(expected_key): AxumState<String>,
-    req: Request,
-    next: Next,
-) -> Response {
-    // Allow CORS preflight through (OPTIONS must pass before auth)
-    if req.method() == axum::http::Method::OPTIONS {
-        return next.run(req).await;
-    }
-
-    // Allow health endpoint without auth
-    if req.uri().path() == "/api/v1/health" {
-        return next.run(req).await;
-    }
-
-    let auth_header = req
-        .headers()
-        .get("authorization")
-        .and_then(|v| v.to_str().ok());
-
-    match auth_header.and_then(|h| h.strip_prefix("Bearer ")) {
-        Some(token) if token == expected_key => next.run(req).await,
-        Some(_) => (
-            StatusCode::UNAUTHORIZED,
-            Json(err_json("Invalid API key")),
-        )
-            .into_response(),
-        None => (
-            StatusCode::UNAUTHORIZED,
-            Json(err_json(
-                "Missing Authorization header. Use: Authorization: Bearer <key from automation.json>",
-            )),
-        )
-            .into_response(),
+/// Check if an IP address is a local/private address.
+/// Allows: loopback (127.x, ::1), RFC 1918 private (10.x, 172.16-31.x, 192.168.x),
+/// and link-local (169.254.x, fe80::).
+fn is_local_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()            // 127.0.0.0/8
+                || v4.octets()[0] == 10  // 10.0.0.0/8
+                || (v4.octets()[0] == 172 && (16..=31).contains(&v4.octets()[1])) // 172.16.0.0/12
+                || (v4.octets()[0] == 192 && v4.octets()[1] == 168) // 192.168.0.0/16
+                || (v4.octets()[0] == 169 && v4.octets()[1] == 254) // 169.254.0.0/16 link-local
+        }
+        IpAddr::V6(v6) => {
+            v6.is_loopback()  // ::1
+                || (v6.segments()[0] & 0xffc0) == 0xfe80 // fe80::/10 link-local
+        }
     }
 }
 
-pub fn build_router(state: ServerState, key: &str) -> Router {
-    let key = key.to_string();
+/// IP allowlist middleware — only permits requests from local/private networks.
+/// Replaces Bearer token auth: since this is localhost/WSL communication,
+/// IP restriction provides equivalent security without key management overhead.
+async fn ip_allowlist_middleware(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    req: Request,
+    next: Next,
+) -> Response {
+    if is_local_ip(&addr.ip()) {
+        next.run(req).await
+    } else {
+        (
+            StatusCode::FORBIDDEN,
+            Json(err_json("Access denied: only local/private network connections are allowed")),
+        )
+            .into_response()
+    }
+}
 
+pub fn build_router(state: ServerState) -> Router {
     Router::new()
         .route("/api/v1/docs", get(api_docs))
         .route("/api/v1/health", get(health))
@@ -253,7 +234,7 @@ pub fn build_router(state: ServerState, key: &str) -> Router {
             "/api/v1/ui/notifications",
             post(ui_toggle_notification_panel),
         )
-        .layer(middleware::from_fn_with_state(key, auth_middleware))
+        .layer(middleware::from_fn(ip_allowlist_middleware))
         .layer(CorsLayer::permissive())
         .with_state(state)
 }
@@ -277,125 +258,32 @@ mod tests {
     }
 
     #[test]
-    fn generate_automation_key_is_unique() {
-        let k1 = generate_automation_key();
-        let k2 = generate_automation_key();
-        assert_ne!(k1, k2);
-        assert!(!k1.is_empty());
-    }
-
-    /// Build a minimal router with auth middleware for testing.
-    fn auth_test_router(key: &str) -> Router {
-        let protected = Router::new()
-            .route("/api/v1/health", get(|| async { StatusCode::OK }))
-            .route("/api/v1/protected", get(|| async { StatusCode::OK }));
-
-        protected
-            .layer(middleware::from_fn_with_state(
-                key.to_string(),
-                auth_middleware,
-            ))
-            .layer(CorsLayer::permissive())
-    }
-
-    #[tokio::test]
-    async fn auth_health_no_token_returns_ok() {
-        let app = auth_test_router("secret-key");
-        let req = axum::http::Request::builder()
-            .uri("/api/v1/health")
-            .body(axum::body::Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    #[tokio::test]
-    async fn auth_valid_token_returns_ok() {
-        let app = auth_test_router("secret-key");
-        let req = axum::http::Request::builder()
-            .uri("/api/v1/protected")
-            .header("Authorization", "Bearer secret-key")
-            .body(axum::body::Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    #[tokio::test]
-    async fn auth_invalid_token_returns_401() {
-        let app = auth_test_router("secret-key");
-        let req = axum::http::Request::builder()
-            .uri("/api/v1/protected")
-            .header("Authorization", "Bearer wrong-key")
-            .body(axum::body::Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[tokio::test]
-    async fn auth_missing_header_returns_401() {
-        let app = auth_test_router("secret-key");
-        let req = axum::http::Request::builder()
-            .uri("/api/v1/protected")
-            .body(axum::body::Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-    }
-
-    /// Verify auth middleware applies to nest_service routes (covers /mcp).
-    #[tokio::test]
-    async fn auth_nest_service_requires_token() {
-        use axum::routing::get;
-        use tower::service_fn;
-
-        let nested_svc = service_fn(|_req: axum::http::Request<axum::body::Body>| async {
-            Ok::<_, std::convert::Infallible>(
-                axum::http::Response::builder()
-                    .status(StatusCode::OK)
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
-        });
-
-        let app =
-            Router::new()
-                .nest_service("/mcp", nested_svc)
-                .layer(middleware::from_fn_with_state(
-                    "secret-key".to_string(),
-                    auth_middleware,
-                ));
-
-        // Without token → 401
-        let req = axum::http::Request::builder()
-            .method("POST")
-            .uri("/mcp")
-            .body(axum::body::Body::empty())
-            .unwrap();
-        let resp = app.clone().oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-
-        // With valid token → 200
-        let req = axum::http::Request::builder()
-            .method("POST")
-            .uri("/mcp")
-            .header("Authorization", "Bearer secret-key")
-            .body(axum::body::Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
+    fn is_local_ip_allows_loopback() {
+        assert!(is_local_ip(&"127.0.0.1".parse().unwrap()));
+        assert!(is_local_ip(&"127.0.0.2".parse().unwrap()));
+        assert!(is_local_ip(&"::1".parse().unwrap()));
     }
 
     #[test]
-    #[serial]
-    fn discovery_file_contains_key() {
-        write_discovery_file(19281, "secret-abc");
-        let path = discovery_file_path();
-        let content = std::fs::read_to_string(&path).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
-        assert_eq!(parsed["key"], "secret-abc");
-        remove_discovery_file();
+    fn is_local_ip_allows_private_ranges() {
+        // 10.0.0.0/8
+        assert!(is_local_ip(&"10.0.0.1".parse().unwrap()));
+        assert!(is_local_ip(&"10.255.255.255".parse().unwrap()));
+        // 172.16.0.0/12
+        assert!(is_local_ip(&"172.16.0.1".parse().unwrap()));
+        assert!(is_local_ip(&"172.31.255.255".parse().unwrap()));
+        // 192.168.0.0/16
+        assert!(is_local_ip(&"192.168.1.1".parse().unwrap()));
+        // link-local
+        assert!(is_local_ip(&"169.254.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn is_local_ip_rejects_public() {
+        assert!(!is_local_ip(&"8.8.8.8".parse().unwrap()));
+        assert!(!is_local_ip(&"172.32.0.1".parse().unwrap()));
+        assert!(!is_local_ip(&"172.15.255.255".parse().unwrap()));
+        assert!(!is_local_ip(&"192.169.0.1".parse().unwrap()));
     }
 
     #[test]
@@ -407,13 +295,13 @@ mod tests {
     #[test]
     #[serial]
     fn write_and_remove_discovery_file() {
-        write_discovery_file(19280, "test-key-123");
+        write_discovery_file(19280);
         let path = discovery_file_path();
         assert!(path.exists());
         let content = std::fs::read_to_string(&path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
         assert_eq!(parsed["port"], 19280);
-        assert_eq!(parsed["key"], "test-key-123");
+        assert!(parsed.get("key").is_none());
         assert!(parsed["pid"].as_u64().unwrap() > 0);
         remove_discovery_file();
         assert!(!path.exists());

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -16,15 +16,9 @@ pub fn greet(name: &str) -> String {
 #[tauri::command]
 pub fn get_automation_info(state: State<Arc<AppState>>) -> Result<serde_json::Value, String> {
     let port = state.automation_port.lock_or_err()?.unwrap_or(0);
-    let key = state
-        .automation_key
-        .lock_or_err()?
-        .clone()
-        .unwrap_or_default();
 
     Ok(serde_json::json!({
         "port": port,
-        "key": key,
     }))
 }
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -41,11 +41,6 @@ pub fn create_terminal_session(
             env.push((ENV_LX_AUTOMATION_PORT.to_string(), port.to_string()));
         }
     }
-    if let Ok(key_lock) = state.automation_key.lock_or_err() {
-        if let Some(ref key) = *key_lock {
-            env.push((ENV_LX_AUTOMATION_KEY.to_string(), key.clone()));
-        }
-    }
 
     // Look up the profile's command_line, startup_command, and starting_directory from settings
     let settings = crate::settings::load_settings();

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -22,7 +22,6 @@ pub const ENV_LX_SOCKET: &str = "LX_SOCKET";
 pub const ENV_LX_TERMINAL_ID: &str = "LX_TERMINAL_ID";
 pub const ENV_LX_GROUP_ID: &str = "LX_GROUP_ID";
 pub const ENV_LX_AUTOMATION_PORT: &str = "LX_AUTOMATION_PORT";
-pub const ENV_LX_AUTOMATION_KEY: &str = "LX_AUTOMATION_KEY";
 pub const ENV_LX_PROPAGATED: &str = "LX_PROPAGATED";
 
 // ── Timeouts & limits ──────────────────────────────────────────────
@@ -118,7 +117,6 @@ mod tests {
             ENV_LX_TERMINAL_ID,
             ENV_LX_GROUP_ID,
             ENV_LX_AUTOMATION_PORT,
-            ENV_LX_AUTOMATION_KEY,
             ENV_LX_PROPAGATED,
         ];
         for name in envs {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -32,9 +32,6 @@ pub struct AppState {
     pub automation_channels:
         Mutex<HashMap<String, tokio::sync::oneshot::Sender<serde_json::Value>>>,
     pub automation_port: Mutex<Option<u16>>,
-    /// Bearer token for Automation API authentication.
-    /// Generated on startup, written to discovery file.
-    pub automation_key: Mutex<Option<String>>,
     /// Terminals that recently received a propagated command (e.g., cd from sync-cwd).
     /// Used to suppress OSC echo loops. Entries expire after PROPAGATION_TIMEOUT.
     pub propagated_terminals: Mutex<HashMap<String, Instant>>,
@@ -66,7 +63,6 @@ impl AppState {
             output_buffers: Arc::new(Mutex::new(HashMap::new())),
             automation_channels: Mutex::new(HashMap::new()),
             automation_port: Mutex::new(None),
-            automation_key: Mutex::new(None),
             propagated_terminals: Mutex::new(HashMap::new()),
             known_claude_terminals: Arc::new(Mutex::new(HashSet::new())),
             known_codex_terminals: Arc::new(Mutex::new(HashSet::new())),

--- a/ui/src/components/views/ConnectionInfoModal.test.tsx
+++ b/ui/src/components/views/ConnectionInfoModal.test.tsx
@@ -10,7 +10,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 describe("ConnectionInfoModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockInvoke.mockResolvedValue({ port: 19280, key: "test-uuid-key-123" });
+    mockInvoke.mockResolvedValue({ port: 19280 });
   });
 
   it("calls get_automation_info on mount", async () => {
@@ -20,13 +20,13 @@ describe("ConnectionInfoModal", () => {
     });
   });
 
-  it("renders host, port, and key as environment variables", async () => {
+  it("renders host and port as environment variables", async () => {
     render(<ConnectionInfoModal />);
     await waitFor(() => {
       const pre = document.querySelector("pre");
       expect(pre?.textContent).toContain("LX_AUTOMATION_HOST=127.0.0.1");
       expect(pre?.textContent).toContain("LX_AUTOMATION_PORT=19280");
-      expect(pre?.textContent).toContain("LX_AUTOMATION_KEY=test-uuid-key-123");
+      expect(pre?.textContent).not.toContain("LX_AUTOMATION_KEY");
     });
   });
 });

--- a/ui/src/components/views/ConnectionInfoModal.tsx
+++ b/ui/src/components/views/ConnectionInfoModal.tsx
@@ -3,7 +3,6 @@ import { invoke } from "@tauri-apps/api/core";
 
 interface AutomationInfo {
   port: number;
-  key: string;
 }
 
 export function ConnectionInfoModal() {
@@ -26,7 +25,6 @@ export function ConnectionInfoModal() {
   const lines = [
     `LX_AUTOMATION_HOST=127.0.0.1`,
     `LX_AUTOMATION_PORT=${info.port}`,
-    `LX_AUTOMATION_KEY=${info.key}`,
   ].join("\n");
 
   return (

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -42,10 +42,9 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
     setState("capturing");
     try {
       const { invoke } = await import("@tauri-apps/api/core");
-      const info = await invoke<{ port: number; key: string }>("get_automation_info");
+      const info = await invoke<{ port: number }>("get_automation_info");
       const res = await fetch(`http://127.0.0.1:${info.port}/api/v1/screenshot`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${info.key}` },
       });
       const data = await res.json();
       if (data.path) setScreenshotPath(data.path);


### PR DESCRIPTION
## Summary
- Automation API 전체에서 Bearer token 인증 제거
- IP allowlist 미들웨어로 교체 (loopback, RFC 1918, link-local만 허용)
- MCP 설정이 laymux 재시작과 무관하게 영구 유효 (URL만으로 연결)
- Windows용 `setup-mcp.ps1` 스크립트 추가

## 변경 내역

| 영역 | 변경 |
|------|------|
| `automation_server/mod.rs` | `auth_middleware` → `ip_allowlist_middleware` (ConnectInfo 기반) |
| `state.rs` | `automation_key` 필드 제거 |
| `constants.rs` | `ENV_LX_AUTOMATION_KEY` 제거 |
| `commands/terminal.rs` | `LX_AUTOMATION_KEY` 환경변수 주입 제거 |
| `commands/misc.rs` | `get_automation_info`에서 key 반환 제거 |
| `handlers_backend.rs` | API docs에서 auth 설명 업데이트 |
| `discovery file` | key 필드 제거 (port, pid, version만) |
| `setup-mcp.sh` | headers/key 로직 제거, 고정 포트 기반 |
| `setup-mcp.ps1` | 신규 — Windows PowerShell용 (Python JSON 처리) |
| `screenshot.md` | 인증 헤더 제거 |
| UI (ConnectionInfoModal, IssueReporterView) | key/Bearer 참조 제거 |

## 배경
다른 IDE (VS Code, Cursor, JetBrains 등)는 로컬 MCP 연결에 인증 없이 운영.
laymux도 로컬 통신이므로 IP 제한만으로 충분하며, Bearer key 동적 갱신 문제 해소.

## Test plan
- [x] `cargo check` 통과
- [x] Rust 단위 테스트 61개 통과 (`is_local_ip` 허용/거부 테스트 포함)
- [x] UI 테스트 1486개 통과
- [ ] dev 빌드 실행 후 인증 없이 API 호출 확인
- [ ] 공인 IP에서 접근 시 403 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)