### PR TITLE
fix(activity): Rust 감지 레이어에 interactiveApp grace window 도입 — #237

### DIFF
--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -7,7 +7,7 @@
 use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 
-use crate::constants::ACTIVITY_SCAN_BYTES;
+use crate::constants::{ACTIVITY_SCAN_BYTES, INTERACTIVE_APP_GRACE_WINDOW};
 use crate::lock_ext::MutexExt;
 use crate::osc;
 use crate::output_buffer::TerminalOutputBuffer;
@@ -211,32 +211,94 @@ pub fn is_codex_terminal_from_buffer(
     detected
 }
 
+/// Remember that `app_name` was successfully detected on `terminal_id` at
+/// `Instant::now()`. Used to seed the grace window (§14.4 / issue #237) so a
+/// subsequent title event that resolves to `None` can still report the
+/// previously known app for a short while.
+fn record_interactive_app_detection(state: &AppState, terminal_id: &str, app_name: &str) {
+    if let Ok(mut guard) = state.last_detected_interactive_app.lock_or_err() {
+        guard.insert(
+            terminal_id.to_string(),
+            (app_name.to_string(), Instant::now()),
+        );
+    }
+}
+
+/// Grace-window fallback: if `terminal_id` had a successful detection within
+/// `INTERACTIVE_APP_GRACE_WINDOW`, return that app name. Expired entries are
+/// evicted so the map does not grow without bound on long-lived terminals.
+fn lookup_interactive_app_within_grace_window(
+    state: &AppState,
+    terminal_id: &str,
+) -> Option<String> {
+    let mut guard = state.last_detected_interactive_app.lock_or_err().ok()?;
+    let Some((name, ts)) = guard.get(terminal_id) else {
+        return None;
+    };
+    if ts.elapsed() <= INTERACTIVE_APP_GRACE_WINDOW {
+        return Some(name.clone());
+    }
+    // Expired — evict so the shell fallback path is stable.
+    guard.remove(terminal_id);
+    None
+}
+
+/// Forget the grace-window entry for `terminal_id`. Called when the terminal
+/// session closes so stale timestamps cannot leak into a new PTY sharing the
+/// same ID.
+pub fn clear_interactive_app_grace_window(state: &AppState, terminal_id: &str) {
+    if let Ok(mut guard) = state.last_detected_interactive_app.lock_or_err() {
+        guard.remove(terminal_id);
+    }
+}
+
 pub fn detect_interactive_app_from_live_title(
     state: &AppState,
     terminal_id: &str,
     title: &str,
     buffer: Option<&TerminalOutputBuffer>,
 ) -> Option<String> {
+    // 1) Direct title match — authoritative. Refresh the grace window so
+    //    subsequent None-returning titles (path-like, spinner, PowerShell
+    //    prompt rewrites) keep reporting the same app.
     if let Some(name) = detect_interactive_app_from_title(title) {
         if name == "Codex" {
             if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
                 known.insert(terminal_id.to_string());
             }
         }
+        record_interactive_app_detection(state, terminal_id, &name);
         return Some(name);
     }
 
+    // 2) Known-Claude fast path (buffer scan populates this set on the first
+    //    "Claude Code" title seen). Also refreshes the grace window.
     if let Ok(known) = state.known_claude_terminals.lock_or_err() {
         if known.contains(terminal_id) {
+            drop(known);
+            record_interactive_app_detection(state, terminal_id, "Claude");
             return Some("Claude".to_string());
         }
     }
 
+    // 3) Codex spinner + buffer banner fallback. Same grace-window refresh.
     if is_codex_spinner_title(title) && is_codex_terminal_from_buffer(state, terminal_id, buffer) {
+        record_interactive_app_detection(state, terminal_id, "Codex");
         return Some("Codex".to_string());
     }
 
-    None
+    // 4) Grace window fallback (issue #237). When every other signal returns
+    //    None — e.g. a Braille-only spinner frame before the buffer has
+    //    accumulated the "Claude Code" banner, a path-like title during
+    //    Claude's splash, or PowerShell rewriting the title on every
+    //    keystroke — keep reporting the last detected app for a short window.
+    //
+    //    Caveat (scope of #237): if the underlying process actually exited
+    //    (`/exit` inside Claude/Codex, external `kill`) the grace window will
+    //    still preserve the stale name for up to `INTERACTIVE_APP_GRACE_WINDOW`
+    //    before clearing itself. Binding the grace entry to child-process
+    //    exit signals / OSC 133;D is tracked as a follow-up.
+    lookup_interactive_app_within_grace_window(state, terminal_id)
 }
 
 /// Detect the activity state of a terminal from its output buffer.
@@ -543,6 +605,7 @@ impl PtyCallbackState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn detect_activity_empty_buffer() {
@@ -724,6 +787,179 @@ mod tests {
         assert_eq!(
             detect_interactive_app_from_title("vi"),
             Some("vim".to_string())
+        );
+    }
+
+    // ── Grace window (#237) ──
+
+    #[test]
+    fn grace_window_preserves_claude_on_path_like_title() {
+        // Regression for #237: Rust currently drops `interactiveApp` to `None`
+        // whenever the live title is path-like (`C:\...`, `~/project`, etc.),
+        // even though the terminal is still running Claude. The grace window
+        // should keep the previously detected app alive across that brief
+        // None gap.
+        let state = AppState::new();
+        let tid = "t-grace-claude";
+
+        // 1) A real Claude detection primes the grace window.
+        assert_eq!(
+            detect_interactive_app_from_live_title(&state, tid, "Claude Code", None),
+            Some("Claude".to_string())
+        );
+
+        // 2) Claude rewrites the title to a path-like value (PowerShell `prompt`
+        //    or the repo path breadcrumb). Rust should still report "Claude".
+        assert_eq!(
+            detect_interactive_app_from_live_title(&state, tid, "C:\\Users\\dev\\project", None,),
+            Some("Claude".to_string())
+        );
+
+        // 3) Braille-only spinner before `known_claude_terminals` would have
+        //    been populated from a buffer banner — still preserved.
+        assert_eq!(
+            detect_interactive_app_from_live_title(&state, tid, "\u{280b} Task", None),
+            Some("Claude".to_string())
+        );
+    }
+
+    #[test]
+    fn grace_window_preserves_codex_without_banner_in_buffer() {
+        // Codex's spinner-title fallback requires "OpenAI Codex" in the buffer.
+        // Before the banner is flushed — or after it rotates out of the 16KB
+        // window — the fallback fails and the frontend sees `None`. The grace
+        // window must bridge that gap once Codex has been detected at least
+        // once.
+        let state = AppState::new();
+        let tid = "t-grace-codex";
+
+        // Prime: real banner + explicit title.
+        let mut explicit = TerminalOutputBuffer::default();
+        explicit.push(b"\x1b]0;OpenAI Codex\x07");
+        assert_eq!(
+            detect_interactive_app_from_live_title(&state, tid, "OpenAI Codex", Some(&explicit),),
+            Some("Codex".to_string())
+        );
+
+        // Simulate that the banner has rotated out and the current title is a
+        // Braille spinner: without grace window this returns None because the
+        // empty buffer has no "OpenAI Codex" for the fallback to anchor on.
+        let empty = TerminalOutputBuffer::default();
+        assert_eq!(
+            detect_interactive_app_from_live_title(&state, tid, "\u{280b} laymux", Some(&empty),),
+            Some("Codex".to_string())
+        );
+    }
+
+    #[test]
+    fn grace_window_expires_after_configured_duration() {
+        // When the grace timestamp is older than the configured window, the
+        // detector must return None again so a truly dead app stops showing up.
+        use crate::constants::INTERACTIVE_APP_GRACE_WINDOW;
+
+        let state = AppState::new();
+        let tid = "t-grace-expire";
+
+        // Prime a detection.
+        assert_eq!(
+            detect_interactive_app_from_live_title(&state, tid, "Claude Code", None),
+            Some("Claude".to_string())
+        );
+
+        // Manually age the entry beyond the grace window.
+        {
+            let mut guard = state.last_detected_interactive_app.lock().unwrap();
+            let entry = guard.get_mut(tid).expect("entry must exist");
+            entry.1 = Instant::now() - INTERACTIVE_APP_GRACE_WINDOW - Duration::from_millis(10);
+        }
+
+        // Remove the known-Claude fast path so only the grace window can save it.
+        state.known_claude_terminals.lock().unwrap().remove(tid);
+
+        assert_eq!(
+            detect_interactive_app_from_live_title(&state, tid, "C:\\Users\\dev\\project", None,),
+            None,
+        );
+    }
+
+    #[test]
+    fn grace_window_refreshes_on_successful_detection() {
+        // A fresh successful detection must refresh the timestamp so the
+        // window slides forward.
+        let state = AppState::new();
+        let tid = "t-grace-refresh";
+
+        // Prime an entry.
+        detect_interactive_app_from_live_title(&state, tid, "Claude Code", None);
+
+        // Age it manually to just under the limit.
+        let aged = {
+            let mut guard = state.last_detected_interactive_app.lock().unwrap();
+            let entry = guard.get_mut(tid).unwrap();
+            entry.1 = Instant::now() - Duration::from_secs(4);
+            entry.1
+        };
+
+        // A brand-new successful detection should overwrite the timestamp
+        // (and the app name, in case it changed).
+        detect_interactive_app_from_live_title(&state, tid, "Claude Code", None);
+        let refreshed = state
+            .last_detected_interactive_app
+            .lock()
+            .unwrap()
+            .get(tid)
+            .map(|(_, t)| *t)
+            .unwrap();
+        assert!(refreshed > aged, "timestamp must be refreshed");
+    }
+
+    #[test]
+    fn grace_window_replaced_when_different_app_detected() {
+        // Transitioning to a different interactive app must update both the
+        // name and timestamp — no stale sticky state.
+        let state = AppState::new();
+        let tid = "t-grace-switch";
+
+        detect_interactive_app_from_live_title(&state, tid, "Claude Code", None);
+        assert_eq!(
+            state
+                .last_detected_interactive_app
+                .lock()
+                .unwrap()
+                .get(tid)
+                .map(|(n, _)| n.clone()),
+            Some("Claude".to_string())
+        );
+
+        // Switch to vim.
+        assert_eq!(
+            detect_interactive_app_from_live_title(&state, tid, "vim", None),
+            Some("vim".to_string())
+        );
+        assert_eq!(
+            state
+                .last_detected_interactive_app
+                .lock()
+                .unwrap()
+                .get(tid)
+                .map(|(n, _)| n.clone()),
+            Some("vim".to_string())
+        );
+    }
+
+    #[test]
+    fn grace_window_ignored_when_never_detected() {
+        // Terminals that never had a successful detection must remain None
+        // — the grace window cannot fabricate one.
+        let state = AppState::new();
+        assert_eq!(
+            detect_interactive_app_from_live_title(
+                &state,
+                "t-fresh",
+                "C:\\Users\\dev\\project",
+                None,
+            ),
+            None,
         );
     }
 

--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -867,14 +867,14 @@ mod tests {
         );
 
         // Manually age the entry beyond the grace window.
+        // (The direct-title match path at step 1 does not touch
+        // `known_claude_terminals`, so no fast-path eviction is needed here —
+        // the grace entry is the sole mechanism keeping detection alive.)
         {
             let mut guard = state.last_detected_interactive_app.lock().unwrap();
             let entry = guard.get_mut(tid).expect("entry must exist");
             entry.1 = Instant::now() - INTERACTIVE_APP_GRACE_WINDOW - Duration::from_millis(10);
         }
-
-        // Remove the known-Claude fast path so only the grace window can save it.
-        state.known_claude_terminals.lock().unwrap().remove(tid);
 
         assert_eq!(
             detect_interactive_app_from_live_title(&state, tid, "C:\\Users\\dev\\project", None,),

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -367,6 +367,10 @@ pub fn create_terminal_session(
                     if let Ok(mut known) = state_for_pty.known_claude_terminals.lock_or_err() {
                         known.remove(&terminal_id);
                     }
+                    // Also drop the grace-window entry so the shell fallback
+                    // kicks in immediately instead of pinning "Claude" for
+                    // up to `INTERACTIVE_APP_GRACE_WINDOW` after exit (#237).
+                    activity::clear_interactive_app_grace_window(&state_for_pty, &terminal_id);
                 }
 
                 if message_changed {
@@ -422,7 +426,13 @@ pub fn create_terminal_session(
                 }
             }
 
-            // Emit structured title change event (OSC 0/2) for frontend activity detection
+            // Emit structured title change event (OSC 0/2) for frontend activity detection.
+            //
+            // `detect_interactive_app_from_live_title` already walks every
+            // fallback layer: direct title match → known_claude_terminals
+            // fast path → Codex spinner+banner → grace window (#237). The
+            // callback therefore only needs to call it once and emit the
+            // result.
             if event.code == 0 || event.code == 2 {
                 let interactive_app =
                     if let Ok(buffers) = state_for_pty.output_buffers.lock_or_err() {
@@ -439,17 +449,7 @@ pub fn create_terminal_session(
                             &event.data,
                             None,
                         )
-                    }
-                    .or_else(|| {
-                        // Title may not contain "Claude Code" (e.g. spinner "✢ Working"),
-                        // but if the terminal is in known_claude_terminals, preserve detection.
-                        if let Ok(known) = state_for_pty.known_claude_terminals.lock_or_err() {
-                            if known.contains(&terminal_id) {
-                                return Some("Claude".to_string());
-                            }
-                        }
-                        None
-                    });
+                    };
                 let notify_gate_armed = if let Ok(terms) = state_for_pty.terminals.lock_or_err() {
                     terms.get(&terminal_id).is_some_and(|s| s.notify_gate_armed)
                 } else {
@@ -703,6 +703,10 @@ pub fn close_terminal_session(
     if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
         known.remove(&id);
     }
+
+    // Clean up interactive-app grace window (#237) so a new terminal that
+    // happens to reuse this ID does not inherit stale detection.
+    activity::clear_interactive_app_grace_window(&state, &id);
 
     // Clean up notifications for this terminal
     if let Ok(mut notifs) = state.notifications.lock_or_err() {

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -101,6 +101,32 @@ pub const EVENT_TERMINALS_LIST_CHANGED: &str = "terminals-list-changed";
 /// notifications are enabled even without observing a user command.
 pub const NOTIFY_GATE_FALLBACK_MS: u64 = 3000;
 
+/// Grace window for preserving a previously detected interactive app when the
+/// current title evaluation returns `None` (issue #237).
+///
+/// TUI apps (Claude Code, Codex, etc.) periodically emit OSC 0/2 title updates
+/// that do not carry the app name:
+///   - Path-like titles (`~/project`, `C:\Users\...`, `//wsl.localhost/...`)
+///     are rejected outright by `detect_interactive_app_from_title`.
+///   - Braille / star spinner titles appear before the output buffer has
+///     accumulated the "Claude Code" / "OpenAI Codex" banner string that
+///     `known_*_terminals` relies on.
+///   - PowerShell's `prompt` function rewrites the window title on every
+///     keystroke while Claude is running.
+///
+/// Within this window after the last successful detection, the live-title
+/// detector keeps returning the previously detected app instead of `None`,
+/// so the frontend never briefly sees `interactiveApp: null` and flips the
+/// workspace icon back to "shell". New detections (including transitions
+/// to a different app) refresh the timestamp immediately.
+///
+/// 5 seconds is long enough to absorb the Claude splash / Codex banner
+/// initialization gap observed in practice while staying short enough that
+/// a process that actually exited becomes visible quickly. Process-exit
+/// integration (child exit signals / OSC 133;D fallback) is tracked as a
+/// follow-up to issue #237.
+pub const INTERACTIVE_APP_GRACE_WINDOW: Duration = Duration::from_secs(5);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -17,10 +17,11 @@ use crate::terminal::{SyncGroup, TerminalNotification, TerminalSession};
 /// 2. `output_buffers`
 /// 3. `known_claude_terminals`
 /// 4. `known_codex_terminals`
-/// 4. `notifications`
-/// 5. `sync_groups`
-/// 6. `propagated_terminals`
-/// 7. `pty_handles` / `automation_channels` / `automation_port` / `ipc_socket_path`
+/// 5. `last_detected_interactive_app`
+/// 6. `notifications`
+/// 7. `sync_groups`
+/// 8. `propagated_terminals`
+/// 9. `pty_handles` / `automation_channels` / `automation_port` / `ipc_socket_path`
 ///
 /// Never acquire a higher-numbered lock while holding a lower-numbered one.
 pub struct AppState {
@@ -46,6 +47,15 @@ pub struct AppState {
     /// Populated proactively by the PTY output callback and frontend command detection.
     /// Removed when the terminal session closes.
     pub known_codex_terminals: Arc<Mutex<HashSet<String>>>,
+    /// Per-terminal grace-window cache of the last successfully detected
+    /// interactive app name and the `Instant` of that detection.
+    ///
+    /// Used by `activity::detect_interactive_app_from_live_title` to preserve
+    /// the previous detection across title events that evaluate to `None`
+    /// (path-like titles, early-splash spinner frames, PowerShell `prompt`
+    /// rewrites). Entries older than `INTERACTIVE_APP_GRACE_WINDOW` are
+    /// ignored. See issue #237.
+    pub last_detected_interactive_app: Arc<Mutex<HashMap<String, (String, Instant)>>>,
     /// Single source of truth for terminal notifications.
     /// Stored in backend so `get_terminal_summaries` can return unread counts.
     pub notifications: Arc<Mutex<Vec<TerminalNotification>>>,
@@ -66,6 +76,7 @@ impl AppState {
             propagated_terminals: Mutex::new(HashMap::new()),
             known_claude_terminals: Arc::new(Mutex::new(HashSet::new())),
             known_codex_terminals: Arc::new(Mutex::new(HashSet::new())),
+            last_detected_interactive_app: Arc::new(Mutex::new(HashMap::new())),
             notifications: Arc::new(Mutex::new(Vec::new())),
             notification_counter: AtomicU64::new(1),
         }


### PR DESCRIPTION
## 요약

Rust `detect_interactive_app_from_live_title`이 잠깐 `None`을 반환하는 과도기 동안 직전 detected 앱을 최대 5초간 유지하는 grace window를 도입한다. 프론트엔드가 `interactiveApp: null`을 잠깐이라도 본 뒤 activity를 shell로 덮어쓰던 경주 조건(issue #234 / PR #236 배경)을 Rust 레이어에서 근본 차단한다.

## 변경 내용

- `AppState.last_detected_interactive_app: HashMap<terminal_id, (app, Instant)>` 추가
- `detect_interactive_app_from_live_title`에 4단계 계층 정리:
  1. 직접 타이틀 매치
  2. `known_claude_terminals` 패스트패스
  3. Codex spinner + buffer banner
  4. **grace window** (신규) — 위 전부 None일 때 최근 5초 내 감지된 앱 반환
- 성공 감지 시 timestamp 갱신, 다른 앱 감지 시 즉시 교체
- 터미널 세션 종료 / Claude 버퍼 해제 시 `clear_interactive_app_grace_window()`로 엔트리 제거 — 새 PTY가 ID를 재사용해도 스테일 감지 안 됨
- PTY 콜백의 중복되던 `known_claude_terminals` `.or_else()` fallback 제거 — 이제 단일 함수 내부에서 통합 처리
- `INTERACTIVE_APP_GRACE_WINDOW = 5s` 상수로 분리 (`constants.rs`)

## 효과

- Claude/Codex가 받던 방어를 Rust 레이어에서 통합 → 프론트 `ClaudeActivityHandler.shouldPreserveActivityOnTitleReset` 등 핸들러별 방어 코드 의존도 감소 (이번 PR에서는 유지, 안정화 후 후속 정리)
- path-like 타이틀(`C:\Users\...`, `~/project`), 초기 Braille 스피너, PowerShell `prompt` 재작성이 자연스럽게 흡수됨
- 향후 Gemini/aider 등 새 interactive app 추가 시 핸들러별 개별 방어 불필요

## 범위 제약 (후속)

프로세스가 실제로 종료된 경우(`/exit`, 외부 kill)에도 최대 5초간 이전 앱 이름이 유지될 수 있다. 자식 프로세스 종료 시그널 / OSC 133;D 연동은 별도 이슈로 추적 예정.

## 테스트

`cargo test --lib`: **712 passed / 0 failed** (799초, 전체 컴파일 포함).

신규 케이스 6개 (`activity::tests`):
- `grace_window_preserves_claude_on_path_like_title`
- `grace_window_preserves_codex_without_banner_in_buffer`
- `grace_window_expires_after_configured_duration`
- `grace_window_refreshes_on_successful_detection`
- `grace_window_replaced_when_different_app_detected`
- `grace_window_ignored_when_never_detected`

Fixes #237