### PR TITLE
Add mobile webview HTTP transport

### DIFF
--- a/src-tauri/src/automation_server/handlers_backend.rs
+++ b/src-tauri/src/automation_server/handlers_backend.rs
@@ -6,7 +6,7 @@ use axum::Json;
 use crate::lock_ext::MutexExt;
 
 use super::helpers::{err_json, ok_json};
-use super::types::{HealthResponse, OutputQuery, WriteBody};
+use super::types::{HealthResponse, NativeInvokeBody, OutputQuery, WriteBody};
 use super::ServerState;
 
 // ---- API self-description ----
@@ -15,9 +15,9 @@ pub async fn api_docs() -> impl IntoResponse {
     Json(serde_json::json!({
         "name": "Laymux IDE Automation API",
         "version": "v1",
-        "description": "Programmatic control of Laymux IDE. Binds to 0.0.0.0 (WSL2 access). Access restricted to loopback, WSL2/Hyper-V bridge (172.16.0.0/12), and link-local.",
+        "description": "Programmatic control of Laymux IDE. Binds to 0.0.0.0 for local, WSL2/Hyper-V, link-local, and Tailscale access.",
         "base_url": format!("http://127.0.0.1:{}/api/v1", super::automation_port()),
-        "auth": "No authentication required. Access is restricted by IP allowlist: loopback (127.x, ::1), WSL2/Hyper-V (172.16.0.0/12), link-local (169.254.x, fe80::).",
+        "auth": "No authentication required. Access is restricted by IP allowlist: loopback (127.x, ::1), WSL2/Hyper-V (172.16.0.0/12), Tailscale CGNAT (100.64.0.0/10), and link-local (169.254.x, fe80::).",
         "discovery": format!("Fixed port: release={}, dev={}. Discovery file: %APPDATA%/laymux/automation.json (release) or %APPDATA%/laymux-dev/automation.json (dev) on Windows, ~/.config/laymux/ or ~/.config/laymux-dev/ on Linux. Contains port and pid. Also LX_AUTOMATION_PORT env var in spawned terminals.", super::RELEASE_PORT, super::DEV_PORT),
         "endpoints": [
             {
@@ -27,6 +27,11 @@ pub async fn api_docs() -> impl IntoResponse {
             {
                 "method": "GET", "path": "/api/v1/docs",
                 "description": "This endpoint. Returns full API documentation as JSON."
+            },
+            {
+                "method": "POST", "path": "/api/v1/native/invoke/{command}",
+                "description": "Browser/WebView transport for selected native commands that are normally called through Tauri invoke. Used by the mobile webview over Tailscale.",
+                "body": { "params": "object ??command parameters using the same camelCase names as tauri-api.ts" }
             },
             {
                 "method": "GET", "path": "/api/v1/workspaces",
@@ -267,6 +272,277 @@ pub async fn health(AxumState(state): AxumState<ServerState>) -> impl IntoRespon
         version: env!("CARGO_PKG_VERSION").into(),
         port,
     })
+}
+
+fn param_string(params: &serde_json::Value, name: &str) -> Result<String, String> {
+    params
+        .get(name)
+        .and_then(|v| v.as_str())
+        .map(ToString::to_string)
+        .ok_or_else(|| format!("Missing string parameter '{name}'"))
+}
+
+fn param_u16(params: &serde_json::Value, name: &str) -> Result<u16, String> {
+    let value = params
+        .get(name)
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| format!("Missing numeric parameter '{name}'"))?;
+    u16::try_from(value).map_err(|_| format!("Parameter '{name}' is out of range"))
+}
+
+fn param_bool_opt(params: &serde_json::Value, name: &str) -> Option<bool> {
+    params.get(name).and_then(|v| v.as_bool())
+}
+
+fn param_string_opt(params: &serde_json::Value, name: &str) -> Option<String> {
+    params
+        .get(name)
+        .and_then(|v| v.as_str())
+        .map(ToString::to_string)
+}
+
+fn json_result<T: serde::Serialize>(
+    result: Result<T, String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match result {
+        Ok(value) => (
+            StatusCode::OK,
+            Json(serde_json::to_value(value).unwrap_or(serde_json::Value::Null)),
+        ),
+        Err(e) => (StatusCode::BAD_REQUEST, Json(err_json(&e))),
+    }
+}
+
+pub async fn native_invoke(
+    AxumState(state): AxumState<ServerState>,
+    Path(command): Path<String>,
+    Json(body): Json<NativeInvokeBody>,
+) -> impl IntoResponse {
+    let params = body.params;
+    match command.as_str() {
+        "create_terminal_session" => {
+            let result = (|| {
+                crate::commands::create_terminal_session_inner(
+                    param_string(&params, "id")?,
+                    param_string(&params, "profile")?,
+                    param_u16(&params, "cols")?,
+                    param_u16(&params, "rows")?,
+                    param_string(&params, "syncGroup")?,
+                    param_bool_opt(&params, "cwdSend"),
+                    param_bool_opt(&params, "cwdReceive"),
+                    param_string_opt(&params, "cwd"),
+                    param_string_opt(&params, "startupCommandOverride"),
+                    &state.app_state,
+                    &state.app_handle,
+                )
+            })();
+            json_result(result)
+        }
+        "write_to_terminal" => json_result((|| {
+            crate::commands::write_to_terminal_inner(
+                &param_string(&params, "id")?,
+                &param_string(&params, "data")?,
+                &state.app_state,
+            )
+        })()),
+        "resize_terminal" => json_result((|| {
+            crate::commands::resize_terminal_inner(
+                &param_string(&params, "id")?,
+                param_u16(&params, "cols")?,
+                param_u16(&params, "rows")?,
+                &state.app_state,
+            )
+        })()),
+        "close_terminal_session" => json_result((|| {
+            crate::commands::close_terminal_session_inner(
+                &param_string(&params, "id")?,
+                &state.app_state,
+                &state.app_handle,
+            )
+        })()),
+        "get_sync_group_terminals" => json_result((|| {
+            let group_name = param_string(&params, "groupName")?;
+            let groups = state.app_state.sync_groups.lock_or_err()?;
+            Ok(groups
+                .get(&group_name)
+                .map(|g| g.terminal_ids.clone())
+                .unwrap_or_default())
+        })()),
+        "handle_lx_message" => json_result(crate::commands::handle_lx_message_inner(
+            &param_string(&params, "messageJson").unwrap_or_default(),
+            &state.app_state,
+            &state.app_handle,
+        )),
+        "load_settings" => json_result(Ok(crate::settings::load_settings())),
+        "load_settings_validated" => json_result(Ok(crate::settings::load_settings_validated())),
+        "reset_settings" => {
+            let default_settings = crate::settings::Settings::default();
+            json_result(
+                crate::settings::save_settings(&default_settings).map(|()| default_settings),
+            )
+        }
+        "get_settings_path" => {
+            json_result(Ok(crate::settings::settings_path().display().to_string()))
+        }
+        "save_settings" => json_result((|| {
+            let settings: crate::settings::Settings = serde_json::from_value(
+                params
+                    .get("settings")
+                    .cloned()
+                    .ok_or_else(|| "Missing settings parameter".to_string())?,
+            )
+            .map_err(|e| format!("Invalid settings: {e}"))?;
+            crate::settings::save_settings(&settings)
+        })()),
+        "load_memo" => json_result(Ok(crate::settings::load_memo(
+            &param_string(&params, "key").unwrap_or_default(),
+        ))),
+        "save_memo" => json_result((|| {
+            crate::settings::save_memo(
+                &param_string(&params, "key")?,
+                &param_string(&params, "content")?,
+            )
+        })()),
+        "save_terminal_output_cache" => json_result(crate::commands::save_terminal_output_cache(
+            param_string(&params, "paneId").unwrap_or_default(),
+            param_string(&params, "data").unwrap_or_default(),
+        )),
+        "load_terminal_output_cache" => json_result(crate::commands::load_terminal_output_cache(
+            param_string(&params, "paneId").unwrap_or_default(),
+        )),
+        "clean_terminal_output_cache" => json_result((|| {
+            let active_pane_ids: Vec<String> = serde_json::from_value(
+                params
+                    .get("activePaneIds")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!([])),
+            )
+            .map_err(|e| format!("Invalid activePaneIds: {e}"))?;
+            crate::commands::clean_terminal_output_cache(active_pane_ids)
+        })()),
+        "save_window_geometry" => json_result(crate::commands::save_window_geometry(
+            params.get("x").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+            params.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+            params.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+            params.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+            params
+                .get("maximized")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+        )),
+        "load_window_geometry" => json_result(crate::commands::load_window_geometry()),
+        "smart_paste" => json_result(crate::commands::smart_paste(
+            param_string(&params, "imageDir").unwrap_or_default(),
+            param_string(&params, "profile").unwrap_or_default(),
+        )),
+        "clipboard_write_text" => json_result(crate::commands::clipboard_write_text(
+            param_string(&params, "text").unwrap_or_default(),
+        )),
+        "read_file_for_viewer" => json_result(crate::commands::read_file_for_viewer(
+            param_string(&params, "path").unwrap_or_default(),
+            params
+                .get("maxBytes")
+                .and_then(|v| v.as_u64())
+                .and_then(|v| usize::try_from(v).ok()),
+        )),
+        "list_directory" => json_result(crate::commands::list_directory(
+            param_string(&params, "path").unwrap_or_default(),
+            param_string_opt(&params, "wslDistro"),
+        )),
+        "get_listening_ports" => json_result(Ok(crate::port_detect::get_listening_ports())),
+        "get_git_branch" => json_result(Ok(crate::commands::get_git_branch(
+            param_string(&params, "workingDir").unwrap_or_default(),
+        ))),
+        "send_os_notification" => json_result(crate::commands::send_os_notification(
+            param_string(&params, "title").unwrap_or_default(),
+            param_string(&params, "body").unwrap_or_default(),
+        )),
+        "set_terminal_cwd_send" => json_result((|| {
+            let terminal_id = param_string(&params, "terminalId")?;
+            let send = params.get("send").and_then(|v| v.as_bool()).unwrap_or(true);
+            let mut terminals = state.app_state.terminals.lock_or_err()?;
+            if let Some(session) = terminals.get_mut(&terminal_id) {
+                session.cwd_send = send;
+            }
+            Ok(())
+        })()),
+        "set_terminal_cwd_receive" => json_result((|| {
+            let terminal_id = param_string(&params, "terminalId")?;
+            let receive = params
+                .get("receive")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            let mut terminals = state.app_state.terminals.lock_or_err()?;
+            if let Some(session) = terminals.get_mut(&terminal_id) {
+                session.cwd_receive = receive;
+            }
+            Ok(())
+        })()),
+        "update_terminal_sync_group" => json_result((|| {
+            let terminal_id = param_string(&params, "terminalId")?;
+            let new_group = param_string(&params, "newGroup")?;
+            crate::commands::update_terminal_sync_group_inner(
+                &terminal_id,
+                &new_group,
+                &state.app_state,
+            )
+        })()),
+        "get_terminal_cwds" => {
+            json_result(crate::commands::get_terminal_cwds_inner(&state.app_state))
+        }
+        "get_terminal_summaries" => json_result((|| {
+            let ids: Vec<String> = serde_json::from_value(
+                params
+                    .get("terminalIds")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!([])),
+            )
+            .map_err(|e| format!("Invalid terminalIds: {e}"))?;
+            crate::commands::get_terminal_summaries_inner(&ids, &state.app_state)
+        })()),
+        "mark_notifications_read" => json_result(crate::commands::mark_notifications_read_inner(
+            serde_json::from_value(
+                params
+                    .get("terminalIds")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!([])),
+            )
+            .map_err(|e| format!("Invalid terminalIds: {e}")),
+            &state.app_state,
+        )),
+        "mark_claude_terminal" => json_result(
+            crate::commands::mark_claude_terminal_inner(
+                &state.app_state,
+                &param_string(&params, "id").unwrap_or_default(),
+            )
+            .map_err(|e| e.to_string()),
+        ),
+        "mark_codex_terminal" => json_result(
+            crate::commands::mark_codex_terminal_inner(
+                &state.app_state,
+                &param_string(&params, "id").unwrap_or_default(),
+            )
+            .map_err(|e| e.to_string()),
+        ),
+        "is_claude_terminal" => json_result((|| {
+            let known = state.app_state.known_claude_terminals.lock_or_err()?;
+            Ok(known.contains(&param_string(&params, "id")?))
+        })()),
+        "is_codex_terminal" => json_result((|| {
+            let known = state.app_state.known_codex_terminals.lock_or_err()?;
+            Ok(known.contains(&param_string(&params, "id")?))
+        })()),
+        "get_claude_session_ids" => json_result(crate::commands::get_claude_session_ids_inner(
+            params.get("sessionMaxAgeHours").and_then(|v| v.as_u64()),
+            &state.app_state,
+        )),
+        _ => (
+            StatusCode::NOT_FOUND,
+            Json(err_json(&format!(
+                "Native invoke command '{command}' is not available over HTTP"
+            ))),
+        ),
+    }
 }
 
 pub async fn terminal_write(

--- a/src-tauri/src/automation_server/mod.rs
+++ b/src-tauri/src/automation_server/mod.rs
@@ -133,7 +133,8 @@ pub async fn start(app_state: Arc<AppState>, app_handle: AppHandle) -> Result<u1
 }
 
 /// Check if an IP address is allowed to access the automation API.
-/// Allows only loopback, link-local, and Hyper-V/WSL2 bridge (172.16.0.0/12).
+/// Allows only loopback, link-local, Hyper-V/WSL2 bridge (172.16.0.0/12),
+/// and Tailscale CGNAT peers (100.64.0.0/10).
 /// Broader RFC 1918 ranges (10.0.0.0/8, 192.168.0.0/16) are excluded to prevent
 /// LAN/VPN peers from accessing the API without authentication.
 fn is_local_ip(ip: &IpAddr) -> bool {
@@ -141,6 +142,7 @@ fn is_local_ip(ip: &IpAddr) -> bool {
         IpAddr::V4(v4) => {
             v4.is_loopback()            // 127.0.0.0/8
                 || (v4.octets()[0] == 172 && (16..=31).contains(&v4.octets()[1])) // 172.16.0.0/12 (WSL2/Hyper-V)
+                || (v4.octets()[0] == 100 && (64..=127).contains(&v4.octets()[1])) // 100.64.0.0/10 (Tailscale)
                 || (v4.octets()[0] == 169 && v4.octets()[1] == 254) // 169.254.0.0/16 link-local
         }
         IpAddr::V6(v6) => {
@@ -154,9 +156,8 @@ fn is_local_ip(ip: &IpAddr) -> bool {
     }
 }
 
-/// IP allowlist middleware — only permits requests from local/private networks.
-/// Replaces Bearer token auth: since this is localhost/WSL communication,
-/// IP restriction provides equivalent security without key management overhead.
+/// IP allowlist middleware: only permits requests from local, WSL/Hyper-V,
+/// link-local, and Tailscale peer addresses.
 async fn ip_allowlist_middleware(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     req: Request,
@@ -168,7 +169,7 @@ async fn ip_allowlist_middleware(
         (
             StatusCode::FORBIDDEN,
             Json(err_json(
-                "Access denied: only local/private network connections are allowed",
+                "Access denied: only local, WSL/Hyper-V, link-local, and Tailscale connections are allowed",
             )),
         )
             .into_response()
@@ -179,6 +180,7 @@ pub fn build_router(state: ServerState, subscriptions: SharedSubscriptionRegistr
     Router::new()
         .route("/api/v1/docs", get(api_docs))
         .route("/api/v1/health", get(health))
+        .route("/api/v1/native/invoke/{command}", post(native_invoke))
         .route("/api/v1/workspaces", get(workspaces_list))
         .route("/api/v1/workspaces", post(workspaces_create))
         .route("/api/v1/workspaces/active", get(workspaces_get_active))
@@ -272,9 +274,7 @@ pub fn build_router(state: ServerState, subscriptions: SharedSubscriptionRegistr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::routing::get;
     use serial_test::serial;
-    use tower::ServiceExt;
 
     #[test]
     fn automation_port_returns_dev_in_debug() {
@@ -304,6 +304,14 @@ mod tests {
     }
 
     #[test]
+    fn is_local_ip_allows_tailscale_cgnat() {
+        // Tailscale assigns peers from 100.64.0.0/10 by default.
+        assert!(is_local_ip(&"100.64.0.1".parse().unwrap()));
+        assert!(is_local_ip(&"100.100.100.100".parse().unwrap()));
+        assert!(is_local_ip(&"100.127.255.255".parse().unwrap()));
+    }
+
+    #[test]
     fn is_local_ip_rejects_lan_and_vpn_ranges() {
         // 10.0.0.0/8 (corporate VPN)
         assert!(!is_local_ip(&"10.0.0.1".parse().unwrap()));
@@ -311,6 +319,9 @@ mod tests {
         // 192.168.0.0/16 (home LAN)
         assert!(!is_local_ip(&"192.168.1.1".parse().unwrap()));
         assert!(!is_local_ip(&"192.168.0.1".parse().unwrap()));
+        // Outside Tailscale's 100.64.0.0/10 CGNAT range
+        assert!(!is_local_ip(&"100.63.255.255".parse().unwrap()));
+        assert!(!is_local_ip(&"100.128.0.0".parse().unwrap()));
     }
 
     #[test]
@@ -327,6 +338,8 @@ mod tests {
         assert!(is_local_ip(&"::ffff:127.0.0.1".parse().unwrap()));
         // ::ffff:172.20.0.1 → WSL2 range
         assert!(is_local_ip(&"::ffff:172.20.0.1".parse().unwrap()));
+        // ::ffff:100.64.0.1 -> Tailscale range
+        assert!(is_local_ip(&"::ffff:100.64.0.1".parse().unwrap()));
         // ::ffff:192.168.1.1 → rejected (LAN)
         assert!(!is_local_ip(&"::ffff:192.168.1.1".parse().unwrap()));
         // ::ffff:8.8.8.8 → rejected (public)

--- a/src-tauri/src/automation_server/types.rs
+++ b/src-tauri/src/automation_server/types.rs
@@ -132,6 +132,12 @@ pub struct FocusTerminalBody {
     pub id: String,
 }
 
+#[derive(Deserialize)]
+pub struct NativeInvokeBody {
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
 #[derive(Serialize)]
 pub struct HealthResponse {
     pub status: String,
@@ -144,6 +150,7 @@ pub struct HealthResponse {
 pub const REGISTERED_ROUTES: &[(&str, &str)] = &[
     ("GET", "/api/v1/docs"),
     ("GET", "/api/v1/health"),
+    ("POST", "/api/v1/native/invoke/{command}"),
     ("GET", "/api/v1/workspaces"),
     ("POST", "/api/v1/workspaces"),
     ("GET", "/api/v1/workspaces/active"),

--- a/src-tauri/src/commands/claude_session.rs
+++ b/src-tauri/src/commands/claude_session.rs
@@ -18,6 +18,13 @@ pub fn get_claude_session_ids(
     session_max_age_hours: Option<u64>,
     state: State<Arc<AppState>>,
 ) -> Result<HashMap<String, String>, String> {
+    get_claude_session_ids_inner(session_max_age_hours, &state)
+}
+
+pub fn get_claude_session_ids_inner(
+    session_max_age_hours: Option<u64>,
+    state: &AppState,
+) -> Result<HashMap<String, String>, String> {
     let known: Vec<String> = {
         let k = state.known_claude_terminals.lock_or_err()?;
         k.iter().cloned().collect()

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -426,6 +426,12 @@ pub fn get_terminal_states(
 pub fn get_terminal_cwds(
     state: State<Arc<AppState>>,
 ) -> Result<std::collections::HashMap<String, String>, String> {
+    get_terminal_cwds_inner(&state)
+}
+
+pub fn get_terminal_cwds_inner(
+    state: &AppState,
+) -> Result<std::collections::HashMap<String, String>, String> {
     let terminals = state.terminals.lock_or_err()?;
     let mut result = std::collections::HashMap::new();
     for (id, session) in terminals.iter() {
@@ -530,6 +536,14 @@ pub fn mark_notifications_read(
     terminal_ids: Vec<String>,
     state: State<Arc<AppState>>,
 ) -> Result<u32, String> {
+    mark_notifications_read_inner(Ok(terminal_ids), &state)
+}
+
+pub fn mark_notifications_read_inner(
+    terminal_ids: Result<Vec<String>, String>,
+    state: &AppState,
+) -> Result<u32, String> {
+    let terminal_ids = terminal_ids?;
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -126,6 +126,35 @@ pub fn create_terminal_session(
     state: State<Arc<AppState>>,
     app: AppHandle,
 ) -> Result<TerminalSession, String> {
+    create_terminal_session_inner(
+        id,
+        profile,
+        cols,
+        rows,
+        sync_group,
+        cwd_send,
+        cwd_receive,
+        cwd,
+        startup_command_override,
+        &state,
+        &app,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn create_terminal_session_inner(
+    id: String,
+    profile: String,
+    cols: u16,
+    rows: u16,
+    sync_group: String,
+    cwd_send: Option<bool>,
+    cwd_receive: Option<bool>,
+    cwd: Option<String>,
+    startup_command_override: Option<String>,
+    state: &Arc<AppState>,
+    app: &AppHandle,
+) -> Result<TerminalSession, String> {
     // Inject LX_SOCKET and LX_AUTOMATION_PORT env vars
     let mut env = Vec::new();
     if let Ok(path_lock) = state.ipc_socket_path.lock_or_err() {
@@ -199,7 +228,7 @@ pub fn create_terminal_session(
     // Spawn PTY with unified OSC processing in the output callback.
     let terminal_id = id.clone();
     let app_clone = app.clone();
-    let state_for_pty = Arc::clone(&*state);
+    let state_for_pty = Arc::clone(state);
     let burst = settings.terminal.output_activity_burst.sanitized();
     let pty_cb_state = Arc::new(activity::PtyCallbackState::new(
         burst.window_ms,
@@ -602,7 +631,7 @@ pub fn create_terminal_session(
     // Start notify gate fallback timer: arms the gate after NOTIFY_GATE_FALLBACK_MS
     // for shells without preexec (e.g., PowerShell which doesn't emit OSC 133;C/E).
     {
-        let state_for_timer = Arc::clone(&*state);
+        let state_for_timer = Arc::clone(state);
         let timer_terminal_id = id.clone();
         std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(NOTIFY_GATE_FALLBACK_MS));
@@ -668,11 +697,20 @@ pub fn resize_terminal(
     rows: u16,
     state: State<Arc<AppState>>,
 ) -> Result<(), String> {
+    resize_terminal_inner(&id, cols, rows, &state)
+}
+
+pub fn resize_terminal_inner(
+    id: &str,
+    cols: u16,
+    rows: u16,
+    state: &AppState,
+) -> Result<(), String> {
     // Update config
     {
         let mut terminals = state.terminals.lock_or_err()?;
         let session = terminals
-            .get_mut(&id)
+            .get_mut(id)
             .ok_or_else(|| format!("Session '{id}' not found"))?;
         session.config.cols = cols;
         session.config.rows = rows;
@@ -680,7 +718,7 @@ pub fn resize_terminal(
 
     // Resize PTY
     let ptys = state.pty_handles.lock_or_err()?;
-    if let Some(handle) = ptys.get(&id) {
+    if let Some(handle) = ptys.get(id) {
         handle.resize(cols, rows)?;
     }
 
@@ -693,6 +731,10 @@ pub fn write_to_terminal(
     data: String,
     state: State<Arc<AppState>>,
 ) -> Result<(), String> {
+    write_to_terminal_inner(&id, &data, &state)
+}
+
+pub fn write_to_terminal_inner(id: &str, data: &str, state: &AppState) -> Result<(), String> {
     if pty_trace::is_pty_trace_enabled() {
         tracing::info!(
             terminal_id = %id,
@@ -707,7 +749,7 @@ pub fn write_to_terminal(
     let ptys = state.pty_handles.lock_or_err()?;
 
     let handle = ptys
-        .get(&id)
+        .get(id)
         .ok_or_else(|| format!("Session '{id}' not found"))?;
 
     handle.write(data.as_bytes())
@@ -719,10 +761,18 @@ pub fn close_terminal_session(
     state: State<Arc<AppState>>,
     app: AppHandle,
 ) -> Result<(), String> {
+    close_terminal_session_inner(&id, &state, &app)
+}
+
+pub fn close_terminal_session_inner(
+    id: &str,
+    state: &AppState,
+    app: &AppHandle,
+) -> Result<(), String> {
     // Remove PTY handle and terminate the child process tree before dropping it.
     {
         let mut ptys = state.pty_handles.lock_or_err()?;
-        if let Some(handle) = ptys.remove(&id) {
+        if let Some(handle) = ptys.remove(id) {
             handle.terminate()?;
         }
     }
@@ -730,20 +780,20 @@ pub fn close_terminal_session(
     // Remove output buffer
     {
         let mut buffers = state.output_buffers.lock_or_err()?;
-        buffers.remove(&id);
+        buffers.remove(id);
     }
 
     let mut terminals = state.terminals.lock_or_err()?;
 
     let session = terminals
-        .remove(&id)
+        .remove(id)
         .ok_or_else(|| format!("Session '{id}' not found"))?;
 
     // Remove from sync group
     if !session.config.sync_group.is_empty() {
         if let Ok(mut groups) = state.sync_groups.lock_or_err() {
             if let Some(group) = groups.get_mut(&session.config.sync_group) {
-                group.remove_terminal(&id);
+                group.remove_terminal(id);
                 if group.terminal_ids.is_empty() {
                     groups.remove(&session.config.sync_group);
                 }
@@ -753,22 +803,22 @@ pub fn close_terminal_session(
 
     // Clean up propagation flag
     if let Ok(mut propagated) = state.propagated_terminals.lock_or_err() {
-        propagated.remove(&id);
+        propagated.remove(id);
     }
 
     // Clean up Claude terminal tracking
     if let Ok(mut known) = state.known_claude_terminals.lock_or_err() {
-        known.remove(&id);
+        known.remove(id);
     }
 
     // Clean up Codex terminal tracking
     if let Ok(mut known) = state.known_codex_terminals.lock_or_err() {
-        known.remove(&id);
+        known.remove(id);
     }
 
     // Clean up interactive-app grace window (#237) so a new terminal that
     // happens to reuse this ID does not inherit stale detection.
-    activity::clear_interactive_app_grace_window(&state, &id);
+    activity::clear_interactive_app_grace_window(state, id);
 
     // Clean up notifications for this terminal
     if let Ok(mut notifs) = state.notifications.lock_or_err() {
@@ -934,13 +984,21 @@ pub fn update_terminal_sync_group(
     new_group: String,
     state: State<Arc<AppState>>,
 ) -> Result<(), String> {
+    update_terminal_sync_group_inner(&terminal_id, &new_group, &state)
+}
+
+pub fn update_terminal_sync_group_inner(
+    terminal_id: &str,
+    new_group: &str,
+    state: &AppState,
+) -> Result<(), String> {
     let mut groups = state.sync_groups.lock_or_err()?;
 
     // Remove from all existing groups
     let empty_groups: Vec<String> = groups
         .iter_mut()
         .filter_map(|(name, group)| {
-            group.remove_terminal(&terminal_id);
+            group.remove_terminal(terminal_id);
             if group.terminal_ids.is_empty() {
                 Some(name.clone())
             } else {
@@ -955,9 +1013,9 @@ pub fn update_terminal_sync_group(
     // Add to new group (if non-empty)
     if !new_group.is_empty() {
         groups
-            .entry(new_group.clone())
-            .or_insert_with(|| crate::terminal::SyncGroup::new(new_group))
-            .add_terminal(terminal_id);
+            .entry(new_group.to_string())
+            .or_insert_with(|| crate::terminal::SyncGroup::new(new_group.to_string()))
+            .add_terminal(terminal_id.to_string());
     }
 
     Ok(())

--- a/ui/src/lib/tauri-api.test.ts
+++ b/ui/src/lib/tauri-api.test.ts
@@ -30,6 +30,8 @@ const mockListen = vi.mocked(listen);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  delete window.__LAYMUX_API_BASE__;
+  vi.unstubAllGlobals();
 });
 
 describe("tauri-api", () => {
@@ -81,6 +83,51 @@ describe("tauri-api", () => {
         cwd: null,
         startupCommandOverride: null,
       });
+    });
+
+    it("uses HTTP native invoke transport when an API base is configured", async () => {
+      window.__LAYMUX_API_BASE__ = "http://100.64.0.2:19281";
+      const mockResult = {
+        id: "t1",
+        title: "Terminal",
+        config: {
+          profile: "PowerShell",
+          cols: 80,
+          rows: 24,
+          sync_group: "default",
+          env: [],
+        },
+      };
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResult),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await createTerminalSession("t1", "PowerShell", 80, 24, "default");
+
+      expect(mockInvoke).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://100.64.0.2:19281/api/v1/native/invoke/create_terminal_session",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            params: {
+              id: "t1",
+              profile: "PowerShell",
+              cols: 80,
+              rows: 24,
+              syncGroup: "default",
+              cwdSend: true,
+              cwdReceive: true,
+              cwd: null,
+              startupCommandOverride: null,
+            },
+          }),
+        }),
+      );
+      expect(result).toEqual(mockResult);
     });
   });
 

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -1,8 +1,82 @@
-import { invoke } from "@tauri-apps/api/core";
+﻿import { invoke as tauriInvoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type { SyncCwdConfig, SyncCwdDefaults } from "./sync-cwd-config";
 
 export type { SyncCwdConfig, SyncCwdDefaults } from "./sync-cwd-config";
+
+declare global {
+  interface Window {
+    __LAYMUX_API_BASE__?: string;
+    __TAURI_INTERNALS__?: unknown;
+  }
+}
+
+function isVitest(): boolean {
+  return Boolean(import.meta.env?.VITEST);
+}
+
+function hasTauriRuntime(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+function getHttpApiBase(): string {
+  if (typeof window === "undefined") return "";
+  const queryValue = new URLSearchParams(window.location.search).get("laymuxApi");
+  const explicit =
+    window.__LAYMUX_API_BASE__ ||
+    queryValue ||
+    window.localStorage.getItem("laymux.apiBase") ||
+    import.meta.env.VITE_LAYMUX_API_BASE;
+  if (explicit) return explicit.replace(/\/$/, "");
+
+  const protocol = window.location.protocol || "http:";
+  const host = window.location.hostname || "127.0.0.1";
+  const port = import.meta.env.DEV ? "19281" : "19280";
+  return `${protocol}//${host}:${port}`;
+}
+
+function shouldUseHttpTransport(): boolean {
+  if (typeof window === "undefined") return false;
+  if (window.__LAYMUX_API_BASE__) return true;
+  if (new URLSearchParams(window.location.search).has("laymuxApi")) return true;
+  if (window.localStorage.getItem("laymux.apiBase")) return true;
+  if (import.meta.env.VITE_LAYMUX_API_BASE) return true;
+  return !hasTauriRuntime() && !isVitest();
+}
+
+async function invokeNative<T>(command: string, params?: Record<string, unknown>): Promise<T> {
+  if (!shouldUseHttpTransport()) {
+    return params === undefined ? tauriInvoke<T>(command) : tauriInvoke<T>(command, params);
+  }
+
+  const response = await fetch(
+    `${getHttpApiBase()}/api/v1/native/invoke/${encodeURIComponent(command)}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ params: params ?? {} }),
+    },
+  );
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message =
+      data && typeof data === "object" && "error" in data
+        ? String(data.error)
+        : response.statusText;
+    throw new Error(message);
+  }
+  return data as T;
+}
+
+function listenNative<T>(
+  event: string,
+  handler: Parameters<typeof listen<T>>[1],
+): Promise<UnlistenFn> {
+  if (shouldUseHttpTransport()) {
+    return Promise.resolve(() => {});
+  }
+  return listen<T>(event, handler);
+}
 
 export interface TerminalSessionResult {
   id: string;
@@ -27,7 +101,7 @@ export async function createTerminalSession(
   cwd?: string,
   startupCommandOverride?: string,
 ): Promise<TerminalSessionResult> {
-  return invoke("create_terminal_session", {
+  return invokeNative("create_terminal_session", {
     id,
     profile,
     cols,
@@ -41,19 +115,19 @@ export async function createTerminalSession(
 }
 
 export async function writeToTerminal(id: string, data: string): Promise<void> {
-  return invoke("write_to_terminal", { id, data });
+  return invokeNative("write_to_terminal", { id, data });
 }
 
 export async function resizeTerminal(id: string, cols: number, rows: number): Promise<void> {
-  return invoke("resize_terminal", { id, cols, rows });
+  return invokeNative("resize_terminal", { id, cols, rows });
 }
 
 export async function closeTerminalSession(id: string): Promise<void> {
-  return invoke("close_terminal_session", { id });
+  return invokeNative("close_terminal_session", { id });
 }
 
 export async function getSyncGroupTerminals(groupName: string): Promise<string[]> {
-  return invoke("get_sync_group_terminals", { groupName });
+  return invokeNative("get_sync_group_terminals", { groupName });
 }
 
 export interface LxResponse {
@@ -63,11 +137,11 @@ export interface LxResponse {
 }
 
 export async function handleLxMessage(messageJson: string): Promise<LxResponse> {
-  return invoke("handle_lx_message", { messageJson });
+  return invokeNative("handle_lx_message", { messageJson });
 }
 
 export async function loadSettings(): Promise<Settings> {
-  return invoke("load_settings");
+  return invokeNative("load_settings");
 }
 
 export interface ValidationWarning {
@@ -82,39 +156,39 @@ export type SettingsLoadResult =
   | { status: "parse_error"; settings: Settings; error: string; settingsPath: string };
 
 export async function loadSettingsValidated(): Promise<SettingsLoadResult> {
-  return invoke("load_settings_validated");
+  return invokeNative("load_settings_validated");
 }
 
 export async function resetSettings(): Promise<Settings> {
-  return invoke("reset_settings");
+  return invokeNative("reset_settings");
 }
 
 export async function getSettingsPath(): Promise<string> {
-  return invoke("get_settings_path");
+  return invokeNative("get_settings_path");
 }
 
 export async function saveSettings(settings: Settings): Promise<void> {
-  return invoke("save_settings", { settings });
+  return invokeNative("save_settings", { settings });
 }
 
 export async function loadMemo(key: string): Promise<string> {
-  return invoke("load_memo", { key });
+  return invokeNative("load_memo", { key });
 }
 
 export async function saveMemo(key: string, content: string): Promise<void> {
-  return invoke("save_memo", { key, content });
+  return invokeNative("save_memo", { key, content });
 }
 
 export async function saveTerminalOutputCache(paneId: string, data: string): Promise<void> {
-  return invoke("save_terminal_output_cache", { paneId, data });
+  return invokeNative("save_terminal_output_cache", { paneId, data });
 }
 
 export async function loadTerminalOutputCache(paneId: string): Promise<string> {
-  return invoke("load_terminal_output_cache", { paneId });
+  return invokeNative("load_terminal_output_cache", { paneId });
 }
 
 export async function cleanTerminalOutputCache(activePaneIds: string[]): Promise<number> {
-  return invoke("clean_terminal_output_cache", { activePaneIds });
+  return invokeNative("clean_terminal_output_cache", { activePaneIds });
 }
 
 export interface WindowGeometry {
@@ -126,11 +200,11 @@ export interface WindowGeometry {
 }
 
 export async function saveWindowGeometry(geo: WindowGeometry): Promise<void> {
-  return invoke("save_window_geometry", { ...geo });
+  return invokeNative("save_window_geometry", { ...geo });
 }
 
 export async function loadWindowGeometry(): Promise<WindowGeometry | null> {
-  return invoke("load_window_geometry");
+  return invokeNative("load_window_geometry");
 }
 
 export interface ConvenienceSettings {
@@ -154,14 +228,14 @@ export interface ClaudeSettings {
   sessionMaxAgeHours: number;
   /** Status message display mode (default: "bullet-title"). */
   statusMessageMode: ClaudeStatusMessageMode;
-  /** Delimiter between bullet and title when both shown (default: " · "). */
+  /** Delimiter between bullet and title when both shown. */
   statusMessageDelimiter: string;
 }
 
 export interface CodexSettings {
   /** Status message display mode (default: "title"). */
   statusMessageMode: CodexStatusMessageMode;
-  /** Delimiter between bullet and title when both shown (default: " · "). */
+  /** Delimiter between bullet and title when both shown. */
   statusMessageDelimiter: string;
 }
 
@@ -357,7 +431,7 @@ export interface SettingsLayout {
 export interface SettingsWorkspace {
   id: string;
   name: string;
-  layoutId?: string; // deprecated — kept for backward compat with old settings.json
+  layoutId?: string; // deprecated; kept for backward compat with old settings.json
   panes: {
     id?: string;
     x: number;
@@ -393,12 +467,12 @@ export interface SmartPasteResult {
 
 /** Perform smart paste: check clipboard for files/images, return path or "none". */
 export async function smartPaste(imageDir: string, profile: string): Promise<SmartPasteResult> {
-  return invoke("smart_paste", { imageDir, profile });
+  return invokeNative("smart_paste", { imageDir, profile });
 }
 
 /** Write text to the system clipboard via Tauri backend. */
 export async function clipboardWriteText(text: string): Promise<void> {
-  return invoke("clipboard_write_text", { text });
+  return invokeNative("clipboard_write_text", { text });
 }
 
 /** A single directory entry returned by the Rust backend. */
@@ -412,7 +486,7 @@ export interface DirEntry {
 
 /** List directory contents via Rust std::fs::read_dir. */
 export async function listDirectory(path: string, wslDistro?: string): Promise<DirEntry[]> {
-  return invoke("list_directory", { path, wslDistro: wslDistro ?? null });
+  return invokeNative("list_directory", { path, wslDistro: wslDistro ?? null });
 }
 
 /** Read a file and classify it for the file viewer. */
@@ -420,22 +494,22 @@ export async function readFileForViewer(
   path: string,
   maxBytes?: number,
 ): Promise<FileViewerContent> {
-  return invoke("read_file_for_viewer", { path, maxBytes: maxBytes ?? null });
+  return invokeNative("read_file_for_viewer", { path, maxBytes: maxBytes ?? null });
 }
 
 /** Update whether a terminal sends CWD changes to other terminals. */
 export async function setTerminalCwdSend(terminalId: string, send: boolean): Promise<void> {
-  return invoke("set_terminal_cwd_send", { terminalId, send });
+  return invokeNative("set_terminal_cwd_send", { terminalId, send });
 }
 
 /** Update whether a terminal accepts CWD sync from other terminals. */
 export async function setTerminalCwdReceive(terminalId: string, receive: boolean): Promise<void> {
-  return invoke("set_terminal_cwd_receive", { terminalId, receive });
+  return invokeNative("set_terminal_cwd_receive", { terminalId, receive });
 }
 
 /** Move a terminal to a different sync group in the backend. */
 export async function updateTerminalSyncGroup(terminalId: string, newGroup: string): Promise<void> {
-  return invoke("update_terminal_sync_group", { terminalId, newGroup });
+  return invokeNative("update_terminal_sync_group", { terminalId, newGroup });
 }
 
 /** Open a URL in the user's default browser via Tauri shell plugin. */
@@ -454,7 +528,40 @@ export function onTerminalOutput(
   terminalId: string,
   callback: (data: Uint8Array) => void,
 ): Promise<UnlistenFn> {
-  return listen<number[]>(`terminal-output-${terminalId}`, (event) => {
+  if (shouldUseHttpTransport()) {
+    let cancelled = false;
+    let lastOutput = "";
+    const encoder = new TextEncoder();
+
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const response = await fetch(
+          `${getHttpApiBase()}/api/v1/terminals/${encodeURIComponent(terminalId)}/output?lines=1000`,
+        );
+        if (response.ok) {
+          const payload = (await response.json()) as { output?: string };
+          const output = payload.output ?? "";
+          if (output.length > lastOutput.length && output.startsWith(lastOutput)) {
+            callback(encoder.encode(output.slice(lastOutput.length)));
+          } else if (output !== lastOutput) {
+            callback(encoder.encode(output));
+          }
+          lastOutput = output;
+        }
+      } catch {
+        // Keep polling; the terminal may not exist yet during initial mount.
+      }
+      if (!cancelled) window.setTimeout(poll, 200);
+    };
+
+    window.setTimeout(poll, 0);
+    return Promise.resolve(() => {
+      cancelled = true;
+    });
+  }
+
+  return listenNative<number[]>(`terminal-output-${terminalId}`, (event) => {
     callback(new Uint8Array(event.payload));
   });
 }
@@ -468,7 +575,7 @@ export function onSyncCwd(
     targets: string[];
   }) => void,
 ): Promise<UnlistenFn> {
-  return listen("sync-cwd", (event) => {
+  return listenNative("sync-cwd", (event) => {
     callback(
       event.payload as {
         path: string;
@@ -484,7 +591,7 @@ export function onSyncCwd(
 export function onSyncBranch(
   callback: (data: { branch: string; terminalId: string; groupId: string }) => void,
 ): Promise<UnlistenFn> {
-  return listen("sync-branch", (event) => {
+  return listenNative("sync-branch", (event) => {
     callback(
       event.payload as {
         branch: string;
@@ -499,7 +606,7 @@ export function onSyncBranch(
 export function onLxNotify(
   callback: (data: { message: string; terminalId: string; level?: string }) => void,
 ): Promise<UnlistenFn> {
-  return listen("lx-notify", (event) => {
+  return listenNative("lx-notify", (event) => {
     callback(event.payload as { message: string; terminalId: string; level?: string });
   });
 }
@@ -508,7 +615,7 @@ export function onLxNotify(
 export function onSetTabTitle(
   callback: (data: { title: string; terminalId: string }) => void,
 ): Promise<UnlistenFn> {
-  return listen("set-tab-title", (event) => {
+  return listenNative("set-tab-title", (event) => {
     callback(event.payload as { title: string; terminalId: string });
   });
 }
@@ -517,7 +624,7 @@ export function onSetTabTitle(
 export function onCommandStatus(
   callback: (data: { terminalId: string; command?: string; exitCode?: number }) => void,
 ): Promise<UnlistenFn> {
-  return listen("command-status", (event) => {
+  return listenNative("command-status", (event) => {
     callback(
       event.payload as {
         terminalId: string;
@@ -536,26 +643,26 @@ export interface ListeningPort {
 
 /** Get currently listening TCP ports. */
 export async function getListeningPorts(): Promise<ListeningPort[]> {
-  return invoke("get_listening_ports");
+  return invokeNative("get_listening_ports");
 }
 
 /** Get the current git branch for a working directory. */
 export async function getGitBranch(workingDir: string): Promise<string | null> {
-  return invoke("get_git_branch", { workingDir });
+  return invokeNative("get_git_branch", { workingDir });
 }
 
 /** Listen for open-file events from the backend. */
 export function onOpenFile(
   callback: (data: { path: string; terminalId: string }) => void,
 ): Promise<UnlistenFn> {
-  return listen("open-file", (event) => {
+  return listenNative("open-file", (event) => {
     callback(event.payload as { path: string; terminalId: string });
   });
 }
 
 /** Send an OS-level notification. */
 export async function sendOsNotification(title: string, body: string): Promise<void> {
-  return invoke("send_os_notification", { title, body });
+  return invokeNative("send_os_notification", { title, body });
 }
 
 // -- Automation API --
@@ -572,7 +679,7 @@ export interface AutomationRequest {
 export function onAutomationRequest(
   callback: (data: AutomationRequest) => void,
 ): Promise<UnlistenFn> {
-  return listen<AutomationRequest>("automation-request", (event) => {
+  return listenNative<AutomationRequest>("automation-request", (event) => {
     callback(event.payload);
   });
 }
@@ -590,7 +697,7 @@ export async function automationResponse(
     data: data ?? null,
     error: error ?? null,
   });
-  return invoke("automation_response", { responseJson });
+  return invokeNative("automation_response", { responseJson });
 }
 
 // -- Claude terminal detection (single source of truth in backend) --
@@ -599,60 +706,66 @@ export async function automationResponse(
 export function onClaudeTerminalDetected(
   callback: (terminalId: string) => void,
 ): Promise<UnlistenFn> {
-  return listen<string>("claude-terminal-detected", (event) => {
+  return listenNative<string>("claude-terminal-detected", (event) => {
     callback(event.payload);
   });
 }
 
 /** Listen for DEC 2026 output activity events from the backend PTY callback.
  *  Emitted (throttled, max 1/sec per terminal) when a TUI app redraws its screen.
- *  active=false is sent when a TUI app transitions from working→idle (e.g., task completion). */
+ *  active=false is sent when a TUI app transitions from working to idle (e.g., task completion). */
 export function onTerminalOutputActivity(
   callback: (data: { terminalId: string; active?: boolean }) => void,
 ): Promise<UnlistenFn> {
-  return listen<{ terminalId: string; active?: boolean }>("terminal-output-activity", (event) => {
-    callback(event.payload);
-  });
+  return listenNative<{ terminalId: string; active?: boolean }>(
+    "terminal-output-activity",
+    (event) => {
+      callback(event.payload);
+    },
+  );
 }
 
-/** Listen for Claude Code white-● message changes from the backend. */
+/** Listen for Claude Code status message changes from the backend. */
 export function onClaudeMessageChanged(
   callback: (data: { terminalId: string; message: string }) => void,
 ): Promise<UnlistenFn> {
-  return listen<{ terminalId: string; message: string }>("claude-message-changed", (event) => {
-    callback(event.payload);
-  });
+  return listenNative<{ terminalId: string; message: string }>(
+    "claude-message-changed",
+    (event) => {
+      callback(event.payload);
+    },
+  );
 }
 
 /** Register a terminal as running Claude Code in the backend (single source of truth).
  *  Called when the frontend detects Claude from command text (OSC 133 E). */
 export async function markClaudeTerminal(id: string): Promise<boolean> {
-  return invoke("mark_claude_terminal", { id });
+  return invokeNative("mark_claude_terminal", { id });
 }
 
 /** Register a terminal as running Codex in the backend.
  *  Called when the frontend detects Codex from command text (OSC 133 E). */
 export async function markCodexTerminal(id: string): Promise<boolean> {
-  return invoke("mark_codex_terminal", { id });
+  return invokeNative("mark_codex_terminal", { id });
 }
 
 /** Check if a terminal is registered as Claude Code in the backend. */
 export async function isClaudeTerminal(id: string): Promise<boolean> {
-  return invoke("is_claude_terminal", { id });
+  return invokeNative("is_claude_terminal", { id });
 }
 
 /** Check if a terminal is registered as Codex in the backend. */
 export async function isCodexTerminal(id: string): Promise<boolean> {
-  return invoke("is_codex_terminal", { id });
+  return invokeNative("is_codex_terminal", { id });
 }
 
 /** Resolve Claude Code session IDs for all known Claude terminals.
- *  Returns a map of terminal_id → Claude session ID.
+ *  Returns a map of terminal_id to Claude session ID.
  *  @param sessionMaxAgeHours - Max session age in hours. 0 disables the filter. */
 export async function getClaudeSessionIds(
   sessionMaxAgeHours?: number,
 ): Promise<Record<string, string>> {
-  return invoke("get_claude_session_ids", {
+  return invokeNative("get_claude_session_ids", {
     sessionMaxAgeHours: sessionMaxAgeHours ?? null,
   });
 }
@@ -660,16 +773,16 @@ export async function getClaudeSessionIds(
 // -- Terminal CWD (single source of truth in backend) --
 
 /** Get CWD for all terminals from backend (single source of truth).
- *  Returns a map of terminal_id → normalized CWD path. */
+ *  Returns a map of terminal_id to normalized CWD path. */
 export async function getTerminalCwds(): Promise<Record<string, string>> {
-  return invoke("get_terminal_cwds");
+  return invokeNative("get_terminal_cwds");
 }
 
 /** Listen for CWD change events detected directly from PTY output in the backend. */
 export function onTerminalCwdChanged(
   callback: (data: { terminalId: string; cwd: string; cwdSend?: boolean }) => void,
 ): Promise<UnlistenFn> {
-  return listen<{ terminalId: string; cwd: string; cwdSend?: boolean }>(
+  return listenNative<{ terminalId: string; cwd: string; cwdSend?: boolean }>(
     "terminal-cwd-changed",
     (event) => {
       callback(event.payload);
@@ -687,7 +800,7 @@ export interface TerminalTitleChangedData {
 export function onTerminalTitleChanged(
   callback: (data: TerminalTitleChangedData) => void,
 ): Promise<UnlistenFn> {
-  return listen<TerminalTitleChangedData>("terminal-title-changed", (event) => {
+  return listenNative<TerminalTitleChangedData>("terminal-title-changed", (event) => {
     callback(event.payload);
   });
 }
@@ -725,10 +838,10 @@ export interface TerminalSummaryResponse {
 export async function getTerminalSummaries(
   terminalIds: string[],
 ): Promise<TerminalSummaryResponse[]> {
-  return invoke("get_terminal_summaries", { terminalIds });
+  return invokeNative("get_terminal_summaries", { terminalIds });
 }
 
 /** Mark notifications as read for the given terminal IDs. Returns count of marked. */
 export async function markNotificationsRead(terminalIds: string[]): Promise<number> {
-  return invoke("mark_notifications_read", { terminalIds });
+  return invokeNative("mark_notifications_read", { terminalIds });
 }

--- a/ui/vite.config.test.ts
+++ b/ui/vite.config.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import config from "./vite.config";
+
+describe("vite config", () => {
+  it("binds the dev server to all interfaces for Tailscale mobile webview access", () => {
+    expect(typeof config).toBe("object");
+    if (typeof config !== "object") {
+      return;
+    }
+
+    expect(config.server?.host).toBe("0.0.0.0");
+    expect(config.server?.port).toBe(1420);
+    expect(config.server?.strictPort).toBe(true);
+  });
+});

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     },
   },
   server: {
+    host: "0.0.0.0",
     port: 1420,
     strictPort: true,
   },


### PR DESCRIPTION
## Summary
- add Tailscale-aware Automation API allowlist and docs
- expose selected native/Tauri commands through HTTP for browser/WebView clients
- add frontend HTTP transport fallback and terminal output polling for mobile WebView
- bind Vite dev server to all interfaces for Tailscale access

## Tests
- npm test -- src/lib/tauri-api.test.ts vite.config.test.ts
- npm run build
- cargo check
- cargo test docs_covers_all_registered_routes
- cargo test is_local_ip

Note: .serena/project.yml had pre-existing local changes and is not included.