### PR TITLE
feat(terminal): WebGL 렌더러를 옵트인 토글로 전환 (기본 OFF)

### DIFF
--- a/ui/src/components/views/SettingsView.test.tsx
+++ b/ui/src/components/views/SettingsView.test.tsx
@@ -817,6 +817,34 @@ describe("SettingsView", () => {
     expect(useSettingsStore.getState().convenience.scrollbarStyle).toBe("separate");
   });
 
+  // -- Terminal WebGL toggle (experimental) --
+
+  it("renders the terminal WebGL toggle, defaulting to disabled", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+
+    await user.click(screen.getByTestId("nav-convenience"));
+    const toggle = screen.getByTestId("terminal-webgl-toggle") as HTMLInputElement;
+    expect(toggle).toBeInTheDocument();
+    expect(toggle.checked).toBe(false);
+    expect(useSettingsStore.getState().convenience.terminalWebgl).toBe(false);
+  });
+
+  it("toggling terminal WebGL writes through to the store after Save", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+
+    await user.click(screen.getByTestId("nav-convenience"));
+    const toggle = screen.getByTestId("terminal-webgl-toggle");
+    await user.click(toggle);
+    // Draft only — store unchanged until Save.
+    expect(useSettingsStore.getState().convenience.terminalWebgl).toBe(false);
+
+    const saveBtn = screen.getByTestId("save-settings-btn");
+    await user.click(saveBtn);
+    expect(useSettingsStore.getState().convenience.terminalWebgl).toBe(true);
+  });
+
   // -- Claude Code section --
 
   it("shows Claude Code nav button", () => {

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1491,6 +1491,36 @@ function ConvenienceSection() {
           </div>
         </div>
 
+        {/* Terminal WebGL renderer toggle (experimental) */}
+        <div className="mt-3 flex items-start gap-3 py-1">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+              Terminal WebGL (실험적)
+            </span>
+            <p
+              className="mt-0.5 text-[11px] leading-tight"
+              style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+            >
+              xterm WebGL 렌더러 사용. 박스 드로잉이 더 또렷하고 빠르지만, 여러 pane을 동시에 띄우면
+              GPU process를 공유해 TUI 종료 시 옆 pane 글자가 깨질 수 있습니다. 변경 사항은 새로
+              생성되는 터미널부터 적용됩니다.
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                data-testid="terminal-webgl-toggle"
+                type="checkbox"
+                checked={convenience.terminalWebgl}
+                onChange={(e) => updateConvenience({ terminalWebgl: e.target.checked })}
+              />
+              <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+                {convenience.terminalWebgl ? "Enabled" : "Disabled"}
+              </span>
+            </label>
+          </div>
+        </div>
+
         {/* Dock Persist State toggle */}
         <div className="mt-3 flex items-start gap-3 py-1">
           <div className="w-36 shrink-0 pt-1">

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -2253,8 +2253,28 @@ describe("TerminalView", () => {
   });
 
   describe("WebGL stagger", () => {
-    it("delays WebGL addon creation based on init counter", async () => {
+    it("does not create WebglAddon when settings.terminalWebgl is disabled (default)", async () => {
       vi.useFakeTimers();
+
+      render(<TerminalView instanceId="t-wgl-off" profile="PowerShell" syncGroup="g" />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(WebglAddon).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it("delays WebGL addon creation based on init counter when enabled", async () => {
+      vi.useFakeTimers();
+      useSettingsStore.setState((state) => ({
+        ...state,
+        convenience: { ...state.convenience, terminalWebgl: true },
+      }));
 
       render(<TerminalView instanceId="t-wgl1" profile="PowerShell" syncGroup="g" />);
       render(<TerminalView instanceId="t-wgl2" profile="PowerShell" syncGroup="g" />);
@@ -2379,6 +2399,10 @@ describe("TerminalView", () => {
     it("cleans up WebGL timer on unmount before it fires", async () => {
       vi.useFakeTimers();
       _resetWebglStagger();
+      useSettingsStore.setState((state) => ({
+        ...state,
+        convenience: { ...state.convenience, terminalWebgl: true },
+      }));
 
       // First terminal gets delay=0, second gets delay=150
       render(<TerminalView instanceId="t-bump" profile="PowerShell" syncGroup="g" />);
@@ -2412,7 +2436,19 @@ describe("TerminalView", () => {
 });
 
 describe("shouldEnableTerminalWebgl", () => {
-  it("keeps WebGL enabled", () => {
+  beforeEach(() => {
+    useSettingsStore.setState(useSettingsStore.getInitialState());
+  });
+
+  it("returns false by default (WebGL is opt-in)", () => {
+    expect(shouldEnableTerminalWebgl()).toBe(false);
+  });
+
+  it("returns true when convenience.terminalWebgl is enabled", () => {
+    useSettingsStore.setState((state) => ({
+      ...state,
+      convenience: { ...state.convenience, terminalWebgl: true },
+    }));
     expect(shouldEnableTerminalWebgl()).toBe(true);
   });
 });

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -178,8 +178,13 @@ function hasDecModeParam(params: readonly (number | number[])[], mode: number): 
   return params.some((param) => (Array.isArray(param) ? param.includes(mode) : param === mode));
 }
 
+/**
+ * @deprecated The WebGL renderer is now opt-in via
+ * `Settings → Convenience → terminalWebgl`. This helper is kept for the
+ * existing test suite and always returns the convenience-store flag.
+ */
 export function shouldEnableTerminalWebgl(): boolean {
-  return true;
+  return useSettingsStore.getState().convenience.terminalWebgl === true;
 }
 
 function getBufferCursorAbsY(terminal: Terminal): number {

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -92,6 +92,19 @@ export interface ConvenienceSettings {
   smartLinkJoin: boolean;
   /** Show a confirmation dialog when pasting large text. */
   largePasteWarning: boolean;
+  /**
+   * Enable the xterm WebGL renderer for terminals. Defaults to false.
+   *
+   * When enabled, xterm renders glyphs through WebGL — sharper box-drawing
+   * characters and better performance, but in WebView2 (the Tauri webview)
+   * every WebGL context shares one GPU process. With multiple panes alive
+   * the texture atlases of sibling panes can corrupt one another whenever
+   * a TUI app exits and dumps a burst of escape sequences (Codex restoring
+   * its main screen is the canonical trigger), producing scattered glyph
+   * fragments. The default xterm canvas renderer has neither customGlyphs
+   * nor that cross-contamination problem, so this stays opt-in.
+   */
+  terminalWebgl: boolean;
 }
 
 /** Which elements to display in WorkspaceSelectorView pane rows. */
@@ -775,6 +788,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     smartRemoveLineBreak: true,
     smartLinkJoin: true,
     largePasteWarning: true,
+    terminalWebgl: false,
   },
   workspaceDisplay: { minimap: true, environment: true, activity: true, path: true, result: true },
   claude: {
@@ -1003,6 +1017,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
           smartRemoveLineBreak: true,
           smartLinkJoin: true,
           largePasteWarning: true,
+          terminalWebgl: false,
           ...(data.convenience as Partial<ConvenienceSettings>),
         }
       : undefined;


### PR DESCRIPTION
## 배경

WebView2(Chromium) 의 단일 GPU process 가 모든 WebGL context 를 공유하기 때문에, 여러 pane 이 동시에 살아있을 때 한쪽 TUI 종료 burst (Codex 가 alt-screen 복귀 + scrollback 재출력) 가 옆 pane 의 WebGL 텍스처 atlas 를 cross-contaminate 시킨다. 결과: 옆 pane (Claude 등) 화면에 글자 fragments 가 흩어지는 깨짐 현상이 거의 100% 재현됨.

## 검증으로 좁혀진 변수

| 구성 | 동시 살아있는 GL context 수 | 깨짐 |
|---|---|---|
| WebGL ON 모든 pane (현재 main) | n 개 | **발생** (사용자 직접 재현) |
| WebGL ON + atlas-clear 신호 | n 개 | **여전히 발생** (사후 패치 무력) |
| WebGL OFF 모든 pane | 0 개 | **0** (두 차례 확인) |
| focused-only WebGL | 1 개 | **0** 이지만 focus 전환 시 두 renderer 간 cell metrics 차이로 너비가 움찔거리는 부작용 |

원인은 "WebView2 의 단일 GPU process 안에 다중 WebGL context 가 공존" 그 자체. atlas / 신호 / 복구 같은 사후 패치로는 안 잡히고, 구조적으로 GL context 수를 줄여야 한다. focused-only 는 깨짐을 막아주지만 default canvas renderer 와 metrics 가 다르다는 xterm 차원의 본질적 차이까지는 우리 코드에서 감출 수 없었다.

## 결정

가장 단순·일관된 방향으로 — **WebGL 을 사용자가 명시적으로 켤 수 있는 옵션으로 강등하고 기본값을 OFF**. 자기 환경에서 안 깨지는 사용자만 켠다.

## 변경

- `ConvenienceSettings.terminalWebgl: boolean` 추가, 기본 `false`.
- `settings.json` 마이그레이션 기본값에도 false 채워 backwards-compat.
- `SettingsView` Convenience 섹션에 **"Terminal WebGL (실험적)"** 토글 + 새로 생성되는 터미널부터 적용된다는 안내.
- `TerminalView.shouldEnableTerminalWebgl()` 이 store 플래그 반환 — 마운트 시점에 한 번 평가, 토글 변경은 새 pane 부터 적용.

## 테스트

- 새 추가
  - 토글이 기본 OFF 로 렌더되고, Save 후 store 에 반영.
  - `shouldEnableTerminalWebgl()` 이 기본 `false`, 플래그 ON 시 `true`.
  - 기존 WebGL stagger 테스트는 토글을 명시적으로 켜는 시나리오로 갱신.
  - 토글 OFF 기본 상태에서는 `WebglAddon` 이 아예 생성되지 않음.
- 전체 UI 테스트 **1711개 통과**, type-check / eslint clean.

## 수동 검증 (dev 19281)

- 기본 OFF 상태에서 좌 codex / 우 claude 시나리오 codex 종료 — 우측 pane 깨짐 0.
- 토글 ON → 새 pane 생성 시 WebGL 활성화 확인. (이때 다중 pane 동시 깨짐 위험은 토글의 '실험적' 라벨로 사용자에게 명시.)

## Test plan

- [ ] Settings → Convenience → "Terminal WebGL (실험적)" 토글 노출 확인
- [ ] 기본 OFF 상태에서 codex+claude 시나리오 깨짐 0 재확인
- [ ] 토글 ON → Save → 새 pane 부터 WebGL 적용 확인 (기존 pane 은 그대로)
- [ ] settings.json 에 `terminalWebgl` 필드가 누락된 기존 사용자 환경에서도 기본 false 로 안전하게 동작
- [ ] 박스 드로잉 / 블록 글자 외양이 default canvas renderer 에서 수용 가능한 수준인지 점검

🤖 Generated with [Claude Code](https://claude.com/claude-code)