### PR TITLE
feat(terminal): xterm 로드 전 로딩 overlay 표시

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -223,6 +223,25 @@ describe("TerminalView", () => {
     expect(screen.getByTestId("terminal-view-t1")).toBeInTheDocument();
   });
 
+  it("shows a loading overlay until the first render event arrives", async () => {
+    render(<TerminalView instanceId="t-loading" profile="PowerShell" syncGroup="" />);
+
+    // Wait for ResizeObserver → terminal.open() → onRender subscription.
+    await vi.waitFor(() => {
+      expect(mockOnRender).toHaveBeenCalled();
+    });
+
+    const overlay = screen.getByTestId("terminal-loading-t-loading");
+    expect(overlay).toHaveClass("visible");
+
+    const renderHandler = mockOnRender.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+    await act(async () => {
+      renderHandler?.();
+    });
+
+    expect(overlay).not.toHaveClass("visible");
+  });
+
   it("applies cursor shape and blink from profile settings", () => {
     useSettingsStore.getState().updateProfile(0, {
       cursorShape: "underscore",

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -242,6 +242,48 @@ describe("TerminalView", () => {
     expect(overlay).not.toHaveClass("visible");
   });
 
+  it("keeps the loading overlay visible when toggling back to a previously ready profile", async () => {
+    const { rerender } = render(
+      <TerminalView instanceId="t-toggle" profile="PowerShell" syncGroup="" />,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockOnRender).toHaveBeenCalled();
+    });
+
+    // First PowerShell terminal becomes ready.
+    const firstHandler = mockOnRender.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+    await act(async () => {
+      firstHandler?.();
+    });
+    expect(screen.getByTestId("terminal-loading-t-toggle")).not.toHaveClass("visible");
+
+    // Switch to WSL — overlay reappears for the new terminal.
+    await act(async () => {
+      rerender(<TerminalView instanceId="t-toggle" profile="WSL" syncGroup="" />);
+    });
+    expect(screen.getByTestId("terminal-loading-t-toggle")).toHaveClass("visible");
+
+    // Switch back to PowerShell BEFORE WSL ever fires onRender. The new PS
+    // xterm has not painted yet, so the overlay must remain visible —
+    // a string-key cache would incorrectly mark it ready here.
+    const callsBeforeFinalSwitch = mockOnRender.mock.calls.length;
+    await act(async () => {
+      rerender(<TerminalView instanceId="t-toggle" profile="PowerShell" syncGroup="" />);
+    });
+    expect(screen.getByTestId("terminal-loading-t-toggle")).toHaveClass("visible");
+
+    // The newly recreated PS terminal eventually fires its own onRender.
+    await vi.waitFor(() => {
+      expect(mockOnRender.mock.calls.length).toBeGreaterThan(callsBeforeFinalSwitch);
+    });
+    const newHandler = mockOnRender.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+    await act(async () => {
+      newHandler?.();
+    });
+    expect(screen.getByTestId("terminal-loading-t-toggle")).not.toHaveClass("visible");
+  });
+
   it("re-shows the loading overlay when the underlying terminal is recreated", async () => {
     const { rerender } = render(
       <TerminalView instanceId="t-recreate" profile="PowerShell" syncGroup="" />,

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -242,6 +242,39 @@ describe("TerminalView", () => {
     expect(overlay).not.toHaveClass("visible");
   });
 
+  it("re-shows the loading overlay when the underlying terminal is recreated", async () => {
+    const { rerender } = render(
+      <TerminalView instanceId="t-recreate" profile="PowerShell" syncGroup="" />,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockOnRender).toHaveBeenCalled();
+    });
+
+    const firstHandler = mockOnRender.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+    await act(async () => {
+      firstHandler?.();
+    });
+    expect(screen.getByTestId("terminal-loading-t-recreate")).not.toHaveClass("visible");
+
+    // Profile change rebuilds xterm. Overlay must reappear before the next paint.
+    const callsBeforeRebuild = mockOnRender.mock.calls.length;
+    await act(async () => {
+      rerender(<TerminalView instanceId="t-recreate" profile="WSL" syncGroup="" />);
+    });
+
+    expect(screen.getByTestId("terminal-loading-t-recreate")).toHaveClass("visible");
+
+    await vi.waitFor(() => {
+      expect(mockOnRender.mock.calls.length).toBeGreaterThan(callsBeforeRebuild);
+    });
+    const secondHandler = mockOnRender.mock.calls.at(-1)?.[0] as (() => void) | undefined;
+    await act(async () => {
+      secondHandler?.();
+    });
+    expect(screen.getByTestId("terminal-loading-t-recreate")).not.toHaveClass("visible");
+  });
+
   it("applies cursor shape and blink from profile settings", () => {
     useSettingsStore.getState().updateProfile(0, {
       cursorShape: "underscore",

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, type CSSProperties } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { FitAddon } from "@xterm/addon-fit";
@@ -258,6 +258,8 @@ export function TerminalView({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const overlayCaretUpdaterRef = useRef<(() => void) | null>(null);
   const openedRef = useRef(false);
+  const [isReady, setIsReady] = useState(false);
+  const isReadyRef = useRef(false);
   const isFocusedRef = useRef(isFocused);
   const activityRef = useRef<TerminalActivityInfo | undefined>(undefined);
   const stabilizeInteractiveCursorRef = useRef(true);
@@ -930,6 +932,10 @@ export function TerminalView({
       scheduleShadowCursorSync();
     });
     const renderDisposable = terminal.onRender(() => {
+      if (!isReadyRef.current) {
+        isReadyRef.current = true;
+        setIsReady(true);
+      }
       scheduleOverlayCaretUpdate();
     });
     const bindHelperTextareaEvents = () => {
@@ -1742,6 +1748,13 @@ export function TerminalView({
         className="terminal-overlay-caret pointer-events-none absolute"
         style={{ opacity: 0 }}
       />
+      <div
+        data-testid={`terminal-loading-${instanceId}`}
+        className={`terminal-loading-overlay ${isReady ? "" : "visible"}`}
+        aria-hidden={isReady}
+      >
+        <div className="terminal-loading-spinner" />
+      </div>
     </div>
   );
 }

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -258,14 +258,22 @@ export function TerminalView({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const overlayCaretUpdaterRef = useRef<(() => void) | null>(null);
   const openedRef = useRef(false);
-  // terminalKey identifies the underlying xterm — changes whenever the main
-  // effect rebuilds it (instanceId or profile). Pairing it with readyKey lets
-  // us derive isReady at render time, so profile switches reset the overlay
-  // before the next paint instead of waiting for useEffect to run.
-  const terminalKey = `${instanceId}:${profile}`;
-  const [readyKey, setReadyKey] = useState<string | null>(null);
-  const readyKeyRef = useRef<string | null>(null);
-  const isReady = readyKey === terminalKey;
+  // Each xterm rebuild gets a fresh generation, bumped at render time when
+  // (instanceId, profile) changes. A monotonic counter is required because the
+  // same (instanceId, profile) pair can be revisited (e.g. PS → WSL → PS quick
+  // toggle) and a string key would let the second PS terminal inherit the first
+  // one's ready state before its first paint.
+  const terminalDepsKey = `${instanceId}:${profile}`;
+  const lastTerminalDepsRef = useRef<string | null>(null);
+  const terminalGenerationRef = useRef(0);
+  if (lastTerminalDepsRef.current !== terminalDepsKey) {
+    lastTerminalDepsRef.current = terminalDepsKey;
+    terminalGenerationRef.current += 1;
+  }
+  const terminalGeneration = terminalGenerationRef.current;
+  const [readyGeneration, setReadyGeneration] = useState(-1);
+  const readyGenerationRef = useRef(-1);
+  const isReady = readyGeneration === terminalGeneration;
   const isFocusedRef = useRef(isFocused);
   const activityRef = useRef<TerminalActivityInfo | undefined>(undefined);
   const stabilizeInteractiveCursorRef = useRef(true);
@@ -938,9 +946,9 @@ export function TerminalView({
       scheduleShadowCursorSync();
     });
     const renderDisposable = terminal.onRender(() => {
-      if (readyKeyRef.current !== terminalKey) {
-        readyKeyRef.current = terminalKey;
-        setReadyKey(terminalKey);
+      if (readyGenerationRef.current !== terminalGeneration) {
+        readyGenerationRef.current = terminalGeneration;
+        setReadyGeneration(terminalGeneration);
       }
       scheduleOverlayCaretUpdate();
     });

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -258,8 +258,14 @@ export function TerminalView({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const overlayCaretUpdaterRef = useRef<(() => void) | null>(null);
   const openedRef = useRef(false);
-  const [isReady, setIsReady] = useState(false);
-  const isReadyRef = useRef(false);
+  // terminalKey identifies the underlying xterm — changes whenever the main
+  // effect rebuilds it (instanceId or profile). Pairing it with readyKey lets
+  // us derive isReady at render time, so profile switches reset the overlay
+  // before the next paint instead of waiting for useEffect to run.
+  const terminalKey = `${instanceId}:${profile}`;
+  const [readyKey, setReadyKey] = useState<string | null>(null);
+  const readyKeyRef = useRef<string | null>(null);
+  const isReady = readyKey === terminalKey;
   const isFocusedRef = useRef(isFocused);
   const activityRef = useRef<TerminalActivityInfo | undefined>(undefined);
   const stabilizeInteractiveCursorRef = useRef(true);
@@ -325,13 +331,6 @@ export function TerminalView({
   const shouldUseWebgl = shouldEnableTerminalWebgl();
 
   useEffect(() => {
-    // Reset loading state on every (re)creation of the underlying xterm. profile
-    // changes rerun this effect to dispose+rebuild the terminal; without this
-    // reset isReady would carry over and the new instance would render without
-    // the overlay until its first paint, reproducing the original flash.
-    isReadyRef.current = false;
-    setIsReady(false);
-
     registerInstance({ id: instanceId, profile, syncGroup, workspaceId });
 
     // Diagnostic shadow-cursor tracer. Bound once per effect mount because
@@ -939,9 +938,9 @@ export function TerminalView({
       scheduleShadowCursorSync();
     });
     const renderDisposable = terminal.onRender(() => {
-      if (!isReadyRef.current) {
-        isReadyRef.current = true;
-        setIsReady(true);
+      if (readyKeyRef.current !== terminalKey) {
+        readyKeyRef.current = terminalKey;
+        setReadyKey(terminalKey);
       }
       scheduleOverlayCaretUpdate();
     });

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -325,6 +325,13 @@ export function TerminalView({
   const shouldUseWebgl = shouldEnableTerminalWebgl();
 
   useEffect(() => {
+    // Reset loading state on every (re)creation of the underlying xterm. profile
+    // changes rerun this effect to dispose+rebuild the terminal; without this
+    // reset isReady would carry over and the new instance would render without
+    // the overlay until its first paint, reproducing the original flash.
+    isReadyRef.current = false;
+    setIsReady(false);
+
     registerInstance({ id: instanceId, profile, syncGroup, workspaceId });
 
     // Diagnostic shadow-cursor tracer. Bound once per effect mount because

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -220,3 +220,36 @@
   will-change: transform;
   z-index: 2;
 }
+
+/* Covers the xterm container while the renderer initialises.
+   Delay + fade keeps fast mounts from flashing a spinner. */
+.terminal-loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--terminal-background-color, #0c0c0c);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 150ms ease;
+  z-index: 4;
+}
+.terminal-loading-overlay.visible {
+  opacity: 1;
+  transition-delay: 60ms;
+}
+.terminal-loading-spinner {
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--terminal-foreground-color, #f0f0f0);
+  border-top-color: transparent;
+  border-radius: 50%;
+  opacity: 0.55;
+  animation: terminal-loading-spin 0.8s linear infinite;
+}
+@keyframes terminal-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- 여러 터미널을 동시에 생성할 때 일부에서 xterm 첫 프레임이 비거나 흰 화면으로 잠시 보였던 문제를 해결한다. 원인: WebGL addon 이 ACCESS_VIOLATION 회피를 위해 `WEBGL_STAGGER_MS=150ms` 간격으로 순차 로드되어 뒤쪽 인스턴스의 첫 paint 가 지연됨.
- `terminal.onRender` 첫 이벤트로 ready 를 감지하고, 그 전까지 wrapper 위에 터미널 배경색 + 스피너 overlay 를 깐다.
- `transition-delay: 60ms` 로 정상(빠른) 케이스에서는 스피너 flash 가 보이지 않게 하고, 느린 경우(다수 동시 생성)에만 자연스럽게 fade-in 한다.

## Test plan
- [x] `npx vitest run src/components/views/TerminalView.test.tsx` — 89/89 통과 (신규 \"loading overlay\" 테스트 포함)
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 신규 경고 없음
- [x] dev 인스턴스(19281)에서 overlay DOM 렌더 확인 (강제 visible 모드로 z-index/배치 검증 후 원복)
- [ ] 사용자 환경에서 다수 터미널 동시 생성 시 흰 화면이 사라졌는지 실사용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)