### PR TITLE
fix(terminal): 리사이즈/폰트 변경 후 글자 왼쪽 쏠림 수정 — #224

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -32,6 +32,7 @@ const mockWrite = vi.fn((_: string | Uint8Array, callback?: () => void) => {
   callback?.();
 });
 const mockRefresh = vi.fn();
+const mockClearTextureAtlas = vi.fn();
 const mockRegisterCsiHandler = vi.fn();
 const mockRegisterOscHandler = vi.fn();
 const mockRegisterEscHandler = vi.fn();
@@ -79,6 +80,7 @@ vi.mock("@xterm/xterm", () => ({
     getSelection = mockGetSelection;
     clearSelection = mockClearSelection;
     refresh = mockRefresh;
+    clearTextureAtlas = mockClearTextureAtlas;
     dispose = vi.fn();
     loadAddon = vi.fn();
     registerLinkProvider = vi.fn().mockReturnValue({ dispose: vi.fn() });
@@ -1311,7 +1313,12 @@ describe("TerminalView", () => {
 
   it("does not zoom when the key is pressed without Ctrl", async () => {
     render(
-      <TerminalView instanceId="t-zoom-nomod" paneId="pane-zoom-nomod" profile="PowerShell" syncGroup="" />,
+      <TerminalView
+        instanceId="t-zoom-nomod"
+        paneId="pane-zoom-nomod"
+        profile="PowerShell"
+        syncGroup=""
+      />,
     );
 
     // ctrlKey false → xterm이 처리하도록 통과, override 그대로.
@@ -1326,7 +1333,12 @@ describe("TerminalView", () => {
     useOverridesStore.getState().setViewOverride("pane-zoom-min", { fontSize: 6 });
 
     render(
-      <TerminalView instanceId="t-zoom-min" paneId="pane-zoom-min" profile="PowerShell" syncGroup="" />,
+      <TerminalView
+        instanceId="t-zoom-min"
+        paneId="pane-zoom-min"
+        profile="PowerShell"
+        syncGroup=""
+      />,
     );
 
     fireTerminalKey({ key: "-", ctrlKey: true });
@@ -1338,7 +1350,12 @@ describe("TerminalView", () => {
     useOverridesStore.getState().setViewOverride("pane-zoom-max", { fontSize: 72 });
 
     render(
-      <TerminalView instanceId="t-zoom-max" paneId="pane-zoom-max" profile="PowerShell" syncGroup="" />,
+      <TerminalView
+        instanceId="t-zoom-max"
+        paneId="pane-zoom-max"
+        profile="PowerShell"
+        syncGroup=""
+      />,
     );
 
     fireTerminalKey({ key: "=", ctrlKey: true });
@@ -1369,6 +1386,104 @@ describe("TerminalView", () => {
 
     expect(Object.keys(useOverridesStore.getState().viewOverrides)).toHaveLength(0);
     expect(useSettingsStore.getState().profiles[0].font).toBeUndefined();
+  });
+
+  // -- Regression: issue #224 — resize/zoom leaves glyphs left-clustered --
+  //
+  // When fontSize changes (zoom, settings update) the WebGL renderer's
+  // texture atlas still holds glyphs measured at the OLD cell dimensions.
+  // xterm's `refresh()` alone does not rebuild the atlas, so cells drawn
+  // afterwards use stale cell widths and glyphs visibly collapse to the
+  // left. The fix: call `term.clearTextureAtlas()` whenever fontSize or
+  // fontFamily changes, *after* `fit()` so the renderer re-measures first.
+  it("clears texture atlas when fontSize changes (issue #224)", async () => {
+    render(
+      <TerminalView
+        instanceId="t-atlas-fontsize"
+        paneId="pane-atlas-fontsize"
+        profile="PowerShell"
+        syncGroup=""
+      />,
+    );
+
+    // Clear the initial-mount bookkeeping calls so we only observe the
+    // font-change-triggered invocation.
+    mockClearTextureAtlas.mockClear();
+    mockFit.mockClear();
+
+    act(() => {
+      useOverridesStore.getState().setViewOverride("pane-atlas-fontsize", { fontSize: 20 });
+    });
+
+    await vi.waitFor(() => {
+      // fit() must run so xterm re-measures cell geometry, then the atlas
+      // must be cleared so the new glyph sizes are re-rasterised.
+      expect(mockFit).toHaveBeenCalled();
+      expect(mockClearTextureAtlas).toHaveBeenCalled();
+    });
+  });
+
+  it("clears texture atlas when devicePixelRatio changes (issue #224)", async () => {
+    // Install a `window.matchMedia` stub that captures the change listener
+    // so the test can synthesise a DPR change without actually zooming.
+    type DprMql = {
+      matches: boolean;
+      media: string;
+      listeners: Array<(e: MediaQueryListEvent) => void>;
+      addEventListener: (type: string, cb: (e: MediaQueryListEvent) => void) => void;
+      removeEventListener: (type: string, cb: (e: MediaQueryListEvent) => void) => void;
+      dispatchEvent: (e: Event) => boolean;
+      onchange: null;
+      addListener: () => void;
+      removeListener: () => void;
+    };
+    const mqls: DprMql[] = [];
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn((query: string) => {
+      const mql: DprMql = {
+        matches: true,
+        media: query,
+        listeners: [],
+        addEventListener: (type, cb) => {
+          if (type === "change") mql.listeners.push(cb);
+        },
+        removeEventListener: (type, cb) => {
+          if (type === "change") mql.listeners = mql.listeners.filter((l) => l !== cb);
+        },
+        dispatchEvent: () => true,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+      };
+      mqls.push(mql);
+      return mql as unknown as MediaQueryList;
+    }) as unknown as typeof window.matchMedia;
+
+    try {
+      render(<TerminalView instanceId="t-atlas-dpr" profile="PowerShell" syncGroup="" />);
+
+      mockClearTextureAtlas.mockClear();
+      mockFit.mockClear();
+
+      // Simulate DPR change (e.g. browser zoom). The listener registered by
+      // TerminalView must respond by re-fitting and clearing the atlas.
+      expect(mqls.length).toBeGreaterThan(0);
+      const listeners = mqls.flatMap((mql) => mql.listeners);
+      expect(listeners.length).toBeGreaterThan(0);
+
+      act(() => {
+        for (const listener of listeners) {
+          listener(new Event("change") as MediaQueryListEvent);
+        }
+      });
+
+      await vi.waitFor(() => {
+        expect(mockFit).toHaveBeenCalled();
+        expect(mockClearTextureAtlas).toHaveBeenCalled();
+      });
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
   });
 
   // -- Scrollbar style --

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -1537,6 +1537,17 @@ export function TerminalView({
         }
       }
       fitAddonRef.current?.fit();
+      // xterm's WebGL renderer caches glyphs in a texture atlas keyed on the
+      // previous cell dimensions. When fontSize / fontFamily change, fit()
+      // re-measures the cells but the atlas still holds stale glyphs, which
+      // manifests as text clustering to the left of each row (issue #224).
+      // Clearing the atlas after fit() forces a full re-rasterise at the new
+      // cell size. Safe no-op if the WebGL renderer is not active.
+      try {
+        (term as unknown as { clearTextureAtlas?: () => void }).clearTextureAtlas?.();
+      } catch {
+        /* older xterm builds / mocks may lack this method */
+      }
       term.refresh(0, term.rows - 1);
     } catch {
       /* xterm mock may not support options setter */
@@ -1550,6 +1561,46 @@ export function TerminalView({
     nativeCursorHidden,
     stabilizeInteractiveCursor,
   ]);
+
+  // Browser zoom / monitor DPR changes invalidate the WebGL texture atlas:
+  // the renderer rasterises glyphs at a resolution tied to the current
+  // devicePixelRatio, and a stale atlas after zoom leaves characters drawn
+  // at the old pixel size, collapsing to the left side of each cell
+  // (issue #224). `window.matchMedia` with a resolution query fires whenever
+  // DPR changes, at which point we re-fit and force the atlas to rebuild.
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    let mql: MediaQueryList | null = null;
+    let cancelled = false;
+    const onChange = () => {
+      if (cancelled) return;
+      const term = terminalRef.current;
+      if (!term) return;
+      try {
+        fitAddonRef.current?.fit();
+        (term as unknown as { clearTextureAtlas?: () => void }).clearTextureAtlas?.();
+        term.refresh(0, term.rows - 1);
+      } catch {
+        /* addon/renderer may not be active yet */
+      }
+      // Re-subscribe to the NEW ratio so the listener keeps firing on
+      // subsequent zoom steps. matchMedia with a fixed resolution only
+      // fires once per crossing of its threshold.
+      attach();
+    };
+    const attach = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const query = `(resolution: ${dpr}dppx)`;
+      mql?.removeEventListener?.("change", onChange);
+      mql = window.matchMedia(query);
+      mql.addEventListener?.("change", onChange);
+    };
+    attach();
+    return () => {
+      cancelled = true;
+      mql?.removeEventListener?.("change", onChange);
+    };
+  }, []);
 
   // Reactively update xterm overviewRuler width when scrollbarStyle changes
   const scrollbarStyleForEffect = useSettingsStore(


### PR DESCRIPTION
## Summary
WebGL 렌더러의 텍스처 아틀라스가 폰트 크기 변경 및 `devicePixelRatio` 변경 후에 무효화되지 않아, 이전 cell 크기의 글리프가 새 cell에 왼쪽 정렬로 그려지던 문제를 수정.

## 근본 원인
xterm.js `@xterm/addon-webgl`은 최초 렌더 시점의 cell 치수로 글리프를 래스터라이즈하여 텍스처 아틀라스에 캐싱한다. 다음 두 경로에서 아틀라스 무효화가 누락되어 있었다.

1. **폰트 크기 변경(줌/설정)**: `fitAddon.fit()` + `term.refresh()` 만 호출하여 cell 크기는 재계산되지만 아틀라스는 이전 글리프를 그대로 사용 → 큰 cell에 작은 글리프가 왼쪽 정렬로 그려짐.
2. **브라우저 zoom / DPR 변경**: `devicePixelRatio` 변경 감지 경로 자체가 없어서 DPR 변경 후 아틀라스가 이전 해상도의 글리프를 계속 사용.

## 수정
- 폰트/테마 업데이트 useEffect 내 `fitAddon.fit()` 직후 `term.clearTextureAtlas()` 호출 추가.
- `window.matchMedia('(resolution: Ndppx)')` 로 DPR 변경을 감지하는 useEffect 추가. 변경 시 `fit → clearTextureAtlas → refresh` 실행 후 새 DPR에 재구독.
- `term.clearTextureAtlas()`는 safe-call (`?.()` + try/catch) 로 감싸 구버전/모킹 환경에서도 안전.

## 변경 파일
- `ui/src/components/views/TerminalView.tsx` (+51)
- `ui/src/components/views/TerminalView.test.tsx` (회귀 테스트 2개, +100)

## Test plan
- [x] TDD: 회귀 테스트 먼저 추가 → Red → 구현 → Green
- [x] `npx vitest run src/components/views/TerminalView.test.tsx` — 81/81 pass
- [x] `npx vitest run` (UI 전체) — 1687/1687 pass
- [x] `npx tsc --noEmit` — 에러 없음
- [x] `npx eslint` — 에러 없음
- [ ] dev 인스턴스에서 시각적 확인 (리뷰 단계에서 `/screenshot` 으로 검증 필요 — jsdom은 WebGL 미지원이라 단위 테스트는 `clearTextureAtlas` 호출 계약만 검증)

Fixes #224