### PR TITLE
fix(copy): strip internal whitespace from copied URLs

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -1152,16 +1152,17 @@ describe("TerminalView", () => {
     expect(mockClipboardWriteText).not.toHaveBeenCalled();
   });
 
-  it("terminal.copy with smartRemoveIndent off copies raw getSelection (no trim)", async () => {
+  it("terminal.copy with all smart-copy toggles off copies raw getSelection (no trim)", async () => {
     // Regression guard for PR review point #2: prepareSelectionForCopy always
-    // trims trailing whitespace regardless of smartRemoveIndent, so we must
-    // bypass it when the toggle is off to preserve the old native-Ctrl+C
-    // clipboard contents byte-for-byte.
+    // trims trailing whitespace regardless of which transforms are selected,
+    // so we must bypass it when *all* smart toggles are off to preserve the
+    // old native-Ctrl+C clipboard contents byte-for-byte.
     useSettingsStore.setState({
       ...useSettingsStore.getState(),
       convenience: {
         ...useSettingsStore.getState().convenience,
         smartRemoveIndent: false,
+        smartRemoveLineBreak: false,
       },
     });
     mockHasSelection.mockReturnValue(true);
@@ -1264,7 +1265,7 @@ describe("TerminalView", () => {
     });
   });
 
-  it("copy-on-select with smartRemoveIndent off writes raw selection (shared runTerminalCopy path)", async () => {
+  it("copy-on-select with all smart-copy toggles off writes raw selection (shared runTerminalCopy path)", async () => {
     // Proves the three copy sites (Ctrl+C, right-click, copy-on-select)
     // share runTerminalCopy — raw-when-off semantics apply uniformly.
     useSettingsStore.setState({
@@ -1273,6 +1274,7 @@ describe("TerminalView", () => {
         ...useSettingsStore.getState().convenience,
         copyOnSelect: true,
         smartRemoveIndent: false,
+        smartRemoveLineBreak: false,
       },
     });
     mockHasSelection.mockReturnValue(true);

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -94,7 +94,7 @@ function pasteFromBrowserClipboard(terminal: Terminal, logPrefix: string): void 
  * terminal.copy keybinding, right-click copy, and copy-on-select so all three
  * paths produce byte-identical clipboard contents.
  *
- * When `smartRemoveIndent` is disabled the raw `getSelection()` string is
+ * When all smart-copy toggles are disabled the raw `getSelection()` string is
  * written verbatim. `prepareSelectionForCopy` always strips trailing
  * whitespace/blank lines, which would otherwise silently modify clipboard
  * contents for users who have opted out of the "smart" transforms.
@@ -105,8 +105,12 @@ function pasteFromBrowserClipboard(terminal: Terminal, logPrefix: string): void 
 function runTerminalCopy(terminal: Terminal): void {
   if (!terminal.hasSelection()) return;
   const { convenience: conv } = useSettingsStore.getState();
-  const text = conv.smartRemoveIndent
-    ? prepareSelectionForCopy(terminal.getSelection(), { smartRemoveIndent: true })
+  const useSmart = conv.smartRemoveIndent || conv.smartRemoveLineBreak;
+  const text = useSmart
+    ? prepareSelectionForCopy(terminal.getSelection(), {
+        smartRemoveIndent: conv.smartRemoveIndent,
+        smartRemoveLineBreak: conv.smartRemoveLineBreak,
+      })
     : terminal.getSelection();
   clipboardWriteText(text).catch((err) => {
     console.warn("[TerminalView] copy to clipboard failed:", err);

--- a/ui/src/lib/smart-text.test.ts
+++ b/ui/src/lib/smart-text.test.ts
@@ -204,6 +204,19 @@ describe("smartRemoveLineBreak", () => {
     const input = "hello world how are you";
     expect(smartRemoveLineBreak(input)).toBe("hello world how are you");
   });
+
+  it("URL + 단일 스페이스로 구분된 prose는 보존한다 (자연어 보호)", () => {
+    // 외부 앱이 newline을 strip하면 터미널 패딩은 multi-space gap으로 남지만,
+    // 자연어에서 URL과 단어 사이는 single space. 이 둘을 구분해서
+    // single-space 케이스는 collapse 하지 않아야 한다.
+    const input = "https://example.com hello world";
+    expect(smartRemoveLineBreak(input)).toBe("https://example.com hello world");
+  });
+
+  it("URL 뒤 single-space-separated 문장이 와도 합치지 않는다", () => {
+    const input = "https://example.com is a great site";
+    expect(smartRemoveLineBreak(input)).toBe("https://example.com is a great site");
+  });
 });
 
 // ============================================================
@@ -266,6 +279,15 @@ describe("applySmartTextTransforms", () => {
     const input = "https://example.com/pa\r\nth";
     expect(applySmartTextTransforms(input, { removeIndent: false, removeLineBreak: true })).toBe(
       "https://example.com/path",
+    );
+  });
+
+  it("paste 시 URL + single-space prose 단일 라인은 보존된다 (false-positive 가드)", () => {
+    // newline이 없고 단일 스페이스로 prose가 이어지는 자연어 입력은
+    // smartRemoveLineBreak이 켜져 있어도 합쳐지면 안 된다.
+    const input = "https://example.com hello world";
+    expect(applySmartTextTransforms(input, { removeIndent: false, removeLineBreak: true })).toBe(
+      "https://example.com hello world",
     );
   });
 });
@@ -333,6 +355,11 @@ describe("transformPasteContent", () => {
   it("returns content unchanged for non-text paste type", () => {
     const input = "  some image data";
     expect(transformPasteContent(input, "image", opts)).toBe("  some image data");
+  });
+
+  it("text paste 시 URL + single-space prose는 그대로 유지 (false-positive 가드)", () => {
+    const input = "https://example.com is a great site";
+    expect(transformPasteContent(input, "text", opts)).toBe("https://example.com is a great site");
   });
 });
 

--- a/ui/src/lib/smart-text.test.ts
+++ b/ui/src/lib/smart-text.test.ts
@@ -217,6 +217,18 @@ describe("smartRemoveLineBreak", () => {
     const input = "https://example.com is a great site";
     expect(smartRemoveLineBreak(input)).toBe("https://example.com is a great site");
   });
+
+  it("멀티라인이라도 URL 다음 줄이 single-space prose면 보존한다", () => {
+    // PR #252 리뷰에서 지적된 회귀 케이스: \n + "hello world"
+    // joined으로는 URL처럼 보여도 single-space로 구분된 prose가 끼어 있으면 자연어다.
+    const input = "https://example.com\nhello world";
+    expect(smartRemoveLineBreak(input)).toBe("https://example.com\nhello world");
+  });
+
+  it("멀티라인 URL + 다음 줄에 single-space-separated 문장도 보존한다", () => {
+    const input = "https://example.com\nis a great site";
+    expect(smartRemoveLineBreak(input)).toBe("https://example.com\nis a great site");
+  });
 });
 
 // ============================================================
@@ -288,6 +300,14 @@ describe("applySmartTextTransforms", () => {
     const input = "https://example.com hello world";
     expect(applySmartTextTransforms(input, { removeIndent: false, removeLineBreak: true })).toBe(
       "https://example.com hello world",
+    );
+  });
+
+  it("paste 시 URL\\n + single-space prose 멀티라인도 보존된다 (false-positive 가드)", () => {
+    // \n이 끼어 있어도 다음 줄이 single-space로 구분된 자연어면 합치지 않는다.
+    const input = "https://example.com\nhello world";
+    expect(applySmartTextTransforms(input, { removeIndent: false, removeLineBreak: true })).toBe(
+      "https://example.com\nhello world",
     );
   });
 });

--- a/ui/src/lib/smart-text.test.ts
+++ b/ui/src/lib/smart-text.test.ts
@@ -185,6 +185,25 @@ describe("smartRemoveLineBreak", () => {
     const input = "https://example.com/very-long-\npath?query=value";
     expect(smartRemoveLineBreak(input)).toBe("https://example.com/very-long-path?query=value");
   });
+
+  it("URL이 한 줄이지만 중간에 공백이 끼어 있어도 모두 제거한다", () => {
+    // 외부 앱에서 newline만 strip하고 paste한 URL: 중간에 4-space gap이 존재
+    const input =
+      "https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61    b-44d9-88ed-5944d1962f5e&response_type=code";
+    const expected =
+      "https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&response_type=code";
+    expect(smartRemoveLineBreak(input)).toBe(expected);
+  });
+
+  it("URL 한 줄 + 탭 문자 혼합 공백도 제거한다", () => {
+    const input = "https://example.com/path?foo=bar&\t baz=qux";
+    expect(smartRemoveLineBreak(input)).toBe("https://example.com/path?foo=bar&baz=qux");
+  });
+
+  it("URL이 아닌 단일 줄 텍스트는 공백을 제거하지 않는다", () => {
+    const input = "hello world how are you";
+    expect(smartRemoveLineBreak(input)).toBe("hello world how are you");
+  });
 });
 
 // ============================================================
@@ -414,6 +433,40 @@ describe("prepareSelectionForCopy", () => {
     const raw = "  hello   \r\n  world   \r\n";
     const result = prepareSelectionForCopy(raw, { smartRemoveIndent: true });
     expect(result).toBe("hello\r\nworld");
+  });
+
+  it("smartRemoveLineBreak 활성 시 멀티라인 URL이 한 줄로 합쳐지고 공백이 제거된다", () => {
+    // 터미널에서 인덴트된 멀티라인 URL을 복사할 때 외부 앱(브라우저 URL bar 등)에
+    // 그대로 붙여넣어도 깨지지 않도록 copy 시점에 정리한다.
+    const raw =
+      "  https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61   \n" +
+      "  b-44d9-88ed-5944d1962f5e&response_type=code                                \n" +
+      "                                                                            \n";
+    const expected =
+      "https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e&response_type=code";
+    const result = prepareSelectionForCopy(raw, {
+      smartRemoveIndent: true,
+      smartRemoveLineBreak: true,
+    });
+    expect(result).toBe(expected);
+  });
+
+  it("smartRemoveLineBreak 비활성 시 멀티라인 URL이 그대로 유지된다", () => {
+    const raw = "  https://example.com/pa   \n  th?q=1   \n";
+    const result = prepareSelectionForCopy(raw, {
+      smartRemoveIndent: true,
+      smartRemoveLineBreak: false,
+    });
+    expect(result).toBe("https://example.com/pa\nth?q=1");
+  });
+
+  it("URL이 아닌 멀티라인 텍스트는 smartRemoveLineBreak가 켜져 있어도 줄바꿈을 유지한다", () => {
+    const raw = "  hello   \n  world   \n";
+    const result = prepareSelectionForCopy(raw, {
+      smartRemoveIndent: true,
+      smartRemoveLineBreak: true,
+    });
+    expect(result).toBe("hello\nworld");
   });
 });
 

--- a/ui/src/lib/smart-text.ts
+++ b/ui/src/lib/smart-text.ts
@@ -3,11 +3,13 @@
  *
  * Copy transforms:
  * - trimSelectionTrailingWhitespace — strip trailing whitespace from xterm.js selection
- * - prepareSelectionForCopy — trim + optional smartRemoveIndent (복사 시점에 인덴트 제거)
+ * - prepareSelectionForCopy — trim + optional smartRemoveIndent + optional smartRemoveLineBreak
  *
  * Paste transforms:
  * 1. smartRemoveIndent — strip common leading whitespace from all lines
  * 2. smartRemoveLineBreak — rejoin URLs that were split across lines
+ *    (strips all internal whitespace, including spaces left over after an
+ *    external paste already removed the newlines)
  *
  * The correct order is: indent first, then linebreak.
  * If linebreak ran on indented text, the indent spaces would corrupt URLs.
@@ -41,6 +43,13 @@ export function trimSelectionTrailingWhitespace(text: string): string {
 
 export interface CopyOptions {
   smartRemoveIndent: boolean;
+  /**
+   * Optional. When true, additionally rejoin a multi-line URL into a single
+   * line at copy time and strip any internal whitespace. Without this, an
+   * external app that strips newlines on paste (e.g. browser address bar)
+   * would still see the leading-indent + trailing-pad as gaps inside the URL.
+   */
+  smartRemoveLineBreak?: boolean;
 }
 
 /**
@@ -49,11 +58,16 @@ export interface CopyOptions {
  * Always applies trimSelectionTrailingWhitespace (remove trailing spaces/blank lines).
  * When smartRemoveIndent is enabled, also removes common leading whitespace so that
  * text copied from terminal doesn't carry unwanted indentation into external apps.
+ * When smartRemoveLineBreak is enabled, a multi-line URL selection is collapsed to a
+ * single clean URL so external paste targets don't end up with whitespace inside it.
  */
 export function prepareSelectionForCopy(text: string, options: CopyOptions): string {
   let result = trimSelectionTrailingWhitespace(text);
   if (options.smartRemoveIndent) {
     result = smartRemoveIndent(result);
+  }
+  if (options.smartRemoveLineBreak) {
+    result = smartRemoveLineBreak(result);
   }
   return result;
 }
@@ -88,26 +102,27 @@ export function smartRemoveIndent(text: string): string {
 }
 
 /**
- * Detect if the entire text (when all newlines are removed) forms a single URL.
- * If so, join lines by removing newlines. Trailing whitespace is trimmed from
- * each line before joining — terminal buffer lines are often padded to the
- * terminal width with spaces.
+ * Detect if the entire text (when all whitespace is removed) forms a single URL.
+ * If so, return the whitespace-stripped form. Otherwise return the input unchanged.
+ *
+ * Handles three shapes that all collapse to the same clean URL:
+ *   1. Multi-line URL with newlines only — split by terminal hard-wrap.
+ *   2. Multi-line URL with newlines + indent + buffer-pad spaces.
+ *   3. Single-line URL where an upstream paste target stripped newlines but
+ *      left leading-indent + trailing-pad as internal gaps.
+ *
+ * URLs forbid raw spaces, so stripping all whitespace is safe when the content
+ * is recognisably a URL.
  *
  * Scope: http:// and https:// only. The \S+ pattern intentionally doesn't
- * validate URL structure — in a clipboard-paste context, false positives
+ * validate URL structure — in a clipboard context, false positives
  * (non-standard chars in a URL-shaped string) are harmless.
  */
 export function smartRemoveLineBreak(text: string): string {
-  if (!text || !text.includes("\n")) return text;
+  if (!text) return text;
 
-  // Check if joining all lines (with trailing whitespace trimmed) produces a URL.
-  // Terminal selections may have trailing spaces from buffer padding.
-  const joined = text
-    .split("\n")
-    .map((line) => line.replace(/\s+$/, ""))
-    .join("");
+  const joined = text.replace(/\s+/g, "");
 
-  // Must start with http:// or https://
   if (/^https?:\/\/\S+$/.test(joined)) {
     return joined;
   }

--- a/ui/src/lib/smart-text.ts
+++ b/ui/src/lib/smart-text.ts
@@ -7,9 +7,10 @@
  *
  * Paste transforms:
  * 1. smartRemoveIndent — strip common leading whitespace from all lines
- * 2. smartRemoveLineBreak — rejoin URLs that were split across lines
- *    (strips all internal whitespace, including spaces left over after an
- *    external paste already removed the newlines)
+ * 2. smartRemoveLineBreak — rejoin a URL that was broken by terminal padding
+ *    or upstream newline-strip (collapses padding-like whitespace runs only;
+ *    natural-language single ASCII spaces between tokens are preserved on
+ *    both copy and paste paths).
  *
  * The correct order is: indent first, then linebreak.
  * If linebreak ran on indented text, the indent spaces would corrupt URLs.
@@ -102,21 +103,29 @@ export function smartRemoveIndent(text: string): string {
 }
 
 /**
- * Detect if the entire text (when all whitespace is removed) forms a single URL.
- * If so, return the whitespace-stripped form. Otherwise return the input unchanged.
+ * Detect if the entire text (when all whitespace is removed) forms a single URL,
+ * AND every internal whitespace run looks like terminal padding / wrap leftover
+ * rather than natural-language word separation. If both hold, return the
+ * whitespace-stripped form. Otherwise return the input unchanged.
  *
- * Handles three shapes that all collapse to the same clean URL:
- *   1. Multi-line URL with newlines only — split by terminal hard-wrap.
- *   2. Multi-line URL with newlines + indent + buffer-pad spaces.
- *   3. Single-line URL where an upstream paste target stripped newlines but
- *      left leading-indent + trailing-pad as internal gaps (≥2-char run or tab).
+ * "Padding-like" run = contains a newline / CR / tab, or is ≥2 ASCII spaces.
+ * A lone ASCII space between tokens is treated as prose and preserved, so
+ * inputs like
  *
- * URLs forbid raw spaces, so stripping all whitespace is safe when the content
- * is recognisably a URL. For single-line input we additionally require every
- * internal whitespace run to be ≥2 chars or contain a tab/CR — that is the
- * signature of terminal padding/indent leftover, while a single ASCII space
- * is the signature of natural-language prose ("https://x.com hello world")
- * which must NOT be collapsed.
+ *     "https://x.com hello world"            (single-line URL + prose)
+ *     "https://x.com\nhello world"           (URL on line 1, prose on line 2)
+ *
+ * survive intact on both copy and paste paths. The shapes that DO collapse:
+ *
+ *     1. Multi-line URL split by terminal hard-wrap (the newline run is the
+ *        only whitespace, possibly fused with indent/pad spaces around it).
+ *     2. Multi-line URL with leading indent + trailing buffer-pad on each line.
+ *     3. Single-line URL where an upstream paste target stripped newlines but
+ *        left leading-indent + trailing-pad as ≥2-char internal gaps, or
+ *        tabs.
+ *
+ * URLs forbid raw whitespace, so collapsing is safe once we have decided the
+ * input is URL-shaped and the gaps look like artefacts.
  *
  * Scope: http:// and https:// only. The \S+ pattern intentionally doesn't
  * validate URL structure — in a clipboard context, false positives
@@ -128,15 +137,13 @@ export function smartRemoveLineBreak(text: string): string {
   const joined = text.replace(/\s+/g, "");
   if (!/^https?:\/\/\S+$/.test(joined)) return text;
 
-  // Multi-line input: terminal hard-wrap / buffer padding scenario — always collapse.
-  if (text.includes("\n")) return joined;
-
-  // Single-line input: only collapse if every internal whitespace run looks like
-  // terminal padding (≥2 chars, or contains tab/CR). A lone ASCII space between
-  // tokens is treated as prose and preserved.
+  // Only collapse when every internal whitespace run looks like terminal
+  // padding / wrap leftover. A lone ASCII space is the prose signature.
   const trimmed = text.replace(/^\s+/, "").replace(/\s+$/, "");
   const internalRuns = trimmed.match(/\s+/g) ?? [];
-  const allRunsLookLikePadding = internalRuns.every((run) => run.length >= 2 || /[\t\r]/.test(run));
+  const allRunsLookLikePadding = internalRuns.every(
+    (run) => run.length >= 2 || /[\t\r\n]/.test(run),
+  );
   if (!allRunsLookLikePadding) return text;
 
   return joined;

--- a/ui/src/lib/smart-text.ts
+++ b/ui/src/lib/smart-text.ts
@@ -109,10 +109,14 @@ export function smartRemoveIndent(text: string): string {
  *   1. Multi-line URL with newlines only — split by terminal hard-wrap.
  *   2. Multi-line URL with newlines + indent + buffer-pad spaces.
  *   3. Single-line URL where an upstream paste target stripped newlines but
- *      left leading-indent + trailing-pad as internal gaps.
+ *      left leading-indent + trailing-pad as internal gaps (≥2-char run or tab).
  *
  * URLs forbid raw spaces, so stripping all whitespace is safe when the content
- * is recognisably a URL.
+ * is recognisably a URL. For single-line input we additionally require every
+ * internal whitespace run to be ≥2 chars or contain a tab/CR — that is the
+ * signature of terminal padding/indent leftover, while a single ASCII space
+ * is the signature of natural-language prose ("https://x.com hello world")
+ * which must NOT be collapsed.
  *
  * Scope: http:// and https:// only. The \S+ pattern intentionally doesn't
  * validate URL structure — in a clipboard context, false positives
@@ -122,12 +126,20 @@ export function smartRemoveLineBreak(text: string): string {
   if (!text) return text;
 
   const joined = text.replace(/\s+/g, "");
+  if (!/^https?:\/\/\S+$/.test(joined)) return text;
 
-  if (/^https?:\/\/\S+$/.test(joined)) {
-    return joined;
-  }
+  // Multi-line input: terminal hard-wrap / buffer padding scenario — always collapse.
+  if (text.includes("\n")) return joined;
 
-  return text;
+  // Single-line input: only collapse if every internal whitespace run looks like
+  // terminal padding (≥2 chars, or contains tab/CR). A lone ASCII space between
+  // tokens is treated as prose and preserved.
+  const trimmed = text.replace(/^\s+/, "").replace(/\s+$/, "");
+  const internalRuns = trimmed.match(/\s+/g) ?? [];
+  const allRunsLookLikePadding = internalRuns.every((run) => run.length >= 2 || /[\t\r]/.test(run));
+  if (!allRunsLookLikePadding) return text;
+
+  return joined;
 }
 
 export interface SmartTextOptions {


### PR DESCRIPTION
## Summary
- 멀티라인 URL을 복사한 뒤 외부 앱(브라우저 주소창 등)에 붙여넣으면 newline은 제거되지만 인덴트/터미널 패딩 공백이 남아 URL 가운데 빈칸이 박히던 문제를 copy 시점에 정리.
- `smartRemoveLineBreak`을 강화: newline 유무로 분기하지 않고 `\s+`(스페이스/탭/개행) 전체를 제거한 결과가 `^https?://...$`이면 정리본을 반환. 이미 한 줄로 합쳐진 케이스도 같은 경로로 정리됨.
- `CopyOptions`에 `smartRemoveLineBreak` 옵션을 추가, `prepareSelectionForCopy`/`runTerminalCopy`가 settings 토글을 따라 copy 시점에도 동일 변환을 적용. 두 smart 토글이 모두 off일 때만 raw-verbatim 경로 유지.

## Test plan
- [x] `npx vitest run src/lib/smart-text.test.ts` — 새 케이스 포함 68개 통과
- [x] `npx vitest run src/components/views/TerminalView.test.tsx` — raw-verbatim 회귀 가드 갱신, 94개 통과
- [x] `npx vitest run` — 전체 UI 테스트 1,719개 통과
- [x] `npx tsc --noEmit` — 타입 클린
- [ ] 수동: 터미널에서 멀티라인 URL 선택 → Ctrl+C → 외부 브라우저 주소창 붙여넣기 시 공백 없이 클린한 URL 확인
- [ ] 수동: 일반 멀티라인 텍스트(코드 등) 복사 시 줄바꿈/포맷 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)