### PR TITLE
fix(terminal): TUI 종료 시 인접 pane WebGL atlas 깨짐 복구

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -6,6 +6,7 @@ import { useTerminalStore } from "@/stores/terminal-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useOverridesStore } from "@/stores/overrides-store";
 import { CODEX_INPUT_PENDING_MARKER } from "@/lib/activity-detection";
+import { publishRendererRefresh, _resetRendererBus } from "@/lib/terminal-renderer-bus";
 
 // Mock xterm since it requires a real DOM with canvas
 const mockOnData = vi.fn();
@@ -143,11 +144,15 @@ vi.mock("@/lib/indented-link-provider", () => ({
 }));
 
 vi.mock("@xterm/addon-webgl", () => {
-  const WebglAddon = vi.fn().mockImplementation(() => ({
-    dispose: vi.fn(),
-    onContextLoss: vi.fn(),
-  }));
-  return { WebglAddon: WebglAddon };
+  // Use a regular function so `new WebglAddon(...)` works as a constructor
+  // call. Arrow functions can't be invoked with `new`, which previously made
+  // every WebGL init silently fail in tests.
+  const WebglAddon = vi.fn(function (this: Record<string, unknown>) {
+    this.dispose = vi.fn();
+    this.onContextLoss = vi.fn();
+    this.clearTextureAtlas = vi.fn();
+  });
+  return { WebglAddon };
 });
 
 const mockSerialize = vi.fn().mockReturnValue("serialized-data");
@@ -2414,5 +2419,136 @@ describe("TerminalView", () => {
 describe("shouldEnableTerminalWebgl", () => {
   it("keeps WebGL enabled", () => {
     expect(shouldEnableTerminalWebgl()).toBe(true);
+  });
+});
+
+describe("renderer refresh bus", () => {
+  beforeEach(() => {
+    useTerminalStore.setState(useTerminalStore.getInitialState());
+    useSettingsStore.setState(useSettingsStore.getInitialState());
+    _resetWebglStagger();
+    _resetRendererBus();
+    vi.clearAllMocks();
+  });
+
+  type WebglMockInstance = {
+    onContextLoss: ReturnType<typeof vi.fn>;
+    clearTextureAtlas: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+  };
+  const getWebglInstance = (idx: number): WebglMockInstance =>
+    (
+      WebglAddon as unknown as {
+        mock: { results: Array<{ value: WebglMockInstance }> };
+      }
+    ).mock.results[idx].value;
+
+  async function flushTimers() {
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+  }
+
+  it("refreshes a peer terminal when another instance leaves an interactiveApp activity", async () => {
+    vi.useFakeTimers();
+
+    render(<TerminalView instanceId="t-peer-A" profile="PowerShell" syncGroup="g" />);
+    render(<TerminalView instanceId="t-peer-B" profile="PowerShell" syncGroup="g" />);
+
+    await flushTimers();
+    expect(WebglAddon).toHaveBeenCalledTimes(2);
+
+    const refreshCallsBefore = mockRefresh.mock.calls.length;
+
+    await act(async () => {
+      useTerminalStore.getState().updateInstanceInfo("t-peer-A", {
+        activity: { type: "interactiveApp", name: "Codex" },
+      });
+    });
+    await act(async () => {
+      useTerminalStore.getState().updateInstanceInfo("t-peer-A", {
+        activity: { type: "shell" },
+      });
+    });
+
+    // Peer B's xterm refresh should be called at least once after the
+    // interactiveApp → shell transition on peer A.
+    expect(mockRefresh.mock.calls.length).toBeGreaterThan(refreshCallsBefore);
+
+    vi.useRealTimers();
+  });
+
+  it("clears the atlas for peer signals but skips self-signals", async () => {
+    vi.useFakeTimers();
+
+    render(<TerminalView instanceId="t-self" profile="PowerShell" syncGroup="g" />);
+    await flushTimers();
+
+    const atlasCallsBefore = mockClearTextureAtlas.mock.calls.length;
+
+    // Self-signal: instanceId match → must NOT clear our atlas.
+    await act(async () => {
+      publishRendererRefresh({ reason: "peer-tui-exit", sourceId: "t-self" });
+    });
+    expect(mockClearTextureAtlas.mock.calls.length).toBe(atlasCallsBefore);
+
+    // Peer signal: different sourceId → must clear our atlas.
+    await act(async () => {
+      publishRendererRefresh({ reason: "peer-tui-exit", sourceId: "t-other" });
+    });
+    expect(mockClearTextureAtlas.mock.calls.length).toBeGreaterThan(atlasCallsBefore);
+
+    vi.useRealTimers();
+  });
+
+  it("recreates the WebglAddon after a context loss", async () => {
+    vi.useFakeTimers();
+
+    render(<TerminalView instanceId="t-ctxloss" profile="PowerShell" syncGroup="g" />);
+    await flushTimers();
+
+    expect(WebglAddon).toHaveBeenCalledTimes(1);
+    const firstInstance = getWebglInstance(0);
+    const lossCb = firstInstance.onContextLoss.mock.calls[0]?.[0] as (() => void) | undefined;
+    expect(typeof lossCb).toBe("function");
+
+    await act(async () => {
+      lossCb!();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // Stagger delay elapsed — addon should have been recreated.
+    expect(WebglAddon).toHaveBeenCalledTimes(2);
+    expect(firstInstance.dispose).toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("notifies peers on unmount so they can rebuild stale atlases", async () => {
+    vi.useFakeTimers();
+
+    const { unmount: unmountA } = render(
+      <TerminalView instanceId="t-um-A" profile="PowerShell" syncGroup="g" />,
+    );
+    render(<TerminalView instanceId="t-um-B" profile="PowerShell" syncGroup="g" />);
+    await flushTimers();
+
+    const refreshCallsBefore = mockRefresh.mock.calls.length;
+
+    unmountA();
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+
+    // Peer B should have received the unmount-driven refresh signal and
+    // called terminal.refresh on its xterm instance.
+    expect(mockRefresh.mock.calls.length).toBeGreaterThan(refreshCallsBefore);
+
+    vi.useRealTimers();
   });
 });

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -5,6 +5,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { createIndentedLinkProvider } from "@/lib/indented-link-provider";
 import { WebglAddon } from "@xterm/addon-webgl";
+import { publishRendererRefresh, subscribeRendererRefresh } from "@/lib/terminal-renderer-bus";
 import { useTerminalStore, type TerminalActivityInfo } from "@/stores/terminal-store";
 import { useSettingsStore, defaultProfileDefaults } from "@/stores/settings-store";
 import { useOverridesStore } from "@/stores/overrides-store";
@@ -256,6 +257,10 @@ export function TerminalView({
   const compositionPreviewRefEl = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  // Live WebglAddon. Tracked so we can rebuild it on context loss and force
+  // an atlas refresh from the renderer-refresh bus when a peer terminal
+  // exits a TUI app (Codex etc.) and risks leaving our atlas stale.
+  const webglAddonRef = useRef<WebglAddon | null>(null);
   const terminalReflowFrameRef = useRef<number | null>(null);
   const overlayCaretUpdaterRef = useRef<(() => void) | null>(null);
   const openedRef = useRef(false);
@@ -1315,6 +1320,40 @@ export function TerminalView({
     // cell size / DPR stay cached and render completely garbled (issue #232).
     let prevWasHidden = false;
     let webglTimer: ReturnType<typeof setTimeout> | undefined;
+    // Build a fresh WebglAddon, attach it to `terminal`, and wire up
+    // context-loss recovery. Returns the addon (or null on failure) and is
+    // shared between first init and post-context-loss recreate so the two
+    // paths stay in sync. The previous code only disposed on context loss
+    // and never recreated, leaving the terminal silently unrendered.
+    const createAndAttachWebgl = (): WebglAddon | null => {
+      if (cancelled) return null;
+      try {
+        const webgl = new WebglAddon(true); // preserveDrawingBuffer for screenshots
+        terminal.loadAddon(webgl);
+        webgl.onContextLoss(() => {
+          // Dispose the dead context, then ask peers to refresh their atlas
+          // (they share the WebView2 GPU process and may have collateral
+          // damage), and finally try to bring our renderer back on the next
+          // stagger tick.
+          try {
+            webgl.dispose();
+          } catch {
+            /* already torn down */
+          }
+          if (webglAddonRef.current === webgl) webglAddonRef.current = null;
+          publishRendererRefresh({ reason: "peer-context-loss", sourceId: instanceId });
+          if (cancelled) return;
+          if (webglTimer !== undefined) clearTimeout(webglTimer);
+          webglTimer = setTimeout(() => {
+            webglAddonRef.current = createAndAttachWebgl();
+          }, WEBGL_STAGGER_MS);
+        });
+        return webgl;
+      } catch (err) {
+        console.warn("[TerminalView] WebGL init failed, falling back:", err);
+        return null;
+      }
+    };
     const resizeObserver = new ResizeObserver((entries) => {
       const { width, height } = entries[0].contentRect;
       const isNowHidden = width === 0 || height === 0;
@@ -1332,14 +1371,7 @@ export function TerminalView({
           const delay = webglInitCount * WEBGL_STAGGER_MS;
           webglInitCount++;
           webglTimer = setTimeout(() => {
-            if (cancelled) return;
-            try {
-              const webgl = new WebglAddon(true); // preserveDrawingBuffer for screenshots
-              terminal.loadAddon(webgl);
-              webgl.onContextLoss(() => webgl.dispose());
-            } catch {
-              // WebGL not available — fall back to default renderer
-            }
+            webglAddonRef.current = createAndAttachWebgl();
           }, delay);
         }
         // Load SerializeAddon for session persistence
@@ -1444,6 +1476,21 @@ export function TerminalView({
     return () => {
       cancelled = true;
       if (webglTimer !== undefined) clearTimeout(webglTimer);
+      // Tear the WebGL renderer down explicitly before terminal.dispose() so
+      // any GPU resources are released in a known order. terminal.dispose()
+      // would otherwise dispose the addon while we still hold a ref; the
+      // explicit dispose also lets a sibling pane's atlas refresh listener
+      // pick up `peer-tui-exit` even if that listener races terminal teardown.
+      try {
+        webglAddonRef.current?.dispose();
+      } catch {
+        /* already torn down */
+      }
+      webglAddonRef.current = null;
+      // Tell every peer that this pane is going away. A pane teardown can
+      // ripple GPU-process state (texture pages freed, context destroyed)
+      // and corrupt sibling atlases the same way a Codex exit does.
+      publishRendererRefresh({ reason: "peer-tui-exit", sourceId: instanceId });
       if (terminalReflowFrameRef.current !== null) {
         cancelAnimationFrame(terminalReflowFrameRef.current);
         terminalReflowFrameRef.current = null;
@@ -1515,6 +1562,34 @@ export function TerminalView({
     }
   }, [isFocused]);
 
+  // Listen for peer renderer-refresh signals — when another pane in the
+  // window exits a TUI app or loses its WebGL context, our atlas may have
+  // been left in a corrupt state by the shared WebView2 GPU process. Drop
+  // the atlas and force a full redraw to recover. clearTextureAtlas is a
+  // no-op when WebGL is off; refresh is safe in any renderer.
+  useEffect(() => {
+    return subscribeRendererRefresh((signal) => {
+      if (signal.sourceId === instanceId) return;
+      const t = terminalRef.current;
+      if (!t) return;
+      try {
+        webglAddonRef.current?.clearTextureAtlas();
+      } catch {
+        /* atlas missing — fall through to terminal-level path */
+      }
+      try {
+        (t as unknown as { clearTextureAtlas?: () => void }).clearTextureAtlas?.();
+      } catch {
+        /* older xterm builds / mocks may lack this method */
+      }
+      try {
+        t.refresh(0, t.rows - 1);
+      } catch {
+        /* terminal already torn down */
+      }
+    });
+  }, [instanceId]);
+
   // Reactively update terminal theme when profile colorScheme or font changes
   const currentSchemeName = useSettingsStore((s) => {
     const prof = s.profiles?.find((p) => p.name === profile);
@@ -1546,6 +1621,20 @@ export function TerminalView({
       );
     }
     prevActivityIsTuiRef.current = isTui;
+  }
+  // Tracks any interactiveApp transition (Codex, vim, neovim, …) so we can
+  // notify peer terminals that a TUI process exited. The exit flushes
+  // alt-screen restore + scrollback redraw + cursor reset in a tight burst,
+  // which can corrupt sibling WebGL atlases sharing the WebView2 GPU
+  // process. Peers respond by clearing their atlas — see the subscribe
+  // hook below.
+  const prevActivityIsInteractiveRef = useRef<boolean>(false);
+  {
+    const isInteractive = activity?.type === "interactiveApp";
+    if (prevActivityIsInteractiveRef.current && !isInteractive) {
+      publishRendererRefresh({ reason: "peer-tui-exit", sourceId: instanceId });
+    }
+    prevActivityIsInteractiveRef.current = isInteractive;
   }
   activityRef.current = activity;
   const cursorShape = useSettingsStore((s) => {

--- a/ui/src/hooks/useContainerSize.test.ts
+++ b/ui/src/hooks/useContainerSize.test.ts
@@ -9,6 +9,7 @@ describe("useContainerSize", () => {
   let OriginalResizeObserver: typeof ResizeObserver;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     mockObserve = vi.fn();
     mockDisconnect = vi.fn();
     OriginalResizeObserver = globalThis.ResizeObserver;
@@ -24,7 +25,23 @@ describe("useContainerSize", () => {
 
   afterEach(() => {
     globalThis.ResizeObserver = OriginalResizeObserver;
+    vi.useRealTimers();
   });
+
+  function fire(width: number, height: number) {
+    act(() => {
+      observerCallback(
+        [{ contentRect: { width, height } } as unknown as ResizeObserverEntry],
+        {} as ResizeObserver,
+      );
+    });
+  }
+
+  function flushFrames() {
+    act(() => {
+      vi.runAllTimers();
+    });
+  }
 
   it("returns initial size {w:0, h:0}", () => {
     const ref = { current: document.createElement("div") };
@@ -39,18 +56,50 @@ describe("useContainerSize", () => {
     expect(mockObserve).toHaveBeenCalledWith(el);
   });
 
-  it("updates size when ResizeObserver fires", () => {
+  it("updates size on the next animation frame", () => {
     const ref = { current: document.createElement("div") };
     const { result } = renderHook(() => useContainerSize(ref));
 
-    act(() => {
-      observerCallback(
-        [{ contentRect: { width: 800, height: 600 } } as unknown as ResizeObserverEntry],
-        {} as ResizeObserver,
-      );
-    });
+    fire(800, 600);
+    flushFrames();
 
     expect(result.current).toEqual({ w: 800, h: 600 });
+  });
+
+  it("rounds fractional dimensions to integers", () => {
+    const ref = { current: document.createElement("div") };
+    const { result } = renderHook(() => useContainerSize(ref));
+
+    fire(800.6, 599.4);
+    flushFrames();
+
+    expect(result.current).toEqual({ w: 801, h: 599 });
+  });
+
+  it("coalesces multiple resizes inside the same frame", () => {
+    const ref = { current: document.createElement("div") };
+    const { result } = renderHook(() => useContainerSize(ref));
+
+    fire(700, 500);
+    fire(720, 520);
+    fire(800, 600);
+    flushFrames();
+
+    expect(result.current).toEqual({ w: 800, h: 600 });
+  });
+
+  it("returns a stable reference when the rounded size is unchanged", () => {
+    const ref = { current: document.createElement("div") };
+    const { result } = renderHook(() => useContainerSize(ref));
+
+    fire(800, 600);
+    flushFrames();
+    const first = result.current;
+
+    fire(800.2, 600.3);
+    flushFrames();
+
+    expect(result.current).toBe(first);
   });
 
   it("disconnects on unmount", () => {

--- a/ui/src/hooks/useContainerSize.ts
+++ b/ui/src/hooks/useContainerSize.ts
@@ -1,17 +1,44 @@
 import { useState, useEffect, type RefObject } from "react";
 
+/**
+ * ResizeObserver-backed element size hook.
+ *
+ * Reports rounded integer pixel dimensions and coalesces multiple resize
+ * notifications inside a single animation frame. Identical sizes never trigger
+ * a state update so subscribers can rely on `Object.is` equality. This keeps
+ * downstream effects from churning during rapid layout shifts (window resize,
+ * pane drag, alt-screen redraws) which would otherwise amplify any rendering
+ * pressure on the WebView2 GPU process.
+ */
 export function useContainerSize(containerRef: RefObject<HTMLElement | null>) {
   const [size, setSize] = useState({ w: 0, h: 0 });
 
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
+
+    let frame: number | null = null;
+    let pending: { w: number; h: number } | null = null;
+
     const ro = new ResizeObserver((entries) => {
       const { width, height } = entries[0].contentRect;
-      setSize({ w: width, h: height });
+      pending = { w: Math.round(width), h: Math.round(height) };
+
+      if (frame !== null) return;
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        if (pending === null) return;
+        const next = pending;
+        pending = null;
+        setSize((prev) => (prev.w === next.w && prev.h === next.h ? prev : next));
+      });
     });
     ro.observe(el);
-    return () => ro.disconnect();
+
+    return () => {
+      if (frame !== null) cancelAnimationFrame(frame);
+      ro.disconnect();
+    };
   }, [containerRef]);
 
   return size;

--- a/ui/src/lib/terminal-renderer-bus.test.ts
+++ b/ui/src/lib/terminal-renderer-bus.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  publishRendererRefresh,
+  subscribeRendererRefresh,
+  _resetRendererBus,
+  type RendererRefreshSignal,
+} from "./terminal-renderer-bus";
+
+describe("terminal-renderer-bus", () => {
+  beforeEach(() => {
+    _resetRendererBus();
+  });
+
+  it("delivers a published signal to subscribers", () => {
+    const listener = vi.fn();
+    subscribeRendererRefresh(listener);
+
+    const signal: RendererRefreshSignal = { reason: "peer-tui-exit", sourceId: "term-A" };
+    publishRendererRefresh(signal);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(signal);
+  });
+
+  it("delivers to all subscribers", () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    subscribeRendererRefresh(a);
+    subscribeRendererRefresh(b);
+
+    publishRendererRefresh({ reason: "peer-tui-exit", sourceId: "term-X" });
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribes via the returned dispose function", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeRendererRefresh(listener);
+    unsubscribe();
+
+    publishRendererRefresh({ reason: "peer-tui-exit", sourceId: "term-A" });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke a listener for its own published signal when the listener filters by sourceId", () => {
+    // Consumers are responsible for self-skip; this test documents the contract.
+    const selfId = "term-self";
+    const handler = vi.fn((signal: RendererRefreshSignal) => {
+      if (signal.sourceId === selfId) return;
+      handler.handled = true;
+    }) as unknown as ReturnType<typeof vi.fn> & { handled?: boolean };
+    subscribeRendererRefresh(handler);
+
+    publishRendererRefresh({ reason: "peer-tui-exit", sourceId: selfId });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect((handler as unknown as { handled?: boolean }).handled).toBeUndefined();
+  });
+
+  it("isolates listener errors so other subscribers still receive the signal", () => {
+    const broken = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const ok = vi.fn();
+    subscribeRendererRefresh(broken);
+    subscribeRendererRefresh(ok);
+
+    expect(() =>
+      publishRendererRefresh({ reason: "peer-tui-exit", sourceId: "term-A" }),
+    ).not.toThrow();
+    expect(ok).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports the peer-context-loss reason", () => {
+    const listener = vi.fn();
+    subscribeRendererRefresh(listener);
+
+    publishRendererRefresh({ reason: "peer-context-loss", sourceId: "term-Y" });
+
+    expect(listener).toHaveBeenCalledWith({
+      reason: "peer-context-loss",
+      sourceId: "term-Y",
+    });
+  });
+});

--- a/ui/src/lib/terminal-renderer-bus.ts
+++ b/ui/src/lib/terminal-renderer-bus.ts
@@ -1,0 +1,48 @@
+/**
+ * In-process bus for cross-terminal renderer refresh signals.
+ *
+ * Why: when one xterm instance in the same WebView2 window exits a TUI app
+ * (e.g. Codex) it floods the buffer with alt-screen restore / clear / scrollback
+ * sequences. The resulting WebGL render burst can leave neighbour xterm WebGL
+ * texture atlases in a stale state — characters render as scattered glyph
+ * fragments. Forcing a `clearTextureAtlas()` + `refresh()` on every peer
+ * terminal whenever a TUI process exits rebuilds the atlas without a visible
+ * flash and avoids the corruption.
+ *
+ * Listeners receive every signal — including ones they themselves published —
+ * and are responsible for filtering by `sourceId` to skip self-signals. This
+ * keeps the bus dumb and side-effect free.
+ */
+
+export type RendererRefreshReason = "peer-tui-exit" | "peer-context-loss";
+
+export interface RendererRefreshSignal {
+  reason: RendererRefreshReason;
+  sourceId: string;
+}
+
+type Listener = (signal: RendererRefreshSignal) => void;
+
+const listeners: Set<Listener> = new Set();
+
+export function subscribeRendererRefresh(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function publishRendererRefresh(signal: RendererRefreshSignal): void {
+  for (const listener of Array.from(listeners)) {
+    try {
+      listener(signal);
+    } catch (err) {
+      console.warn("[terminal-renderer-bus] listener threw:", err);
+    }
+  }
+}
+
+/** Test-only: clear all subscribers between cases. */
+export function _resetRendererBus(): void {
+  listeners.clear();
+}


### PR DESCRIPTION
## 배경

같은 WebView2 윈도우의 한 xterm 인스턴스에서 Codex 등 TUI 앱이 종료되면 alt-screen 복귀 / 화면 클리어 / scrollback 재출력이 한꺼번에 쏟아져 GPU 프로세스를 흔든다. 그 결과 옆 pane(예: Claude Code)의 WebGL 텍스처 아틀라스가 stale 상태로 남아 글자 조각이 화면 곳곳에 흩어지는 현상이 거의 100% 재현됐다 — *왼쪽 pane 에 codex, 오른쪽 pane 에 Claude 띄운 뒤 codex 종료* 시나리오.

## 핵심 변경

- **`ui/src/lib/terminal-renderer-bus.ts` (신규)** — pane 간 atlas refresh 신호 버스. publish/subscribe 단순 구조이며, listener 가 `sourceId` 비교로 자기 신호를 스스로 걸러낸다.
- **`TerminalView.tsx`**
  - 인스턴스의 activity 가 `interactiveApp` 에서 빠져나갈 때 peer 에 `peer-tui-exit` 신호 발행.
  - peer 신호 수신 시 자기 인스턴스의 `clearTextureAtlas()` + `refresh()` 호출 (WebGL/DOM 양쪽 안전).
  - `WebglAddon` 을 ref 로 보관하고, `onContextLoss` 에서 단순히 `dispose` 만 하던 기존 코드를 **dispose → stagger 지연 → 재생성 → 실패 시 graceful fallback** 으로 교체. 컨텍스트 손실 시점에도 peer 신호를 발행해 같은 GPU 프로세스를 공유하는 인접 pane 의 atlas 도 같이 회복시킨다.
  - 컴포넌트 unmount 시점에도 `peer-tui-exit` 발행 — pane 제거가 GPU 프로세스 상태를 흔드는 케이스 대응.
- **`useContainerSize.ts` (보조)** — ResizeObserver 콜백을 rAF 한 프레임 안에서 coalesce, 정수 반올림, 동일 사이즈일 때 같은 객체 reference 유지. 리렌더 폭주가 WebGL 취약점을 자극하던 보조 트리거를 줄인다.

## 테스트

- 신규 단위 테스트
  - `terminal-renderer-bus.test.ts` — 6 케이스 (publish/subscribe, multi-listener, unsubscribe, self-skip 컨트랙트, listener 예외 격리, peer-context-loss reason).
  - `TerminalView.test.tsx > renderer refresh bus` — 4 케이스 (peer activity 전환 시 인접 pane refresh, sourceId 자기 신호 skip, WebglAddon 재생성, unmount 시 peer 알림).
  - `useContainerSize.test.ts` — rAF 디바운스, 정수화, 동일값 무시 검증 추가.
- **전체 UI 테스트 1720개 통과.** type-check / eslint clean.

## 수동 검증 (dev 19281)

1. PowerShell pane 좌우 split → 우측에 `Get-ChildItem` 출력 (글자 풍부한 상태).
2. 좌측 pane 에서 `codex` 실행 → `/quit` 으로 종료를 **3회 반복**.
3. 매 라운드 종료 직후 풀 스크린샷 캡처. 우측 pane 에 글자 fragment 없음을 확인 — fix 전에는 거의 100% 재현되던 깨짐이 발생하지 않음.

## Test plan

- [ ] 좌측 codex / 우측 claude 시나리오에서 codex 종료 시 우측 pane 깨짐 재발 여부 점검
- [ ] WebGL context loss (예: GPU driver 충돌) 발생 시 터미널이 침묵하지 않고 자동 복구하는지 점검
- [ ] 워크스페이스 전환 / pane 닫기 등 일반 시나리오에서 atlas refresh 가 시각적 깜빡임 없이 동작하는지 점검
- [ ] 다중 모니터 / DPR 변경 시 회귀 없음 점검

🤖 Generated with [Claude Code](https://claude.com/claude-code)