### PR TITLE
fix(claude): local agent 모드에서 체크 표시 오류 수정 (#225)

### DIFF
--- a/ui/src/lib/claude-activity-handler.test.ts
+++ b/ui/src/lib/claude-activity-handler.test.ts
@@ -81,6 +81,58 @@ describe("ClaudeActivityHandler", () => {
         color: "var(--text-secondary)",
       });
     });
+
+    // ── Claude "working" title detection (issue #225) ──
+    // Claude Code's local agent / spinning task titles use Braille spinners
+    // (U+2800..U+28FF) or star spinners (✶ ✻ ✽ ✢), NOT the ✳ (U+2733) idle
+    // prefix. Previously these fell through to ShellActivityHandler, which
+    // returned a stale ✓ from the last synthetic exitCode=0. That made the
+    // workspace icon show ✓ while Claude was actively working.
+    //
+    // Fix: treat a working-spinner title as "⏳ running" regardless of
+    // outputActive/exitCode, mirroring the Rust `is_claude_working_title`
+    // contract in `src-tauri/src/claude_activity.rs`.
+
+    it("returns ⏳ for Braille spinner title (Claude local agent working)", () => {
+      // Real example observed in production:
+      //   title: "⠂ Remove unnecessary round from laymux outer edges"
+      //   outputActive: false, lastExitCode: 0
+      // Before the fix this showed ✓ because of the stale exitCode.
+      expect(
+        handler.computeStatus(
+          raw({
+            title: "\u2802 Remove unnecessary round from laymux outer edges",
+            exitCode: 0,
+            outputActive: false,
+          }),
+        ),
+      ).toEqual({ icon: "⏳", color: "var(--yellow)" });
+    });
+
+    it("returns ⏳ for star spinner title (Claude working)", () => {
+      expect(
+        handler.computeStatus(raw({ title: "\u2736 Working on task", exitCode: 0 })).icon,
+      ).toBe("⏳");
+      expect(handler.computeStatus(raw({ title: "\u273B Analyzing code", exitCode: 0 })).icon).toBe(
+        "⏳",
+      );
+      expect(handler.computeStatus(raw({ title: "\u273D Building", exitCode: 0 })).icon).toBe("⏳");
+      expect(handler.computeStatus(raw({ title: "\u2722 Running tests", exitCode: 0 })).icon).toBe(
+        "⏳",
+      );
+    });
+
+    it("returns ⏳ for Braille spinner even when previous exitCode was non-zero", () => {
+      // Make sure the working-title rule overrides a ✗ too, not just ✓.
+      expect(handler.computeStatus(raw({ title: "\u280B Analyzing", exitCode: 1 })).icon).toBe(
+        "⏳",
+      );
+    });
+
+    it("does NOT treat ✳ idle as a working spinner", () => {
+      // Regression guard: ✳ is the idle prefix and must keep returning ✓.
+      expect(handler.computeStatus(raw({ title: "\u2733 Claude Code" })).icon).toBe("✓");
+    });
   });
 
   describe("computeStatusMessage", () => {

--- a/ui/src/lib/claude-activity-handler.ts
+++ b/ui/src/lib/claude-activity-handler.ts
@@ -1,19 +1,49 @@
 import { ShellActivityHandler } from "./shell-activity-handler";
 import type { RawTerminalState, StatusResult } from "./activity-handler";
 
+/**
+ * Star-based working spinner prefixes emitted by Claude Code while a task is
+ * in progress. Mirrors `WORKING_STAR_SPINNERS` in
+ * `src-tauri/src/claude_activity.rs` — keep both lists in sync.
+ */
 const WORKING_STAR_SPINNERS = ["\u2736", "\u273B", "\u273D", "\u2722"];
+
+/**
+ * Idle prefix (✳ U+2733). Claude Code switches to this exact character when
+ * it is waiting for user input.
+ */
 const CLAUDE_IDLE_PREFIX = "\u2733"; // ✳
+
+/** Inclusive Braille Patterns block used by Claude's spinner animation. */
+const BRAILLE_RANGE_START = 0x2800;
+const BRAILLE_RANGE_END = 0x28ff;
+
 const DEFAULT_STATUS_MESSAGE_DELIMITER = " \u00b7 ";
 
 function isBraille(ch: string): boolean {
   const code = ch.codePointAt(0) ?? 0;
-  return code >= 0x2800 && code <= 0x28ff;
+  return code >= BRAILLE_RANGE_START && code <= BRAILLE_RANGE_END;
+}
+
+/**
+ * Returns true when `title` starts with a Claude working spinner (star or
+ * Braille). Excludes the idle prefix (✳) — that means "task finished, waiting
+ * for input", not "working".
+ *
+ * Keep in sync with `is_claude_working_title()` in
+ * `src-tauri/src/claude_activity.rs`. Both title sources (Rust-detected
+ * `terminal-title-changed` events and direct OSC 0/2) flow through this helper
+ * so the status icon always reflects live spinner activity.
+ */
+function isClaudeWorkingTitle(title: string | undefined): boolean {
+  if (!title) return false;
+  const first = title.charAt(0);
+  return WORKING_STAR_SPINNERS.includes(first) || isBraille(first);
 }
 
 function extractTitleMessage(title: string | undefined): string | undefined {
   if (!title) return undefined;
-  const first = title.charAt(0);
-  if (!WORKING_STAR_SPINNERS.includes(first) && !isBraille(first)) return undefined;
+  if (!isClaudeWorkingTitle(title)) return undefined;
 
   const stripped = title.slice(1).trim();
   if (!stripped || stripped === "Claude Code") return undefined;
@@ -27,6 +57,18 @@ export class ClaudeActivityHandler extends ShellActivityHandler {
 
   computeStatus(raw: RawTerminalState): StatusResult {
     if (raw.outputActive) return { icon: "⏳", color: "var(--yellow)" };
+
+    // Working spinner title (star or Braille) means Claude is actively
+    // processing — e.g. the local-agent / sub-agent path where the title
+    // is "⠂ Task description" but no OSC 133;C burst fires and outputActive
+    // stays false. Without this branch, the status would fall through to
+    // ShellActivityHandler which inherits the stale `exitCode=0` from the
+    // previous synthetic completion and display ✓ even though work is in
+    // progress. See issue #225.
+    if (isClaudeWorkingTitle(raw.title)) {
+      return { icon: "⏳", color: "var(--yellow)" };
+    }
+
     // Claude keeps its process alive after finishing a task and switches its
     // title to the idle marker (✳ U+2733). A synthetic exitCode=0 is emitted
     // on task completion, but the claude process itself never exits, so on a


### PR DESCRIPTION
## Summary
- Claude Code의 local agent(서브에이전트) 모드에서 Braille/별 스피너 타이틀이 붙은 "작업 중" 상태인데도 이전 `exitCode=0` 때문에 ✓(초록 체크)로 잘못 표시되던 문제 수정
- `ClaudeActivityHandler.computeStatus()`에 working-title 감지 분기 추가 — Rust `is_claude_working_title()`와 동일 규칙 (U+2800..U+28FF Braille 또는 ✶ ✻ ✽ ✢)
- 매직 문자열은 상수로 추출, 두 언어 간 미러링을 JSDoc에 명시

## 근본 원인
local agent 모드에서는 `outputActive=false`, `title`이 ✳(idle 접두사)가 아닌 스피너로 시작, `lastExitCode=0`(직전 synthetic 완료). 기존 로직은 이 조합을 `ShellActivityHandler`로 fallthrough시켜 ✓를 반환했다. Rust 쪽에는 동일 스피너 구분 로직이 이미 있었지만 UI에 빠져 있었다.

## Test plan
- [x] TDD RED: Braille 스피너 + exitCode=0 케이스 실패 확인
- [x] TDD GREEN: `npx vitest run ui/src/lib/claude-activity-handler.test.ts` → 29 passed (기존 24 + 신규 5)
- [x] 회귀 가드: ✳ idle은 여전히 ✓, exitCode=1 + working title은 ⏳ 우선
- [x] 전체: `npx vitest run` → 1689 passed (72 files)
- [x] `tsc --noEmit`, ESLint pre-commit 훅 통과

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)