### PR TITLE
fix(claude): working→exit 전환 시 작업 완료 알림 누락 수정

### DIFF
--- a/src-tauri/src/claude_activity.rs
+++ b/src-tauri/src/claude_activity.rs
@@ -138,7 +138,15 @@ pub fn process_claude_title(
     // Exit detection: was detected but title no longer matches any Claude pattern
     if was_detected && !is_claude {
         result.exited = true;
-        return result; // No further processing on exit
+        // Working → exit: treat the in-flight working phase as a completed
+        // task (policy established in commit 580e201). Claude can drop from
+        // a spinner title straight to the shell prompt when the user runs
+        // `/exit` right after a response, so without this the completion
+        // notification silently disappears.
+        if was_working {
+            result.task_completed = Some(completion_text_from_prev(prev_working_title));
+        }
+        return result;
     }
 
     // Working/idle state tracking (only when Claude is active)
@@ -154,21 +162,25 @@ pub fn process_claude_title(
             let text = if !idle_description.is_empty() && idle_description != "Claude Code" {
                 idle_description.to_string()
             } else {
-                // Fallback to the preceding working title's task text.
-                let prev_description = prev_working_title
-                    .map(strip_claude_spinner_prefix)
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty() && *s != "Claude Code");
-                match prev_description {
-                    Some(desc) => desc.to_string(),
-                    None => "Claude Code task completed".to_string(),
-                }
+                completion_text_from_prev(prev_working_title)
             };
             result.task_completed = Some(text);
         }
     }
 
     result
+}
+
+/// Build a completion notification text from the previous working title.
+/// Falls back to a generic default when the working title is missing or
+/// carries no specific task description.
+fn completion_text_from_prev(prev_working_title: Option<&str>) -> String {
+    prev_working_title
+        .map(strip_claude_spinner_prefix)
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && *s != "Claude Code")
+        .map(str::to_string)
+        .unwrap_or_else(|| "Claude Code task completed".to_string())
 }
 
 #[cfg(test)]
@@ -272,6 +284,54 @@ mod tests {
         let r = process_claude_title("bash", true, false, None);
         assert!(!r.entered);
         assert!(r.exited);
+    }
+
+    // ── working→exit task completion (regression guard) ──
+    // Regression guard for commit 580e201 policy: when Claude drops from a
+    // working spinner straight to a non-Claude title (e.g. shell prompt),
+    // the working phase is treated as a completed task so the user still
+    // gets a success notification. Without this, `/exit` right after a
+    // response — or any same-frame working→shell transition — silently
+    // loses the notification.
+
+    #[test]
+    fn process_working_to_exit_uses_prev_working_title() {
+        let r = process_claude_title("bash", true, true, Some("\u{2736} Fix login bug"));
+        assert!(r.exited);
+        assert_eq!(r.task_completed, Some("Fix login bug".to_string()));
+    }
+
+    #[test]
+    fn process_working_to_exit_generic_title_uses_default() {
+        let r = process_claude_title(
+            "/home/user/project",
+            true,
+            true,
+            Some("\u{2736} Claude Code"),
+        );
+        assert!(r.exited);
+        assert_eq!(
+            r.task_completed,
+            Some("Claude Code task completed".to_string())
+        );
+    }
+
+    #[test]
+    fn process_working_to_exit_without_prev_title_uses_default() {
+        let r = process_claude_title("bash", true, true, None);
+        assert!(r.exited);
+        assert_eq!(
+            r.task_completed,
+            Some("Claude Code task completed".to_string())
+        );
+    }
+
+    #[test]
+    fn process_idle_to_exit_no_task_completion() {
+        // Claude exited from idle state (✳). No working phase to complete.
+        let r = process_claude_title("bash", true, false, Some("\u{2736} Old task"));
+        assert!(r.exited);
+        assert!(r.task_completed.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Claude Code가 working 스피너 상태에서 바로 non-Claude 타이틀(셸 프롬프트 등)로 전환될 때, `process_claude_title`이 `task_completed`를 채우지 않고 즉시 반환하여 완료 알림이 누락되던 **회귀**를 수정한다.

응답 직후 사용자가 `/exit`을 치거나 Claude가 한 프레임에 idle 단계를 건너뛰고 종료하는 경우 자주 발생하는 경로다.

## 회귀 원인

580e201 \"fix: Claude Code 종료 시 notification 및 activity 미갱신 버그 수정\" 커밋에서 `detectClaudeTaskTransition`의 `claudeExited` 플래그를 통해 **working→exit를 '완료된 태스크'로 처리**하는 정책이 수립되어 있었다. 이후 `claude_activity` 모듈이 Rust로 분리되는 과정에서 해당 정책이 누락되어 Claude 종료 시 완료 알림이 사라짐.

## 동작 변경

| 전이 | Before | After |
|---|---|---|
| working → non-Claude 타이틀 | `exited=true`, task_completed=None (알림 없음) | `exited=true`, task_completed=**Some** (알림 발송) |
| idle(✳) → non-Claude 타이틀 | `exited=true`, task_completed=None | 동일 (완료로 볼 근거 없음) |
| working → idle(✳) | 기존 동작 유지 | 기존 동작 유지 |

working title이 구체적(예: `✶ Fix login bug`)이면 그 태스크명을, 그렇지 않으면 generic \"Claude Code task completed\"를 사용. `completion_text_from_prev` 헬퍼로 working→idle 경로와 공통 로직 공유.

## Test plan

- [x] \`cargo test --lib claude_activity\` — 30 tests passed (+4 신규)
  - `process_working_to_exit_uses_prev_working_title`
  - `process_working_to_exit_generic_title_uses_default`
  - `process_working_to_exit_without_prev_title_uses_default`
  - `process_idle_to_exit_no_task_completion`
- [x] \`cargo test\` 전체 — lib 638 / e2e 79 / integration 4 모두 통과
- [x] \`cargo fmt --check\` 통과

## 참고

코드 리뷰에서 지적된 세 항목 중 이 PR이 다루는 것:
- [P1] working→exit 완료 알림 누락 ← **본 PR**
- [P1] `computeCommandStatus`가 activity 무시 → main에서 이미 `getHandler(activity)` 패턴으로 수정됨
- [P2] completion text가 idle title만 사용 → main의 `prev_working_title` fallback으로 이미 수정됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)