### PR TITLE
fix: 터미널뷰 고정(pin) 모드에서 타이틀/브랜치/CWD 헤더 표시 (#209)

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -5,6 +5,10 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { CODEX_INPUT_PENDING_MARKER } from "@/lib/activity-detection";
+import {
+  PaneControlContext,
+  type PaneControlContextValue,
+} from "@/components/layout/PaneControlContext";
 
 // Mock xterm since it requires a real DOM with canvas
 const mockOnData = vi.fn();
@@ -1884,6 +1888,90 @@ describe("TerminalView", () => {
       expect(WebglAddon).toHaveBeenCalledTimes(callsBefore);
 
       vi.useRealTimers();
+    });
+  });
+
+  describe("pinned header (issue #209)", () => {
+    function makeCtx(overrides: Partial<PaneControlContextValue> = {}): PaneControlContextValue {
+      return {
+        paneControls: <div data-testid="mock-pane-controls">controls</div>,
+        mode: "pinned",
+        hovered: false,
+        onSetMode: vi.fn(),
+        registerHeader: vi.fn(),
+        unregisterHeader: vi.fn(),
+        ...overrides,
+      };
+    }
+
+    function renderWithCtx(ctx: PaneControlContextValue, ui: React.ReactElement) {
+      return render(<PaneControlContext.Provider value={ctx}>{ui}</PaneControlContext.Provider>);
+    }
+
+    it("hides the pinned header when control bar mode is hover", () => {
+      renderWithCtx(
+        makeCtx({ mode: "hover" }),
+        <TerminalView instanceId="t-pin-hover" profile="PowerShell" syncGroup="g" />,
+      );
+      expect(screen.queryByTestId("terminal-pinned-header-t-pin-hover")).not.toBeInTheDocument();
+    });
+
+    it("renders the pinned header when control bar mode is pinned", () => {
+      renderWithCtx(
+        makeCtx({ mode: "pinned" }),
+        <TerminalView instanceId="t-pin-show" profile="PowerShell" syncGroup="g" />,
+      );
+      expect(screen.getByTestId("terminal-pinned-header-t-pin-show")).toBeInTheDocument();
+    });
+
+    it("does not render pinned header when PaneControlContext is absent", () => {
+      render(<TerminalView instanceId="t-pin-nocxt" profile="PowerShell" syncGroup="" />);
+      expect(screen.queryByTestId("terminal-pinned-header-t-pin-nocxt")).not.toBeInTheDocument();
+    });
+
+    it("renders the terminal title and CWD from the terminal store when pinned", () => {
+      renderWithCtx(
+        makeCtx({ mode: "pinned" }),
+        <TerminalView instanceId="t-pin-info" profile="WSL" syncGroup="g" />,
+      );
+
+      // store 업데이트 → title/cwd 반영
+      act(() => {
+        useTerminalStore.getState().updateInstanceInfo("t-pin-info", {
+          title: "zsh — /home/user/proj",
+          cwd: "/home/user/proj",
+          branch: "main",
+        });
+      });
+
+      const header = screen.getByTestId("terminal-pinned-header-t-pin-info");
+      expect(header).toHaveTextContent("zsh — /home/user/proj");
+      // abbreviatePath(/home/user/proj) → "~/proj"
+      expect(header).toHaveTextContent("~/proj");
+      expect(header).toHaveTextContent("main");
+    });
+
+    it("converts WSL /mnt paths to Windows form for Windows profiles", () => {
+      renderWithCtx(
+        makeCtx({ mode: "pinned" }),
+        <TerminalView instanceId="t-pin-mnt" profile="PowerShell" syncGroup="g" />,
+      );
+      act(() => {
+        useTerminalStore.getState().updateInstanceInfo("t-pin-mnt", {
+          cwd: "/mnt/d/projects/laymux",
+        });
+      });
+      const header = screen.getByTestId("terminal-pinned-header-t-pin-mnt");
+      // mntPathToWindows → D:\projects\laymux → abbreviatePath은 30자 미만이면 그대로
+      expect(header).toHaveTextContent(/D:\\projects\\laymux/);
+    });
+
+    it("does not render the pinned header for minimized mode", () => {
+      renderWithCtx(
+        makeCtx({ mode: "minimized" }),
+        <TerminalView instanceId="t-pin-mini" profile="PowerShell" syncGroup="g" />,
+      );
+      expect(screen.queryByTestId("terminal-pinned-header-t-pin-mini")).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -62,6 +62,9 @@ import {
   registerTerminalSerializer,
   unregisterTerminalSerializer,
 } from "@/lib/terminal-serialize-registry";
+import { ViewHeader } from "@/components/ui/ViewHeader";
+import { usePaneControl } from "@/components/layout/PaneControlContext";
+import { abbreviatePath, isWindowsProfile, mntPathToWindows } from "@/lib/workspace-summary";
 
 /** Default silence timeout for output idle detection (ms). */
 const OUTPUT_IDLE_TIMEOUT_MS = 5000;
@@ -1577,10 +1580,11 @@ export function TerminalView({
     <div
       ref={wrapperRef}
       data-testid={`terminal-view-${instanceId}`}
-      className={`relative h-full w-full ${scrollbarClass} ${nativeCursorHidden ? "terminal-native-cursor-hidden" : ""}`}
+      className={`relative flex h-full w-full flex-col ${scrollbarClass} ${nativeCursorHidden ? "terminal-native-cursor-hidden" : ""}`}
       style={wrapperStyle}
     >
-      <div ref={containerRef} className="h-full w-full" />
+      <PinnedTerminalHeader instanceId={instanceId} profile={profile} />
+      <div ref={containerRef} className="min-h-0 flex-1 w-full" />
       <div
         ref={compositionPreviewRefEl}
         data-testid={`terminal-composition-preview-${instanceId}`}
@@ -1599,5 +1603,64 @@ export function TerminalView({
         style={{ opacity: 0 }}
       />
     </div>
+  );
+}
+
+/**
+ * Pinned 상태에서 터미널 상단에 표시되는 헤더.
+ * Issue #209: 터미널 뷰가 고정(pinned)되면 workspace 수준의 CWD/title을 표시한다.
+ *
+ * - `PaneControlContext`가 있고 mode === "pinned"일 때만 렌더.
+ * - 렌더되면 `ViewHeader`가 `registerHeader()`를 호출해 `PaneControlBar`의
+ *   자체 pinned 바 렌더를 억제하고, 대신 우측에 pane 컨트롤을 합성한다.
+ * - terminalStore에서 title/cwd/branch를 구독하여 원시 상태 → 표시 계산.
+ * - CWD 경로는 Windows 프로필이면 `/mnt/x` → `X:\...`로 변환, 그리고
+ *   `abbreviatePath`로 홈/접두사 축약 및 길이 제한을 적용한다.
+ */
+function PinnedTerminalHeader({ instanceId, profile }: { instanceId: string; profile: string }) {
+  const ctx = usePaneControl();
+  const instance = useTerminalStore((s) => s.instances.find((i) => i.id === instanceId));
+
+  if (!ctx || ctx.mode !== "pinned") return null;
+
+  const title = instance?.title?.trim() || "";
+  const branch = instance?.branch?.trim() || "";
+  const rawCwd = instance?.cwd?.trim() || "";
+  const displayCwd = rawCwd
+    ? abbreviatePath(isWindowsProfile(profile) ? mntPathToWindows(rawCwd) : rawCwd)
+    : "";
+
+  return (
+    <ViewHeader testId={`terminal-pinned-header-${instanceId}`}>
+      <div className="flex min-w-0 flex-1 items-center gap-2 truncate text-[11px]">
+        {title && (
+          <span
+            data-testid={`terminal-pinned-header-title-${instanceId}`}
+            className="min-w-0 truncate font-medium"
+            style={{ color: "var(--text-primary)" }}
+          >
+            {title}
+          </span>
+        )}
+        {branch && (
+          <span
+            data-testid={`terminal-pinned-header-branch-${instanceId}`}
+            className="shrink-0"
+            style={{ color: "var(--green)" }}
+          >
+            {branch}
+          </span>
+        )}
+        {displayCwd && (
+          <span
+            data-testid={`terminal-pinned-header-cwd-${instanceId}`}
+            className="min-w-0 truncate"
+            style={{ color: "var(--text-secondary)", opacity: 0.8 }}
+          >
+            {displayCwd}
+          </span>
+        )}
+      </div>
+    </ViewHeader>
   );
 }

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -9,6 +9,7 @@ import {
   computeCommandStatus,
   abbreviatePath,
   mntPathToWindows,
+  isWindowsProfile,
   formatCommand,
   ACTIVITY_MSG_TRUNCATE_LEN,
   formatRelativeTime,
@@ -34,11 +35,6 @@ const LABEL_ABBREV: Record<string, string> = {
   Empty: "---",
   EmptyView: "---",
 };
-/** Check if a profile is a Windows-native shell (PowerShell, CMD) that uses Windows paths. */
-function isWindowsProfile(profile: string): boolean {
-  const lower = profile.toLowerCase();
-  return lower.includes("powershell") || lower === "cmd" || lower === "command prompt";
-}
 
 function getStatusDisplaySettings(
   activity: TerminalActivityInfo | undefined,

--- a/ui/src/lib/workspace-summary.ts
+++ b/ui/src/lib/workspace-summary.ts
@@ -232,6 +232,16 @@ function abbreviateProfile(profile: string): string {
 }
 
 /**
+ * Check if a profile is a Windows-native shell (PowerShell, CMD) that uses
+ * Windows-style paths. Used to decide whether `/mnt/x/...` CWDs should be
+ * converted to `X:\...` for display.
+ */
+export function isWindowsProfile(profile: string): boolean {
+  const lower = profile.toLowerCase();
+  return lower.includes("powershell") || lower === "cmd" || lower === "command prompt";
+}
+
+/**
  * Abbreviate a file path for display.
  * @param cwd - The raw path string
  * @param ellipsis - "start" (default) truncates the beginning (shows end), "end" truncates the end (shows beginning)


### PR DESCRIPTION
## Summary
- 고정(pinned) 모드의 터미널 뷰 상단에 `ViewHeader`를 렌더하여 타이틀, git 브랜치, 축약된 CWD를 표시 (workspace 수준)
- Hover/minimized 모드는 기존 overlay 컨트롤 바 동작 유지
- `isWindowsProfile`을 `workspace-summary.ts`로 승격하여 중복 제거

## 설계 원칙
- `terminalStore`에서 원시 title/cwd/branch만 구독, 표시 값은 계산 함수로 도출
- `ViewHeader`·`abbreviatePath`·`mntPathToWindows` 재사용으로 WorkspaceSelectorView와 동일한 축약 규칙 적용
- CSS 변수 사용(`--text-primary`, `--green`, `--text-secondary`), 매직 넘버 없음

## Test plan
- [x] `ui/src/components/views/TerminalView.test.tsx` 6개 테스트 신규 추가 (TDD)
- [x] TerminalView 테스트 83개 모두 통과
- [x] WorkspaceSelectorView + workspace-summary 테스트 185개 통과
- [x] Prettier / ESLint / `tsc --noEmit` 통과
- [ ] 시각적 검증은 dev 인스턴스 재시작 후 수동 확인 권장

Fixes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)