### PR TITLE
fix(terminal): activity 변화에 WebGL atlas 재구축이 일어나지 않도록 reflow 분리

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -347,8 +347,20 @@ describe("TerminalView", () => {
     });
   });
 
-  it("refreshes and refits existing terminal when settings change", async () => {
+  it("updates terminal options on cursor settings change without re-fitting", async () => {
+    // xterm applies option changes (cursor style/blink) on the next paint
+    // automatically — there is no need to call fit() or refresh(). Coupling
+    // those calls to cursor-setting changes turned activity transitions
+    // (Codex start/exit) into atlas-rebuild bursts that race with TUI exit
+    // sequences.
     render(<TerminalView instanceId="t-settings-refresh" profile="PowerShell" syncGroup="" />);
+
+    await vi.waitFor(() => {
+      expect(mockCreateTerminalSession).toHaveBeenCalled();
+    });
+
+    mockFit.mockClear();
+    mockRefresh.mockClear();
 
     act(() => {
       useSettingsStore.getState().updateProfile(0, {
@@ -358,9 +370,11 @@ describe("TerminalView", () => {
     });
 
     await vi.waitFor(() => {
-      expect(mockFit).toHaveBeenCalled();
-      expect(mockRefresh).toHaveBeenCalledWith(0, 23);
+      expect(createdTerminals[0].options.cursorStyle).toBe("underline");
+      expect(createdTerminals[0].options.cursorBlink).toBe(false);
     });
+    expect(mockFit).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
   });
 
   it("updates an existing terminal when profile defaults change", async () => {
@@ -1561,7 +1575,7 @@ describe("TerminalView", () => {
   // afterwards use stale cell widths and glyphs visibly collapse to the
   // left. The fix: call `term.clearTextureAtlas()` whenever fontSize or
   // fontFamily changes, *after* `fit()` so the renderer re-measures first.
-  it("reflows twice and clears texture atlas when fontSize changes (issue #224)", async () => {
+  it("schedules a single deferred reflow and clears texture atlas when fontSize changes (issue #224)", async () => {
     render(
       <TerminalView
         instanceId="t-atlas-fontsize"
@@ -1575,18 +1589,92 @@ describe("TerminalView", () => {
     // font-change-triggered invocation.
     mockClearTextureAtlas.mockClear();
     mockFit.mockClear();
+    mockRequestAnimationFrame.mockClear();
 
     act(() => {
       useOverridesStore.getState().setViewOverride("pane-atlas-fontsize", { fontSize: 20 });
     });
 
     await vi.waitFor(() => {
-      // Font metrics can settle one frame after the option write, so the fix
-      // must both invalidate the current atlas and schedule a deferred reflow.
+      // Font metrics settle one frame after the option write, so the fix
+      // schedules the fit + atlas rebuild in a single rAF (avoiding the
+      // double-call burst that races with TUI exit sequences).
       expect(mockFit).toHaveBeenCalled();
       expect(mockClearTextureAtlas).toHaveBeenCalled();
       expect(mockRequestAnimationFrame).toHaveBeenCalled();
     });
+  });
+
+  // -- Regression: reflow must NOT fire on activity / cursor changes --
+  //
+  // The font/cursor option-update effect runs whenever Codex starts/exits
+  // (`nativeCursorHidden` toggles), focus moves, or cursor shape is edited.
+  // Coupling fit() + clearTextureAtlas() to that effect causes WebGL atlas
+  // rebuild bursts to overlap with TUI exit sequences (`ESC[?1049l`,
+  // scrollback re-emit), which is when glyph corruption surfaces in
+  // adjacent panes. Cell geometry only moves on font changes — so reflow
+  // must be gated to font.
+  it("does not reflow when Codex activity toggles native cursor hidden", async () => {
+    render(
+      <TerminalView
+        instanceId="t-no-reflow-activity"
+        paneId="pane-no-reflow-activity"
+        profile="PowerShell"
+        syncGroup=""
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockCreateTerminalSession).toHaveBeenCalled();
+    });
+
+    mockClearTextureAtlas.mockClear();
+    mockFit.mockClear();
+
+    // Codex starts → nativeCursorHidden flips on.
+    act(() => {
+      useTerminalStore.getState().updateInstanceInfo("t-no-reflow-activity", {
+        activity: { type: "interactiveApp", name: "Codex" },
+      });
+    });
+    // Codex exits → nativeCursorHidden flips off (this is the burst window).
+    act(() => {
+      useTerminalStore.getState().updateInstanceInfo("t-no-reflow-activity", {
+        activity: { type: "shell" },
+      });
+    });
+
+    expect(mockFit).not.toHaveBeenCalled();
+    expect(mockClearTextureAtlas).not.toHaveBeenCalled();
+  });
+
+  it("does not reflow when cursor shape changes", async () => {
+    render(
+      <TerminalView
+        instanceId="t-no-reflow-cursor"
+        paneId="pane-no-reflow-cursor"
+        profile="PowerShell"
+        syncGroup=""
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockCreateTerminalSession).toHaveBeenCalled();
+    });
+
+    mockClearTextureAtlas.mockClear();
+    mockFit.mockClear();
+
+    act(() => {
+      useSettingsStore.getState().updateProfile(0, { cursorShape: "underscore" });
+    });
+
+    // Options should still update, but no fit/atlas rebuild should fire.
+    await vi.waitFor(() => {
+      expect(createdTerminals[0].options.cursorStyle).toBe("underline");
+    });
+    expect(mockFit).not.toHaveBeenCalled();
+    expect(mockClearTextureAtlas).not.toHaveBeenCalled();
   });
 
   it("clears texture atlas when devicePixelRatio changes (issue #224)", async () => {
@@ -1769,6 +1857,104 @@ describe("TerminalView", () => {
         expect(mockFit).toHaveBeenCalled();
       });
       expect(mockClearTextureAtlas).not.toHaveBeenCalled();
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+
+  // -- Regression: same-size ResizeObserver entries must not trigger fit() --
+  //
+  // ResizeObserver fires a fresh entry on sub-pixel layout shifts (DPR
+  // rounding, scrollbar shimmies, hover bars). Calling fit() — and through
+  // it `terminal.onResize` → PTY resize round-trips — for changes the user
+  // never perceives is wasteful and overlaps with TUI exit bursts.
+  it("ignores same-size ResizeObserver entries", async () => {
+    type Observer = {
+      target: Element | null;
+      callback: (entries: ResizeObserverEntry[], obs: ResizeObserver) => void;
+    };
+    const observers: Observer[] = [];
+    const originalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      private obs: Observer;
+      constructor(cb: (entries: ResizeObserverEntry[], obs: ResizeObserver) => void) {
+        this.obs = { target: null, callback: cb };
+        observers.push(this.obs);
+      }
+      observe(target: Element) {
+        this.obs.target = target;
+        setTimeout(() => {
+          this.obs.callback(
+            [
+              {
+                target,
+                contentRect: { width: 800, height: 600 },
+              } as unknown as ResizeObserverEntry,
+            ],
+            this as unknown as ResizeObserver,
+          );
+        }, 0);
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      render(<TerminalView instanceId="t-resize-dedup" profile="PowerShell" syncGroup="" />);
+
+      await vi.waitFor(() => {
+        expect(mockCreateTerminalSession).toHaveBeenCalled();
+      });
+
+      const obs = observers[0];
+      expect(obs).toBeDefined();
+      const target = obs.target as Element;
+
+      // Initial mount opens the terminal at 800×600. Now fire two more
+      // identical entries — the guard must short-circuit both.
+      mockFit.mockClear();
+
+      act(() => {
+        obs.callback(
+          [
+            {
+              target,
+              contentRect: { width: 800, height: 600 },
+            } as unknown as ResizeObserverEntry,
+          ],
+          {} as ResizeObserver,
+        );
+      });
+      act(() => {
+        obs.callback(
+          [
+            {
+              target,
+              contentRect: { width: 800.4, height: 600.2 }, // sub-pixel jitter
+            } as unknown as ResizeObserverEntry,
+          ],
+          {} as ResizeObserver,
+        );
+      });
+
+      expect(mockFit).not.toHaveBeenCalled();
+
+      // A real change (different integer dimensions) must still fit.
+      act(() => {
+        obs.callback(
+          [
+            {
+              target,
+              contentRect: { width: 900, height: 700 },
+            } as unknown as ResizeObserverEntry,
+          ],
+          {} as ResizeObserver,
+        );
+      });
+
+      await vi.waitFor(() => {
+        expect(mockFit).toHaveBeenCalled();
+      });
     } finally {
       globalThis.ResizeObserver = originalResizeObserver;
     }

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -1314,12 +1314,21 @@ export function TerminalView({
     // texture atlas to rebuild — otherwise glyphs rasterised at the pre-hide
     // cell size / DPR stay cached and render completely garbled (issue #232).
     let prevWasHidden = false;
+    // Last visible integer dimensions we acted on. ResizeObserver fires a
+    // fresh entry every time `contentBoxSize` shifts by sub-pixel amounts
+    // (DPR rounding, scrollbar layout, hover bars), so without this guard
+    // we would call fit() — and through it `terminal.onResize` → PTY
+    // resize round-trips — for changes the user never perceives.
+    let prevW = 0;
+    let prevH = 0;
     let webglTimer: ReturnType<typeof setTimeout> | undefined;
     const resizeObserver = new ResizeObserver((entries) => {
       const { width, height } = entries[0].contentRect;
       const isNowHidden = width === 0 || height === 0;
       if (width > 0 && height > 0 && !sessionCreated) {
         sessionCreated = true;
+        prevW = Math.round(width);
+        prevH = Math.round(height);
         // Open terminal now that container has real dimensions
         if (containerRef.current) {
           terminal.open(containerRef.current);
@@ -1419,6 +1428,17 @@ export function TerminalView({
         }
       } else if (sessionCreated && width > 0 && height > 0) {
         const recoveringFromHidden = prevWasHidden;
+        const w = Math.round(width);
+        const h = Math.round(height);
+        // Skip identical-size callbacks unless we are returning from a
+        // display:none hide (those still need an atlas rebuild even if
+        // dimensions match the pre-hide values).
+        if (!recoveringFromHidden && w === prevW && h === prevH) {
+          prevWasHidden = isNowHidden;
+          return;
+        }
+        prevW = w;
+        prevH = h;
         fitAddon.fit();
         if (recoveringFromHidden) {
           // See `prevWasHidden` definition: the WebGL atlas can go stale
@@ -1574,13 +1594,17 @@ export function TerminalView({
   const effectiveCursorBlink = cursorBlink;
   const nativeCursorHidden = stabilizeInteractiveCursor && isOverlayCaretActivity(activity);
   const effectiveNativeCursorBlink = nativeCursorHidden ? false : effectiveCursorBlink;
-  const runTerminalRendererReflow = (
-    term: Terminal,
-    options?: {
-      defer?: boolean;
-    },
-  ) => {
-    const perform = () => {
+  // Coalesce all reflow requests into a single rAF. Calling fit() +
+  // clearTextureAtlas() + refresh() multiple times per tick (or even twice
+  // back-to-back) compounds with TUI exit bursts (e.g. Codex's `ESC[?1049l`,
+  // scrollback re-emit) and is what makes the WebGL atlas race manifest as
+  // glyph corruption in adjacent panes.
+  const runTerminalRendererReflow = (term: Terminal) => {
+    if (terminalReflowFrameRef.current !== null) {
+      cancelAnimationFrame(terminalReflowFrameRef.current);
+    }
+    terminalReflowFrameRef.current = requestAnimationFrame(() => {
+      terminalReflowFrameRef.current = null;
       fitAddonRef.current?.fit();
       try {
         (term as unknown as { clearTextureAtlas?: () => void }).clearTextureAtlas?.();
@@ -1589,24 +1613,17 @@ export function TerminalView({
       }
       term.refresh(0, term.rows - 1);
       overlayCaretUpdaterRef.current?.();
-    };
-
-    if (!options?.defer) {
-      perform();
-      return;
-    }
-
-    if (terminalReflowFrameRef.current !== null) {
-      cancelAnimationFrame(terminalReflowFrameRef.current);
-    }
-    terminalReflowFrameRef.current = requestAnimationFrame(() => {
-      terminalReflowFrameRef.current = null;
-      perform();
     });
   };
   useEffect(() => {
     overlayCaretUpdaterRef.current?.();
   }, [activity, isFocused, font, cursorShape, stabilizeInteractiveCursor]);
+  // Option-only updates: theme, font (just the values), and cursor settings.
+  // This effect must NOT call fit()/clearTextureAtlas()/refresh() directly —
+  // cursor and theme changes do not move cell geometry, and triggering an
+  // atlas rebuild on every activity transition (e.g. Codex start/exit) makes
+  // the WebGL renderer race with TUI exit bursts. Cell-geometry reflow lives
+  // in the dedicated effect below.
   useEffect(() => {
     const term = terminalRef.current;
     if (!term?.options) return;
@@ -1659,12 +1676,6 @@ export function TerminalView({
           delete (term.options as { cursorWidth?: number }).cursorWidth;
         }
       }
-      // Font updates land on the host element immediately, but xterm's final
-      // measured cell geometry can settle on the next frame. Reflow once now
-      // and once after layout so FitAddon and the WebGL atlas agree on the
-      // final glyph metrics (issue #224).
-      runTerminalRendererReflow(term);
-      runTerminalRendererReflow(term, { defer: true });
     } catch {
       /* xterm mock may not support options setter */
     }
@@ -1677,6 +1688,18 @@ export function TerminalView({
     nativeCursorHidden,
     stabilizeInteractiveCursor,
   ]);
+
+  // Cell-geometry reflow: only fontSize/fontFamily changes move xterm's
+  // measured cell width/height, so the texture atlas only needs invalidation
+  // on those transitions (issue #224). Cursor mode / activity changes must
+  // not enter this path — they would trigger a fit + atlas rebuild during
+  // TUI exit bursts and surface as glyph corruption (issue surfaced after
+  // #224 fix).
+  useEffect(() => {
+    const term = terminalRef.current;
+    if (!term?.options) return;
+    runTerminalRendererReflow(term);
+  }, [font]);
 
   // Browser zoom / monitor DPR changes invalidate the WebGL texture atlas:
   // the renderer rasterises glyphs at a resolution tied to the current
@@ -1694,7 +1717,6 @@ export function TerminalView({
       if (!term) return;
       try {
         runTerminalRendererReflow(term);
-        runTerminalRendererReflow(term, { defer: true });
       } catch {
         /* addon/renderer may not be active yet */
       }

--- a/ui/src/hooks/useContainerSize.test.ts
+++ b/ui/src/hooks/useContainerSize.test.ts
@@ -53,6 +53,43 @@ describe("useContainerSize", () => {
     expect(result.current).toEqual({ w: 800, h: 600 });
   });
 
+  it("preserves the previous reference on identical integer sizes", () => {
+    // ResizeObserver fires on every sub-pixel layout shift. Without a guard,
+    // each tick produces a fresh `{w, h}` object that re-renders consumers
+    // (e.g. PaneControlBar) and re-runs their measurement loops — which is
+    // the burst that compounds with WebGL atlas rebuilds in adjacent panes.
+    const ref = { current: document.createElement("div") };
+    const { result } = renderHook(() => useContainerSize(ref));
+
+    act(() => {
+      observerCallback(
+        [{ contentRect: { width: 800, height: 600 } } as unknown as ResizeObserverEntry],
+        {} as ResizeObserver,
+      );
+    });
+    const first = result.current;
+
+    // Sub-pixel jitter — same integer size after rounding.
+    act(() => {
+      observerCallback(
+        [{ contentRect: { width: 800.4, height: 599.7 } } as unknown as ResizeObserverEntry],
+        {} as ResizeObserver,
+      );
+    });
+
+    // Reference identity preserved → consumers do not re-render.
+    expect(result.current).toBe(first);
+
+    // A real integer-level change must still update.
+    act(() => {
+      observerCallback(
+        [{ contentRect: { width: 900, height: 700 } } as unknown as ResizeObserverEntry],
+        {} as ResizeObserver,
+      );
+    });
+    expect(result.current).toEqual({ w: 900, h: 700 });
+  });
+
   it("disconnects on unmount", () => {
     const ref = { current: document.createElement("div") };
     const { unmount } = renderHook(() => useContainerSize(ref));

--- a/ui/src/hooks/useContainerSize.ts
+++ b/ui/src/hooks/useContainerSize.ts
@@ -8,7 +8,14 @@ export function useContainerSize(containerRef: RefObject<HTMLElement | null>) {
     if (!el) return;
     const ro = new ResizeObserver((entries) => {
       const { width, height } = entries[0].contentRect;
-      setSize({ w: width, h: height });
+      // Round to integer pixels and skip same-value updates so consumers
+      // (PaneControlBar etc.) do not re-render on sub-pixel DPR jitter,
+      // hover bars, or scrollbar layout shimmies. Without this guard a
+      // single ControlBar mounting cascades into a fit/atlas-rebuild storm
+      // that races with TUI exit bursts.
+      const w = Math.round(width);
+      const h = Math.round(height);
+      setSize((prev) => (prev.w === w && prev.h === h ? prev : { w, h }));
     });
     ro.observe(el);
     return () => ro.disconnect();


### PR DESCRIPTION
## Summary

- `font` / `cursor` 옵션 갱신과 cell-geometry reflow를 두 개의 useEffect로 분리하여, `nativeCursorHidden` 같은 **activity 의존 값** 변화에 `fit + clearTextureAtlas + refresh`가 호출되지 않도록 한다.
- `runTerminalRendererReflow`를 즉시 + defer 이중 호출에서 **단일 rAF**로 통합한다.
- `TerminalView`의 ResizeObserver와 `useContainerSize` 훅에 **정수 동일값 가드**를 추가해 sub-pixel jitter / scrollbar shimmy / hover bar 토글로 발생하던 fit 호출 storm을 차단한다.

## 배경

#224(글자 좌측 몰림) 수정에서 `runTerminalRendererReflow`가 도입되어 font/cursor 옵션을 갱신하는 useEffect 내부에서 `즉시 + rAF`로 두 번씩 호출되도록 변경됐다. 그런데 해당 useEffect의 의존성에는

\`\`\`ts
nativeCursorHidden = stabilizeInteractiveCursor && isOverlayCaretActivity(activity);
// → activity?.type === "interactiveApp" && activity.name === "Codex"
\`\`\`

처럼 **Codex 활성/비활성에 따라 토글되는 값**이 포함되어 있다. 결과적으로 Codex 시작·종료 시점마다 `fit + clearTextureAtlas + refresh`가 두 번씩 호출되며, Codex 종료 burst(`ESC[?1049l`, screen clear, prompt 복귀, scrollback re-emit)와 시간상 겹쳐 다중 WebGL context 환경에서 인접 pane의 atlas 손상을 더 잘 드러나게 만드는 트리거가 되었다.

이번 PR은 #224 회귀(글자 좌측 몰림)를 그대로 막으면서, **cell geometry가 실제로 변하는 fontSize/fontFamily 경로**에서만 reflow가 일어나도록 좁혔다.

## 변경 사항

- `TerminalView.tsx`
  - 단일 거대 useEffect를 (a) theme/font/cursor **옵션 갱신만** 하는 effect와 (b) `font` 변화에만 반응하여 reflow를 거는 effect로 분리.
  - `runTerminalRendererReflow`: 즉시 + defer 이중 호출 제거, **rAF 1회**로 통합.
  - `ResizeObserver`: `Math.round(width/height)` 기반 동일값 가드 추가. hidden→shown 복귀 경로는 동일값이어도 atlas rebuild가 실행되도록 예외.
  - DPR 변경 핸들러에서도 reflow 이중 호출 제거.
- `useContainerSize.ts`: ResizeObserver 콜백에서 정수 동일값이면 `setSize`로 새 객체를 반환하지 않아 consumer 리렌더 storm을 차단.
- 테스트
  - 기존 `reflows twice and clears texture atlas when fontSize changes (#224)` → `schedules a single deferred reflow ...`로 갱신 (단일 rAF 경로 검증).
  - 기존 `refreshes and refits existing terminal when settings change` → `updates terminal options on cursor settings change without re-fitting`으로 갱신 (cursor 옵션 변경 시 fit/refresh가 호출되지 않음을 검증).
  - 신규: Codex activity 토글 / cursor shape 변경 시 reflow가 호출되지 않음을 검증하는 회귀 테스트.
  - 신규: 동일 사이즈 ResizeObserver 콜백에서 fit이 호출되지 않음을 검증.
  - 신규: `useContainerSize` 동일값에서 객체 참조가 보존됨을 검증.

## Test plan

- [x] `npx vitest run` (1711/1711 통과)
- [x] `npm run build` (tsc + vite 통과)
- [ ] Codex 시작 → 종료 시점에 인접 Claude pane의 글자 깨짐이 재현되지 않는지 수동 확인
- [ ] 폰트 크기 변경(`Ctrl +/-`) 후 글자 좌측 몰림(#224) 미재현 확인
- [ ] 워크스페이스 hide → show 전환 시 atlas rebuild가 정상 동작하는지(#232) 확인
- [ ] PaneControlBar narrow ↔ wide 전환에서 ControlBar 자체 동작 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)