### PR TITLE
fix(activity): Claude/Codex 캐시 비대칭 제거 — known_* 동기화 + title-less 헬퍼화

### DIFF
--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -211,8 +211,10 @@ pub fn is_codex_terminal_from_buffer(
 /// Without this, a pane that previously ran Claude keeps its
 /// `known_claude_terminals` membership forever — and the live-title detector's
 /// Claude fast path then masks any later Codex transition (the inverse holds
-/// too). Called whenever a direct title match confirms which app is running.
-fn sync_known_caches(state: &AppState, terminal_id: &str, app_name: &str) {
+/// too). Called whenever a direct title match confirms which app is running,
+/// and whenever the PTY callback observes a Codex/Claude entry transition
+/// or the frontend command-text detector marks a terminal.
+pub fn sync_known_caches(state: &AppState, terminal_id: &str, app_name: &str) {
     match app_name {
         "Codex" => {
             if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
@@ -296,13 +298,23 @@ pub fn detect_interactive_app_from_live_title(
     //    Symmetric on purpose: callers may pass an empty title (e.g.
     //    `detect_terminal_state` when the recent window has no OSC 0/2) and
     //    still recover the right app.
-    if is_codex_terminal_from_buffer(state, terminal_id, buffer) {
-        record_interactive_app_detection(state, terminal_id, "Codex");
-        return Some("Codex".to_string());
-    }
+    //
+    //    Order matters: Claude is checked first. `sync_known_caches` and
+    //    the Codex PTY exit path (`codex_activity::process_codex_title`
+    //    -> exited) keep the two `known_*_terminals` sets mutually
+    //    exclusive in steady state, but a brief overlap can occur when
+    //    frontend command-text detection (`mark_claude_terminal`)
+    //    populates Claude before the next OSC 0/2 title arrives to drive
+    //    Codex cleanup. In that window Claude is the right answer —
+    //    Codex-first ordering misclassified Claude sessions for spinner/
+    //    path-like/empty titles (PR 242 P1 #2 regression).
     if is_claude_terminal_from_buffer(state, terminal_id, buffer) {
         record_interactive_app_detection(state, terminal_id, "Claude");
         return Some("Claude".to_string());
+    }
+    if is_codex_terminal_from_buffer(state, terminal_id, buffer) {
+        record_interactive_app_detection(state, terminal_id, "Codex");
+        return Some("Codex".to_string());
     }
 
     // 3) Grace window fallback (issue #237). When every other signal returns
@@ -586,6 +598,12 @@ impl<const N: usize> MarkerTailScanner<N> {
 /// Groups individual `Arc<Atomic*>` fields into a single `Arc<PtyCallbackState>`.
 pub struct PtyCallbackState {
     pub claude_detected: AtomicBool,
+    /// Mirrors `claude_detected` for Codex (OpenAI Codex CLI). Tracks whether
+    /// the most recent OSC 0/2 title sequence on this terminal indicated
+    /// Codex was running. Without this companion flag the entry-detection
+    /// path in `codex_activity::process_codex_title` cannot fire — there
+    /// is no other persistent signal in the PTY callback closure.
+    pub codex_detected: AtomicBool,
     pub burst_detector: BurstDetector,
     /// Boundary-aware DEC 2026 marker scanner. Mutex because `scan` mutates
     /// the internal tail, while the enclosing `PtyCallbackState` is shared
@@ -597,6 +615,7 @@ impl PtyCallbackState {
     pub fn new(burst_window_ms: u64, burst_threshold: u64, throttle_ms: u64) -> Self {
         Self {
             claude_detected: AtomicBool::new(false),
+            codex_detected: AtomicBool::new(false),
             burst_detector: BurstDetector::new(burst_window_ms, burst_threshold, throttle_ms),
             dec_sync_scanner: std::sync::Mutex::new(MarkerTailScanner::new(
                 crate::constants::DEC_SYNC_OUTPUT_SET,
@@ -1049,6 +1068,100 @@ mod tests {
             TerminalActivity::InteractiveApp {
                 name: "Codex".to_string()
             }
+        );
+    }
+
+    #[test]
+    fn sync_known_caches_clears_codex_when_claude_marked() {
+        // Mirrors what `mark_claude_terminal` now does after frontend
+        // command-text detection: a pane that previously hosted Codex
+        // loses its `known_codex_terminals` membership the moment the
+        // frontend reports Claude. Without this the next persistent-
+        // signal lookup would race between two populated caches.
+        let state = AppState::new();
+        let tid = "t-codex-then-marked-claude";
+
+        state
+            .known_codex_terminals
+            .lock()
+            .unwrap()
+            .insert(tid.to_string());
+
+        sync_known_caches(&state, tid, "Claude");
+
+        assert!(state.known_claude_terminals.lock().unwrap().contains(tid));
+        assert!(
+            !state.known_codex_terminals.lock().unwrap().contains(tid),
+            "marking a terminal as Claude must drop any stale Codex cache entry"
+        );
+    }
+
+    #[test]
+    fn claude_wins_when_both_caches_contain_id() {
+        // Regression for the Codex→Claude pane-reuse window:
+        // a pane that previously ran Codex still has its ID in
+        // `known_codex_terminals` (Codex now has its own exit path that
+        // normally clears it, but the cache can transiently hold both
+        // entries when frontend command-text detection populates
+        // `known_claude_terminals` before the next OSC 0/2 title arrives
+        // to drive the Codex exit cleanup). In that window the persistent-
+        // signal layer must still report Claude — Codex-first ordering
+        // misclassified Claude sessions for spinner/path-like/empty titles.
+        let state = AppState::new();
+        let tid = "t-codex-then-claude";
+
+        state
+            .known_codex_terminals
+            .lock()
+            .unwrap()
+            .insert(tid.to_string());
+        state
+            .known_claude_terminals
+            .lock()
+            .unwrap()
+            .insert(tid.to_string());
+
+        // Buffer holds neither "OpenAI Codex" nor "Claude Code" — only a
+        // path-like title that no INTERACTIVE_APP_PATTERN can match
+        // (path-like titles short-circuit `detect_interactive_app_from_title`).
+        let mut buf = TerminalOutputBuffer::default();
+        buf.push(b"\x1b]0;~/projects/laymux\x07");
+
+        assert_eq!(
+            detect_terminal_state(&state, tid, Some(&buf)).activity,
+            TerminalActivity::InteractiveApp {
+                name: "Claude".to_string()
+            },
+            "Claude must win the cache-collision window; Codex-first ordering is a regression"
+        );
+    }
+
+    #[test]
+    fn codex_classification_recovers_after_cache_cleanup_when_banner_gone() {
+        // Effect-level companion to the `process_codex_title` -> exited
+        // unit test in `codex_activity::tests`. Once the PTY callback's
+        // exit path has run (cache removed + grace window cleared) AND
+        // the "OpenAI Codex" banner has scrolled out of the
+        // ACTIVITY_SCAN_BYTES window, classification must fall back to
+        // Shell/Running. Pre-fix the cache survived indefinitely, so this
+        // recovery never happened — sync-cwd stayed blocked forever.
+        let state = AppState::new();
+        let tid = "t-codex-stale-cleared";
+
+        // Simulate the post-cleanup invariant directly: cache is empty,
+        // grace window is empty, and the buffer carries no Codex banner.
+        // (Live PTY exit-path coverage is unit-tested in codex_activity.)
+        let mut buf = TerminalOutputBuffer::default();
+        buf.push(b"\x1b]0;PS C:\\Users\\me\x07PS> dir\r\n\x1b]133;D\x07");
+
+        let activity = detect_terminal_state(&state, tid, Some(&buf)).activity;
+        assert!(
+            matches!(
+                activity,
+                TerminalActivity::Shell | TerminalActivity::Running
+            ),
+            "post-cleanup classification must recover, got {:?}",
+            activity
         );
     }
 

--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -172,11 +172,6 @@ fn is_word_match(text: &str, pattern: &str) -> bool {
     false
 }
 
-pub(crate) fn is_codex_spinner_title(title: &str) -> bool {
-    let first = title.chars().next().unwrap_or_default() as u32;
-    (0x2800..=0x28ff).contains(&first)
-}
-
 fn recent_buffer_contains(recent: &[u8], needle: &str) -> bool {
     let needle = needle.as_bytes();
     !needle.is_empty() && recent.windows(needle.len()).any(|window| window == needle)
@@ -209,6 +204,34 @@ pub fn is_codex_terminal_from_buffer(
         }
     }
     detected
+}
+
+/// Sync the per-app `known_*_terminals` sets so they stay mutually exclusive.
+///
+/// Without this, a pane that previously ran Claude keeps its
+/// `known_claude_terminals` membership forever — and the live-title detector's
+/// Claude fast path then masks any later Codex transition (the inverse holds
+/// too). Called whenever a direct title match confirms which app is running.
+fn sync_known_caches(state: &AppState, terminal_id: &str, app_name: &str) {
+    match app_name {
+        "Codex" => {
+            if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
+                known.insert(terminal_id.to_string());
+            }
+            if let Ok(mut known) = state.known_claude_terminals.lock_or_err() {
+                known.remove(terminal_id);
+            }
+        }
+        "Claude" => {
+            if let Ok(mut known) = state.known_claude_terminals.lock_or_err() {
+                known.insert(terminal_id.to_string());
+            }
+            if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
+                known.remove(terminal_id);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Remember that `app_name` was successfully detected on `terminal_id` at
@@ -258,54 +281,31 @@ pub fn detect_interactive_app_from_live_title(
     title: &str,
     buffer: Option<&TerminalOutputBuffer>,
 ) -> Option<String> {
-    // 1) Direct title match — authoritative. Refresh the grace window so
-    //    subsequent None-returning titles (path-like, spinner, PowerShell
-    //    prompt rewrites) keep reporting the same app.
+    // 1) Direct title match — authoritative. `sync_known_caches` keeps the
+    //    per-app sets mutually exclusive so a Claude→Codex (or reverse)
+    //    handover never leaves a stale fast-path entry behind.
     if let Some(name) = detect_interactive_app_from_title(title) {
-        if name == "Codex" {
-            if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
-                known.insert(terminal_id.to_string());
-            }
-        }
-        if name == "Claude" {
-            if let Ok(mut known) = state.known_claude_terminals.lock_or_err() {
-                known.insert(terminal_id.to_string());
-            }
-        }
+        sync_known_caches(state, terminal_id, &name);
         record_interactive_app_detection(state, terminal_id, &name);
         return Some(name);
     }
 
-    // 2) Known-Claude fast path. The PTY callback, frontend
-    //    (`mark_claude_terminal`), or a prior buffer scan may have registered
-    //    this terminal even if the current title has drifted (task description
-    //    like "✻ Exploring code", spinner frame, etc.). Also refreshes the
-    //    grace window.
-    if let Ok(known) = state.known_claude_terminals.lock_or_err() {
-        if known.contains(terminal_id) {
-            drop(known);
-            record_interactive_app_detection(state, terminal_id, "Claude");
-            return Some("Claude".to_string());
-        }
+    // 2) Persistent signals. Both helpers cover the cache fast-path AND a
+    //    full-buffer banner scan, so this single layer subsumes the previous
+    //    Claude-fast-path / Claude-buffer-scan / Codex-spinner-fallback split.
+    //    Symmetric on purpose: callers may pass an empty title (e.g.
+    //    `detect_terminal_state` when the recent window has no OSC 0/2) and
+    //    still recover the right app.
+    if is_codex_terminal_from_buffer(state, terminal_id, buffer) {
+        record_interactive_app_detection(state, terminal_id, "Codex");
+        return Some("Codex".to_string());
     }
-
-    // 3) Full-buffer Claude title scan (prong 2 of
-    //    `is_claude_terminal_from_buffer`): catches the case where the
-    //    "Claude Code" title appeared earlier but has since scrolled past the
-    //    live-title position. Also populates `known_claude_terminals` so
-    //    subsequent lookups stay O(1). Refreshes the grace window.
     if is_claude_terminal_from_buffer(state, terminal_id, buffer) {
         record_interactive_app_detection(state, terminal_id, "Claude");
         return Some("Claude".to_string());
     }
 
-    // 4) Codex spinner + buffer banner fallback. Same grace-window refresh.
-    if is_codex_spinner_title(title) && is_codex_terminal_from_buffer(state, terminal_id, buffer) {
-        record_interactive_app_detection(state, terminal_id, "Codex");
-        return Some("Codex".to_string());
-    }
-
-    // 5) Grace window fallback (issue #237). When every other signal returns
+    // 3) Grace window fallback (issue #237). When every other signal returns
     //    None — e.g. a Braille-only spinner frame before the buffer has
     //    accumulated the "Claude Code" banner, a path-like title during
     //    Claude's splash, or PowerShell rewriting the title on every
@@ -357,23 +357,16 @@ pub fn detect_terminal_state(
         return TerminalStateInfo { activity };
     }
 
-    if let Some(title) = osc::extract_last_terminal_title(&recent) {
-        if let Some(name) =
-            detect_interactive_app_from_live_title(state, terminal_id, &title, buffer)
-        {
-            return TerminalStateInfo {
-                activity: TerminalActivity::InteractiveApp { name },
-            };
-        }
-    } else if is_claude_terminal_from_buffer(state, terminal_id, buffer) {
-        // No OSC 0/2 title in the live window, but persistent tracking or
-        // a full-buffer scan still identifies this terminal as Claude.
-        // Without this branch, issue #239 leaks: cd propagation reaches a
-        // Claude target whose title has scrolled out of view.
+    // Run the same persistent-signal pipeline regardless of whether the
+    // recent window currently carries an OSC 0/2 title. Passing an empty
+    // string when no title is available lets the symmetric Codex/Claude
+    // recovery in `detect_interactive_app_from_live_title` cover both #239
+    // (Claude title scrolled out) and its Codex mirror — without it Codex
+    // panes were misclassified as Shell, leaking cd-sync into them.
+    let title = osc::extract_last_terminal_title(&recent).unwrap_or_default();
+    if let Some(name) = detect_interactive_app_from_live_title(state, terminal_id, &title, buffer) {
         return TerminalStateInfo {
-            activity: TerminalActivity::InteractiveApp {
-                name: "Claude".to_string(),
-            },
+            activity: TerminalActivity::InteractiveApp { name },
         };
     }
 
@@ -990,6 +983,72 @@ mod tests {
                 None,
             ),
             None,
+        );
+    }
+
+    // ── Cache symmetry between Claude and Codex (P2 / P1) ──
+
+    #[test]
+    fn claude_cache_cleared_when_codex_title_takes_over() {
+        // P2: a pane that previously ran Claude is reused for Codex. The
+        // direct OpenAI Codex title hit must remove the stale
+        // known_claude_terminals entry, otherwise a subsequent None-
+        // returning title (path-like, spinner, brief gap) would fall back
+        // through the Claude fast path and report Claude forever.
+        let state = AppState::new();
+        let tid = "t-claude-then-codex";
+
+        let mut buf_claude = TerminalOutputBuffer::default();
+        buf_claude.push(b"\x1b]0;Claude Code\x07");
+        assert_eq!(
+            detect_terminal_state(&state, tid, Some(&buf_claude)).activity,
+            TerminalActivity::InteractiveApp {
+                name: "Claude".to_string()
+            }
+        );
+        assert!(state.known_claude_terminals.lock().unwrap().contains(tid));
+
+        let mut buf_codex = TerminalOutputBuffer::default();
+        buf_codex.push(b"\x1b]0;OpenAI Codex\x07");
+        assert_eq!(
+            detect_terminal_state(&state, tid, Some(&buf_codex)).activity,
+            TerminalActivity::InteractiveApp {
+                name: "Codex".to_string()
+            }
+        );
+        assert!(
+            !state.known_claude_terminals.lock().unwrap().contains(tid),
+            "stale Claude cache must be cleared once Codex is confirmed"
+        );
+        assert!(state.known_codex_terminals.lock().unwrap().contains(tid));
+    }
+
+    #[test]
+    fn known_codex_preserved_when_title_scrolls_off_buffer() {
+        // P1: detect_terminal_state used to fall back only to
+        // is_claude_terminal_from_buffer when the recent window had no OSC
+        // title, so a Codex pane whose "OpenAI Codex" title had scrolled
+        // past was reclassified as Shell — letting cd-sync inject into the
+        // active Codex (the same class of bug as #239 but mirrored).
+        let state = AppState::new();
+        let tid = "t-codex-title-scrolled";
+
+        let mut explicit = TerminalOutputBuffer::default();
+        explicit.push(b"\x1b]0;OpenAI Codex\x07");
+        assert_eq!(
+            detect_terminal_state(&state, tid, Some(&explicit)).activity,
+            TerminalActivity::InteractiveApp {
+                name: "Codex".to_string()
+            }
+        );
+
+        let mut no_title = TerminalOutputBuffer::default();
+        no_title.push(b"plain output without an OSC title\r\n\x1b]133;D\x07");
+        assert_eq!(
+            detect_terminal_state(&state, tid, Some(&no_title)).activity,
+            TerminalActivity::InteractiveApp {
+                name: "Codex".to_string()
+            }
         );
     }
 

--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -7,6 +7,7 @@
 use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 
+use crate::claude_activity;
 use crate::constants::{ACTIVITY_SCAN_BYTES, INTERACTIVE_APP_GRACE_WINDOW};
 use crate::lock_ext::MutexExt;
 use crate::osc;
@@ -36,38 +37,79 @@ pub const INTERACTIVE_APP_PATTERNS: &[(&str, &str)] = &[
 ];
 
 /// Check if a terminal is running Claude Code.
-/// Uses two-pronged detection:
-/// 1. Persistent tracking (`known_claude_terminals`) — instant O(1) check
-/// 2. Full buffer title scan — checks ALL OSC 0/2 titles, not just the last one
+///
+/// **Cache is a hint, not a verdict.** The persistent tracker
+/// (`known_claude_terminals`) is consulted only as a tie-breaker for
+/// signals that are themselves ambiguous — never as a stand-alone
+/// authority. Without that constraint a pane that ever ran Claude
+/// stayed pinned as InteractiveApp{Claude} forever (PR 242 review P1 #1
+/// regression: cached IDs were treated as authoritative after every
+/// observable signal had vanished).
+///
+/// Returns `true` when:
+/// 1. Any OSC 0/2 title in the recent window literally contains
+///    "Claude Code" (strong signal — refreshes the cache), OR
+/// 2. The cache already has this ID AND the live OSC 0/2 title still
+///    looks like a Claude title (`claude_activity::is_claude_title` —
+///    star/Braille spinner, idle ✳, etc.). The live-title check is
+///    what disambiguates Claude's spinner from Codex's identical
+///    Braille range (#239 use case).
+///
+/// Otherwise returns `false` AND lazy-invalidates a stale cache entry,
+/// so subsequent calls converge to the correct classification even if
+/// the PTY exit path never fired (SIGKILL, callback dropped, OSC chunk
+/// boundary loss, etc.).
 pub fn is_claude_terminal_from_buffer(
     state: &AppState,
     terminal_id: &str,
     buffer: Option<&TerminalOutputBuffer>,
 ) -> bool {
-    // Prong 1: Check persistent tracking
-    if let Ok(known) = state.known_claude_terminals.lock_or_err() {
-        if known.contains(terminal_id) {
-            return true;
-        }
-    }
-
-    // Prong 2: Scan ALL titles in buffer for "Claude Code"
     let Some(buf) = buffer else {
         return false;
     };
     let recent = buf.recent_bytes(ACTIVITY_SCAN_BYTES);
     if recent.is_empty() {
+        // No live signal to corroborate; if the cache still has us,
+        // treat as stale — the grace window owns the early-startup
+        // window via `mark_claude_terminal` seeding.
+        if let Ok(mut known) = state.known_claude_terminals.lock_or_err() {
+            known.remove(terminal_id);
+        }
         return false;
     }
 
+    // Strong signal: literal "Claude Code" anywhere in the recent OSC
+    // 0/2 titles. Refresh the cache so subsequent disambiguations work.
     if osc::any_terminal_title_contains(&recent, "Claude Code") {
-        // Mark persistently for future calls
         if let Ok(mut known) = state.known_claude_terminals.lock_or_err() {
             known.insert(terminal_id.to_string());
         }
         return true;
     }
 
+    // Disambiguator: cache + live Claude-shaped title (idle ✳, star
+    // spinner, Braille spinner, task title like "✻ Exploring code"
+    // which `is_claude_title` recognizes via the spinner-prefix path).
+    let cache_hit = state
+        .known_claude_terminals
+        .lock_or_err()
+        .map(|known| known.contains(terminal_id))
+        .unwrap_or(false);
+    let live_title_is_claude = osc::extract_last_terminal_title(&recent)
+        .as_deref()
+        .map(claude_activity::is_claude_title)
+        .unwrap_or(false);
+
+    if cache_hit && live_title_is_claude {
+        return true;
+    }
+
+    // No live signal; drop the stale entry so the next call converges.
+    if cache_hit {
+        if let Ok(mut known) = state.known_claude_terminals.lock_or_err() {
+            known.remove(terminal_id);
+        }
+    }
     false
 }
 
@@ -177,33 +219,74 @@ fn recent_buffer_contains(recent: &[u8], needle: &str) -> bool {
     !needle.is_empty() && recent.windows(needle.len()).any(|window| window == needle)
 }
 
+/// Check if a terminal is running Codex (OpenAI Codex CLI).
+///
+/// Mirror of `is_claude_terminal_from_buffer` with the same cache-as-
+/// hint rule. The Braille spinner that Codex uses for its working
+/// frame overlaps with Claude's range, so the cache *is* required to
+/// disambiguate — but only in combination with a live spinner title,
+/// never as a stand-alone authority.
+///
+/// Returns `true` when:
+/// 1. Either an OSC 0/2 title or the buffer body in the recent window
+///    contains the literal "OpenAI Codex" banner (strong signal —
+///    refreshes the cache), OR
+/// 2. The cache already has this ID AND the live OSC 0/2 title is a
+///    Braille spinner frame (Codex's working state, #239 mirror).
+///
+/// Otherwise returns `false` AND lazy-invalidates the stale cache
+/// entry. Critical for P1 #1 (PR 242 review): without this, a pane
+/// that ever ran Codex stayed pinned as InteractiveApp{Codex} forever
+/// because the PTY exit path is not guaranteed to fire (no OSC 0/2
+/// emitted on process exit, callback dropped, etc.).
 pub fn is_codex_terminal_from_buffer(
     state: &AppState,
     terminal_id: &str,
     buffer: Option<&TerminalOutputBuffer>,
 ) -> bool {
-    if let Ok(known) = state.known_codex_terminals.lock_or_err() {
-        if known.contains(terminal_id) {
-            return true;
-        }
-    }
-
     let Some(buf) = buffer else {
         return false;
     };
     let recent = buf.recent_bytes(ACTIVITY_SCAN_BYTES);
     if recent.is_empty() {
+        if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
+            known.remove(terminal_id);
+        }
         return false;
     }
 
-    let detected = osc::any_terminal_title_contains(&recent, "OpenAI Codex")
+    let banner_in_buffer = osc::any_terminal_title_contains(&recent, "OpenAI Codex")
         || recent_buffer_contains(&recent, "OpenAI Codex");
-    if detected {
+    if banner_in_buffer {
         if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
             known.insert(terminal_id.to_string());
         }
+        return true;
     }
-    detected
+
+    let cache_hit = state
+        .known_codex_terminals
+        .lock_or_err()
+        .map(|known| known.contains(terminal_id))
+        .unwrap_or(false);
+    let live_title_is_braille_spinner = osc::extract_last_terminal_title(&recent)
+        .map(|t| {
+            t.chars()
+                .next()
+                .is_some_and(|c| ('\u{2800}'..='\u{28FF}').contains(&c))
+        })
+        .unwrap_or(false);
+
+    if cache_hit && live_title_is_braille_spinner {
+        return true;
+    }
+
+    if cache_hit {
+        if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
+            known.remove(terminal_id);
+        }
+    }
+    false
 }
 
 /// Sync the per-app `known_*_terminals` sets so they stay mutually exclusive.
@@ -240,7 +323,14 @@ pub fn sync_known_caches(state: &AppState, terminal_id: &str, app_name: &str) {
 /// `Instant::now()`. Used to seed the grace window (§14.4 / issue #237) so a
 /// subsequent title event that resolves to `None` can still report the
 /// previously known app for a short while.
-fn record_interactive_app_detection(state: &AppState, terminal_id: &str, app_name: &str) {
+///
+/// Also called externally by `mark_claude_terminal` so frontend command-text
+/// detection (OSC 133;E) keeps the pane classified as Claude until the first
+/// "Claude Code" title arrives to drive the steady-state pipeline. Without
+/// that seed, the strict-signal helpers below would reject a cache-only
+/// hit and the multi-second Claude startup window would misclassify the
+/// pane as Shell.
+pub fn record_interactive_app_detection(state: &AppState, terminal_id: &str, app_name: &str) {
     if let Ok(mut guard) = state.last_detected_interactive_app.lock_or_err() {
         guard.insert(
             terminal_id.to_string(),
@@ -1043,14 +1133,16 @@ mod tests {
     }
 
     #[test]
-    fn known_codex_preserved_when_title_scrolls_off_buffer() {
-        // P1: detect_terminal_state used to fall back only to
-        // is_claude_terminal_from_buffer when the recent window had no OSC
-        // title, so a Codex pane whose "OpenAI Codex" title had scrolled
-        // past was reclassified as Shell — letting cd-sync inject into the
-        // active Codex (the same class of bug as #239 but mirrored).
+    fn known_codex_preserved_via_live_spinner_when_banner_scrolled_off() {
+        // #239 mirror — fixed reading after the P1 #1 review.
+        // Codex is still working: its banner has rotated out of the
+        // ACTIVITY_SCAN_BYTES window, but the live OSC 0/2 title is a
+        // Braille spinner frame. The cache was populated when the banner
+        // was first observed, and the helper must keep the classification
+        // alive via (cache_hit + live spinner) — NOT via cache alone, so
+        // a pane with no live signal still falls back to Shell (P1 #1).
         let state = AppState::new();
-        let tid = "t-codex-title-scrolled";
+        let tid = "t-codex-spinner-only";
 
         let mut explicit = TerminalOutputBuffer::default();
         explicit.push(b"\x1b]0;OpenAI Codex\x07");
@@ -1061,13 +1153,89 @@ mod tests {
             }
         );
 
-        let mut no_title = TerminalOutputBuffer::default();
-        no_title.push(b"plain output without an OSC title\r\n\x1b]133;D\x07");
+        // Banner has scrolled off; live title is a Braille spinner — Codex's
+        // working frame. Cache + spinner must keep the classification.
+        let mut spinner = TerminalOutputBuffer::default();
+        spinner.push("\x1b]0;\u{280B} working\x07".as_bytes());
         assert_eq!(
-            detect_terminal_state(&state, tid, Some(&no_title)).activity,
+            detect_terminal_state(&state, tid, Some(&spinner)).activity,
             TerminalActivity::InteractiveApp {
                 name: "Codex".to_string()
             }
+        );
+    }
+
+    // ── P1 #1 stale-cache regressions (review follow-up) ──
+
+    #[test]
+    fn stale_codex_cache_yields_shell_without_live_signal() {
+        // P1 #1: a pane previously ran Codex so its ID sits in
+        // `known_codex_terminals`. The PTY exit path may not have fired
+        // (callback dropped, no OSC 0/2 emitted on exit, exit detected by
+        // a non-title channel, etc.), so the cache alone cannot be
+        // authoritative. Pre-fix the helper returned true on cache hit
+        // alone and pinned the pane as InteractiveApp{Codex} forever,
+        // blocking sync-cwd. Post-fix: no live signal -> Shell, AND the
+        // stale cache entry is dropped so subsequent calls don't recurse.
+        let state = AppState::new();
+        let tid = "t-codex-stale-no-signal";
+
+        state
+            .known_codex_terminals
+            .lock()
+            .unwrap()
+            .insert(tid.to_string());
+
+        let mut buf = TerminalOutputBuffer::default();
+        // No "OpenAI Codex" anywhere; latest title is a normal shell prompt
+        // (not a Braille spinner). No live Codex signal at all.
+        buf.push(b"\x1b]0;PS C:\\Users\\me\x07PS C:\\Users\\me> dir\r\n");
+
+        let activity = detect_terminal_state(&state, tid, Some(&buf)).activity;
+        assert!(
+            matches!(
+                activity,
+                TerminalActivity::Shell | TerminalActivity::Running
+            ),
+            "stale Codex cache without live signal must yield Shell, got {:?}",
+            activity
+        );
+        assert!(
+            !state.known_codex_terminals.lock().unwrap().contains(tid),
+            "lazy invalidation must drop the stale cache entry"
+        );
+    }
+
+    #[test]
+    fn stale_claude_cache_yields_shell_without_live_signal() {
+        // Mirror of stale_codex_cache_yields_shell. Claude has an exit
+        // path (cr.exited), but the same hazard exists if the title
+        // sequence never fires (SIGKILL, callback drop, PTY chunk
+        // boundary loss). Cache alone must not pin classification.
+        let state = AppState::new();
+        let tid = "t-claude-stale-no-signal";
+
+        state
+            .known_claude_terminals
+            .lock()
+            .unwrap()
+            .insert(tid.to_string());
+
+        let mut buf = TerminalOutputBuffer::default();
+        buf.push(b"\x1b]0;PS C:\\Users\\me\x07PS C:\\Users\\me> dir\r\n");
+
+        let activity = detect_terminal_state(&state, tid, Some(&buf)).activity;
+        assert!(
+            matches!(
+                activity,
+                TerminalActivity::Shell | TerminalActivity::Running
+            ),
+            "stale Claude cache without live signal must yield Shell, got {:?}",
+            activity
+        );
+        assert!(
+            !state.known_claude_terminals.lock().unwrap().contains(tid),
+            "lazy invalidation must drop the stale Claude cache entry"
         );
     }
 
@@ -1097,33 +1265,45 @@ mod tests {
     }
 
     #[test]
-    fn claude_wins_when_both_caches_contain_id() {
-        // Regression for the Codex→Claude pane-reuse window:
-        // a pane that previously ran Codex still has its ID in
-        // `known_codex_terminals` (Codex now has its own exit path that
-        // normally clears it, but the cache can transiently hold both
-        // entries when frontend command-text detection populates
-        // `known_claude_terminals` before the next OSC 0/2 title arrives
-        // to drive the Codex exit cleanup). In that window the persistent-
-        // signal layer must still report Claude — Codex-first ordering
-        // misclassified Claude sessions for spinner/path-like/empty titles.
+    fn command_detected_claude_wins_via_grace_window_when_codex_cache_stale() {
+        // P1 #2 (review follow-up): a pane that previously ran Codex
+        // still carries its stale entry in `known_codex_terminals`
+        // because the PTY exit path didn't fire. The frontend then
+        // detects `claude` from OSC 133;E and calls
+        // `mark_claude_terminal`, which:
+        //   (a) inserts into `known_claude_terminals`,
+        //   (b) `sync_known_caches` mutual-excludes the stale Codex,
+        //   (c) seeds the grace window so the brief startup gap (before
+        //       the first "Claude Code" title arrives) still classifies
+        //       as Claude.
+        // Pre-fix (cache-only fast-path with Codex first), the stale
+        // Codex cache hit and reported Codex even after `sync_known_caches`
+        // — because mark_claude_terminal called sync AFTER inserting
+        // into known_claude. Post-fix the strict-signal helpers reject
+        // both caches (no live banner, no live spinner) and the grace
+        // window seeded by mark_claude_terminal yields Claude.
         let state = AppState::new();
         let tid = "t-codex-then-claude";
 
+        // Stale Codex cache (PTY exit path didn't fire).
         state
             .known_codex_terminals
             .lock()
             .unwrap()
             .insert(tid.to_string());
+
+        // Simulate `mark_claude_terminal`: it inserts known_claude, syncs
+        // (clearing known_codex), and seeds the grace window.
         state
             .known_claude_terminals
             .lock()
             .unwrap()
             .insert(tid.to_string());
+        sync_known_caches(&state, tid, "Claude");
+        record_interactive_app_detection(&state, tid, "Claude");
 
-        // Buffer holds neither "OpenAI Codex" nor "Claude Code" — only a
-        // path-like title that no INTERACTIVE_APP_PATTERN can match
-        // (path-like titles short-circuit `detect_interactive_app_from_title`).
+        // Buffer carries no banner — Claude splash hasn't reached its
+        // "Claude Code" title yet, just a path-like prompt.
         let mut buf = TerminalOutputBuffer::default();
         buf.push(b"\x1b]0;~/projects/laymux\x07");
 
@@ -1132,7 +1312,11 @@ mod tests {
             TerminalActivity::InteractiveApp {
                 name: "Claude".to_string()
             },
-            "Claude must win the cache-collision window; Codex-first ordering is a regression"
+            "command-detected Claude must win via grace window; cache-only Codex hit is a regression"
+        );
+        assert!(
+            !state.known_codex_terminals.lock().unwrap().contains(tid),
+            "the strict-signal helper must lazy-invalidate the stale Codex cache during this lookup"
         );
     }
 
@@ -1166,21 +1350,58 @@ mod tests {
     }
 
     #[test]
-    fn claude_removed_from_known_returns_false() {
+    fn claude_helper_is_false_without_a_live_signal() {
+        // After the P1 #1 review the cache is no longer authoritative on
+        // its own. Buffer=None means the helper has no live signal to
+        // corroborate against, so it returns false even when the cache
+        // contains the ID. The grace window owns early-startup retention
+        // (see `mark_claude_terminal`), not the helper.
+        //
+        // Note: buffer=None is the "caller could not fetch a buffer"
+        // case — the helper conservatively returns false but does NOT
+        // touch the cache (no observable signal to invalidate against).
+        // Lazy invalidation is reserved for the buffer-present-but-no-
+        // live-signal case, where the absence of a Claude title in the
+        // recent window IS evidence.
         let state = AppState::new();
         let tid = "terminal-test";
 
-        // Insert into known_claude_terminals
         state
             .known_claude_terminals
             .lock()
             .unwrap()
             .insert(tid.to_string());
-        assert!(is_claude_terminal_from_buffer(&state, tid, None));
-
-        // Remove (simulates Claude exit detection)
-        state.known_claude_terminals.lock().unwrap().remove(tid);
         assert!(!is_claude_terminal_from_buffer(&state, tid, None));
+        assert!(
+            state.known_claude_terminals.lock().unwrap().contains(tid),
+            "buffer=None must not lazy-invalidate the cache"
+        );
+
+        // With a live "Claude Code" title in the buffer the helper does
+        // return true and refreshes the cache.
+        let mut claude_buf = TerminalOutputBuffer::default();
+        claude_buf.push(b"\x1b]0;Claude Code\x07");
+        assert!(is_claude_terminal_from_buffer(
+            &state,
+            tid,
+            Some(&claude_buf)
+        ));
+        assert!(state.known_claude_terminals.lock().unwrap().contains(tid));
+
+        // A buffer carrying a normal shell title (no Claude signal at
+        // all) IS evidence of absence — lazy-invalidate so the next
+        // call converges to false.
+        let mut shell_buf = TerminalOutputBuffer::default();
+        shell_buf.push(b"\x1b]0;PS C:\\Users\\me\x07$ ");
+        assert!(!is_claude_terminal_from_buffer(
+            &state,
+            tid,
+            Some(&shell_buf)
+        ));
+        assert!(
+            !state.known_claude_terminals.lock().unwrap().contains(tid),
+            "absence of a Claude signal in a live buffer must drop the stale cache"
+        );
     }
 
     // ── BurstDetector tests ──

--- a/src-tauri/src/codex_activity.rs
+++ b/src-tauri/src/codex_activity.rs
@@ -1,0 +1,173 @@
+//! Codex (OpenAI Codex CLI) terminal activity detection.
+//!
+//! Mirror of `claude_activity` for Codex sessions, intentionally simpler:
+//! Codex does not expose a working/idle distinction in its title (it cycles
+//! a Braille spinner during work and reverts to "OpenAI Codex" at idle), so
+//! the state machine only tracks entry and exit.
+//!
+//! Like `claude_activity`, this module has no side effects — it analyzes
+//! title strings and returns structured results. The PTY callback owns
+//! `known_codex_terminals` mutation, grace-window cleanup, and event
+//! emission based on what `process_codex_title` reports.
+
+/// Returns `true` when `title` looks like a Codex session title:
+/// either the literal "OpenAI Codex" banner or a Braille spinner frame
+/// (U+2800..U+28FF) which Codex emits during work.
+///
+/// Notes
+/// - Braille spinners are *not* exclusive to Codex (Claude Code uses the
+///   same range). Entry detection therefore requires the literal
+///   "OpenAI Codex" — see `process_codex_title`. The spinner-tolerant
+///   `is_codex_title` is only used to decide *exit*: a Braille frame
+///   right after a confirmed Codex session means we're still inside
+///   Codex, not in a shell.
+/// - We do not strip the spinner first: Codex prefixes the spinner with
+///   a Braille char and the rest is short status text, never the
+///   "OpenAI Codex" literal — so a substring check on the raw title is
+///   sufficient and avoids surprising matches against unrelated apps
+///   that happen to start with a Braille char.
+pub fn is_codex_title(title: &str) -> bool {
+    if title.contains("OpenAI Codex") {
+        return true;
+    }
+    title
+        .chars()
+        .next()
+        .is_some_and(|c| ('\u{2800}'..='\u{28FF}').contains(&c))
+}
+
+/// Result of processing an OSC 0/2 title change against Codex state.
+#[derive(Debug, Default, PartialEq)]
+pub struct CodexTitleResult {
+    /// Codex was just detected (first "OpenAI Codex" title since the
+    /// session was last unknown). Used to populate
+    /// `known_codex_terminals` and emit the detection event.
+    pub entered: bool,
+    /// Codex just exited (was previously detected, current title is
+    /// neither "OpenAI Codex" nor a Braille spinner frame). Used to
+    /// remove the ID from `known_codex_terminals` and clear the grace
+    /// window so the shell fallback engages immediately.
+    pub exited: bool,
+}
+
+/// Process an OSC 0/2 title change for Codex state tracking.
+///
+/// `was_detected` is the persistent flag the caller maintains
+/// (`PtyCallbackState::codex_detected` || `known_codex_terminals` lookup).
+/// The contract mirrors `process_claude_title`:
+///
+/// - `entered` fires only when the title literally contains
+///   "OpenAI Codex" — Braille spinners alone are too ambiguous (the same
+///   range is used by Claude Code, fzf, etc.) to seed a fresh detection.
+/// - `exited` fires when the previous state was detected but the new
+///   title belongs to neither "OpenAI Codex" nor any Braille frame, i.e.
+///   we have observably returned to a shell (or other) prompt.
+pub fn process_codex_title(title: &str, was_detected: bool) -> CodexTitleResult {
+    let mut result = CodexTitleResult::default();
+
+    if !was_detected && title.contains("OpenAI Codex") {
+        result.entered = true;
+        return result;
+    }
+
+    if was_detected && !is_codex_title(title) {
+        result.exited = true;
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── is_codex_title ──
+
+    #[test]
+    fn codex_title_literal_banner() {
+        assert!(is_codex_title("OpenAI Codex"));
+        assert!(is_codex_title("OpenAI Codex - some-project"));
+    }
+
+    #[test]
+    fn codex_title_braille_spinner_frames() {
+        assert!(is_codex_title("\u{2800} working"));
+        assert!(is_codex_title("\u{2802} thinking"));
+        assert!(is_codex_title("\u{280B}"));
+        assert!(is_codex_title("\u{28FF}"));
+    }
+
+    #[test]
+    fn codex_title_rejects_shell_prompts_and_paths() {
+        assert!(!is_codex_title("bash"));
+        assert!(!is_codex_title("PS C:\\Users\\me"));
+        assert!(!is_codex_title("~/projects/laymux"));
+        assert!(!is_codex_title(""));
+    }
+
+    // ── process_codex_title — entry ──
+
+    #[test]
+    fn process_entry_on_first_codex_title() {
+        let r = process_codex_title("OpenAI Codex", false);
+        assert!(r.entered);
+        assert!(!r.exited);
+    }
+
+    #[test]
+    fn process_no_entry_when_already_detected() {
+        let r = process_codex_title("OpenAI Codex", true);
+        assert!(!r.entered);
+        assert!(!r.exited);
+    }
+
+    #[test]
+    fn process_no_entry_on_braille_only_title() {
+        // Braille frames are too ambiguous to seed detection — Claude
+        // Code uses the same range. Caller must observe a literal
+        // "OpenAI Codex" first.
+        let r = process_codex_title("\u{2802} working", false);
+        assert!(!r.entered);
+        assert!(!r.exited);
+    }
+
+    // ── process_codex_title — exit (regression for P1 #1) ──
+
+    #[test]
+    fn process_exit_on_shell_prompt_after_codex() {
+        // Without this transition there is no path that removes a Codex
+        // ID from `known_codex_terminals`. The cache then pins the pane
+        // as InteractiveApp{Codex} indefinitely, blocking sync-cwd —
+        // mirror of the `cr.exited` regression noted on PR 242.
+        let r = process_codex_title("PS C:\\Users\\me", true);
+        assert!(!r.entered);
+        assert!(r.exited);
+    }
+
+    #[test]
+    fn process_exit_on_path_like_title_after_codex() {
+        let r = process_codex_title("~/projects/laymux", true);
+        assert!(r.exited);
+    }
+
+    #[test]
+    fn process_exit_on_empty_title_after_codex() {
+        let r = process_codex_title("", true);
+        assert!(r.exited);
+    }
+
+    #[test]
+    fn process_no_exit_on_braille_frame_during_codex() {
+        // Codex's spinner replaces the literal banner mid-session. That
+        // is not an exit — the session is still alive.
+        let r = process_codex_title("\u{2802} working", true);
+        assert!(!r.entered);
+        assert!(!r.exited);
+    }
+
+    #[test]
+    fn process_no_exit_when_banner_persists() {
+        let r = process_codex_title("OpenAI Codex", true);
+        assert!(!r.exited);
+    }
+}

--- a/src-tauri/src/commands/ipc_dispatch.rs
+++ b/src-tauri/src/commands/ipc_dispatch.rs
@@ -2657,17 +2657,29 @@ mod tests {
 
     #[test]
     fn filter_targets_not_busy_skips_claude_when_activity_is_claude_but_title_absent() {
-        // Claude Code was detected earlier (persistent tracking), but the last
-        // buffer window only contains a path-like title and a stale OSC 133;D
-        // from before Claude started. `is_terminal_at_prompt_from_buffer` would
-        // naively report "at prompt", but the activity pipeline correctly
-        // reports `InteractiveApp { name: "Claude" }`.
+        // Claude Code was detected earlier (persistent tracking + grace
+        // window seeded by either the PTY callback's cr.entered or by
+        // `mark_claude_terminal` from frontend command-text detection),
+        // but the last buffer window only contains a path-like title and
+        // a stale OSC 133;D from before Claude started.
+        // `is_terminal_at_prompt_from_buffer` would naively report
+        // "at prompt", but the activity pipeline must keep the target
+        // classified as `InteractiveApp { name: "Claude" }` so cd-sync
+        // does not inject into Claude's input.
+        //
+        // Post-PR-242-review: the cache is a hint, not a verdict. The
+        // strict-signal helper rejects a path-like title as non-Claude
+        // (cache + path-like is not enough), so the grace-window seed
+        // is what carries the classification through this gap.
         let state = AppState::new();
         state
             .known_claude_terminals
             .lock()
             .unwrap()
             .insert("t-claude".to_string());
+        // Grace-window seed — what `mark_claude_terminal` and the PTY
+        // entry path do in production.
+        crate::activity::record_interactive_app_detection(&state, "t-claude", "Claude");
         {
             let mut buffers = state.output_buffers.lock().unwrap();
             let mut buf = crate::output_buffer::TerminalOutputBuffer::default();

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -7,6 +7,7 @@ use tauri::{AppHandle, Emitter, State};
 use crate::activity;
 use crate::claude_activity;
 use crate::claude_bullet;
+use crate::codex_activity;
 use crate::constants::*;
 use crate::lock_ext::MutexExt;
 use crate::osc;
@@ -426,6 +427,47 @@ pub fn create_terminal_session(
                 }
             }
 
+            // ── Codex (OpenAI Codex CLI) title state machine ──
+            // Mirror of the Claude block above but simpler: no working/idle
+            // tracking, only entry + exit. Without this branch Codex sessions
+            // had no way to clear `known_codex_terminals` once they ended,
+            // so a pane that previously ran Codex stayed pinned as
+            // InteractiveApp{Codex} forever (PR 242 follow-up).
+            //
+            // Lock note: `sync_known_caches` and `known_codex_terminals.lock`
+            // each acquire and release the relevant mutex independently —
+            // no overlap with the Claude-block locks above.
+            if event.code == 0 || event.code == 2 {
+                let was_detected = pty_cb_state.codex_detected.load(Ordering::Relaxed)
+                    || state_for_pty
+                        .known_codex_terminals
+                        .lock_or_err()
+                        .map(|known| known.contains(&terminal_id))
+                        .unwrap_or(false);
+
+                let cr_codex = codex_activity::process_codex_title(&event.data, was_detected);
+
+                if cr_codex.entered {
+                    pty_cb_state.codex_detected.store(true, Ordering::Relaxed);
+                    // Mutually-exclusive: also clears any stale Claude
+                    // membership left over from a previous session in this
+                    // pane (and inserts into known_codex_terminals).
+                    activity::sync_known_caches(&state_for_pty, &terminal_id, "Codex");
+                }
+
+                if cr_codex.exited {
+                    pty_cb_state.codex_detected.store(false, Ordering::Relaxed);
+                    if let Ok(mut known) = state_for_pty.known_codex_terminals.lock_or_err() {
+                        known.remove(&terminal_id);
+                    }
+                    // Drop the grace-window entry so the shell fallback
+                    // engages immediately instead of pinning "Codex" for
+                    // up to `INTERACTIVE_APP_GRACE_WINDOW` after exit
+                    // (#237 mirror for Codex).
+                    activity::clear_interactive_app_grace_window(&state_for_pty, &terminal_id);
+                }
+            }
+
             // Emit structured title change event (OSC 0/2) for frontend activity detection.
             //
             // `detect_interactive_app_from_live_title` already walks every
@@ -770,10 +812,21 @@ pub fn log_terminal_trace_batch(
 /// Called by the frontend when it detects Claude from command text (OSC 133 E).
 /// The PTY callback also populates this from title detection, but the frontend
 /// may detect earlier via command text (e.g., user typed "claude").
+///
+/// Mutual exclusion: also clears any stale `known_codex_terminals` entry
+/// for this ID via `sync_known_caches`. Without that, a pane that
+/// previously ran Codex would have both caches populated until the next
+/// OSC 0/2 title drove the Codex exit path, and Codex-first ordering
+/// (or any future cache-collision codepath) would misclassify the new
+/// Claude session for spinner/path-like/empty titles.
 #[tauri::command]
 pub fn mark_claude_terminal(id: String, state: State<Arc<AppState>>) -> Result<bool, String> {
-    let mut known = state.known_claude_terminals.lock_or_err()?;
-    Ok(known.insert(id))
+    let inserted = {
+        let mut known = state.known_claude_terminals.lock_or_err()?;
+        known.insert(id.clone())
+    };
+    activity::sync_known_caches(&state, &id, "Claude");
+    Ok(inserted)
 }
 
 /// Check if a terminal is registered as running Claude Code.

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -813,12 +813,19 @@ pub fn log_terminal_trace_batch(
 /// The PTY callback also populates this from title detection, but the frontend
 /// may detect earlier via command text (e.g., user typed "claude").
 ///
-/// Mutual exclusion: also clears any stale `known_codex_terminals` entry
-/// for this ID via `sync_known_caches`. Without that, a pane that
-/// previously ran Codex would have both caches populated until the next
-/// OSC 0/2 title drove the Codex exit path, and Codex-first ordering
-/// (or any future cache-collision codepath) would misclassify the new
-/// Claude session for spinner/path-like/empty titles.
+/// Three-step seeding so the strict-signal helpers (which reject cache-
+/// only hits — see `is_claude_terminal_from_buffer` doc) still classify
+/// the pane correctly during the multi-second Claude startup window
+/// before the first "Claude Code" title arrives:
+///
+/// 1. Insert into `known_claude_terminals` (consumed by the cache + live
+///    Claude-title disambiguator once spinner frames start).
+/// 2. `sync_known_caches` mutual-excludes any stale `known_codex_terminals`
+///    entry left over from a previous Codex session in this pane (PTY
+///    Codex exit path may not have fired).
+/// 3. Seed the grace window so the helpers' "no live signal" verdict
+///    falls through to step 3 of `detect_interactive_app_from_live_title`,
+///    which still reports Claude until the window expires.
 #[tauri::command]
 pub fn mark_claude_terminal(id: String, state: State<Arc<AppState>>) -> Result<bool, String> {
     let inserted = {
@@ -826,6 +833,7 @@ pub fn mark_claude_terminal(id: String, state: State<Arc<AppState>>) -> Result<b
         known.insert(id.clone())
     };
     activity::sync_known_caches(&state, &id, "Claude");
+    activity::record_interactive_app_detection(&state, &id, "Claude");
     Ok(inserted)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod claude_activity;
 pub mod claude_bullet;
 pub mod cli;
 pub mod clipboard;
+pub mod codex_activity;
 pub mod commands;
 pub mod constants;
 pub mod crash_reporter;


### PR DESCRIPTION
## Summary
리뷰에서 지적된 두 가지 비대칭 버그를 수정한다.

### P2 — Claude→Codex 전환 시 stale 캐시 잔존
`detect_interactive_app_from_live_title` 의 step 1(direct title match)에서 Codex/Claude를 확정할 때 반대편 `known_*` 캐시를 비우는 `sync_known_caches` 헬퍼를 도입했다. 이전에는 `known_claude_terminals` 가 세션 종료까지 남아있어, 같은 pane이 Codex로 재사용돼도 Claude fast-path에 먼저 걸려 Codex spinner/제목 없는 업데이트가 모두 Claude로 잘못 보고됐다.

### P1 — OSC title이 버퍼에서 사라진 Codex pane이 Shell로 재분류
`detect_terminal_state` 의 title 유무 분기에서 Codex 복구 경로가 누락돼 sync-cwd가 활성 Codex pane에 cd를 주입할 위험이 있었다. step 2~3을 `is_codex_terminal_from_buffer` / `is_claude_terminal_from_buffer` 양쪽으로 대칭화하고, title이 없을 땐 빈 문자열을 넘겨 동일 pipeline을 재사용한다.

### 부수 정리
- `is_codex_spinner_title` 는 새 pipeline에서 사용처가 없어 제거
- step 1에서 직접 `known_*` 에 insert 하던 분기 로직을 `sync_known_caches` 로 통합

## 회귀 방지 테스트
- `claude_cache_cleared_when_codex_title_takes_over` (P2): 같은 terminal이 Claude → Codex 로 넘어갈 때 stale Claude 캐시가 제거되는지 검증
- `known_codex_preserved_when_title_scrolls_off_buffer` (P1): \"OpenAI Codex\" title이 recent window 에서 사라져도 `known_codex_terminals` 만으로 Codex 분류가 유지되는지 검증

## Test plan
- [x] `cargo test --lib activity` — 99/99 통과 (신규 P2/P1 테스트 포함)
- [x] `cargo test --lib` — 722/722 통과
- [x] `cargo build --lib` — 새 경고 없음
- [x] `cargo fmt --check` 통과
- [ ] 사용자 환경에서 Claude → Codex 전환 후 cd 주입이 차단되는지 실사용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)