### PR TITLE
fix: Ctrl+휠 줌이 스크롤 불가능할 때만 동작하던 버그 수정 (#211)

### DIFF
--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -34,6 +34,7 @@ import {
   type CompositionPreviewState,
 } from "@/lib/ime-composition-controller";
 import { shouldDeferTerminalKeyToIme } from "@/lib/ime-key-policy";
+import { computeWheelZoom } from "@/lib/wheel-zoom";
 import {
   applyActivityLeftTuiToShadowCursor,
   applyDec2026ResetToShadowCursor,
@@ -1203,23 +1204,28 @@ export function TerminalView({
     };
     outerContainer?.addEventListener("contextmenu", handleContextMenu);
 
-    // Ctrl+Wheel: zoom font size (up = bigger, down = smaller)
+    // Ctrl+Wheel: zoom font size (up = bigger, down = smaller).
+    // Capture 단계로 등록해야 xterm.js viewport가 wheel을 먼저 소비하는 것을
+    // 막을 수 있다(#211). bubbling으로 등록하면 스크롤백이 남아 있을 때
+    // xterm이 이벤트를 먼저 소비해 Ctrl+Wheel 줌이 동작하지 않는다.
     const handleWheel = (e: WheelEvent) => {
-      if (!e.ctrlKey) return;
-      e.preventDefault();
       const state = useSettingsStore.getState();
       const currentFont = state.resolveFont(profile);
-      const delta = e.deltaY < 0 ? 1 : -1;
-      const newSize = Math.max(6, Math.min(72, currentFont.size + delta));
-      if (newSize !== currentFont.size) {
-        // Update the profile's font override
-        const idx = state.profiles.findIndex((p) => p.name === profile);
-        if (idx >= 0) {
-          state.updateProfile(idx, { font: { ...currentFont, size: newSize } });
-        }
+      const decision = computeWheelZoom(e, currentFont.size);
+      if (!decision.intercept) return;
+      // Ctrl이 눌린 wheel은 xterm 스크롤로 전달하지 않고 줌으로만 사용한다.
+      e.preventDefault();
+      e.stopPropagation();
+      if (decision.newSize === null) return;
+      const idx = state.profiles.findIndex((p) => p.name === profile);
+      if (idx >= 0) {
+        state.updateProfile(idx, { font: { ...currentFont, size: decision.newSize } });
       }
     };
-    outerContainer?.addEventListener("wheel", handleWheel, { passive: false });
+    outerContainer?.addEventListener("wheel", handleWheel, {
+      capture: true,
+      passive: false,
+    });
 
     // Wait for container to have actual dimensions before opening terminal.
     // xterm.js viewport gets height 0 if opened in a zero-sized container,
@@ -1344,7 +1350,7 @@ export function TerminalView({
       idleDetector.dispose();
       resizeObserver.disconnect();
       outerContainer?.removeEventListener("contextmenu", handleContextMenu);
-      outerContainer?.removeEventListener("wheel", handleWheel);
+      outerContainer?.removeEventListener("wheel", handleWheel, { capture: true });
       outerEl?.removeEventListener("keydown", handleKeyDown);
       outerEl?.removeEventListener("mousemove", handleMouseMove);
       compositionController.dispose();

--- a/ui/src/lib/wheel-zoom.test.ts
+++ b/ui/src/lib/wheel-zoom.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { computeWheelZoom, WHEEL_ZOOM_MIN_SIZE, WHEEL_ZOOM_MAX_SIZE } from "./wheel-zoom";
+
+describe("computeWheelZoom", () => {
+  it("Ctrl 키가 눌리지 않았으면 가로채지 않는다 (스크롤 허용)", () => {
+    const result = computeWheelZoom({ ctrlKey: false, deltaY: -100 }, 14);
+    expect(result.intercept).toBe(false);
+    expect(result.newSize).toBeNull();
+  });
+
+  it("Ctrl 키가 눌리지 않았으면 아래로 스크롤해도 가로채지 않는다", () => {
+    const result = computeWheelZoom({ ctrlKey: false, deltaY: 100 }, 14);
+    expect(result.intercept).toBe(false);
+    expect(result.newSize).toBeNull();
+  });
+
+  it("Ctrl+위로 스크롤: 폰트 크기 증가, intercept=true", () => {
+    const result = computeWheelZoom({ ctrlKey: true, deltaY: -100 }, 14);
+    expect(result.intercept).toBe(true);
+    expect(result.newSize).toBe(15);
+  });
+
+  it("Ctrl+아래로 스크롤: 폰트 크기 감소, intercept=true", () => {
+    const result = computeWheelZoom({ ctrlKey: true, deltaY: 100 }, 14);
+    expect(result.intercept).toBe(true);
+    expect(result.newSize).toBe(13);
+  });
+
+  it("최대 크기에서 Ctrl+위로 스크롤: intercept=true, newSize=null (변경 없음)", () => {
+    const result = computeWheelZoom({ ctrlKey: true, deltaY: -100 }, WHEEL_ZOOM_MAX_SIZE);
+    expect(result.intercept).toBe(true);
+    expect(result.newSize).toBeNull();
+  });
+
+  it("최소 크기에서 Ctrl+아래로 스크롤: intercept=true, newSize=null (변경 없음)", () => {
+    const result = computeWheelZoom({ ctrlKey: true, deltaY: 100 }, WHEEL_ZOOM_MIN_SIZE);
+    expect(result.intercept).toBe(true);
+    expect(result.newSize).toBeNull();
+  });
+
+  it("최대 크기 근처에서 Ctrl+위: 최대 값으로 clamp", () => {
+    const result = computeWheelZoom({ ctrlKey: true, deltaY: -100 }, WHEEL_ZOOM_MAX_SIZE - 1);
+    expect(result.intercept).toBe(true);
+    expect(result.newSize).toBe(WHEEL_ZOOM_MAX_SIZE);
+  });
+
+  it("최소 크기 근처에서 Ctrl+아래: 최소 값으로 clamp", () => {
+    const result = computeWheelZoom({ ctrlKey: true, deltaY: 100 }, WHEEL_ZOOM_MIN_SIZE + 1);
+    expect(result.intercept).toBe(true);
+    expect(result.newSize).toBe(WHEEL_ZOOM_MIN_SIZE);
+  });
+
+  it("Ctrl + deltaY=0: 가로채되 크기는 유지 (null)", () => {
+    const result = computeWheelZoom({ ctrlKey: true, deltaY: 0 }, 14);
+    expect(result.intercept).toBe(true);
+    expect(result.newSize).toBeNull();
+  });
+});
+
+/**
+ * DOM 통합 테스트: capture 단계 리스너가 bubbling 단계보다 먼저 실행되는지
+ * 검증한다. xterm.js의 viewport가 wheel을 소비하기 전에 Ctrl+Wheel을
+ * 가로채기 위해서는 반드시 capture 단계 등록이 필요하다.
+ */
+describe("wheel capture phase integration", () => {
+  it("capture 단계 리스너가 bubbling 리스너보다 먼저 실행된다", () => {
+    const outer = document.createElement("div");
+    const inner = document.createElement("div");
+    outer.appendChild(inner);
+    document.body.appendChild(outer);
+
+    const order: string[] = [];
+
+    // xterm viewport를 모방: bubbling 단계에서 이벤트를 소비한다.
+    inner.addEventListener("wheel", (e) => {
+      order.push("inner-bubbling");
+      e.stopPropagation();
+    });
+
+    // 우리 핸들러: capture 단계로 등록하면 inner 리스너보다 먼저 실행되어야 한다.
+    outer.addEventListener(
+      "wheel",
+      (e) => {
+        order.push("outer-capture");
+        if ((e as WheelEvent).ctrlKey) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      },
+      { capture: true, passive: false },
+    );
+
+    const event = new WheelEvent("wheel", {
+      ctrlKey: true,
+      deltaY: -100,
+      bubbles: true,
+      cancelable: true,
+    });
+    inner.dispatchEvent(event);
+
+    // capture가 먼저 실행되고, Ctrl이 눌린 경우 stopPropagation으로 inner는 호출되지 않는다.
+    expect(order).toEqual(["outer-capture"]);
+
+    document.body.removeChild(outer);
+  });
+
+  it("Ctrl이 없으면 capture에서 가로채지 않아 bubbling으로 전달된다", () => {
+    const outer = document.createElement("div");
+    const inner = document.createElement("div");
+    outer.appendChild(inner);
+    document.body.appendChild(outer);
+
+    const order: string[] = [];
+
+    inner.addEventListener("wheel", () => {
+      order.push("inner-bubbling");
+    });
+
+    outer.addEventListener(
+      "wheel",
+      (e) => {
+        order.push("outer-capture");
+        if ((e as WheelEvent).ctrlKey) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      },
+      { capture: true, passive: false },
+    );
+
+    const event = new WheelEvent("wheel", {
+      ctrlKey: false,
+      deltaY: -100,
+      bubbles: true,
+      cancelable: true,
+    });
+    inner.dispatchEvent(event);
+
+    expect(order).toEqual(["outer-capture", "inner-bubbling"]);
+
+    document.body.removeChild(outer);
+  });
+});

--- a/ui/src/lib/wheel-zoom.ts
+++ b/ui/src/lib/wheel-zoom.ts
@@ -1,0 +1,45 @@
+/**
+ * Ctrl+Wheel 줌 처리 유틸리티
+ *
+ * 터미널 컨테이너에 bubbling 단계로 wheel 리스너를 등록하면 xterm.js의
+ * viewport가 이벤트를 먼저 소비하여 스크롤백이 존재할 때만 Ctrl+Wheel 줌이
+ * 먹히고, 스크롤이 끝에 도달했을 때만 줌이 동작하는 버그(#211)가 발생한다.
+ *
+ * 해결: capture 단계에서 먼저 가로채고, Ctrl이 눌린 경우에만
+ * `preventDefault`/`stopPropagation`으로 xterm에 이벤트가 전달되지 않게 한다.
+ * Ctrl이 눌리지 않았으면 아무 일도 하지 않고 터미널 스크롤이 정상 동작한다.
+ */
+
+/** Ctrl+Wheel 줌 계산 결과 (테스트 가능한 순수 로직). */
+export interface WheelZoomDecision {
+  /** 이벤트를 가로챌지 여부. `true`이면 preventDefault + stopPropagation 필요. */
+  intercept: boolean;
+  /** 새로 적용할 폰트 크기. `null`이면 변경 없음 (범위 한계 도달 등). */
+  newSize: number | null;
+}
+
+/** 폰트 크기 허용 범위 (px). */
+export const WHEEL_ZOOM_MIN_SIZE = 6;
+export const WHEEL_ZOOM_MAX_SIZE = 72;
+
+/**
+ * Ctrl+Wheel 이벤트를 처리할지 계산한다.
+ *
+ * @param event 수신한 wheel 이벤트 (의 일부 속성)
+ * @param currentSize 현재 폰트 크기 (px)
+ */
+export function computeWheelZoom(
+  event: Pick<WheelEvent, "ctrlKey" | "deltaY">,
+  currentSize: number,
+): WheelZoomDecision {
+  if (!event.ctrlKey) {
+    return { intercept: false, newSize: null };
+  }
+
+  // deltaY < 0: 위로 스크롤 → 확대, deltaY > 0: 아래로 스크롤 → 축소.
+  // deltaY === 0: 의도가 불분명 → 가로채되 크기는 유지.
+  const delta = event.deltaY < 0 ? 1 : event.deltaY > 0 ? -1 : 0;
+  const clamped = Math.max(WHEEL_ZOOM_MIN_SIZE, Math.min(WHEEL_ZOOM_MAX_SIZE, currentSize + delta));
+  const newSize = clamped === currentSize ? null : clamped;
+  return { intercept: true, newSize };
+}


### PR DESCRIPTION
## 요약

Ctrl + 휠로 터미널 폰트 크기를 조정할 때, 스크롤백이 있는 상태에서는 xterm.js 뷰포트가 wheel 이벤트를 먼저 소비해 버려서 스크롤 한계에 도달한 뒤에만 줌이 동작하던 버그를 수정.

Fixes #211

## 원인

`TerminalView`의 wheel 리스너가 **bubbling 단계**(`addEventListener("wheel", ..., { passive: false })`)로 등록되어 있어, 이벤트가 자식인 xterm viewport에 먼저 도달하여 스크롤백이 남아 있으면 그쪽에서 소비됨. 버블링으로 올라오지 않으니 Ctrl+휠 줌 핸들러가 호출되지 않았음.

## 변경 내용

- `ui/src/components/views/TerminalView.tsx`: wheel 리스너를 **capture 단계**(`{ capture: true, passive: false }`)로 등록. `removeEventListener`에도 동일한 `capture: true` 전달.
- `ui/src/lib/wheel-zoom.ts`: Ctrl + 휠 줌 결정 로직을 순수 함수 `computeWheelZoom()`으로 분리. Ctrl 미포함이면 `intercept: false`를 반환해 xterm 스크롤이 정상 동작하도록 위임. Ctrl 포함이면 `preventDefault` + `stopPropagation`으로 xterm까지 내려가지 않게 막고 폰트 크기만 clamp.
- `ui/src/lib/wheel-zoom.test.ts`: 순수 로직 단위 테스트 9건 + 실제 DOM에서 capture가 bubbling보다 먼저 실행되는지, Ctrl 미포함 시 bubbling이 정상 동작하는지 검증하는 통합 테스트 2건.

## 테스트 결과

- `npx vitest run ui/src/lib/wheel-zoom.test.ts ui/src/components/views/TerminalView.test.tsx` — 88건 모두 통과
- 전체 vitest 실행 시 기존부터 존재하던 `FileExplorerView.test.tsx`의 Ctrl+C 클립보드 테스트 1건이 실패하지만 이번 변경과 무관 (main 브랜치에서도 실패 재현 확인)
- Prettier / 린트 통과 (신규 경고 없음)

## 테스트 체크리스트

- [x] 단위/통합 테스트 통과
- [ ] dev 인스턴스(포트 19281)에서 터미널 스크롤백을 채운 뒤 Ctrl+휠로 폰트 크기 조정이 즉시 동작하는지 수동 확인
- [ ] Ctrl 없이 휠만 돌렸을 때 터미널 스크롤은 영향 없이 동작하는지 확인