### PR TITLE
fix(claude): activity 유지 — title reset 시 shell 오판 방지 (#234)

### DIFF
--- a/ui/src/hooks/useSyncEvents.test.ts
+++ b/ui/src/hooks/useSyncEvents.test.ts
@@ -524,6 +524,45 @@ describe("useSyncEvents", () => {
     expect(instance?.outputActive).toBe(true);
   });
 
+  // ── Regression guard for issue #234 ──
+  // Claude Code can emit OSC 0/2 title changes that Rust cannot resolve back
+  // to "Claude" (e.g. a path-like title "~/project", a PowerShell prompt
+  // rewrite, or a Braille spinner before `known_claude_terminals` has been
+  // populated). In those cases the event carries `interactiveApp: null`.
+  // Before the fix, `useSyncEvents` would overwrite the live Claude activity
+  // with `{ type: "shell" }`, so the workspace icon in the top-left flipped
+  // to "shell" while Claude was still running.
+  it("preserves Claude activity when title no longer resolves to Claude (issue #234)", () => {
+    useTerminalStore.getState().registerInstance({
+      id: "t1",
+      profile: "WSL",
+      syncGroup: "g1",
+      workspaceId: "ws-1",
+    });
+    useTerminalStore.getState().updateInstanceInfo("t1", {
+      activity: { type: "interactiveApp", name: "Claude" },
+    });
+
+    renderHook(() => useSyncEvents());
+
+    const callback = mockOnTerminalTitleChanged.mock.calls[0][0];
+    // A path-like title that Rust's `detect_interactive_app_from_title`
+    // rejects outright (contains `/` or `\`), producing `interactiveApp: null`.
+    callback({
+      terminalId: "t1",
+      title: "~/project",
+      interactiveApp: null,
+      notifyGateArmed: false,
+    });
+
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+    // Activity MUST remain interactiveApp/Claude — NOT shell.
+    expect(instance?.activity).toEqual({ type: "interactiveApp", name: "Claude" });
+    // Title itself is still recorded so ClaudeActivityHandler.computeStatus
+    // can reason about working/idle spinners later.
+    expect(instance?.title).toBe("~/project");
+  });
+
   it("stores Codex spinner title text as activityMessage", () => {
     useTerminalStore.getState().registerInstance({
       id: "t1",

--- a/ui/src/lib/claude-activity-handler.test.ts
+++ b/ui/src/lib/claude-activity-handler.test.ts
@@ -23,6 +23,23 @@ describe("ClaudeActivityHandler", () => {
     expect(handler.shouldPreserveActivityOnExitCode(raw({ exitCode: 0 }))).toBe(true);
   });
 
+  // ── Regression guard for issue #234 ──
+  // When Claude Code is running, its title can flip to:
+  //   - a path-like string (e.g. "~/project" or PowerShell's prompt rewrite)
+  //   - a Braille-only spinner title whose buffer hasn't yet logged
+  //     "Claude Code" in a form `any_terminal_title_contains` can match
+  // In those cases Rust's `detect_interactive_app_from_live_title` returns
+  // `None`, so the `terminal-title-changed` event carries
+  // `interactiveApp: null`. Without `shouldPreserveActivityOnTitleReset`,
+  // useSyncEvents would overwrite the current `interactiveApp: Claude`
+  // activity with `shell`, causing the workspace icon in the top-left to
+  // flip back to "shell" even though Claude Code is still alive in the
+  // terminal. Codex already preserves on title reset — this test locks in
+  // the same behaviour for Claude.
+  it("preserves activity on title reset (issue #234)", () => {
+    expect(handler.shouldPreserveActivityOnTitleReset?.(raw({ title: "~/project" }))).toBe(true);
+  });
+
   describe("computeStatus", () => {
     it("returns pending while output is active", () => {
       expect(handler.computeStatus(raw({ outputActive: true }))).toEqual({

--- a/ui/src/lib/claude-activity-handler.ts
+++ b/ui/src/lib/claude-activity-handler.ts
@@ -55,6 +55,31 @@ export class ClaudeActivityHandler extends ShellActivityHandler {
     return true;
   }
 
+  /**
+   * Keep the `interactiveApp: Claude` activity even when the incoming
+   * `terminal-title-changed` event carries `interactiveApp: null`.
+   *
+   * Claude Code emits OSC 0/2 title sequences that the Rust side cannot
+   * always resolve back to "Claude":
+   *   - Path-like titles (e.g. `~/project`, `C:\\Users\\...`) — Rust's
+   *     `detect_interactive_app_from_title` rejects anything containing
+   *     `/` or `\` outright.
+   *   - Braille-only spinner titles emitted before the buffer has logged
+   *     a `"Claude Code"` substring that `any_terminal_title_contains`
+   *     can match and insert into `known_claude_terminals`.
+   *   - PowerShell's `prompt` function rewriting the window title on
+   *     every keystroke while Claude is running.
+   *
+   * Without this override, `useSyncEvents` would overwrite the live
+   * Claude activity with `{ type: "shell" }`, so the top-left workspace
+   * icon flips back to "shell" even though Claude Code is still alive.
+   * Mirrors `CodexActivityHandler.shouldPreserveActivityOnTitleReset`.
+   * See issue #234.
+   */
+  shouldPreserveActivityOnTitleReset(): boolean {
+    return true;
+  }
+
   computeStatus(raw: RawTerminalState): StatusResult {
     if (raw.outputActive) return { icon: "⏳", color: "var(--yellow)" };
 


### PR DESCRIPTION
## Summary
- `ClaudeActivityHandler`에 `shouldPreserveActivityOnTitleReset()` 오버라이드 추가 — 기존에 `CodexActivityHandler`에만 있던 보호 장치를 Claude에도 동일하게 적용
- Claude Code 실행 중 path-like 타이틀/Braille 스피너/PowerShell prompt 재작성 등으로 Rust가 `interactiveApp: null`을 보내는 순간 activity가 shell로 덮어써지던 문제를 차단
- 좌상단 WorkspaceSelectorView에 "shell" 아이콘이 잘못 표시되는 증상 해결

## Root Cause
`useSyncEvents`는 `terminal-title-changed` 이벤트의 `interactiveApp`이 null일 때 핸들러의 `shouldPreserveActivityOnTitleReset()`이 true가 아니면 `activity = { type: "shell" }`로 덮어쓴다. Codex는 이 훅을 구현했지만 Claude는 누락되어 있어, Rust `detect_interactive_app_from_live_title`이 path-like 타이틀을 None 처리하고 `known_claude_terminals` fallback이 타이밍상 miss되는 순간 Claude activity가 shell로 강등되었다.

## Changes
- `ui/src/lib/claude-activity-handler.ts` — `shouldPreserveActivityOnTitleReset()` 추가
- `ui/src/lib/claude-activity-handler.test.ts` — 핸들러 단위 테스트
- `ui/src/hooks/useSyncEvents.test.ts` — `interactiveApp: null` 이벤트 수신 시 Claude activity 보존 회귀 가드

## Test plan
- [x] `npx vitest run` — 1693/1693 통과
- [x] `cargo test --lib` — 674/674 통과
- [x] 추가한 2개 테스트 모두 수정 전 실패, 수정 후 통과 확인
- [ ] dev 인스턴스에서 Claude Code 실행 후 좌상단 아이콘이 Claude로 유지되는지 수동 확인 (리뷰어 환경에서 검증 권장)

Fixes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)