### PR TITLE
feat: 터미널 복사/붙여넣기 키바인딩 오버라이드 지원

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1212,6 +1212,23 @@ container.addEventListener("copy", (e) => { copySelectedPaths(); });
 if (matchesKeybinding(e, "issueReporter.submit")) { handleSubmit(); }
 ```
 
+##### 예외: 터미널 copy/paste 하이브리드
+
+터미널(xterm.js)에서는 전통적으로 Linux 환경에서 `Ctrl+Shift+C`/`Ctrl+Shift+V`를
+복사/붙여넣기로 쓰는 관행이 있어, 복사/붙여넣기도 **키바인딩으로 재바인딩할 수
+있어야 한다**. 단, 기본값(`Ctrl+C`/`Ctrl+V`)은 OS가 이미 `copy`/`paste` 이벤트를
+발화시키므로 시스템 이벤트 경로로 충분하다. 따라서 터미널은 다음 하이브리드로
+운영한다.
+
+- `terminal.copy`/`terminal.paste`를 키바인딩 레지스트리에 등록(기본 `Ctrl+C`/`Ctrl+V`).
+- 시스템 이벤트(`copy`/`paste`) 리스너는 그대로 유지해 기본값/우클릭/컨텍스트 메뉴를
+  포괄한다.
+- `attachCustomKeyEventHandler`에서 `matchesKeybinding("terminal.copy/paste")`로
+  분기하되, **해상된 키가 기본값과 같으면 브라우저 이벤트에 위임**하고(중복 방지),
+  다르면 수동으로 `smartPaste` / `clipboardWriteText`를 호출한다.
+- 이 예외는 터미널에 한정한다. 파일 탐색기 등 다른 컴포넌트의 copy/paste는 여전히
+  시스템 이벤트 전용이다.
+
 ### 15.6 앱 전용 편의 코드 격리
 
 각 앱 activity 타입별로 **ActivityHandler** 클래스를 구현하여 notification, status, statusMessage 계산을 분기한다. 원시 상태는 공통으로 저장하고, activity 타입에 따라 해당 핸들러가 최종 표시를 도출한다.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1212,20 +1212,20 @@ container.addEventListener("copy", (e) => { copySelectedPaths(); });
 if (matchesKeybinding(e, "issueReporter.submit")) { handleSubmit(); }
 ```
 
-##### 예외: 터미널 copy/paste 하이브리드
+##### 예외: 터미널 copy/paste는 키바인딩으로 통합
 
 터미널(xterm.js)에서는 전통적으로 Linux 환경에서 `Ctrl+Shift+C`/`Ctrl+Shift+V`를
 복사/붙여넣기로 쓰는 관행이 있어, 복사/붙여넣기도 **키바인딩으로 재바인딩할 수
-있어야 한다**. 단, 기본값(`Ctrl+C`/`Ctrl+V`)은 OS가 이미 `copy`/`paste` 이벤트를
-발화시키므로 시스템 이벤트 경로로 충분하다. 따라서 터미널은 다음 하이브리드로
-운영한다.
+있어야 한다**. 따라서 터미널은 시스템 `copy`/`paste` 이벤트 리스너를 두지 않고,
+`terminal.copy` / `terminal.paste` 키바인딩 한 경로로 통합한다.
 
 - `terminal.copy`/`terminal.paste`를 키바인딩 레지스트리에 등록(기본 `Ctrl+C`/`Ctrl+V`).
-- 시스템 이벤트(`copy`/`paste`) 리스너는 그대로 유지해 기본값/우클릭/컨텍스트 메뉴를
-  포괄한다.
 - `attachCustomKeyEventHandler`에서 `matchesKeybinding("terminal.copy/paste")`로
-  분기하되, **해상된 키가 기본값과 같으면 브라우저 이벤트에 위임**하고(중복 방지),
-  다르면 수동으로 `smartPaste` / `clipboardWriteText`를 호출한다.
+  감지하여 `smartPaste`/`clipboardWriteText`를 직접 호출한다 — 기본값/오버라이드
+  구분 없이 동일 경로.
+- `Ctrl+C`는 선택 영역이 없을 때만 xterm에 위임해 SIGINT를 그대로 전달한다(선택 상태로만
+  판단, 키 조합을 하드코딩하지 않음).
+- 우클릭 경로(`handleContextMenu`)도 같은 헬퍼(`runTerminalPaste`)를 재사용한다.
 - 이 예외는 터미널에 한정한다. 파일 탐색기 등 다른 컴포넌트의 copy/paste는 여전히
   시스템 이벤트 전용이다.
 

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -1151,6 +1151,31 @@ describe("TerminalView", () => {
     });
   });
 
+  it("copy-on-select with smartRemoveIndent off writes raw selection (shared runTerminalCopy path)", async () => {
+    // Proves the three copy sites (Ctrl+C, right-click, copy-on-select)
+    // share runTerminalCopy — raw-when-off semantics apply uniformly.
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      convenience: {
+        ...useSettingsStore.getState().convenience,
+        copyOnSelect: true,
+        smartRemoveIndent: false,
+      },
+    });
+    mockHasSelection.mockReturnValue(true);
+    const raw = "trailing ws   \n\n";
+    mockGetSelection.mockReturnValue(raw);
+
+    render(<TerminalView instanceId="t-cos-raw" profile="PowerShell" syncGroup="" />);
+
+    const selectionCallback = mockOnSelectionChange.mock.calls[0][0];
+    selectionCallback();
+
+    await vi.waitFor(() => {
+      expect(mockClipboardWriteText).toHaveBeenCalledWith(raw);
+    });
+  });
+
   it("does not auto-copy when copyOnSelect is disabled", async () => {
     useSettingsStore.setState({
       ...useSettingsStore.getState(),

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -46,6 +46,14 @@ const mockRequestAnimationFrame = vi.fn((callback: FrameRequestCallback) =>
 const mockCancelAnimationFrame = vi.fn((handle: number) => window.clearTimeout(handle));
 vi.stubGlobal("requestAnimationFrame", mockRequestAnimationFrame);
 vi.stubGlobal("cancelAnimationFrame", mockCancelAnimationFrame);
+
+// jsdom doesn't expose navigator.clipboard; stub a minimal readText/writeText
+// so the plain-paste fallback in runTerminalPaste doesn't throw.
+const mockClipboardReadText = vi.fn().mockResolvedValue("");
+Object.defineProperty(globalThis.navigator, "clipboard", {
+  value: { readText: mockClipboardReadText, writeText: vi.fn().mockResolvedValue(undefined) },
+  configurable: true,
+});
 vi.mock("@xterm/xterm", () => ({
   Terminal: class MockTerminal {
     constructor(options: Record<string, unknown> = {}) {
@@ -950,15 +958,16 @@ describe("TerminalView", () => {
     });
   });
 
-  it("does not intercept Ctrl+V when smart paste disabled", async () => {
+  it("skips the smart paste pipeline when smartPaste is disabled but still consumes the key", async () => {
+    // Override bindings like Ctrl+Shift+V can't rely on the browser's native
+    // paste event, so the keybinding handler must always consume the event.
+    // When smartPaste is off we just skip the Rust clipboard pipeline and
+    // fall back to plain navigator.clipboard in runTerminalPaste.
     useSettingsStore.setState({
       ...useSettingsStore.getState(),
       convenience: {
+        ...useSettingsStore.getState().convenience,
         smartPaste: false,
-        pasteImageDir: "",
-        hoverIdleSeconds: 2,
-        notificationDismiss: "workspace" as const,
-        copyOnSelect: false,
       },
     });
 
@@ -969,10 +978,13 @@ describe("TerminalView", () => {
     });
 
     const event = new KeyboardEvent("keydown", { key: "v", ctrlKey: true });
+    Object.defineProperty(event, "preventDefault", { value: vi.fn() });
     const result = capturedKeyHandler!(event);
 
-    // Should return true (let xterm handle normally)
-    expect(result).toBe(true);
+    // Handler intercepts: return false + preventDefault, but smartPaste is
+    // bypassed — plain clipboard paste is used instead.
+    expect(result).toBe(false);
+    expect(event.preventDefault).toHaveBeenCalled();
     expect(mockSmartPaste).not.toHaveBeenCalled();
   });
 
@@ -988,6 +1000,74 @@ describe("TerminalView", () => {
     const result = capturedKeyHandler!(event);
     expect(result).toBe(true);
     expect(mockSmartPaste).not.toHaveBeenCalled();
+  });
+
+  // -- terminal.copy keybinding --
+
+  it("Ctrl+C with selection copies via clipboardWriteText (smartRemoveIndent default on)", async () => {
+    mockHasSelection.mockReturnValue(true);
+    mockGetSelection.mockReturnValue("copied text");
+
+    render(<TerminalView instanceId="t-copy1" profile="PowerShell" syncGroup="" />);
+
+    await vi.waitFor(() => {
+      expect(mockAttachCustomKeyEventHandler).toHaveBeenCalled();
+    });
+
+    const event = new KeyboardEvent("keydown", { key: "c", ctrlKey: true });
+    Object.defineProperty(event, "preventDefault", { value: vi.fn() });
+    const result = capturedKeyHandler!(event);
+
+    expect(result).toBe(false);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(mockClipboardWriteText).toHaveBeenCalledWith("copied text");
+  });
+
+  it("Ctrl+C with empty selection lets xterm handle (SIGINT path)", async () => {
+    mockHasSelection.mockReturnValue(false);
+
+    render(<TerminalView instanceId="t-copy2" profile="PowerShell" syncGroup="" />);
+
+    await vi.waitFor(() => {
+      expect(mockAttachCustomKeyEventHandler).toHaveBeenCalled();
+    });
+
+    const event = new KeyboardEvent("keydown", { key: "c", ctrlKey: true });
+    const result = capturedKeyHandler!(event);
+
+    expect(result).toBe(true);
+    expect(mockClipboardWriteText).not.toHaveBeenCalled();
+  });
+
+  it("terminal.copy with smartRemoveIndent off copies raw getSelection (no trim)", async () => {
+    // Regression guard for PR review point #2: prepareSelectionForCopy always
+    // trims trailing whitespace regardless of smartRemoveIndent, so we must
+    // bypass it when the toggle is off to preserve the old native-Ctrl+C
+    // clipboard contents byte-for-byte.
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      convenience: {
+        ...useSettingsStore.getState().convenience,
+        smartRemoveIndent: false,
+      },
+    });
+    mockHasSelection.mockReturnValue(true);
+    // Selection with trailing whitespace + blank line that prepareSelectionForCopy
+    // would strip. If the raw branch is taken, the trailing spaces survive.
+    const raw = "line with trailing   \n\n";
+    mockGetSelection.mockReturnValue(raw);
+
+    render(<TerminalView instanceId="t-copy3" profile="PowerShell" syncGroup="" />);
+
+    await vi.waitFor(() => {
+      expect(mockAttachCustomKeyEventHandler).toHaveBeenCalled();
+    });
+
+    const event = new KeyboardEvent("keydown", { key: "c", ctrlKey: true });
+    Object.defineProperty(event, "preventDefault", { value: vi.fn() });
+    capturedKeyHandler!(event);
+
+    expect(mockClipboardWriteText).toHaveBeenCalledWith(raw);
   });
 
   // -- Right-click behavior --

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -25,7 +25,7 @@ import {
 import { colorSchemeToXtermTheme, type WTColorScheme } from "@/lib/color-scheme";
 import { transformPasteContent, prepareSelectionForCopy } from "@/lib/smart-text";
 import { isLxShortcut } from "@/lib/lx-shortcuts";
-import { matchesKeybinding, resolveKeybinding } from "@/lib/keybinding-registry";
+import { matchesKeybinding } from "@/lib/keybinding-registry";
 
 import {
   CODEX_INPUT_PENDING_MARKER,
@@ -54,6 +54,35 @@ const OUTPUT_IDLE_TIMEOUT_MS = 5000;
 const LARGE_PASTE_THRESHOLD = 5120;
 
 const textEncoder = new TextEncoder();
+
+/**
+ * Execute the smart-paste pipeline and write the result into xterm.
+ * Shared by the keybinding handler (terminal.paste) and the right-click paste
+ * fallback so both paths produce identical behavior (image handling, indent
+ * normalization, large-paste guard).
+ */
+function runTerminalPaste(terminal: Terminal, profile: string): void {
+  const { convenience: conv } = useSettingsStore.getState();
+  smartPaste(conv.pasteImageDir, profile)
+    .then((result) => {
+      if (result.pasteType === "none" || !result.content) return;
+      const content = transformPasteContent(result.content, result.pasteType, {
+        removeIndent: conv.smartRemoveIndent,
+        removeLineBreak: conv.smartRemoveLineBreak,
+      });
+      if (shouldBlockLargePaste(content, conv.largePasteWarning)) return;
+      terminal.paste(content);
+    })
+    .catch(() => {
+      // Rust clipboard failed — fall back to browser clipboard → xterm paste
+      navigator.clipboard
+        .readText()
+        .then((text) => {
+          if (text) terminal.paste(text);
+        })
+        .catch(() => {});
+    });
+}
 
 /**
  * Check if a large paste should be blocked. Returns true if the user cancelled.
@@ -610,70 +639,34 @@ export function TerminalView({
       helperTextarea.addEventListener("compositionend", handleCompositionEnd);
     };
 
-    // Custom key event handler: let IDE shortcuts pass through xterm,
-    // and route the user-configurable terminal.copy / terminal.paste bindings
-    // when they are rebound to combos that don't fire native copy/paste events.
-    //
-    // Copy/paste are normally system events (browser `copy`/`paste` fires on
-    // Ctrl+C / Ctrl+V). Those defaults keep working through the DOM listeners
-    // below. If the user overrides the binding to e.g. Ctrl+Shift+C / Ctrl+Shift+V
-    // (the conventional Linux terminal combo), the browser won't fire those
-    // events on its own, so we dispatch the action manually here.
+    // Single entry point for all terminal key handling:
+    //   - IDE-level shortcuts → pass through to document handler (return false).
+    //   - terminal.copy / terminal.paste (default Ctrl+C / Ctrl+V, user-rebindable)
+    //     → dispatch directly, no reliance on browser `copy`/`paste` events.
+    //   - Ctrl+C with empty selection → fall through so xterm sends SIGINT.
     terminal.attachCustomKeyEventHandler((e) => {
       if (e.type !== "keydown") return true;
       if (isLxShortcut(e)) return false;
 
-      // terminal.paste — manually trigger smart paste when the bound combo is
-      // not the OS-default Ctrl+V (which the `paste` listener below handles).
       if (matchesKeybinding(e, "terminal.paste")) {
-        if (resolveKeybinding("terminal.paste") !== "Ctrl+V") {
-          const { convenience: conv } = useSettingsStore.getState();
-          e.preventDefault();
-          smartPaste(conv.pasteImageDir, profile)
-            .then((result) => {
-              if (result.pasteType !== "none" && result.content) {
-                const content = transformPasteContent(result.content, result.pasteType, {
-                  removeIndent: conv.smartRemoveIndent,
-                  removeLineBreak: conv.smartRemoveLineBreak,
-                });
-                if (shouldBlockLargePaste(content, conv.largePasteWarning)) return;
-                terminal.paste(content);
-              }
-            })
-            .catch(() => {
-              navigator.clipboard
-                .readText()
-                .then((text) => {
-                  if (text) terminal.paste(text);
-                })
-                .catch(() => {});
-            });
-          return false;
-        }
-        // Default Ctrl+V: let the browser `paste` event fire — handled below.
-        return true;
+        // Honor the smartPaste toggle: when off, defer to xterm's native paste
+        // (only works for default Ctrl+V since the browser fires `paste` then).
+        if (!useSettingsStore.getState().convenience.smartPaste) return true;
+        e.preventDefault();
+        runTerminalPaste(terminal, profile);
+        return false;
       }
 
-      // terminal.copy — manually copy the current selection when rebound away
-      // from the OS-default Ctrl+C. Default Ctrl+C continues to mean
-      // "copy if selection, SIGINT otherwise" via xterm's native handling.
       if (matchesKeybinding(e, "terminal.copy")) {
-        if (resolveKeybinding("terminal.copy") !== "Ctrl+C") {
-          if (terminal.hasSelection()) {
-            const { convenience: conv } = useSettingsStore.getState();
-            const text = prepareSelectionForCopy(terminal.getSelection(), {
-              smartRemoveIndent: conv.smartRemoveIndent,
-            });
-            clipboardWriteText(text).catch(() => {});
-            e.preventDefault();
-            return false;
-          }
-          // No selection on a non-default binding: consume the event to avoid
-          // xterm injecting a control code for the underlying key.
-          return false;
-        }
-        // Default Ctrl+C: let xterm handle natively (copy-or-SIGINT).
-        return true;
+        // No selection: let xterm process the raw key (default Ctrl+C → SIGINT).
+        if (!terminal.hasSelection()) return true;
+        const { convenience: conv } = useSettingsStore.getState();
+        const text = prepareSelectionForCopy(terminal.getSelection(), {
+          smartRemoveIndent: conv.smartRemoveIndent,
+        });
+        clipboardWriteText(text).catch(() => {});
+        e.preventDefault();
+        return false;
       }
 
       return true;
@@ -696,22 +689,6 @@ export function TerminalView({
     };
     outerEl?.addEventListener("keydown", handleKeyDown);
     outerEl?.addEventListener("mousemove", handleMouseMove);
-
-    // Smart copy: intercept DOM copy event to apply smartRemoveIndent.
-    // xterm.js handles Ctrl+C natively (copy if selection, SIGINT if not).
-    // We hook into the resulting copy event to transform clipboard content
-    // without breaking bare Ctrl+C → SIGINT flow.
-    const handleCopy = (e: ClipboardEvent) => {
-      const { convenience: conv } = useSettingsStore.getState();
-      if (conv.smartRemoveIndent && terminal.hasSelection()) {
-        e.preventDefault();
-        const transformed = prepareSelectionForCopy(terminal.getSelection(), {
-          smartRemoveIndent: true,
-        });
-        e.clipboardData?.setData("text/plain", transformed);
-      }
-    };
-    containerRef.current?.addEventListener("copy", handleCopy);
 
     // Copy-on-select: auto-copy to clipboard when text is selected
     terminal.onSelectionChange(() => {
@@ -941,68 +918,11 @@ export function TerminalView({
         ).catch(() => {});
         terminal.clearSelection();
       } else {
-        // No selection → paste via terminal.paste() (same as Ctrl+V for bracketed paste support)
-        const { convenience: conv } = useSettingsStore.getState();
-        smartPaste(conv.pasteImageDir, profile)
-          .then((result) => {
-            if (result.pasteType !== "none" && result.content) {
-              const content = transformPasteContent(result.content, result.pasteType, {
-                removeIndent: conv.smartRemoveIndent,
-                removeLineBreak: conv.smartRemoveLineBreak,
-              });
-              if (shouldBlockLargePaste(content, conv.largePasteWarning)) {
-                return;
-              }
-              terminal.paste(content);
-            }
-          })
-          .catch(() => {
-            // Rust clipboard failed — fall back to browser clipboard
-            navigator.clipboard
-              .readText()
-              .then((text) => {
-                if (text) terminal.paste(text);
-              })
-              .catch(() => {});
-          });
+        // No selection → paste via the shared smart-paste pipeline.
+        runTerminalPaste(terminal, profile);
       }
     };
     outerContainer?.addEventListener("contextmenu", handleContextMenu);
-
-    // Smart paste: intercept the system paste event (Ctrl+V, Cmd+V, context menu paste, etc.)
-    // By listening to the 'paste' event instead of a specific key combo, this works
-    // regardless of OS or how the user triggers paste.
-    const handlePaste = (e: ClipboardEvent) => {
-      const { convenience } = useSettingsStore.getState();
-      if (!convenience.smartPaste) return; // Let xterm handle normally
-
-      e.preventDefault();
-      e.stopPropagation();
-
-      smartPaste(convenience.pasteImageDir, profile)
-        .then((result) => {
-          if (result.pasteType !== "none" && result.content) {
-            const content = transformPasteContent(result.content, result.pasteType, {
-              removeIndent: convenience.smartRemoveIndent,
-              removeLineBreak: convenience.smartRemoveLineBreak,
-            });
-            if (shouldBlockLargePaste(content, convenience.largePasteWarning)) {
-              return;
-            }
-            terminal.paste(content);
-          }
-        })
-        .catch(() => {
-          // Rust clipboard failed — fall back to browser clipboard → xterm paste
-          navigator.clipboard
-            .readText()
-            .then((text) => {
-              if (text) terminal.paste(text);
-            })
-            .catch(() => {});
-        });
-    };
-    outerContainer?.addEventListener("paste", handlePaste, { capture: true });
 
     // Ctrl+Wheel: zoom font size (up = bigger, down = smaller)
     const handleWheel = (e: WheelEvent) => {
@@ -1145,13 +1065,9 @@ export function TerminalView({
       idleDetector.dispose();
       resizeObserver.disconnect();
       outerContainer?.removeEventListener("contextmenu", handleContextMenu);
-      outerContainer?.removeEventListener("paste", handlePaste, {
-        capture: true,
-      } as EventListenerOptions);
       outerContainer?.removeEventListener("wheel", handleWheel);
       outerEl?.removeEventListener("keydown", handleKeyDown);
       outerEl?.removeEventListener("mousemove", handleMouseMove);
-      containerRef.current?.removeEventListener("copy", handleCopy);
       helperTextarea?.removeEventListener("compositionstart", handleCompositionStart);
       helperTextarea?.removeEventListener("compositionend", handleCompositionEnd);
       if (overlayCaretFrame !== undefined) cancelAnimationFrame(overlayCaretFrame);

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -25,6 +25,7 @@ import {
 import { colorSchemeToXtermTheme, type WTColorScheme } from "@/lib/color-scheme";
 import { transformPasteContent, prepareSelectionForCopy } from "@/lib/smart-text";
 import { isLxShortcut } from "@/lib/lx-shortcuts";
+import { matchesKeybinding, resolveKeybinding } from "@/lib/keybinding-registry";
 
 import {
   CODEX_INPUT_PENDING_MARKER,
@@ -609,10 +610,72 @@ export function TerminalView({
       helperTextarea.addEventListener("compositionend", handleCompositionEnd);
     };
 
-    // Custom key event handler: let IDE shortcuts pass through xterm.
-    // Returning false prevents xterm from consuming the event.
+    // Custom key event handler: let IDE shortcuts pass through xterm,
+    // and route the user-configurable terminal.copy / terminal.paste bindings
+    // when they are rebound to combos that don't fire native copy/paste events.
+    //
+    // Copy/paste are normally system events (browser `copy`/`paste` fires on
+    // Ctrl+C / Ctrl+V). Those defaults keep working through the DOM listeners
+    // below. If the user overrides the binding to e.g. Ctrl+Shift+C / Ctrl+Shift+V
+    // (the conventional Linux terminal combo), the browser won't fire those
+    // events on its own, so we dispatch the action manually here.
     terminal.attachCustomKeyEventHandler((e) => {
+      if (e.type !== "keydown") return true;
       if (isLxShortcut(e)) return false;
+
+      // terminal.paste — manually trigger smart paste when the bound combo is
+      // not the OS-default Ctrl+V (which the `paste` listener below handles).
+      if (matchesKeybinding(e, "terminal.paste")) {
+        if (resolveKeybinding("terminal.paste") !== "Ctrl+V") {
+          const { convenience: conv } = useSettingsStore.getState();
+          e.preventDefault();
+          smartPaste(conv.pasteImageDir, profile)
+            .then((result) => {
+              if (result.pasteType !== "none" && result.content) {
+                const content = transformPasteContent(result.content, result.pasteType, {
+                  removeIndent: conv.smartRemoveIndent,
+                  removeLineBreak: conv.smartRemoveLineBreak,
+                });
+                if (shouldBlockLargePaste(content, conv.largePasteWarning)) return;
+                terminal.paste(content);
+              }
+            })
+            .catch(() => {
+              navigator.clipboard
+                .readText()
+                .then((text) => {
+                  if (text) terminal.paste(text);
+                })
+                .catch(() => {});
+            });
+          return false;
+        }
+        // Default Ctrl+V: let the browser `paste` event fire — handled below.
+        return true;
+      }
+
+      // terminal.copy — manually copy the current selection when rebound away
+      // from the OS-default Ctrl+C. Default Ctrl+C continues to mean
+      // "copy if selection, SIGINT otherwise" via xterm's native handling.
+      if (matchesKeybinding(e, "terminal.copy")) {
+        if (resolveKeybinding("terminal.copy") !== "Ctrl+C") {
+          if (terminal.hasSelection()) {
+            const { convenience: conv } = useSettingsStore.getState();
+            const text = prepareSelectionForCopy(terminal.getSelection(), {
+              smartRemoveIndent: conv.smartRemoveIndent,
+            });
+            clipboardWriteText(text).catch(() => {});
+            e.preventDefault();
+            return false;
+          }
+          // No selection on a non-default binding: consume the event to avoid
+          // xterm injecting a control code for the underlying key.
+          return false;
+        }
+        // Default Ctrl+C: let xterm handle natively (copy-or-SIGINT).
+        return true;
+      }
+
       return true;
     });
 

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -56,13 +56,30 @@ const LARGE_PASTE_THRESHOLD = 5120;
 const textEncoder = new TextEncoder();
 
 /**
- * Execute the smart-paste pipeline and write the result into xterm.
- * Shared by the keybinding handler (terminal.paste) and the right-click paste
- * fallback so both paths produce identical behavior (image handling, indent
- * normalization, large-paste guard).
+ * Execute the paste pipeline and write the result into xterm. Shared by the
+ * keybinding handler (terminal.paste) and the right-click paste path so both
+ * always behave identically.
+ *
+ * Honors the `smartPaste` convenience toggle internally: when the toggle is
+ * disabled we skip image handling, indent/linebreak transforms, and the
+ * large-paste guard, and fall back to a plain `navigator.clipboard.readText()`
+ * → `terminal.paste()`. Keeping the toggle check here (rather than at each
+ * call site) means an override binding like Ctrl+Shift+V still pastes — just
+ * as plain text — instead of silently doing nothing.
  */
 function runTerminalPaste(terminal: Terminal, profile: string): void {
   const { convenience: conv } = useSettingsStore.getState();
+  if (!conv.smartPaste) {
+    navigator.clipboard
+      .readText()
+      .then((text) => {
+        if (text) terminal.paste(text);
+      })
+      .catch((err) => {
+        console.warn("[TerminalView] plain paste failed:", err);
+      });
+    return;
+  }
   smartPaste(conv.pasteImageDir, profile)
     .then((result) => {
       if (result.pasteType === "none" || !result.content) return;
@@ -73,14 +90,17 @@ function runTerminalPaste(terminal: Terminal, profile: string): void {
       if (shouldBlockLargePaste(content, conv.largePasteWarning)) return;
       terminal.paste(content);
     })
-    .catch(() => {
+    .catch((err) => {
       // Rust clipboard failed — fall back to browser clipboard → xterm paste
+      console.warn("[TerminalView] smart paste failed, falling back to browser clipboard:", err);
       navigator.clipboard
         .readText()
         .then((text) => {
           if (text) terminal.paste(text);
         })
-        .catch(() => {});
+        .catch((fallbackErr) => {
+          console.warn("[TerminalView] fallback paste also failed:", fallbackErr);
+        });
     });
 }
 
@@ -649,9 +669,9 @@ export function TerminalView({
       if (isLxShortcut(e)) return false;
 
       if (matchesKeybinding(e, "terminal.paste")) {
-        // Honor the smartPaste toggle: when off, defer to xterm's native paste
-        // (only works for default Ctrl+V since the browser fires `paste` then).
-        if (!useSettingsStore.getState().convenience.smartPaste) return true;
+        // runTerminalPaste honors the smartPaste toggle internally and falls
+        // back to plain clipboard paste when it's off, so override bindings
+        // like Ctrl+Shift+V still work regardless of the toggle.
         e.preventDefault();
         runTerminalPaste(terminal, profile);
         return false;
@@ -661,10 +681,17 @@ export function TerminalView({
         // No selection: let xterm process the raw key (default Ctrl+C → SIGINT).
         if (!terminal.hasSelection()) return true;
         const { convenience: conv } = useSettingsStore.getState();
-        const text = prepareSelectionForCopy(terminal.getSelection(), {
-          smartRemoveIndent: conv.smartRemoveIndent,
+        // When smartRemoveIndent is off, copy the selection verbatim. The
+        // transform helper (`prepareSelectionForCopy`) always strips trailing
+        // whitespace/blank lines — a behavior change for users who had the
+        // toggle off under the old native-Ctrl+C path. Keep them byte-exact
+        // with xterm's native copy output, but still honor override bindings.
+        const text = conv.smartRemoveIndent
+          ? prepareSelectionForCopy(terminal.getSelection(), { smartRemoveIndent: true })
+          : terminal.getSelection();
+        clipboardWriteText(text).catch((err) => {
+          console.warn("[TerminalView] copy to clipboard failed:", err);
         });
-        clipboardWriteText(text).catch(() => {});
         e.preventDefault();
         return false;
       }

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -56,6 +56,46 @@ const LARGE_PASTE_THRESHOLD = 5120;
 const textEncoder = new TextEncoder();
 
 /**
+ * Plain browser-clipboard paste. Shared by two spots in `runTerminalPaste`:
+ * the smartPaste-off fast path and the Rust-clipboard error fallback.
+ * `logPrefix` disambiguates the two in warnings.
+ */
+function pasteFromBrowserClipboard(terminal: Terminal, logPrefix: string): void {
+  navigator.clipboard
+    .readText()
+    .then((text) => {
+      if (text) terminal.paste(text);
+    })
+    .catch((err) => {
+      console.warn(`[TerminalView] ${logPrefix} failed:`, err);
+    });
+}
+
+/**
+ * Copy the current xterm selection to the system clipboard. Shared by the
+ * terminal.copy keybinding, right-click copy, and copy-on-select so all three
+ * paths produce byte-identical clipboard contents.
+ *
+ * When `smartRemoveIndent` is disabled the raw `getSelection()` string is
+ * written verbatim. `prepareSelectionForCopy` always strips trailing
+ * whitespace/blank lines, which would otherwise silently modify clipboard
+ * contents for users who have opted out of the "smart" transforms.
+ *
+ * No-op when there is no selection so every call site can delegate the
+ * has-selection check without repeating it.
+ */
+function runTerminalCopy(terminal: Terminal): void {
+  if (!terminal.hasSelection()) return;
+  const { convenience: conv } = useSettingsStore.getState();
+  const text = conv.smartRemoveIndent
+    ? prepareSelectionForCopy(terminal.getSelection(), { smartRemoveIndent: true })
+    : terminal.getSelection();
+  clipboardWriteText(text).catch((err) => {
+    console.warn("[TerminalView] copy to clipboard failed:", err);
+  });
+}
+
+/**
  * Execute the paste pipeline and write the result into xterm. Shared by the
  * keybinding handler (terminal.paste) and the right-click paste path so both
  * always behave identically.
@@ -70,14 +110,7 @@ const textEncoder = new TextEncoder();
 function runTerminalPaste(terminal: Terminal, profile: string): void {
   const { convenience: conv } = useSettingsStore.getState();
   if (!conv.smartPaste) {
-    navigator.clipboard
-      .readText()
-      .then((text) => {
-        if (text) terminal.paste(text);
-      })
-      .catch((err) => {
-        console.warn("[TerminalView] plain paste failed:", err);
-      });
+    pasteFromBrowserClipboard(terminal, "plain paste");
     return;
   }
   smartPaste(conv.pasteImageDir, profile)
@@ -93,14 +126,7 @@ function runTerminalPaste(terminal: Terminal, profile: string): void {
     .catch((err) => {
       // Rust clipboard failed — fall back to browser clipboard → xterm paste
       console.warn("[TerminalView] smart paste failed, falling back to browser clipboard:", err);
-      navigator.clipboard
-        .readText()
-        .then((text) => {
-          if (text) terminal.paste(text);
-        })
-        .catch((fallbackErr) => {
-          console.warn("[TerminalView] fallback paste also failed:", fallbackErr);
-        });
+      pasteFromBrowserClipboard(terminal, "fallback paste");
     });
 }
 
@@ -680,18 +706,7 @@ export function TerminalView({
       if (matchesKeybinding(e, "terminal.copy")) {
         // No selection: let xterm process the raw key (default Ctrl+C → SIGINT).
         if (!terminal.hasSelection()) return true;
-        const { convenience: conv } = useSettingsStore.getState();
-        // When smartRemoveIndent is off, copy the selection verbatim. The
-        // transform helper (`prepareSelectionForCopy`) always strips trailing
-        // whitespace/blank lines — a behavior change for users who had the
-        // toggle off under the old native-Ctrl+C path. Keep them byte-exact
-        // with xterm's native copy output, but still honor override bindings.
-        const text = conv.smartRemoveIndent
-          ? prepareSelectionForCopy(terminal.getSelection(), { smartRemoveIndent: true })
-          : terminal.getSelection();
-        clipboardWriteText(text).catch((err) => {
-          console.warn("[TerminalView] copy to clipboard failed:", err);
-        });
+        runTerminalCopy(terminal);
         e.preventDefault();
         return false;
       }
@@ -717,15 +732,12 @@ export function TerminalView({
     outerEl?.addEventListener("keydown", handleKeyDown);
     outerEl?.addEventListener("mousemove", handleMouseMove);
 
-    // Copy-on-select: auto-copy to clipboard when text is selected
+    // Copy-on-select: auto-copy to clipboard when text is selected.
+    // `runTerminalCopy` handles the has-selection guard and smart-indent
+    // branching, keeping this path in lockstep with Ctrl+C and right-click.
     terminal.onSelectionChange(() => {
-      const { convenience: conv } = useSettingsStore.getState();
-      if (conv.copyOnSelect && terminal.hasSelection()) {
-        clipboardWriteText(
-          prepareSelectionForCopy(terminal.getSelection(), {
-            smartRemoveIndent: conv.smartRemoveIndent,
-          }),
-        ).catch(() => {});
+      if (useSettingsStore.getState().convenience.copyOnSelect) {
+        runTerminalCopy(terminal);
       }
     });
 
@@ -936,13 +948,8 @@ export function TerminalView({
     const handleContextMenu = (e: MouseEvent) => {
       e.preventDefault();
       if (terminal.hasSelection()) {
-        // Selection exists → copy to clipboard via Tauri, then clear
-        const { convenience: conv } = useSettingsStore.getState();
-        clipboardWriteText(
-          prepareSelectionForCopy(terminal.getSelection(), {
-            smartRemoveIndent: conv.smartRemoveIndent,
-          }),
-        ).catch(() => {});
+        // Selection exists → copy via the shared helper, then clear.
+        runTerminalCopy(terminal);
         terminal.clearSelection();
       } else {
         // No selection → paste via the shared smart-paste pipeline.

--- a/ui/src/lib/keybinding-registry.test.ts
+++ b/ui/src/lib/keybinding-registry.test.ts
@@ -31,13 +31,15 @@ describe("keybinding-registry", () => {
       expect(new Set(ids).size).toBe(ids.length);
     });
 
-    it("should not include clipboard operations (copy/paste are system events)", () => {
-      expect(DEFAULT_KEYBINDINGS.find((d) => d.id === "fileExplorer.copy")).toBeUndefined();
-      expect(DEFAULT_KEYBINDINGS.find((d) => d.id === "terminal.paste")).toBeUndefined();
-    });
-
     it("should include issueReporter.submit", () => {
       expect(DEFAULT_KEYBINDINGS.find((d) => d.id === "issueReporter.submit")).toBeDefined();
+    });
+
+    it("should include terminal.copy / terminal.paste with OS-default combos", () => {
+      const copy = DEFAULT_KEYBINDINGS.find((d) => d.id === "terminal.copy");
+      const paste = DEFAULT_KEYBINDINGS.find((d) => d.id === "terminal.paste");
+      expect(copy?.defaultKeys).toBe("Ctrl+C");
+      expect(paste?.defaultKeys).toBe("Ctrl+V");
     });
   });
 
@@ -99,6 +101,27 @@ describe("keybinding-registry", () => {
     it("should match Ctrl+, to settings.open", () => {
       const e = makeKeyEvent(",", { ctrl: true });
       expect(matchesKeybinding(e, "settings.open")).toBe(true);
+    });
+
+    it("should match Ctrl+Shift+C to terminal.copy when overridden", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [
+          { command: "terminal.copy", keys: "Ctrl+Shift+C" },
+          { command: "terminal.paste", keys: "Ctrl+Shift+V" },
+        ],
+      });
+      const copyEvent = makeKeyEvent("C", { ctrl: true, shift: true });
+      expect(matchesKeybinding(copyEvent, "terminal.copy")).toBe(true);
+      // The OS-default Ctrl+C should no longer match the rebound action
+      const oldCopy = makeKeyEvent("c", { ctrl: true });
+      expect(matchesKeybinding(oldCopy, "terminal.copy")).toBe(false);
+    });
+
+    it("should match Ctrl+C / Ctrl+V to terminal.copy / terminal.paste by default", () => {
+      const copy = makeKeyEvent("c", { ctrl: true });
+      const paste = makeKeyEvent("v", { ctrl: true });
+      expect(matchesKeybinding(copy, "terminal.copy")).toBe(true);
+      expect(matchesKeybinding(paste, "terminal.paste")).toBe(true);
     });
   });
 });

--- a/ui/src/lib/keybinding-registry.ts
+++ b/ui/src/lib/keybinding-registry.ts
@@ -93,6 +93,12 @@ export const DEFAULT_KEYBINDINGS: KeybindingDef[] = [
     group: "UI",
   },
   { id: "settings.open", label: "설정 열기", defaultKeys: "Ctrl+,", group: "UI" },
+  // -- Terminal --
+  // 기본값은 OS의 시스템 클립보드 단축키(Ctrl+C / Ctrl+V)와 동일하여, 별도 설정 없이도
+  // 브라우저 `copy` / `paste` 이벤트로 동작한다. 사용자가 Ctrl+Shift+C / Ctrl+Shift+V
+  // 등으로 재바인딩하면 TerminalView의 키 이벤트 핸들러가 수동으로 copy/paste를 실행한다.
+  { id: "terminal.copy", label: "터미널 복사", defaultKeys: "Ctrl+C", group: "Terminal" },
+  { id: "terminal.paste", label: "터미널 붙여넣기", defaultKeys: "Ctrl+V", group: "Terminal" },
   // -- Issue Reporter --
   {
     id: "issueReporter.submit",


### PR DESCRIPTION
## Summary
- 터미널의 복사/붙여넣기를 **사용자가 재바인딩할 수 있는 키바인딩**으로 등록 (기본값 `Ctrl+C` / `Ctrl+V`).
- 시스템 `copy`/`paste` 이벤트 리스너 경로를 모두 제거하고, `attachCustomKeyEventHandler`가 유일한 진입점. `matchesKeybinding("terminal.copy"/"terminal.paste")` 매칭 시 바로 수동으로 copy/paste 수행.
- `runTerminalPaste` 헬퍼가 `smartPaste` 토글을 내부에서 처리 → 오버라이드 바인딩(Ctrl+Shift+V 등)도 토글 off 상태에서 plain clipboard 폴백으로 정상 동작. 우클릭 paste도 같은 헬퍼를 재사용해 두 경로가 진짜로 동일.
- `smartRemoveIndent` off 상태에서는 copy 경로가 raw `getSelection()`을 그대로 클립보드에 기록해 기존 native Ctrl+C와 바이트 동일성 유지.
- `ARCHITECTURE.md §15.5`에 "터미널 copy/paste는 키바인딩으로 통합" 예외를 명시.

## 변경 파일
- `ui/src/lib/keybinding-registry.ts` — `terminal.copy`, `terminal.paste` 항목 추가 (Settings UI "Terminal" 그룹)
- `ui/src/components/views/TerminalView.tsx` — 키바인딩 단일 경로, `runTerminalPaste` 헬퍼, smartPaste 내부 처리, copy 경로 smartRemoveIndent 분기, 실패 시 `console.warn`
- `ARCHITECTURE.md §15.5` — 키바인딩 단일 경로 설계 문서화
- `ui/src/lib/keybinding-registry.test.ts` — 기본값/오버라이드 테스트
- `ui/src/components/views/TerminalView.test.tsx` — 키 핸들러 통합 테스트 추가

## 동작 규칙
| 조건 | 동작 |
|------|------|
| `terminal.copy` 매치 + 선택 있음 + smartRemoveIndent on | `prepareSelectionForCopy` 후 `clipboardWriteText` |
| `terminal.copy` 매치 + 선택 있음 + smartRemoveIndent off | raw `getSelection()` 그대로 `clipboardWriteText` (기존 native copy와 동일) |
| `terminal.copy` 매치 + 선택 없음 | `return true` → xterm에 위임 (Ctrl+C면 SIGINT) |
| `terminal.paste` 매치 + smartPaste on | `smartPaste` Rust 파이프라인 (이미지/indent/linebreak/large-paste) |
| `terminal.paste` 매치 + smartPaste off | `navigator.clipboard.readText()` → `terminal.paste()` plain |
| 우클릭 (선택 있음) | `clipboardWriteText` + `clearSelection` |
| 우클릭 (선택 없음) | `runTerminalPaste` (동일 헬퍼) |

## Test plan
- [x] `npx vitest run` — 1559 passed (남은 1 failure는 main에서부터 깨져 있던 `FileExplorerView` 스테일 테스트로 본 PR과 무관)
- [x] keybinding registry 단위 테스트 15건
- [x] TerminalView 키 핸들러 통합 테스트 (Ctrl+C/selection/empty, smartRemoveIndent off, smartPaste off)
- [ ] `settings.json`에서 `terminal.copy` → `Ctrl+Shift+C`, `terminal.paste` → `Ctrl+Shift+V` 오버라이드 후 수동 확인
- [ ] Settings UI의 Keybindings 섹션에 "Terminal" 그룹 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)