### PR TITLE
feat(mcp): clear_notifications 도구 추가 — #200 마무리

### DIFF
--- a/src-tauri/src/automation_server/handlers_backend.rs
+++ b/src-tauri/src/automation_server/handlers_backend.rs
@@ -156,6 +156,12 @@ pub async fn api_docs() -> impl IntoResponse {
                 "body": { "workspaceId": "string" }
             },
             {
+                "method": "DELETE", "path": "/api/v1/notifications",
+                "description": "Clear notifications by ID list or by age. Provide exactly one of 'ids' or 'before'. With 'before', set 'readOnly' to preserve older unread items.",
+                "body": { "ids": "(optional) string[] — specific notification IDs to clear", "before": "(optional) number — epoch ms; clears notifications older than this", "readOnly": "(optional) boolean — with 'before', clear only already-read notifications" },
+                "response": "{ cleared: number }"
+            },
+            {
                 "method": "GET", "path": "/api/v1/workspaces/{id}/summary",
                 "description": "Get aggregated workspace summary: branch, cwd, ports, unreadCount, latestNotification, hasUnread.",
                 "response": "{ summary: { workspaceId, branch, cwd, ports, unreadCount, latestNotification, hasUnread } }"

--- a/src-tauri/src/automation_server/handlers_bridge.rs
+++ b/src-tauri/src/automation_server/handlers_bridge.rs
@@ -567,6 +567,10 @@ pub async fn notifications_clear(
             )),
         );
     }
+    let ids_count = body.ids.as_ref().map(|v| v.len());
+    let before = body.before;
+    let read_only = body.read_only.unwrap_or(false);
+
     let mut params = serde_json::json!({});
     if let Some(ids) = body.ids {
         params["ids"] = serde_json::json!(ids);
@@ -578,7 +582,17 @@ pub async fn notifications_clear(
         params["readOnly"] = serde_json::json!(read_only);
     }
     match bridge_request(&state, "action", "notifications", "clear", params).await {
-        Ok(data) => (StatusCode::OK, Json(data)),
+        Ok(data) => {
+            let cleared = data.get("cleared").and_then(|v| v.as_u64()).unwrap_or(0);
+            tracing::info!(
+                cleared,
+                ids_count = ?ids_count,
+                before = ?before,
+                read_only,
+                "notifications.clear (REST)"
+            );
+            (StatusCode::OK, Json(data))
+        }
         Err(e) => e,
     }
 }

--- a/src-tauri/src/automation_server/handlers_bridge.rs
+++ b/src-tauri/src/automation_server/handlers_bridge.rs
@@ -551,6 +551,38 @@ pub async fn notifications_mark_read(
     }
 }
 
+/// DELETE /api/v1/notifications — clear notifications by IDs or before a
+/// timestamp. Enforces that exactly one of `ids` or `before` is provided.
+pub async fn notifications_clear(
+    AxumState(state): AxumState<ServerState>,
+    Json(body): Json<ClearNotificationsBody>,
+) -> impl IntoResponse {
+    let has_ids = body.ids.is_some();
+    let has_before = body.before.is_some();
+    if has_ids == has_before {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(super::helpers::err_json(
+                "Provide exactly one of 'ids' or 'before'",
+            )),
+        );
+    }
+    let mut params = serde_json::json!({});
+    if let Some(ids) = body.ids {
+        params["ids"] = serde_json::json!(ids);
+    }
+    if let Some(before) = body.before {
+        params["before"] = serde_json::json!(before);
+    }
+    if let Some(read_only) = body.read_only {
+        params["readOnly"] = serde_json::json!(read_only);
+    }
+    match bridge_request(&state, "action", "notifications", "clear", params).await {
+        Ok(data) => (StatusCode::OK, Json(data)),
+        Err(e) => e,
+    }
+}
+
 pub async fn workspaces_get_summary(
     AxumState(state): AxumState<ServerState>,
     Path(id): Path<String>,

--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -1346,6 +1346,10 @@ impl McpHandler {
                 "Provide exactly one of 'ids' or 'before'",
             )]));
         }
+        let ids_count = p.ids.as_ref().map(|v| v.len());
+        let before = p.before;
+        let read_only = p.read_only.unwrap_or(false);
+
         let mut params = json!({});
         if let Some(ids) = p.ids {
             params["ids"] = json!(ids);
@@ -1356,8 +1360,23 @@ impl McpHandler {
         if let Some(read_only) = p.read_only {
             params["readOnly"] = json!(read_only);
         }
-        self.bridge("action", "notifications", "clear", params)
+        match self
+            .bridge_raw("action", "notifications", "clear", params)
             .await
+        {
+            Ok(data) => {
+                let cleared = data.get("cleared").and_then(|v| v.as_u64()).unwrap_or(0);
+                tracing::info!(
+                    cleared,
+                    ids_count = ?ids_count,
+                    before = ?before,
+                    read_only,
+                    "notifications.clear (MCP)"
+                );
+                Ok(json_result(&data))
+            }
+            Err(e) => Ok(e),
+        }
     }
 
     /// Create a notification in the IDE. terminal_id and workspace_id are optional —

--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -151,6 +151,22 @@ struct ListNotificationsParam {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct ClearNotificationsParam {
+    /// Specific notification IDs to clear. Mutually exclusive with `before`.
+    #[serde(default)]
+    ids: Option<Vec<String>>,
+    /// Clear notifications created strictly before this epoch ms.
+    /// Mutually exclusive with `ids`.
+    #[serde(default)]
+    before: Option<u64>,
+    /// Combined with `before`: when true, only already-read notifications
+    /// (readAt != null) older than the timestamp are cleared. Unread older
+    /// notifications are preserved. Ignored when `ids` is used. Default false.
+    #[serde(default)]
+    read_only: Option<bool>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct SearchOutputParam {
     /// Terminal ID
     terminal_id: String,
@@ -1314,6 +1330,36 @@ impl McpHandler {
         .await
     }
 
+    /// Clear notifications by ID list or before a timestamp.
+    /// Provide exactly one of `ids` or `before`. When using `before`, set
+    /// `read_only=true` to preserve older unread notifications. Returns the
+    /// number of notifications actually cleared.
+    #[tool]
+    async fn clear_notifications(
+        &self,
+        Parameters(p): Parameters<ClearNotificationsParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let has_ids = p.ids.is_some();
+        let has_before = p.before.is_some();
+        if has_ids == has_before {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "Provide exactly one of 'ids' or 'before'",
+            )]));
+        }
+        let mut params = json!({});
+        if let Some(ids) = p.ids {
+            params["ids"] = json!(ids);
+        }
+        if let Some(before) = p.before {
+            params["before"] = json!(before);
+        }
+        if let Some(read_only) = p.read_only {
+            params["readOnly"] = json!(read_only);
+        }
+        self.bridge("action", "notifications", "clear", params)
+            .await
+    }
+
     /// Create a notification in the IDE. terminal_id and workspace_id are optional —
     /// omit both for a global notification on the active workspace.
     #[tool]
@@ -1569,7 +1615,7 @@ impl ServerHandler for McpHandler {
                  - Which workspace you are in (id, name, whether it is active)\n\
                  - Your pane position in the grid (x, y, w, h as 0-1 normalized coordinates, pane index)\n\
                  - Neighboring panes (left, right, above, below) and their terminal IDs\n\
-                 - Your terminal metadata (cwd, branch, activity state)\n\n\
+                 - Your terminal metadata (cwd, activity state)\n\n\
                  ## Other env vars\n\
                  - LX_AUTOMATION_PORT: The port this MCP server runs on\n\
                  - LX_GROUP_ID: Your sync group (terminals in the same group share CWD)\n\n\

--- a/src-tauri/src/automation_server/mod.rs
+++ b/src-tauri/src/automation_server/mod.rs
@@ -223,6 +223,7 @@ pub fn build_router(state: ServerState, subscriptions: SharedSubscriptionRegistr
         .route("/api/v1/terminals/{id}/output", get(terminal_output))
         .route("/api/v1/notifications", get(notifications_list))
         .route("/api/v1/notifications", post(notifications_add))
+        .route("/api/v1/notifications", delete(notifications_clear))
         .route(
             "/api/v1/notifications/mark-read",
             post(notifications_mark_read),

--- a/src-tauri/src/automation_server/types.rs
+++ b/src-tauri/src/automation_server/types.rs
@@ -112,6 +112,21 @@ pub struct MarkReadBody {
     pub workspace_id: String,
 }
 
+/// Body for `DELETE /api/v1/notifications`.
+///
+/// Provide exactly one of `ids` or `before`. When `before` is set, `read_only`
+/// controls whether only already-read notifications are cleared.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClearNotificationsBody {
+    #[serde(default)]
+    pub ids: Option<Vec<String>>,
+    #[serde(default)]
+    pub before: Option<u64>,
+    #[serde(default)]
+    pub read_only: Option<bool>,
+}
+
 #[derive(Deserialize)]
 pub struct FocusTerminalBody {
     pub id: String,
@@ -158,6 +173,7 @@ pub const REGISTERED_ROUTES: &[(&str, &str)] = &[
     ("GET", "/api/v1/terminals/{id}/output"),
     ("GET", "/api/v1/notifications"),
     ("POST", "/api/v1/notifications"),
+    ("DELETE", "/api/v1/notifications"),
     ("POST", "/api/v1/notifications/mark-read"),
     ("GET", "/api/v1/workspaces/{id}/summary"),
     ("POST", "/api/v1/terminals/{id}/focus"),
@@ -278,5 +294,32 @@ mod tests {
         let json = r#"{"id":"terminal-1"}"#;
         let body: FocusTerminalBody = serde_json::from_str(json).unwrap();
         assert_eq!(body.id, "terminal-1");
+    }
+
+    #[test]
+    fn clear_notifications_body_ids() {
+        let json = r#"{"ids":["notif-1","notif-2"]}"#;
+        let body: ClearNotificationsBody = serde_json::from_str(json).unwrap();
+        assert_eq!(body.ids.as_deref().unwrap().len(), 2);
+        assert!(body.before.is_none());
+        assert!(body.read_only.is_none());
+    }
+
+    #[test]
+    fn clear_notifications_body_before_camel_case_read_only() {
+        let json = r#"{"before":1776000000000,"readOnly":true}"#;
+        let body: ClearNotificationsBody = serde_json::from_str(json).unwrap();
+        assert!(body.ids.is_none());
+        assert_eq!(body.before, Some(1776000000000));
+        assert_eq!(body.read_only, Some(true));
+    }
+
+    #[test]
+    fn clear_notifications_body_empty() {
+        let json = "{}";
+        let body: ClearNotificationsBody = serde_json::from_str(json).unwrap();
+        assert!(body.ids.is_none());
+        assert!(body.before.is_none());
+        assert!(body.read_only.is_none());
     }
 }

--- a/ui/src/hooks/useAutomationBridge.test.ts
+++ b/ui/src/hooks/useAutomationBridge.test.ts
@@ -971,7 +971,9 @@ describe("identify_caller and enriched responses", () => {
     });
     expect(result.success).toBe(true);
     expect(useNotificationStore.getState().notifications).toHaveLength(1);
-    expect((result.data as { notification?: { workspaceId?: string } }).notification?.workspaceId).toBe(wsId);
+    expect(
+      (result.data as { notification?: { workspaceId?: string } }).notification?.workspaceId,
+    ).toBe(wsId);
   });
 
   it("resize_pane applies delta relative to current pane size", () => {
@@ -1047,9 +1049,7 @@ describe("identify_caller and enriched responses", () => {
     });
     expect(result.success).toBe(true);
     // Find the newly created workspace
-    const ws = useWorkspaceStore
-      .getState()
-      .workspaces.find((w) => w.name === "CWD Test")!;
+    const ws = useWorkspaceStore.getState().workspaces.find((w) => w.name === "CWD Test")!;
     expect(ws).toBeDefined();
     expect(ws.panes.length).toBeGreaterThan(0);
     // Convert any non-TerminalView panes so we can test — but at minimum, check
@@ -1111,8 +1111,18 @@ describe("identify_caller and enriched responses", () => {
     const pane1Id = ws.panes[1].id;
     useTerminalStore.setState({
       instances: [
-        { id: `terminal-${pane0Id}`, workspaceId: ws.id, label: "", profile: "PowerShell" } as never,
-        { id: `terminal-${pane1Id}`, workspaceId: ws.id, label: "", profile: "PowerShell" } as never,
+        {
+          id: `terminal-${pane0Id}`,
+          workspaceId: ws.id,
+          label: "",
+          profile: "PowerShell",
+        } as never,
+        {
+          id: `terminal-${pane1Id}`,
+          workspaceId: ws.id,
+          label: "",
+          profile: "PowerShell",
+        } as never,
       ],
     });
 
@@ -1168,5 +1178,187 @@ describe("identify_caller and enriched responses", () => {
     });
     expect(result.success).toBe(false);
     expect(result.error).toContain("out of range");
+  });
+});
+
+describe("notifications.clear bridge handler", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
+    useNotificationStore.setState(useNotificationStore.getInitialState());
+  });
+
+  it("clears notifications by ids and returns the cleared count", () => {
+    const { addNotification } = useNotificationStore.getState();
+    addNotification({ terminalId: "t1", workspaceId: "ws-a", message: "a" });
+    addNotification({ terminalId: "t2", workspaceId: "ws-a", message: "b" });
+    addNotification({ terminalId: "t3", workspaceId: "ws-b", message: "c" });
+
+    const targets = useNotificationStore
+      .getState()
+      .notifications.slice(0, 2)
+      .map((n) => n.id);
+
+    const result = handleAutomationRequest({
+      requestId: "cn-ids",
+      category: "action",
+      target: "notifications",
+      method: "clear",
+      params: { ids: targets },
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { cleared: number }).cleared).toBe(2);
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it("clears notifications before the timestamp", () => {
+    const now = Date.now();
+    useNotificationStore.setState({
+      notifications: [
+        {
+          id: "old-1",
+          terminalId: "t1",
+          workspaceId: "ws-x",
+          message: "old",
+          level: "info",
+          createdAt: now - 10000,
+          readAt: null,
+        },
+        {
+          id: "fresh-1",
+          terminalId: "t2",
+          workspaceId: "ws-x",
+          message: "fresh",
+          level: "info",
+          createdAt: now - 100,
+          readAt: null,
+        },
+      ],
+    });
+
+    const result = handleAutomationRequest({
+      requestId: "cn-before",
+      category: "action",
+      target: "notifications",
+      method: "clear",
+      params: { before: now - 5000 },
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { cleared: number }).cleared).toBe(1);
+    const ids = useNotificationStore.getState().notifications.map((n) => n.id);
+    expect(ids).toEqual(["fresh-1"]);
+  });
+
+  it("with before + read_only, only clears already-read older notifications", () => {
+    const now = Date.now();
+    useNotificationStore.setState({
+      notifications: [
+        {
+          id: "old-read",
+          terminalId: "t1",
+          workspaceId: "ws-ro",
+          message: "old read",
+          level: "info",
+          createdAt: now - 10000,
+          readAt: now - 5000,
+        },
+        {
+          id: "old-unread",
+          terminalId: "t2",
+          workspaceId: "ws-ro",
+          message: "old unread",
+          level: "info",
+          createdAt: now - 9000,
+          readAt: null,
+        },
+      ],
+    });
+
+    const result = handleAutomationRequest({
+      requestId: "cn-ro",
+      category: "action",
+      target: "notifications",
+      method: "clear",
+      params: { before: now - 2000, read_only: true },
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { cleared: number }).cleared).toBe(1);
+    const ids = useNotificationStore.getState().notifications.map((n) => n.id);
+    expect(ids).toEqual(["old-unread"]);
+  });
+
+  it("also accepts camelCase readOnly alias", () => {
+    const now = Date.now();
+    useNotificationStore.setState({
+      notifications: [
+        {
+          id: "old-read",
+          terminalId: "t1",
+          workspaceId: "ws-ro",
+          message: "old read",
+          level: "info",
+          createdAt: now - 10000,
+          readAt: now - 5000,
+        },
+        {
+          id: "old-unread",
+          terminalId: "t2",
+          workspaceId: "ws-ro",
+          message: "old unread",
+          level: "info",
+          createdAt: now - 9000,
+          readAt: null,
+        },
+      ],
+    });
+
+    const result = handleAutomationRequest({
+      requestId: "cn-ro-camel",
+      category: "action",
+      target: "notifications",
+      method: "clear",
+      params: { before: now - 2000, readOnly: true },
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { cleared: number }).cleared).toBe(1);
+  });
+
+  it("errors when neither ids nor before is provided", () => {
+    const result = handleAutomationRequest({
+      requestId: "cn-none",
+      category: "action",
+      target: "notifications",
+      method: "clear",
+      params: {},
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/exactly one/i);
+  });
+
+  it("errors when both ids and before are provided", () => {
+    const result = handleAutomationRequest({
+      requestId: "cn-both",
+      category: "action",
+      target: "notifications",
+      method: "clear",
+      params: { ids: ["notif-1"], before: 1 },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/exactly one/i);
+  });
+
+  it("errors when ids is not an array", () => {
+    const result = handleAutomationRequest({
+      requestId: "cn-badids",
+      category: "action",
+      target: "notifications",
+      method: "clear",
+      params: { ids: "notif-1" },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/array/i);
   });
 });

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -555,6 +555,32 @@ const handlers: HandlerMap = {
       useNotificationStore.getState().markWorkspaceAsRead(p.workspaceId as string);
       return ok({ marked: true });
     },
+    clear: (p) => {
+      const ids = p.ids as unknown;
+      const before = p.before as unknown;
+      const readOnlyRaw = (p.readOnly ?? p.read_only) as unknown;
+
+      const hasIds = ids !== undefined && ids !== null;
+      const hasBefore = before !== undefined && before !== null;
+      if (hasIds === hasBefore) {
+        return err("Provide exactly one of 'ids' or 'before'");
+      }
+
+      if (hasIds) {
+        if (!Array.isArray(ids) || !ids.every((v) => typeof v === "string")) {
+          return err("'ids' must be a string array");
+        }
+        const cleared = useNotificationStore.getState().removeNotifications(ids as string[]);
+        return ok({ cleared });
+      }
+
+      if (typeof before !== "number" || !Number.isFinite(before)) {
+        return err("'before' must be a finite epoch ms number");
+      }
+      const readOnly = readOnlyRaw === undefined ? false : Boolean(readOnlyRaw);
+      const cleared = useNotificationStore.getState().clearNotificationsBefore(before, readOnly);
+      return ok({ cleared });
+    },
   },
 
   layouts: {

--- a/ui/src/stores/notification-store.test.ts
+++ b/ui/src/stores/notification-store.test.ts
@@ -179,6 +179,145 @@ describe("NotificationStore", () => {
     expect(useNotificationStore.getState().hasUnreadForTerminal("terminal-p3")).toBe(false);
   });
 
+  describe("removeNotifications", () => {
+    it("removes notifications by ID and returns the cleared count", () => {
+      const { addNotification } = useNotificationStore.getState();
+      addNotification({ terminalId: "t1", workspaceId: "ws-other-1", message: "a" });
+      addNotification({ terminalId: "t2", workspaceId: "ws-other-2", message: "b" });
+      addNotification({ terminalId: "t3", workspaceId: "ws-other-3", message: "c" });
+
+      const ids = useNotificationStore
+        .getState()
+        .notifications.slice(0, 2)
+        .map((n) => n.id);
+      const cleared = useNotificationStore.getState().removeNotifications(ids);
+
+      expect(cleared).toBe(2);
+      const remaining = useNotificationStore.getState().notifications;
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].message).toBe("c");
+    });
+
+    it("returns 0 and preserves state when no ID matches", () => {
+      useNotificationStore.getState().addNotification({
+        terminalId: "t1",
+        workspaceId: "ws-other",
+        message: "keep me",
+      });
+      const cleared = useNotificationStore.getState().removeNotifications(["nope-1", "nope-2"]);
+      expect(cleared).toBe(0);
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+
+    it("updates getUnreadCount after removal", () => {
+      const { addNotification } = useNotificationStore.getState();
+      addNotification({ terminalId: "t1", workspaceId: "ws-unread-a", message: "a" });
+      addNotification({ terminalId: "t2", workspaceId: "ws-unread-a", message: "b" });
+      expect(useNotificationStore.getState().getUnreadCount("ws-unread-a")).toBe(2);
+
+      const firstId = useNotificationStore.getState().notifications[0].id;
+      useNotificationStore.getState().removeNotifications([firstId]);
+      expect(useNotificationStore.getState().getUnreadCount("ws-unread-a")).toBe(1);
+    });
+  });
+
+  describe("clearNotificationsBefore", () => {
+    it("removes notifications with createdAt strictly before timestamp", () => {
+      const now = Date.now();
+      useNotificationStore.setState({
+        notifications: [
+          {
+            id: "old-1",
+            terminalId: "t1",
+            workspaceId: "ws-old",
+            message: "old",
+            level: "info",
+            createdAt: now - 10000,
+            readAt: now - 5000,
+          },
+          {
+            id: "old-2",
+            terminalId: "t2",
+            workspaceId: "ws-old",
+            message: "old unread",
+            level: "info",
+            createdAt: now - 5000,
+            readAt: null,
+          },
+          {
+            id: "new-1",
+            terminalId: "t3",
+            workspaceId: "ws-new",
+            message: "fresh",
+            level: "info",
+            createdAt: now - 1000,
+            readAt: null,
+          },
+        ],
+      });
+
+      const cleared = useNotificationStore.getState().clearNotificationsBefore(now - 2000);
+      expect(cleared).toBe(2);
+      const remaining = useNotificationStore.getState().notifications;
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].id).toBe("new-1");
+    });
+
+    it("with readOnly=true, only removes already-read notifications older than timestamp", () => {
+      const now = Date.now();
+      useNotificationStore.setState({
+        notifications: [
+          {
+            id: "read-old",
+            terminalId: "t1",
+            workspaceId: "ws-ro",
+            message: "read + old",
+            level: "info",
+            createdAt: now - 10000,
+            readAt: now - 5000,
+          },
+          {
+            id: "unread-old",
+            terminalId: "t2",
+            workspaceId: "ws-ro",
+            message: "unread + old",
+            level: "info",
+            createdAt: now - 8000,
+            readAt: null,
+          },
+          {
+            id: "read-new",
+            terminalId: "t3",
+            workspaceId: "ws-ro",
+            message: "read + new",
+            level: "info",
+            createdAt: now - 500,
+            readAt: now - 100,
+          },
+        ],
+      });
+
+      const cleared = useNotificationStore.getState().clearNotificationsBefore(now - 2000, true);
+      expect(cleared).toBe(1);
+      const ids = useNotificationStore.getState().notifications.map((n) => n.id);
+      expect(ids).toContain("unread-old");
+      expect(ids).toContain("read-new");
+      expect(ids).not.toContain("read-old");
+    });
+
+    it("returns 0 when nothing matches", () => {
+      const now = Date.now();
+      useNotificationStore.getState().addNotification({
+        terminalId: "t1",
+        workspaceId: "ws-keep",
+        message: "keep",
+      });
+      const cleared = useNotificationStore.getState().clearNotificationsBefore(now - 100000);
+      expect(cleared).toBe(0);
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+  });
+
   describe("auto-dismiss for active workspace", () => {
     it("marks notification as read immediately when added to the active workspace in workspace dismiss mode", () => {
       const activeWsId = useWorkspaceStore.getState().activeWorkspaceId;

--- a/ui/src/stores/notification-store.ts
+++ b/ui/src/stores/notification-store.ts
@@ -30,6 +30,14 @@ interface NotificationStoreState {
   }) => Notification;
   markWorkspaceAsRead: (workspaceId: string) => void;
   markNotificationsAsRead: (ids: string[]) => void;
+  /** Remove notifications by ID. Returns the number of notifications actually removed. */
+  removeNotifications: (ids: string[]) => number;
+  /**
+   * Remove notifications created strictly before `timestamp` (epoch ms).
+   * When `readOnly` is true, only already-read notifications (readAt != null)
+   * are removed. Returns the number of notifications actually removed.
+   */
+  clearNotificationsBefore: (timestamp: number, readOnly?: boolean) => number;
   getUnreadCount: (workspaceId: string) => number;
   getLatestNotification: (workspaceId: string) => Notification | undefined;
   hasUnreadForTerminal: (terminalId: string) => boolean;
@@ -80,6 +88,33 @@ export const useNotificationStore = create<NotificationStoreState>()((set, get) 
         idSet.has(n.id) && n.readAt === null ? { ...n, readAt: now } : n,
       ),
     }));
+  },
+
+  removeNotifications: (ids) => {
+    const idSet = new Set(ids);
+    const before = get().notifications.length;
+    const remaining = get().notifications.filter((n) => !idSet.has(n.id));
+    const cleared = before - remaining.length;
+    if (cleared > 0) {
+      set({ notifications: remaining });
+    }
+    return cleared;
+  },
+
+  clearNotificationsBefore: (timestamp, readOnly = false) => {
+    const before = get().notifications.length;
+    const remaining = get().notifications.filter((n) => {
+      const isOlder = n.createdAt < timestamp;
+      if (!isOlder) return true;
+      // Keep older notifications only if readOnly filter excludes them (still unread).
+      if (readOnly && n.readAt === null) return true;
+      return false;
+    });
+    const cleared = before - remaining.length;
+    if (cleared > 0) {
+      set({ notifications: remaining });
+    }
+    return cleared;
   },
 
   getUnreadCount: (workspaceId) => {


### PR DESCRIPTION
## Summary

이슈 #200(MCP 사용성 개선 모음) 트래커의 마지막 미해결 항목들을 정리한다. PR #201(P0 버그 6개)과 #220(MCP Resources)이 이미 대부분을 처리했고, 이 PR은 남은 2개의 gap을 한 커밋으로 마무리한다.

- `clear_notifications` MCP 도구 추가 (항목 #5 후반부)
  - 파라미터: `ids` (특정 알림 삭제), `before` (timestamp 이전 삭제), `read_only` (before와 조합; 읽은 것만 삭제)
  - `ids`와 `before`는 배타적 — 둘 다 없거나 둘 다 있으면 에러
- `DELETE /api/v1/notifications` REST 엔드포인트 추가 (MCP↔REST 패리티)
- `notificationStore`에 `removeNotifications`, `clearNotificationsBefore` 메서드 추가
- MCP instructions에서 실제 응답에 없는 `branch` 필드 문구 제거 (항목 #17)

## 이슈 #200 24개 항목 현황

### 🔴 P0: 버그 — PR #201에서 해결

| # | 항목 | 해결 |
|---|------|------|
| 25 | split_pane → EmptyView | ✅ PR #201 |
| 24 | create_workspace silent failure | ✅ PR #201 |
| 15 | focus_pane 상태 오염 | ✅ PR #201 |
| 20 | activity 불일치 | ✅ PR #201 |
| 9 | focus_terminal silent failure | ✅ PR #201 |
| 16 | send_notification 무검증 | ✅ PR #201 |

### 🟠 P1: 핵심 기능 — PR #201에서 해결

| # | 항목 | 해결 |
|---|------|------|
| 2 | read_terminal_output ANSI 스트립 (`format`) | ✅ PR #201 |
| 3 | execute_command 고수준 도구 | ✅ PR #201 |
| 6 | 페인 생명주기 (close/resize/swap) | ✅ PR #201 |
| 7 | 생성 도구 cwd + ID 반환 | ✅ PR #201 |
| 17 | 도구 설명 정확성 (branch/\r\n/running) | ✅ PR #201 + **본 PR** (잔재 제거) |

### 🟡 P2: 효율성 — PR #201 + #220에서 해결

| # | 항목 | 해결 |
|---|------|------|
| 4+19 | workspace_id 필터 + 단건 조회 | ✅ PR #201 |
| 8 | take_screenshot(pane_index) | ✅ PR #201 |
| 11 | switch_workspace(name) + summary | ✅ PR #201 |
| 20 | get_active_workspace 통합 응답 | ✅ PR #201 |
| 21 | MCP Resources | ✅ PR #220 |

### 🟢 P3: 완성도 — PR #201 + **본 PR**

| # | 항목 | 해결 |
|---|------|------|
| 1 | split_pane profile | ✅ PR #201 |
| 5 | list_notifications 필터 + **clear_notifications** | ✅ PR #201(필터) + **본 PR** (clear) |
| 10 | search_terminal_output | ✅ PR #201 |
| 12 | delete/rename_workspace | ✅ PR #201 |
| 13 | write_to_terminal 브로드캐스트 | ✅ PR #201 |
| 14+18 | shell_type + list_profiles | ✅ PR #201 |
| 22 | list_layouts + REST↔MCP 패리티 | ✅ PR #201 + **본 PR** (DELETE 패리티) |

## Test plan

- [x] \`cd ui && npx vitest run\` — 72 suites / 1685 tests 전체 통과 (+3 store 테스트, +7 bridge 테스트 신규)
- [x] \`cd src-tauri && cargo test\` — lib 637 / integration 4 / e2e 79 모두 통과 (clear_notifications_body_ids / _before / _empty 신규)
- [x] \`cd src-tauri && cargo check\` 성공
- [x] \`cd src-tauri && cargo clippy --all-targets -- -D warnings\` — 기존 에러 동일 (본 PR로 인한 신규 clippy 경고 0건; 기존 warning은 settings/pty/error 모듈의 pre-existing 이슈)

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)