### PR TITLE
feat: MCP caller context 도구 및 응답 강화

### DIFF
--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -233,12 +233,44 @@ fn local_interface_ips() -> Vec<String> {
 
 #[tool_router]
 impl McpHandler {
-    // ── Terminal (5) ──
+    // ── Terminal (7) ──
 
-    /// List all terminal instances with id, profile, syncGroup, workspaceId, cwd, branch.
+    /// List all terminal instances with id, profile, syncGroup, workspaceId, cwd, branch, paneIndex, and panePosition (x,y,w,h).
     #[tool]
     async fn list_terminals(&self) -> Result<CallToolResult, ErrorData> {
         self.bridge("query", "terminals", "list", json!({})).await
+    }
+
+    /// Identify a terminal's full context: workspace, pane position (x,y,w,h), and neighboring panes.
+    /// Pass the value of the LX_TERMINAL_ID environment variable from your shell.
+    /// Use this as the first step to understand your position in the IDE grid.
+    #[tool]
+    async fn identify_caller(
+        &self,
+        Parameters(p): Parameters<TerminalIdParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.bridge(
+            "query",
+            "terminals",
+            "identify",
+            json!({ "id": p.terminal_id }),
+        )
+        .await
+    }
+
+    /// Get details for a single terminal by ID, including pane position and workspace info.
+    #[tool]
+    async fn get_terminal(
+        &self,
+        Parameters(p): Parameters<TerminalIdParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.bridge(
+            "query",
+            "terminals",
+            "get",
+            json!({ "id": p.terminal_id }),
+        )
+        .await
     }
 
     /// Send input to a terminal (like typing). For control characters set
@@ -332,7 +364,7 @@ impl McpHandler {
         self.bridge("query", "workspaces", "list", json!({})).await
     }
 
-    /// Get the currently active workspace with full pane details.
+    /// Get the currently active workspace with full pane details including paneIndex and terminalId for each pane.
     #[tool]
     async fn get_active_workspace(&self) -> Result<CallToolResult, ErrorData> {
         self.bridge("query", "workspaces", "getActive", json!({}))
@@ -354,7 +386,7 @@ impl McpHandler {
         .await
     }
 
-    /// Create a new workspace, optionally from a layout template.
+    /// Create a new workspace, optionally from a layout template. Returns the new workspace's id, name, and pane count.
     #[tool]
     async fn create_workspace(
         &self,
@@ -367,9 +399,9 @@ impl McpHandler {
         self.bridge("action", "workspaces", "add", params).await
     }
 
-    // ── Grid/Pane (3) ──
+    // ── Grid/Pane (4) ──
 
-    /// Get grid state: editMode, focusedPaneIndex.
+    /// Get grid state: editMode, focusedPaneIndex, and activeWorkspaceId.
     #[tool]
     async fn get_grid_state(&self) -> Result<CallToolResult, ErrorData> {
         self.bridge("query", "grid", "getState", json!({})).await
@@ -390,7 +422,7 @@ impl McpHandler {
         .await
     }
 
-    /// Split a pane horizontally or vertically.
+    /// Split a pane horizontally or vertically. Returns info about the new pane created.
     #[tool]
     async fn split_pane(
         &self,
@@ -401,6 +433,21 @@ impl McpHandler {
             "panes",
             "split",
             json!({ "paneIndex": p.pane_index, "direction": p.direction.to_string() }),
+        )
+        .await
+    }
+
+    /// Remove a pane from the active workspace grid. Remaining panes redistribute space.
+    #[tool]
+    async fn remove_pane(
+        &self,
+        Parameters(p): Parameters<PaneIndexParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.bridge(
+            "action",
+            "panes",
+            "remove",
+            json!({ "paneIndex": p.pane_index }),
         )
         .await
     }
@@ -475,7 +522,21 @@ impl ServerHandler for McpHandler {
             ))
             .with_instructions(
                 "Laymux IDE automation via MCP. \
-                 Control terminals, workspaces, grid layout, and capture screenshots."
+                 Control terminals, workspaces, grid layout, and capture screenshots.\n\n\
+                 ## Self-identification\n\
+                 Your terminal has the env var LX_TERMINAL_ID (e.g. \"terminal-pane-a1b2c3d4\"). \
+                 Read it with `echo $LX_TERMINAL_ID` then call `identify_caller` with that value to learn:\n\
+                 - Which workspace you are in (id, name, whether it is active)\n\
+                 - Your pane position in the grid (x, y, w, h as 0-1 normalized coordinates, pane index)\n\
+                 - Neighboring panes (left, right, above, below) and their terminal IDs\n\
+                 - Your terminal metadata (cwd, branch, activity state)\n\n\
+                 ## Other env vars\n\
+                 - LX_AUTOMATION_PORT: The port this MCP server runs on\n\
+                 - LX_GROUP_ID: Your sync group (terminals in the same group share CWD)\n\n\
+                 ## Common workflows\n\
+                 - Find yourself: echo $LX_TERMINAL_ID → identify_caller\n\
+                 - Send command to adjacent pane: identify_caller → use neighbors.right.terminalId → write_to_terminal\n\
+                 - Read another pane's output: list_terminals → read_terminal_output with target terminal_id"
                     .to_string(),
             )
     }

--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -525,7 +525,8 @@ impl ServerHandler for McpHandler {
                  Control terminals, workspaces, grid layout, and capture screenshots.\n\n\
                  ## Self-identification\n\
                  Your terminal has the env var LX_TERMINAL_ID (e.g. \"terminal-pane-a1b2c3d4\"). \
-                 Read it with `echo $LX_TERMINAL_ID` then call `identify_caller` with that value to learn:\n\
+                 Read it with `echo $LX_TERMINAL_ID` (bash/zsh) or `echo $env:LX_TERMINAL_ID` (PowerShell), \
+                 then call `identify_caller` with that value to learn:\n\
                  - Which workspace you are in (id, name, whether it is active)\n\
                  - Your pane position in the grid (x, y, w, h as 0-1 normalized coordinates, pane index)\n\
                  - Neighboring panes (left, right, above, below) and their terminal IDs\n\
@@ -534,7 +535,7 @@ impl ServerHandler for McpHandler {
                  - LX_AUTOMATION_PORT: The port this MCP server runs on\n\
                  - LX_GROUP_ID: Your sync group (terminals in the same group share CWD)\n\n\
                  ## Common workflows\n\
-                 - Find yourself: echo $LX_TERMINAL_ID → identify_caller\n\
+                 - Find yourself: echo $LX_TERMINAL_ID (or $env:LX_TERMINAL_ID in PowerShell) → identify_caller\n\
                  - Send command to adjacent pane: identify_caller → use neighbors.right.terminalId → write_to_terminal\n\
                  - Read another pane's output: list_terminals → read_terminal_output with target terminal_id"
                     .to_string(),

--- a/ui/src/hooks/useAutomationBridge.test.ts
+++ b/ui/src/hooks/useAutomationBridge.test.ts
@@ -550,7 +550,8 @@ describe("identify_caller and enriched responses", () => {
     expect(instances[0].panePosition).toHaveProperty("x");
   });
 
-  it("get_active_workspace includes paneIndex and terminalId per pane", () => {
+  it("get_active_workspace: EmptyView pane has terminalId null", () => {
+    // Default workspace pane is EmptyView — no terminal registered
     const result = handleAutomationRequest({
       requestId: "gaw1",
       category: "query",
@@ -563,8 +564,26 @@ describe("identify_caller and enriched responses", () => {
     const ws = data.workspace as Record<string, unknown>;
     const panes = ws.panes as Array<Record<string, unknown>>;
     expect(panes[0]).toHaveProperty("paneIndex", 0);
-    expect(panes[0]).toHaveProperty("terminalId");
-    expect((panes[0].terminalId as string).startsWith("terminal-")).toBe(true);
+    expect(panes[0].terminalId).toBeNull();
+  });
+
+  it("get_active_workspace: TerminalView pane has terminalId set", () => {
+    // Set the pane to TerminalView
+    const ws = useWorkspaceStore.getState().getActiveWorkspace()!;
+    useWorkspaceStore.getState().setPaneView(0, { type: "TerminalView" });
+
+    const result = handleAutomationRequest({
+      requestId: "gaw2",
+      category: "query",
+      target: "workspaces",
+      method: "getActive",
+      params: {},
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const wsData = data.workspace as Record<string, unknown>;
+    const panes = wsData.panes as Array<Record<string, unknown>>;
+    expect(panes[0].terminalId).toBe(`terminal-${ws.panes[0].id}`);
   });
 
   it("get_grid_state includes activeWorkspaceId", () => {
@@ -596,7 +615,8 @@ describe("identify_caller and enriched responses", () => {
     const newPane = data.newPane as Record<string, unknown>;
     expect(newPane).not.toBeNull();
     expect(newPane.paneIndex).toBe(1);
-    expect(newPane).toHaveProperty("terminalId");
+    // New split pane is EmptyView — terminalId should be null
+    expect(newPane.terminalId).toBeNull();
     expect(newPane).toHaveProperty("x");
   });
 
@@ -616,6 +636,53 @@ describe("identify_caller and enriched responses", () => {
     expect(ws.name).toBe("TestWS");
     expect(typeof ws.id).toBe("string");
     expect(ws.paneCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("identify_caller: isFocusedPane is false for inactive workspace", () => {
+    // Create a second workspace and register a terminal in it
+    const { addWorkspace, layouts, workspaces } = useWorkspaceStore.getState();
+    addWorkspace("WS2", layouts[0].id);
+    const ws2 = useWorkspaceStore.getState().workspaces.find((ws) => ws.name === "WS2")!;
+
+    // Set pane to TerminalView so we can register a terminal
+    useWorkspaceStore.getState().setPaneView(0, { type: "TerminalView" }); // active ws pane 0
+    // For WS2 we need to switch, set view, then switch back
+    useWorkspaceStore.getState().setActiveWorkspace(ws2.id);
+    useWorkspaceStore.getState().setPaneView(0, { type: "TerminalView" });
+    // Switch back to original workspace
+    const originalWsId = workspaces[0].id;
+    useWorkspaceStore.getState().setActiveWorkspace(originalWsId);
+
+    // Register terminal in the inactive WS2's pane 0
+    const ws2Updated = useWorkspaceStore.getState().workspaces.find((ws) => ws.id === ws2.id)!;
+    const ws2Pane = ws2Updated.panes[0];
+    useTerminalStore.getState().registerInstance({
+      id: `terminal-${ws2Pane.id}`,
+      profile: "WSL",
+      syncGroup: "Default",
+      workspaceId: ws2.id,
+    });
+
+    // focusedPaneIndex defaults to 0, and WS2 also has pane index 0
+    // But WS2 is inactive, so isFocusedPane should be false
+    useGridStore.setState({ focusedPaneIndex: 0 });
+
+    const result = handleAutomationRequest({
+      requestId: "ifp1",
+      category: "query",
+      target: "terminals",
+      method: "identify",
+      params: { id: `terminal-${ws2Pane.id}` },
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const workspace = data.workspace as Record<string, unknown>;
+    expect(workspace.isActive).toBe(false);
+    const pane = data.pane as Record<string, unknown>;
+    expect(pane.index).toBe(0);
+    // Key assertion: even though focusedPaneIndex === 0 === paneIndex,
+    // isFocusedPane must be false because this is an inactive workspace
+    expect(pane.isFocusedPane).toBe(false);
   });
 
   it("reorders workspaces via automation API", () => {

--- a/ui/src/hooks/useAutomationBridge.test.ts
+++ b/ui/src/hooks/useAutomationBridge.test.ts
@@ -436,6 +436,10 @@ describe("identify_caller and enriched responses", () => {
       params: { paneIndex: 0, direction: "vertical" },
     });
 
+    // Set both panes to TerminalView (split creates EmptyView by default)
+    useWorkspaceStore.getState().setPaneView(0, { type: "TerminalView" });
+    useWorkspaceStore.getState().setPaneView(1, { type: "TerminalView" });
+
     const ws = useWorkspaceStore.getState().getActiveWorkspace()!;
     const leftPane = ws.panes[0];
     const rightPane = ws.panes[1];
@@ -636,6 +640,57 @@ describe("identify_caller and enriched responses", () => {
     expect(ws.name).toBe("TestWS");
     expect(typeof ws.id).toBe("string");
     expect(ws.paneCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("identify_caller: neighbor terminalId is null when neighbor is EmptyView", () => {
+    // Split to get 2 panes — only register terminal for the LEFT pane
+    handleAutomationRequest({
+      requestId: "sn1",
+      category: "action",
+      target: "panes",
+      method: "split",
+      params: { paneIndex: 0, direction: "vertical" },
+    });
+
+    const ws = useWorkspaceStore.getState().getActiveWorkspace()!;
+    const leftPane = ws.panes[0];
+    // Set left pane to TerminalView, right pane stays EmptyView
+    useWorkspaceStore.getState().setPaneView(0, { type: "TerminalView" });
+
+    useTerminalStore.getState().registerInstance({
+      id: `terminal-${leftPane.id}`,
+      profile: "WSL",
+      syncGroup: "Default",
+      workspaceId: ws.id,
+    });
+
+    const result = handleAutomationRequest({
+      requestId: "nid1",
+      category: "query",
+      target: "terminals",
+      method: "identify",
+      params: { id: `terminal-${leftPane.id}` },
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const neighbors = data.neighbors as Record<string, unknown>;
+    const right = neighbors.right as Record<string, unknown>;
+    expect(right).not.toBeNull();
+    expect(right.paneIndex).toBe(1);
+    // Right pane is EmptyView — terminalId should be null
+    expect(right.terminalId).toBeNull();
+  });
+
+  it("create_workspace returns error for invalid layoutId", () => {
+    const result = handleAutomationRequest({
+      requestId: "cwf1",
+      category: "action",
+      target: "workspaces",
+      method: "add",
+      params: { name: "FailWS", layoutId: "nonexistent-layout" },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("layout");
   });
 
   it("identify_caller: isFocusedPane is false for inactive workspace", () => {

--- a/ui/src/hooks/useAutomationBridge.test.ts
+++ b/ui/src/hooks/useAutomationBridge.test.ts
@@ -416,6 +416,207 @@ describe("useAutomationBridge hook", () => {
       expect.anything(),
     );
   });
+});
+
+describe("identify_caller and enriched responses", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
+    useGridStore.setState(useGridStore.getInitialState());
+    useTerminalStore.setState(useTerminalStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  it("identifies caller terminal with workspace, pane, and neighbors", () => {
+    // Split to get 2 panes (left/right via vertical split)
+    handleAutomationRequest({
+      requestId: "s1",
+      category: "action",
+      target: "panes",
+      method: "split",
+      params: { paneIndex: 0, direction: "vertical" },
+    });
+
+    const ws = useWorkspaceStore.getState().getActiveWorkspace()!;
+    const leftPane = ws.panes[0];
+    const rightPane = ws.panes[1];
+
+    // Register terminals for both panes
+    useTerminalStore.getState().registerInstance({
+      id: `terminal-${leftPane.id}`,
+      profile: "WSL",
+      syncGroup: "Default",
+      workspaceId: ws.id,
+    });
+    useTerminalStore.getState().registerInstance({
+      id: `terminal-${rightPane.id}`,
+      profile: "WSL",
+      syncGroup: "Default",
+      workspaceId: ws.id,
+    });
+
+    // Identify the left pane terminal
+    const result = handleAutomationRequest({
+      requestId: "id1",
+      category: "query",
+      target: "terminals",
+      method: "identify",
+      params: { id: `terminal-${leftPane.id}` },
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+
+    // Should have terminal info
+    const terminal = data.terminal as Record<string, unknown>;
+    expect(terminal.id).toBe(`terminal-${leftPane.id}`);
+
+    // Should have workspace info
+    const workspace = data.workspace as Record<string, unknown>;
+    expect(workspace.id).toBe(ws.id);
+    expect(workspace.isActive).toBe(true);
+    expect(workspace.totalPanes).toBe(2);
+
+    // Should have pane info
+    const pane = data.pane as Record<string, unknown>;
+    expect(pane.index).toBe(0);
+    expect(typeof pane.x).toBe("number");
+
+    // Should have right neighbor (the second pane)
+    const neighbors = data.neighbors as Record<string, unknown>;
+    const right = neighbors.right as Record<string, unknown>;
+    expect(right).not.toBeNull();
+    expect(right.terminalId).toBe(`terminal-${rightPane.id}`);
+    expect(right.paneIndex).toBe(1);
+  });
+
+  it("returns error for identify with unknown terminal", () => {
+    const result = handleAutomationRequest({
+      requestId: "id2",
+      category: "query",
+      target: "terminals",
+      method: "identify",
+      params: { id: "terminal-nonexistent" },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not found");
+  });
+
+  it("gets single terminal with pane position", () => {
+    const ws = useWorkspaceStore.getState().getActiveWorkspace()!;
+    const pane = ws.panes[0];
+    useTerminalStore.getState().registerInstance({
+      id: `terminal-${pane.id}`,
+      profile: "PowerShell",
+      syncGroup: "Default",
+      workspaceId: ws.id,
+    });
+
+    const result = handleAutomationRequest({
+      requestId: "gt1",
+      category: "query",
+      target: "terminals",
+      method: "get",
+      params: { id: `terminal-${pane.id}` },
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const terminal = data.terminal as Record<string, unknown>;
+    expect(terminal.paneIndex).toBe(0);
+    expect(terminal.panePosition).toHaveProperty("x");
+    const workspace = data.workspace as Record<string, unknown>;
+    expect(workspace.id).toBe(ws.id);
+  });
+
+  it("list_terminals includes paneIndex and panePosition", () => {
+    const ws = useWorkspaceStore.getState().getActiveWorkspace()!;
+    const pane = ws.panes[0];
+    useTerminalStore.getState().registerInstance({
+      id: `terminal-${pane.id}`,
+      profile: "WSL",
+      syncGroup: "Default",
+      workspaceId: ws.id,
+    });
+
+    const result = handleAutomationRequest({
+      requestId: "lt1",
+      category: "query",
+      target: "terminals",
+      method: "list",
+      params: {},
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const instances = data.instances as Array<Record<string, unknown>>;
+    expect(instances[0].paneIndex).toBe(0);
+    expect(instances[0].panePosition).toHaveProperty("x");
+  });
+
+  it("get_active_workspace includes paneIndex and terminalId per pane", () => {
+    const result = handleAutomationRequest({
+      requestId: "gaw1",
+      category: "query",
+      target: "workspaces",
+      method: "getActive",
+      params: {},
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const ws = data.workspace as Record<string, unknown>;
+    const panes = ws.panes as Array<Record<string, unknown>>;
+    expect(panes[0]).toHaveProperty("paneIndex", 0);
+    expect(panes[0]).toHaveProperty("terminalId");
+    expect((panes[0].terminalId as string).startsWith("terminal-")).toBe(true);
+  });
+
+  it("get_grid_state includes activeWorkspaceId", () => {
+    const result = handleAutomationRequest({
+      requestId: "gs1",
+      category: "query",
+      target: "grid",
+      method: "getState",
+      params: {},
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty("activeWorkspaceId");
+    expect(data.activeWorkspaceId).toBe(useWorkspaceStore.getState().activeWorkspaceId);
+  });
+
+  it("split_pane returns new pane info", () => {
+    const result = handleAutomationRequest({
+      requestId: "sp1",
+      category: "action",
+      target: "panes",
+      method: "split",
+      params: { paneIndex: 0, direction: "vertical" },
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.split).toBe(true);
+    expect(data.totalPanes).toBe(2);
+    const newPane = data.newPane as Record<string, unknown>;
+    expect(newPane).not.toBeNull();
+    expect(newPane.paneIndex).toBe(1);
+    expect(newPane).toHaveProperty("terminalId");
+    expect(newPane).toHaveProperty("x");
+  });
+
+  it("create_workspace returns new workspace info", () => {
+    const result = handleAutomationRequest({
+      requestId: "cw1",
+      category: "action",
+      target: "workspaces",
+      method: "add",
+      params: { name: "TestWS", layoutId: "default-layout" },
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.created).toBe(true);
+    const ws = data.workspace as Record<string, unknown>;
+    expect(ws).not.toBeNull();
+    expect(ws.name).toBe("TestWS");
+    expect(typeof ws.id).toBe("string");
+    expect(ws.paneCount).toBeGreaterThanOrEqual(1);
+  });
 
   it("reorders workspaces via automation API", () => {
     // Create additional workspaces

--- a/ui/src/hooks/useAutomationBridge.test.ts
+++ b/ui/src/hooks/useAutomationBridge.test.ts
@@ -693,6 +693,24 @@ describe("identify_caller and enriched responses", () => {
     expect(result.error).toContain("layout");
   });
 
+  it("create_workspace uses default layout when layoutId is omitted", () => {
+    const before = useWorkspaceStore.getState().workspaces.length;
+    const result = handleAutomationRequest({
+      requestId: "cwdl1",
+      category: "action",
+      target: "workspaces",
+      method: "add",
+      params: { name: "NoLayoutWS" },
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.created).toBe(true);
+    const ws = data.workspace as Record<string, unknown>;
+    expect(ws).not.toBeNull();
+    expect(ws.name).toBe("NoLayoutWS");
+    expect(useWorkspaceStore.getState().workspaces.length).toBe(before + 1);
+  });
+
   it("identify_caller: isFocusedPane is false for inactive workspace", () => {
     // Create a second workspace and register a terminal in it
     const { addWorkspace, layouts, workspaces } = useWorkspaceStore.getState();

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -104,9 +104,13 @@ function findTerminalContext(terminalId: string) {
   return { terminal, workspace, pane, paneIndex, activeWorkspaceId };
 }
 
-/** Enrich a pane with its index and terminal ID. */
+/** Enrich a pane with its index and terminal ID (null for non-terminal panes). */
 function enrichPane(p: WorkspacePane, index: number) {
-  return { ...p, paneIndex: index, terminalId: `terminal-${p.id}` };
+  return {
+    ...p,
+    paneIndex: index,
+    terminalId: p.view.type === "TerminalView" ? `terminal-${p.id}` : null,
+  };
 }
 
 const handlers: HandlerMap = {
@@ -195,7 +199,7 @@ const handlers: HandlerMap = {
         newPane: newPane
           ? {
               id: newPane.id,
-              terminalId: `terminal-${newPane.id}`,
+              terminalId: newPane.view.type === "TerminalView" ? `terminal-${newPane.id}` : null,
               paneIndex: newPaneIndex,
               x: newPane.x,
               y: newPane.y,
@@ -348,7 +352,7 @@ const handlers: HandlerMap = {
               y: pane.y,
               w: pane.w,
               h: pane.h,
-              isFocusedPane: focusedPaneIndex === paneIndex,
+              isFocusedPane: workspace.id === activeWorkspaceId && focusedPaneIndex === paneIndex,
             }
           : null,
         neighbors: pane ? computeNeighbors(workspace.panes, paneIndex) : null,

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -9,7 +9,7 @@ import { useNotificationStore, type NotificationLevel } from "@/stores/notificat
 import { useUiStore } from "@/stores/ui-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { computeWorkspaceSummary } from "@/lib/workspace-summary";
-import type { DockPosition, ViewType } from "@/stores/types";
+import type { DockPosition, ViewType, WorkspacePane } from "@/stores/types";
 
 interface HandlerResult {
   success: boolean;
@@ -28,6 +28,87 @@ function err(message: string): HandlerResult {
   return { success: false, error: message };
 }
 
+/** Check if two 1D ranges overlap (with tolerance for floating point). */
+function rangesOverlap(a: number, aLen: number, b: number, bLen: number): boolean {
+  const eps = 0.01;
+  return a < b + bLen - eps && b < a + aLen - eps;
+}
+
+/** Compute directional neighbors for a pane in the grid. */
+function computeNeighbors(
+  panes: WorkspacePane[],
+  targetIndex: number,
+): Record<string, { paneIndex: number; terminalId: string } | null> {
+  const target = panes[targetIndex];
+  if (!target) return { left: null, right: null, above: null, below: null };
+
+  const result: Record<string, { paneIndex: number; terminalId: string } | null> = {
+    left: null,
+    right: null,
+    above: null,
+    below: null,
+  };
+
+  for (let i = 0; i < panes.length; i++) {
+    if (i === targetIndex) continue;
+    const other = panes[i];
+    const entry = { paneIndex: i, terminalId: `terminal-${other.id}` };
+
+    // Right: other starts where target ends on x-axis, y ranges overlap
+    if (
+      Math.abs(other.x - (target.x + target.w)) < 0.01 &&
+      rangesOverlap(target.y, target.h, other.y, other.h)
+    ) {
+      if (!result.right || other.y < panes[result.right.paneIndex].y) result.right = entry;
+    }
+    // Left: other ends where target starts on x-axis
+    if (
+      Math.abs(other.x + other.w - target.x) < 0.01 &&
+      rangesOverlap(target.y, target.h, other.y, other.h)
+    ) {
+      if (!result.left || other.y < panes[result.left.paneIndex].y) result.left = entry;
+    }
+    // Below: other starts where target ends on y-axis
+    if (
+      Math.abs(other.y - (target.y + target.h)) < 0.01 &&
+      rangesOverlap(target.x, target.w, other.x, other.w)
+    ) {
+      if (!result.below || other.x < panes[result.below.paneIndex].x) result.below = entry;
+    }
+    // Above: other ends where target starts on y-axis
+    if (
+      Math.abs(other.y + other.h - target.y) < 0.01 &&
+      rangesOverlap(target.x, target.w, other.x, other.w)
+    ) {
+      if (!result.above || other.x < panes[result.above.paneIndex].x) result.above = entry;
+    }
+  }
+
+  return result;
+}
+
+/** Find the workspace and pane for a given terminal ID. */
+function findTerminalContext(terminalId: string) {
+  const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState();
+  const { instances } = useTerminalStore.getState();
+  const terminal = instances.find((i) => i.id === terminalId);
+  if (!terminal) return null;
+
+  const workspace = workspaces.find((ws) => ws.id === terminal.workspaceId);
+  if (!workspace) return null;
+
+  const paneId = terminalId.replace(/^terminal-/, "");
+  const paneIndex = workspace.panes.findIndex((p) => p.id === paneId);
+  const pane = paneIndex >= 0 ? workspace.panes[paneIndex] : null;
+
+  return { terminal, workspace, pane, paneIndex, activeWorkspaceId };
+}
+
+/** Enrich a pane with its index and terminal ID. */
+function enrichPane(p: WorkspacePane, index: number) {
+  return { ...p, paneIndex: index, terminalId: `terminal-${p.id}` };
+}
+
 const handlers: HandlerMap = {
   workspaces: {
     list: () => {
@@ -36,15 +117,26 @@ const handlers: HandlerMap = {
     },
     getActive: () => {
       const ws = useWorkspaceStore.getState().getActiveWorkspace();
-      return ok({ workspace: ws ?? null });
+      if (!ws) return ok({ workspace: null });
+      const enriched = {
+        ...ws,
+        panes: ws.panes.map(enrichPane),
+      };
+      return ok({ workspace: enriched });
     },
     switchActive: (p) => {
       useWorkspaceStore.getState().setActiveWorkspace(p.id as string);
       return ok({ switched: p.id });
     },
     add: (p) => {
+      const before = useWorkspaceStore.getState().workspaces;
       useWorkspaceStore.getState().addWorkspace(p.name as string, p.layoutId as string);
-      return ok({ created: true });
+      const after = useWorkspaceStore.getState().workspaces;
+      const newWs = after.find((ws) => !before.some((b) => b.id === ws.id));
+      return ok({
+        created: true,
+        workspace: newWs ? { id: newWs.id, name: newWs.name, paneCount: newWs.panes.length } : null,
+      });
     },
     remove: (p) => {
       useWorkspaceStore.getState().removeWorkspace(p.id as string);
@@ -72,7 +164,8 @@ const handlers: HandlerMap = {
   grid: {
     getState: () => {
       const { editMode, focusedPaneIndex } = useGridStore.getState();
-      return ok({ editMode, focusedPaneIndex });
+      const { activeWorkspaceId } = useWorkspaceStore.getState();
+      return ok({ editMode, focusedPaneIndex, activeWorkspaceId });
     },
     setEditMode: (p) => {
       useGridStore.getState().setEditMode(p.enabled as boolean);
@@ -94,7 +187,24 @@ const handlers: HandlerMap = {
       useWorkspaceStore
         .getState()
         .splitPane(p.paneIndex as number, p.direction as "horizontal" | "vertical");
-      return ok({ split: true });
+      const ws = useWorkspaceStore.getState().getActiveWorkspace();
+      const newPaneIndex = (p.paneIndex as number) + 1;
+      const newPane = ws?.panes[newPaneIndex];
+      return ok({
+        split: true,
+        newPane: newPane
+          ? {
+              id: newPane.id,
+              terminalId: `terminal-${newPane.id}`,
+              paneIndex: newPaneIndex,
+              x: newPane.x,
+              y: newPane.y,
+              w: newPane.w,
+              h: newPane.h,
+            }
+          : null,
+        totalPanes: ws?.panes.length ?? 0,
+      });
     },
     remove: (p) => {
       useWorkspaceStore.getState().removePane(p.paneIndex as number);
@@ -181,7 +291,68 @@ const handlers: HandlerMap = {
   terminals: {
     list: () => {
       const { instances } = useTerminalStore.getState();
-      return ok({ instances });
+      const { workspaces } = useWorkspaceStore.getState();
+      const enriched = instances.map((inst) => {
+        const ws = workspaces.find((w) => w.id === inst.workspaceId);
+        const paneId = inst.id.replace(/^terminal-/, "");
+        const paneIndex = ws?.panes.findIndex((p) => p.id === paneId) ?? -1;
+        const pane = paneIndex >= 0 ? ws!.panes[paneIndex] : null;
+        return {
+          ...inst,
+          paneIndex: paneIndex >= 0 ? paneIndex : null,
+          panePosition: pane ? { x: pane.x, y: pane.y, w: pane.w, h: pane.h } : null,
+        };
+      });
+      return ok({ instances: enriched });
+    },
+    get: (p) => {
+      const ctx = findTerminalContext(p.id as string);
+      if (!ctx) return err(`Terminal '${p.id}' not found`);
+      const { terminal, workspace, pane, paneIndex, activeWorkspaceId } = ctx;
+      return ok({
+        terminal: {
+          ...terminal,
+          paneIndex: paneIndex >= 0 ? paneIndex : null,
+          panePosition: pane ? { x: pane.x, y: pane.y, w: pane.w, h: pane.h } : null,
+        },
+        workspace: { id: workspace.id, name: workspace.name, isActive: workspace.id === activeWorkspaceId },
+      });
+    },
+    identify: (p) => {
+      const ctx = findTerminalContext(p.id as string);
+      if (!ctx) return err(`Terminal '${p.id}' not found`);
+      const { terminal, workspace, pane, paneIndex, activeWorkspaceId } = ctx;
+      const { focusedPaneIndex } = useGridStore.getState();
+
+      return ok({
+        terminal: {
+          id: terminal.id,
+          profile: terminal.profile,
+          syncGroup: terminal.syncGroup,
+          cwd: terminal.cwd,
+          branch: terminal.branch,
+          activity: terminal.activity,
+          isFocused: terminal.isFocused,
+        },
+        workspace: {
+          id: workspace.id,
+          name: workspace.name,
+          isActive: workspace.id === activeWorkspaceId,
+          totalPanes: workspace.panes.length,
+        },
+        pane: pane
+          ? {
+              id: pane.id,
+              index: paneIndex,
+              x: pane.x,
+              y: pane.y,
+              w: pane.w,
+              h: pane.h,
+              isFocusedPane: focusedPaneIndex === paneIndex,
+            }
+          : null,
+        neighbors: pane ? computeNeighbors(workspace.panes, paneIndex) : null,
+      });
     },
     setFocus: (p) => {
       useTerminalStore.getState().setTerminalFocus(p.id as string);

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -136,11 +136,14 @@ const handlers: HandlerMap = {
       return ok({ switched: p.id });
     },
     add: (p) => {
+      const { layouts } = useWorkspaceStore.getState();
+      const layoutId = (p.layoutId as string | undefined) ?? layouts[0]?.id;
+      if (!layoutId) return err("No layouts available");
       const before = useWorkspaceStore.getState().workspaces;
-      useWorkspaceStore.getState().addWorkspace(p.name as string, p.layoutId as string);
+      useWorkspaceStore.getState().addWorkspace(p.name as string, layoutId);
       const after = useWorkspaceStore.getState().workspaces;
       const newWs = after.find((ws) => !before.some((b) => b.id === ws.id));
-      if (!newWs) return err(`Failed to create workspace: layout '${p.layoutId}' not found`);
+      if (!newWs) return err(`Failed to create workspace: layout '${layoutId}' not found`);
       return ok({
         created: true,
         workspace: { id: newWs.id, name: newWs.name, paneCount: newWs.panes.length },

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -38,11 +38,11 @@ function rangesOverlap(a: number, aLen: number, b: number, bLen: number): boolea
 function computeNeighbors(
   panes: WorkspacePane[],
   targetIndex: number,
-): Record<string, { paneIndex: number; terminalId: string } | null> {
+): Record<string, { paneIndex: number; terminalId: string | null } | null> {
   const target = panes[targetIndex];
   if (!target) return { left: null, right: null, above: null, below: null };
 
-  const result: Record<string, { paneIndex: number; terminalId: string } | null> = {
+  const result: Record<string, { paneIndex: number; terminalId: string | null } | null> = {
     left: null,
     right: null,
     above: null,
@@ -52,7 +52,10 @@ function computeNeighbors(
   for (let i = 0; i < panes.length; i++) {
     if (i === targetIndex) continue;
     const other = panes[i];
-    const entry = { paneIndex: i, terminalId: `terminal-${other.id}` };
+    const entry = {
+      paneIndex: i,
+      terminalId: other.view.type === "TerminalView" ? `terminal-${other.id}` : null,
+    };
 
     // Right: other starts where target ends on x-axis, y ranges overlap
     if (
@@ -137,9 +140,10 @@ const handlers: HandlerMap = {
       useWorkspaceStore.getState().addWorkspace(p.name as string, p.layoutId as string);
       const after = useWorkspaceStore.getState().workspaces;
       const newWs = after.find((ws) => !before.some((b) => b.id === ws.id));
+      if (!newWs) return err(`Failed to create workspace: layout '${p.layoutId}' not found`);
       return ok({
         created: true,
-        workspace: newWs ? { id: newWs.id, name: newWs.name, paneCount: newWs.panes.length } : null,
+        workspace: { id: newWs.id, name: newWs.name, paneCount: newWs.panes.length },
       });
     },
     remove: (p) => {


### PR DESCRIPTION
## Summary
- **`identify_caller` MCP 도구 신설**: `$LX_TERMINAL_ID` 환경변수로 자신의 워크스페이스, 페인 좌표(x,y,w,h), 인접 페인(상하좌우)을 한 번에 파악
- **기존 응답 강화**: `list_terminals`에 panePosition, `get_active_workspace`에 terminalId, `get_grid_state`에 activeWorkspaceId, `split_pane`/`create_workspace`에 생성 결과 포함
- **MCP Instructions 확장**: Self-identification 워크플로우(`echo $LX_TERMINAL_ID → identify_caller`) 및 환경변수 안내 추가
- **추가 도구**: `get_terminal`(단일 조회), `remove_pane`(페인 제거) MCP 노출

## Test plan
- [x] `cargo test` — Rust 565+ 단위 테스트 통과
- [x] `vitest run useAutomationBridge.test.ts` — 33개 테스트 통과 (신규 8개 포함)
- [x] ESLint / Clippy 경고 없음
- [ ] dev 빌드에서 MCP `identify_caller` 호출하여 워크스페이스/페인/이웃 반환 확인
- [ ] Claude Code에서 "우측 pane에 ls 보내줘" 시나리오 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)