### PR TITLE
Notify when Claude is parked on a permission modal

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -6,7 +6,7 @@ import { useTerminalStore } from "@/stores/terminal-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useOverridesStore } from "@/stores/overrides-store";
 import { useNotificationStore } from "@/stores/notification-store";
-import { CODEX_INPUT_PENDING_MARKER } from "@/lib/activity-detection";
+import { CODEX_INPUT_PENDING_MARKER, CLAUDE_INPUT_PENDING_MARKER } from "@/lib/activity-detection";
 
 // Mock xterm since it requires a real DOM with canvas
 const mockOnData = vi.fn();
@@ -1074,6 +1074,270 @@ describe("TerminalView", () => {
     expect(
       useTerminalStore.getState().instances.find((i) => i.id === "t-codex-split")?.activityMessage,
     ).toBe(CODEX_INPUT_PENDING_MARKER);
+  });
+
+  it("marks Claude permission prompts as input pending and emits one notification", async () => {
+    // Regression guard for the WSL-Claude scenario: the working spinner title
+    // keeps animating behind the modal, so the existing working→idle
+    // notification path in `claude_activity.rs` never fires. Detecting the
+    // modal directly from the rolling output tail surfaces the "needs your
+    // input" badge that was previously missing.
+    render(<TerminalView instanceId="t-claude-prompt" profile="WSL" syncGroup="" />);
+    useTerminalStore.getState().updateInstanceInfo("t-claude-prompt", {
+      activity: { type: "interactiveApp", name: "Claude" },
+    });
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    act(() => {
+      onOutput?.(
+        new TextEncoder().encode(
+          "│ Do you want to make this edit to file.rs?  │\r\n" +
+            "│ ❯ 1. Yes                                    │\r\n" +
+            "│   2. Yes, and don't ask again this session  │\r\n" +
+            "│   3. No                                     │\r\n",
+        ),
+      );
+    });
+
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === "t-claude-prompt");
+    expect(instance?.activityMessage).toBe(CLAUDE_INPUT_PENDING_MARKER);
+
+    const notifications = useNotificationStore.getState().notifications;
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      terminalId: "t-claude-prompt",
+      message: "Claude is waiting for your input",
+      level: "info",
+    });
+
+    // A second identical chunk must not re-notify — the prompt is the same
+    // modal sliding through the rolling tail, not a fresh user-actionable
+    // event.
+    act(() => {
+      onOutput?.(
+        new TextEncoder().encode(
+          "│ ❯ 1. Yes                                    │\r\n" +
+            "│   2. Yes, and don't ask again this session  │\r\n" +
+            "│   3. No                                     │\r\n",
+        ),
+      );
+    });
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it("clears Claude input-pending marker after the modal is dismissed", async () => {
+    render(<TerminalView instanceId="t-claude-prompt-done" profile="WSL" syncGroup="" />);
+    useTerminalStore.getState().updateInstanceInfo("t-claude-prompt-done", {
+      activity: { type: "interactiveApp", name: "Claude" },
+    });
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    act(() => {
+      onOutput?.(
+        new TextEncoder().encode(
+          "│ Do you want to proceed?       │\r\n" +
+            "│ ❯ 1. Yes                      │\r\n" +
+            "│   2. No                       │\r\n",
+        ),
+      );
+    });
+
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-claude-prompt-done")
+        ?.activityMessage,
+    ).toBe(CLAUDE_INPUT_PENDING_MARKER);
+
+    // User answered — Claude writes enough non-modal content to push
+    // the ❯ arrow out of the 4 KB dismissal window. Marker must
+    // then clear so the next ⏳ working spinner can take over and
+    // the *next* modal can re-fire its notification. Keying
+    // dismissal off the larger 16 KB detection buffer (an earlier
+    // attempt) pinned the marker for ~30 seconds and suppressed the
+    // follow-up alert; trusting `text` alone (a later attempt)
+    // dismissed mid-frame on WSL where modals split across chunks.
+    // ~30 chars × 200 lines = ~6 KB clears the 4 KB window.
+    act(() => {
+      onOutput?.(new TextEncoder().encode("Continuing with the edit...\r\n".repeat(200)));
+    });
+
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-claude-prompt-done")
+        ?.activityMessage,
+    ).toBeUndefined();
+
+    // The unread badge for this terminal's requiresAction alert must
+    // also clear — otherwise the badge would hang around forever after
+    // the user has already resolved the modal.
+    const pending = useNotificationStore
+      .getState()
+      .notifications.filter((n) => n.terminalId === "t-claude-prompt-done" && n.requiresAction);
+    expect(pending.length).toBeGreaterThan(0);
+    expect(pending.every((n) => n.readAt !== null)).toBe(true);
+  });
+
+  it("keeps the marker steady when a modal frame is split across PTY chunks (WSL/ConPTY)", async () => {
+    // WSL via ConPTY routinely emits a single Claude modal redraw as
+    // 3-10 small PTY chunks. The first chunk holds the arrow line and
+    // satisfies detection, but the next chunk is a spinner footer
+    // continuation that contains no modal pattern at all. A naive
+    // dismissal that trusted `text` alone would clear the marker 60 ms
+    // after firing, and `notif-1.readAt - notif-1.createdAt = 60` in
+    // production confirmed exactly that race. This test locks in the
+    // fix: the marker survives the spinner-only continuation.
+    render(<TerminalView instanceId="t-claude-chunked" profile="WSL" syncGroup="" />);
+    useTerminalStore.getState().updateInstanceInfo("t-claude-chunked", {
+      activity: { type: "interactiveApp", name: "Claude" },
+      workspaceId: "ws-test",
+    });
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    // Chunk 1: full modal frame.
+    act(() => {
+      onOutput?.(
+        new TextEncoder().encode(
+          "│ Do you want to proceed?       │\r\n" +
+            "│ ❯ 1. Yes                      │\r\n" +
+            "│   2. No                       │\r\n",
+        ),
+      );
+    });
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-claude-chunked")
+        ?.activityMessage,
+    ).toBe(CLAUDE_INPUT_PENDING_MARKER);
+
+    // Chunk 2: spinner footer continuation (modal still on screen,
+    // but this chunk's text doesn't include the modal box). Marker
+    // must NOT flap to undefined.
+    act(() => {
+      onOutput?.(new TextEncoder().encode("✶ Hashing… (5s)\r\n"));
+    });
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-claude-chunked")
+        ?.activityMessage,
+    ).toBe(CLAUDE_INPUT_PENDING_MARKER);
+  });
+
+  it("re-fires the input-pending notification when a fresh modal arrives after the previous one was dismissed", async () => {
+    // User answered modal #1, Claude started a new task, then asked
+    // for input again. The previous modal text may still sit in the
+    // rolling buffer but the marker has been cleared, so the new
+    // modal must trigger a fresh notification — without this the
+    // status icon stays on ⏳ silently and the user is never told
+    // Claude is parked on the second prompt.
+    render(<TerminalView instanceId="t-claude-second-modal" profile="WSL" syncGroup="" />);
+    useTerminalStore.getState().updateInstanceInfo("t-claude-second-modal", {
+      activity: { type: "interactiveApp", name: "Claude" },
+      workspaceId: "ws-test",
+    });
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    const notifCountBefore = useNotificationStore
+      .getState()
+      .notifications.filter((n) => n.terminalId === "t-claude-second-modal").length;
+
+    // First modal arrives → notification fires.
+    act(() => {
+      onOutput?.(
+        new TextEncoder().encode(
+          "│ Do you want to proceed?       │\r\n" +
+            "│ ❯ 1. Yes                      │\r\n" +
+            "│   2. No                       │\r\n",
+        ),
+      );
+    });
+    expect(
+      useNotificationStore
+        .getState()
+        .notifications.filter((n) => n.terminalId === "t-claude-second-modal").length,
+    ).toBe(notifCountBefore + 1);
+
+    // User answered — Claude writes enough non-modal content to push
+    // the ❯ arrow out of the 4 KB dismissal window.
+    act(() => {
+      onOutput?.(new TextEncoder().encode("Continuing with the edit...\r\n".repeat(200)));
+    });
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-claude-second-modal")
+        ?.activityMessage,
+    ).toBeUndefined();
+
+    // Second modal arrives → notification fires AGAIN.
+    act(() => {
+      onOutput?.(
+        new TextEncoder().encode(
+          "│ Run this command?             │\r\n" +
+            "│ ❯ 1. Yes                      │\r\n" +
+            "│   2. Edit                     │\r\n" +
+            "│   3. No                       │\r\n",
+        ),
+      );
+    });
+    expect(
+      useNotificationStore
+        .getState()
+        .notifications.filter((n) => n.terminalId === "t-claude-second-modal").length,
+    ).toBe(notifCountBefore + 2);
+  });
+
+  it("does not fire Claude pending notification for an unrelated numbered list", async () => {
+    render(<TerminalView instanceId="t-claude-no-prompt" profile="WSL" syncGroup="" />);
+    useTerminalStore.getState().updateInstanceInfo("t-claude-no-prompt", {
+      activity: { type: "interactiveApp", name: "Claude" },
+    });
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    act(() => {
+      onOutput?.(
+        new TextEncoder().encode(
+          "Steps to reproduce:\r\n 1. open file\r\n 2. press enter\r\n 3. observe\r\n",
+        ),
+      );
+    });
+
+    const instance = useTerminalStore
+      .getState()
+      .instances.find((i) => i.id === "t-claude-no-prompt");
+    expect(instance?.activityMessage).toBeUndefined();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
   });
 
   it("parses Codex footer status messages from output", async () => {

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -1191,6 +1191,53 @@ describe("TerminalView", () => {
     expect(pending.every((n) => n.readAt !== null)).toBe(true);
   });
 
+  it("clears Claude input-pending marker when Claude returns to the normal prompt", async () => {
+    render(<TerminalView instanceId="t-claude-normal-prompt" profile="WSL" syncGroup="" />);
+    useTerminalStore.getState().updateInstanceInfo("t-claude-normal-prompt", {
+      activity: { type: "interactiveApp", name: "Claude" },
+      workspaceId: "ws-test",
+    });
+
+    await vi.waitFor(() => {
+      expect(mockOnTerminalOutput).toHaveBeenCalled();
+    });
+
+    const onOutput = mockOnTerminalOutput.mock.calls.at(-1)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    expect(onOutput).toBeTypeOf("function");
+
+    act(() => {
+      onOutput?.(
+        new TextEncoder().encode(
+          "│ Do you want to proceed?       │\r\n" +
+            "│ ❯ 1. Yes                      │\r\n" +
+            "│   2. No                       │\r\n",
+        ),
+      );
+    });
+
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-claude-normal-prompt")
+        ?.activityMessage,
+    ).toBe(CLAUDE_INPUT_PENDING_MARKER);
+
+    act(() => {
+      onOutput?.(new TextEncoder().encode("╰─❯ "));
+    });
+
+    expect(
+      useTerminalStore.getState().instances.find((i) => i.id === "t-claude-normal-prompt")
+        ?.activityMessage,
+    ).toBeUndefined();
+
+    const pending = useNotificationStore
+      .getState()
+      .notifications.filter((n) => n.terminalId === "t-claude-normal-prompt" && n.requiresAction);
+    expect(pending.length).toBeGreaterThan(0);
+    expect(pending.every((n) => n.readAt !== null)).toBe(true);
+  });
+
   it("keeps the marker steady when a modal frame is split across PTY chunks (WSL/ConPTY)", async () => {
     // WSL via ConPTY routinely emits a single Claude modal redraw as
     // 3-10 small PTY chunks. The first chunk holds the arrow line and

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -57,6 +57,7 @@ import {
   detectActivityFromTitle,
   detectActivityFromCommand,
   detectActivityFromOutput,
+  shouldDismissClaudeInputPendingFromOutput,
 } from "@/lib/activity-detection";
 import { useNotificationStore } from "@/stores/notification-store";
 import { resolveWorkspaceId } from "@/lib/workspace-utils";
@@ -1300,18 +1301,12 @@ export function TerminalView({
         } else if (
           current.activityMessage === CLAUDE_INPUT_PENDING_MARKER &&
           text.trim() &&
-          !claudeDismissalBuffer.includes("❯")
+          shouldDismissClaudeInputPendingFromOutput(claudeDismissalBuffer)
         ) {
-          // Modal truly gone: the ❯ arrow hasn't appeared anywhere in
-          // the last ~4 KB of output. WSL/ConPTY routinely splits a
-          // single modal frame across several small PTY chunks, so a
-          // chunk-local check (`text` alone) would mistake a frame
-          // continuation for a dismissal and clear the marker 60 ms
-          // after firing — that's exactly what made `notif-1` read
-          // itself within milliseconds and hid the badge from the
-          // user. A small rolling buffer keyed off the arrow
-          // character holds the marker steady through chunk splits
-          // and only releases once Claude has truly moved on.
+          // Modal truly gone: either the recent output has no modal arrow,
+          // or Claude has returned to the normal `╰─❯ ` input prompt. The
+          // latter also contains `❯`, so the dismissal check must distinguish
+          // it from an arrowed modal option.
           useTerminalStore.getState().updateInstanceInfo(instanceId, {
             activityMessage: undefined,
           });

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -47,10 +47,12 @@ import {
 
 import {
   CODEX_INPUT_PENDING_MARKER,
+  CLAUDE_INPUT_PENDING_MARKER,
   detectCodexConversationMessageFromOutput,
   detectCodexInputPendingFromOutput,
   detectNewCodexInputPendingPrompt,
   detectCodexStatusMessageFromOutput,
+  detectNewClaudeInputPendingPrompt,
   isCodexFooterStatusLine,
   detectActivityFromTitle,
   detectActivityFromCommand,
@@ -1168,6 +1170,21 @@ export function TerminalView({
     let unlistenOutput: (() => void) | undefined;
     let inAltScreen = false;
     let recentOutputTail = "";
+    // Separate, larger rolling buffer for Claude modal detection only.
+    // Claude redraws its modal every spinner tick in alt-screen mode, and
+    // one ANSI-heavy frame is ~4 KB. The 1 KB `recentOutputTail` above
+    // routinely drops the modal text within a few frames, leaving the
+    // permission/response detector blind. 16 KB comfortably keeps the
+    // modal visible until the user answers it.
+    let claudeDetectionBuffer = "";
+    // Smaller buffer for dismissal: when this window no longer contains
+    // a `❯` arrow we conclude the modal is truly gone. Sized to ~1-2
+    // spinner ticks of post-modal output (modal frames are ~4 KB so
+    // anything smaller would dismiss the marker mid-frame; anything
+    // larger would leave the marker pinned for several seconds after
+    // the user actually answered).
+    let claudeDismissalBuffer = "";
+    const CLAUDE_DISMISSAL_WINDOW = 4096;
     onTerminalOutput(instanceId, (data) => {
       if (cancelled) return;
       terminal.write(data, () => {
@@ -1177,6 +1194,9 @@ export function TerminalView({
       const previousOutputTail = recentOutputTail;
       const combinedText = (recentOutputTail + text).slice(-1024);
       recentOutputTail = combinedText;
+      const previousClaudeBuffer = claudeDetectionBuffer;
+      claudeDetectionBuffer = (claudeDetectionBuffer + text).slice(-16384);
+      claudeDismissalBuffer = (claudeDismissalBuffer + text).slice(-CLAUDE_DISMISSAL_WINDOW);
 
       // OSC parsing and hook dispatch are now handled entirely in the Rust
       // PTY callback (iter_osc_events + match_hooks + dispatch_osc_action).
@@ -1247,6 +1267,70 @@ export function TerminalView({
           useTerminalStore.getState().updateInstanceInfo(instanceId, {
             activityMessage: nextCodexMessage,
           });
+        }
+      }
+
+      // Claude Code permission / response prompt — mirror of the Codex
+      // input-pending wiring above. Without this branch the WSL Claude path
+      // shows ⏳ indefinitely while Claude is parked on a y/N modal: the
+      // working spinner title is still animating behind the modal, so the
+      // working→idle title transition (which fires `task_completed` in
+      // `claude_activity.rs`) never runs and no notification is emitted.
+      // Detecting the modal directly from the rolling output tail closes
+      // that gap.
+      if (current?.activity?.type === "interactiveApp" && current.activity.name === "Claude") {
+        const claudePromptBecamePending = detectNewClaudeInputPendingPrompt(
+          previousClaudeBuffer,
+          text,
+        );
+        if (claudePromptBecamePending && current.activityMessage !== CLAUDE_INPUT_PENDING_MARKER) {
+          useTerminalStore.getState().updateInstanceInfo(instanceId, {
+            activityMessage: CLAUDE_INPUT_PENDING_MARKER,
+          });
+          useNotificationStore.getState().addNotification({
+            terminalId: instanceId,
+            workspaceId: resolveWorkspaceId(instanceId),
+            message: "Claude is waiting for your input",
+            level: "info",
+            // The modal needs an actual user response — keep the badge
+            // up even if this happens to be the active workspace, so
+            // the user can step away and still find the alert later.
+            requiresAction: true,
+          });
+        } else if (
+          current.activityMessage === CLAUDE_INPUT_PENDING_MARKER &&
+          text.trim() &&
+          !claudeDismissalBuffer.includes("❯")
+        ) {
+          // Modal truly gone: the ❯ arrow hasn't appeared anywhere in
+          // the last ~4 KB of output. WSL/ConPTY routinely splits a
+          // single modal frame across several small PTY chunks, so a
+          // chunk-local check (`text` alone) would mistake a frame
+          // continuation for a dismissal and clear the marker 60 ms
+          // after firing — that's exactly what made `notif-1` read
+          // itself within milliseconds and hid the badge from the
+          // user. A small rolling buffer keyed off the arrow
+          // character holds the marker steady through chunk splits
+          // and only releases once Claude has truly moved on.
+          useTerminalStore.getState().updateInstanceInfo(instanceId, {
+            activityMessage: undefined,
+          });
+          // The user has resolved the modal; clear the unread badge
+          // for the input-pending alert this terminal raised. The
+          // notification record is left in the panel as history but
+          // no longer counts as unread.
+          const notificationStore = useNotificationStore.getState();
+          const pendingIds = notificationStore.notifications
+            .filter((n) => n.terminalId === instanceId && n.requiresAction && n.readAt === null)
+            .map((n) => n.id);
+          if (pendingIds.length > 0) {
+            notificationStore.markNotificationsAsRead(pendingIds);
+          }
+          // Reset the detection buffer so the just-resolved modal's
+          // residue cannot re-trigger detection on the next chunk
+          // (the 16 KB window still holds the answered modal frame).
+          // The next genuine modal will refill the buffer naturally.
+          claudeDetectionBuffer = "";
         }
       }
 

--- a/ui/src/hooks/useSyncEvents.test.ts
+++ b/ui/src/hooks/useSyncEvents.test.ts
@@ -320,6 +320,36 @@ describe("useSyncEvents", () => {
     expect(instance?.activityMessage).toBe("모든 테스트 통과했습니다.");
   });
 
+  it("does NOT overwrite the input-pending marker on claude-message-changed", async () => {
+    // Rust emits `claude-message-changed` every time Claude's title changes
+    // — i.e. on every spinner-tick frame while a modal is on screen. The
+    // frontend's input-pending detector sets `activityMessage` to
+    // CLAUDE_INPUT_PENDING_MARKER to signal "user response needed". If the
+    // Rust message handler clobbered that marker with the title-derived
+    // task description, the status icon would flap back to ⏳ within
+    // milliseconds and the user would never see the ✓ "waiting for input"
+    // state. This guards that interaction: while the marker is set, the
+    // Rust message is ignored.
+    const { CLAUDE_INPUT_PENDING_MARKER } = await import("@/lib/activity-markers");
+    useTerminalStore.getState().registerInstance({
+      id: "t1",
+      profile: "WSL",
+      syncGroup: "g1",
+      workspaceId: "ws-1",
+    });
+    useTerminalStore.getState().updateInstanceInfo("t1", {
+      activityMessage: CLAUDE_INPUT_PENDING_MARKER,
+    });
+
+    renderHook(() => useSyncEvents());
+
+    const callback = mockOnClaudeMessageChanged.mock.calls[0][0];
+    callback({ terminalId: "t1", message: "Thinking with xhigh effort" });
+
+    const instance = useTerminalStore.getState().instances.find((i) => i.id === "t1");
+    expect(instance?.activityMessage).toBe(CLAUDE_INPUT_PENDING_MARKER);
+  });
+
   it("calls markClaudeTerminal when command text detects Claude", () => {
     useTerminalStore.getState().registerInstance({
       id: "t1",

--- a/ui/src/hooks/useSyncEvents.ts
+++ b/ui/src/hooks/useSyncEvents.ts
@@ -18,6 +18,7 @@ import {
 import { persistSession } from "@/lib/persist-session";
 import { sendDesktopNotification } from "./useOsNotification";
 import {
+  CLAUDE_INPUT_PENDING_MARKER,
   CODEX_INPUT_PENDING_MARKER,
   detectActivityFromCommand,
   detectCodexConversationMessageFromOutput,
@@ -165,6 +166,21 @@ export function useSyncEvents() {
     trackListener(
       onClaudeMessageChanged((data) => {
         if (cancelled) return;
+        const instance = useTerminalStore
+          .getState()
+          .instances.find((i) => i.id === data.terminalId);
+        // The frontend's modal detector sets activityMessage to
+        // CLAUDE_INPUT_PENDING_MARKER when a permission/response prompt is on
+        // screen. Rust fires `claude-message-changed` on every title change
+        // (i.e. every spinner-tick frame while Claude is animating ✶/Braille
+        // behind the modal), so without this guard the marker would be
+        // clobbered within ~150 ms by the title-derived task description and
+        // the status icon would flap back to ⏳. The marker is cleared by
+        // the same detector when the modal scrolls out of the rolling
+        // buffer, at which point the next Rust message naturally applies.
+        if (instance?.activityMessage === CLAUDE_INPUT_PENDING_MARKER) {
+          return;
+        }
         useTerminalStore.getState().updateInstanceInfo(data.terminalId, {
           activityMessage: data.message,
         });

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -6,6 +6,8 @@ import {
   detectNewCodexInputPendingPrompt,
   detectCodexConversationMessageFromOutput,
   detectCodexStatusMessageFromOutput,
+  detectClaudeInputPendingFromOutput,
+  detectNewClaudeInputPendingPrompt,
 } from "./activity-detection";
 
 describe("detectActivityFromTitle", () => {
@@ -69,6 +71,192 @@ describe("detectActivityFromTitle", () => {
     ).toBeUndefined();
     expect(detectActivityFromTitle("/home/user/vim-config")).toBeUndefined();
     expect(detectActivityFromTitle("C:\\Users\\name\\node_modules")).toBeUndefined();
+  });
+});
+
+describe("detectClaudeInputPendingFromOutput", () => {
+  // Claude Code renders permission modals with an arrowed numbered option
+  // (e.g. "❯ 1. Yes") plus sibling options on consecutive lines. Both the
+  // arrow AND at least two numbered options are required so the regular
+  // input prompt "╰─❯ 1. anything" the user could type does not false-fire.
+
+  it("detects a Yes/No permission modal", () => {
+    expect(
+      detectClaudeInputPendingFromOutput(
+        "│ Do you want to make this edit to file.rs?  │\r\n" +
+          "│ ❯ 1. Yes                                    │\r\n" +
+          "│   2. Yes, and don't ask again this session  │\r\n" +
+          "│   3. No                                     │\r\n",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects when the selection arrow is on a later option", () => {
+    expect(
+      detectClaudeInputPendingFromOutput(
+        "   1. Yes\r\n" + "   2. Yes, and don't ask again\r\n" + " ❯ 3. No\r\n",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores the regular Claude input prompt with user-typed text", () => {
+    // The steady-state Claude prompt is "╰─❯ " — when the user starts a
+    // message with "1. test" the arrow + numbered shape appears, but there
+    // is only ONE numbered option in the rolling tail, so detection must
+    // refuse to fire and avoid a spurious notification.
+    expect(detectClaudeInputPendingFromOutput("╰─❯ 1. test draft for the team")).toBe(false);
+  });
+
+  it("ignores unrelated multi-line output containing numbered lists", () => {
+    expect(
+      detectClaudeInputPendingFromOutput(
+        "Steps to reproduce:\r\n 1. open file\r\n 2. press enter\r\n 3. observe\r\n",
+      ),
+    ).toBe(false);
+  });
+
+  it("detects a modal interleaved with ANSI color escapes", () => {
+    // The real PTY stream Claude Code emits puts SGR codes (e.g.
+    // `\x1b[38;5;246m`) BETWEEN the selection arrow and the option text:
+    //   "❯ \x1b[38;5;246m1. \x1b[38;5;153m1"
+    // Without stripping CSI sequences first, the arrowed-option regex looked
+    // for `❯\s*\d+` and saw `❯ \x1b` instead of `❯ 1`, so the modal in
+    // a live WSL Claude session never matched — the notification badge never
+    // fired even though the user was parked on a y/N prompt.
+    expect(
+      detectClaudeInputPendingFromOutput(
+        "\x1b[1m선택지를\x1b[m\x1b[38;5;231m\x1b[1m 고르시겠습니까?\x1b[m\r\n" +
+          "\x1b[38;5;153m\r\n❯ \x1b[38;5;246m1. \x1b[38;5;153m1\x1b[K\x1b[m\r\n" +
+          "     \x1b[38;5;246m첫 번째 선택지\x1b[K\x1b[m\r\n" +
+          "  \x1b[38;5;246m2. \x1b[m2\x1b[K\r\n" +
+          "     \x1b[38;5;246m두 번째 선택지\x1b[K\x1b[m\r\n" +
+          "  \x1b[38;5;246m3. \x1b[m3\x1b[K\r\n",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects a modal that renders option rows via CUP/CUF cursor escapes (real WSL Claude)", () => {
+    // This is the bytestream shape captured from a live WSL Claude session
+    // that the previous detector silently refused to fire on. Unlike the
+    // synthetic fixtures above (which use literal '\r\n' and spaces),
+    // Claude in alt-screen mode actually paints the modal frame using
+    // cursor-control escapes:
+    //   - `\x1b[1C` (CUF: cursor forward 1) for the space between the
+    //     option number and its text
+    //   - `\x1b[17;3H` (CUP: cursor position) for placing each option on
+    //     its own terminal row
+    // After a naïve strip-all-CSI pass, "2.\x1b[1C코드" collapses to
+    // "2.코드" (no whitespace) and "\x1b[17;3H2." collapses next to the
+    // previous option (no line break), so the `\d+\.\s+\S` regex finds
+    // exactly ONE match — failing the two-options floor and never
+    // notifying the user. The fix converts CUP to '\n' and CUF(N) to N
+    // spaces inside stripAnsi so the regex sees the layout the user sees.
+    const realWslModal =
+      "❯ \x1b[38;5;246m1. \x1b[38;5;153m코드 작성/수정\x1b[K\x1b[m" +
+      "\x1b[16;3H   \x1b[38;5;246m새 기능 구현, 버그 수정, 리팩토링 등\x1b[K" +
+      "\x1b[17;3H2.\x1b[m\x1b[1C코드\x1b[1C탐색/분석\x1b[38;5;246m" +
+      "\x1b[18;6H코드베이스\x1b[1C구조\x1b[1C파악,\x1b[1C특정\x1b[1C함수\x1b[1C찾기" +
+      "\x1b[19;3H3.\x1b[m\x1b[1C문서/설명\x1b[38;5;246m" +
+      "\x1b[20;6H코드\x1b[1C동작\x1b[1C설명,\x1b[1C문서\x1b[1C작성" +
+      "\x1b[21;3H4.\x1b[m\x1b[1C기타\x1b[38;5;246m" +
+      "\x1b[22;6H위에\x1b[1C해당하지\x1b[1C않는\x1b[1C작업" +
+      "\x1b[23;3H5.\x1b[1CType\x1b[1Csomething.\n";
+    expect(detectClaudeInputPendingFromOutput(realWslModal)).toBe(true);
+  });
+});
+
+describe("detectNewClaudeInputPendingPrompt", () => {
+  it("detects a freshly rendered permission modal", () => {
+    expect(
+      detectNewClaudeInputPendingPrompt(
+        "✶ Working on task\r\n",
+        "│ Do you want to make this edit?  │\r\n" +
+          "│ ❯ 1. Yes                        │\r\n" +
+          "│   2. No                         │\r\n",
+      ),
+    ).toBe(true);
+  });
+
+  it("still reports true while a modal sits in the rolling buffer — dedupe is the caller's job", () => {
+    // This function intentionally does NOT subtract `previousText`. WSL
+    // splits a modal frame across many small PTY chunks, so a "no arrow
+    // in this chunk" early-return would refuse to fire on continuation
+    // chunks even though the combined buffer holds the complete modal.
+    // Dedupe is owned by the call site's marker (CLAUDE_INPUT_PENDING_MARKER)
+    // which also clears the detection buffer on dismissal, so this function
+    // can stay simple and report ground truth: "is a modal visible in the
+    // rolling window right now?"
+    const modal =
+      "│ Do you want to make this edit?  │\r\n" +
+      "│ ❯ 1. Yes                        │\r\n" +
+      "│   2. No                         │\r\n";
+    expect(detectNewClaudeInputPendingPrompt(modal, "later spinner frame\r\n")).toBe(true);
+  });
+
+  it("does not fire when neither the new chunk nor the tail has a selection arrow", () => {
+    // The arrow is the unique TUI cursor for Claude's modal; without it
+    // anywhere in the combined buffer the detector must refuse, even if
+    // the text happens to look like a numbered list.
+    expect(
+      detectNewClaudeInputPendingPrompt(
+        "previous spinner frame\r\n",
+        "  1. apples\r\n  2. oranges\r\n  3. pears\r\n",
+      ),
+    ).toBe(false);
+  });
+
+  it("fires when an ANSI-coloured modal frame arrives", () => {
+    // Matches the live-stream shape from a real WSL Claude prompt. The
+    // unit-test fixture above (`detects a modal interleaved with ANSI color
+    // escapes`) is the steady-state combined buffer; this verifies the
+    // newness check also tolerates the ANSI-laden chunk.
+    expect(
+      detectNewClaudeInputPendingPrompt(
+        "✶ Hashing… (5m 25s)\r\n",
+        "\x1b[38;5;153m\r\n❯ \x1b[38;5;246m1. \x1b[m1\x1b[K\r\n" +
+          "  \x1b[38;5;246m2. \x1b[m2\x1b[K\r\n" +
+          "  \x1b[38;5;246m3. \x1b[m3\x1b[K\r\n",
+      ),
+    ).toBe(true);
+  });
+
+  it("still detects when ANSI-laden filler pushes the modal out of a small slice", () => {
+    // Real WSL Claude: alt-screen redraws every spinner tick (~150ms),
+    // re-emitting box-drawing + colour codes for the entire modal frame.
+    // A single frame easily exceeds 4 KB once ANSI escapes are counted —
+    // the actual session that hit this bug had 29 KB of raw output where
+    // the last 1 KB held only spinner footer text. If the detector
+    // collapsed the combined buffer to 1 KB it would scroll the modal
+    // off the window and never fire. Mirror that shape with ~8 KB of
+    // ANSI-cursor filler trailing the modal text.
+    const modalChunk =
+      "\x1b[1m어떤 것을 선택하시겠습니까?\x1b[m\r\n" +
+      "\x1b[38;5;153m❯ \x1b[38;5;246m1. \x1b[m1번 선택지\x1b[K\r\n" +
+      "  \x1b[38;5;246m2. \x1b[m2번 선택지\x1b[K\r\n" +
+      "  \x1b[38;5;246m3. \x1b[m3번 선택지\x1b[K\r\n";
+    const spinnerFiller =
+      "\x1b[1;1H\x1b[K\x1b[2;1H\x1b[K\x1b[3;1H\x1b[K\x1b[4;1H\x1b[K".repeat(80) +
+      "\x1b[1m✶ Hashing… (28s)\x1b[m\r\n";
+    // Combined > 8 KB; modal sits in `previousText`, only spinner in `nextText`
+    // that includes a fresh arrow to satisfy the gate.
+    expect(
+      detectNewClaudeInputPendingPrompt(modalChunk, "\x1b[38;5;153m❯\x1b[m" + spinnerFiller),
+    ).toBe(true);
+  });
+
+  it("detects every fresh modal even when the previous one lingers in the tail", () => {
+    // Real WSL Claude session: the user answers modal #1 and Claude continues
+    // working, then renders modal #2 within a few seconds. The 1024-char
+    // rolling tail still contains modal #1's text, so a naive
+    // `!previousText.has(modal)` check would say "not new" and the second
+    // notification would never fire — exactly the regression the user hit
+    // ("first modal alerts, follow-up modals do not"). De-duplication is
+    // the call-site marker's job, not this function's: as long as the new
+    // chunk itself shows the modal shape, return true.
+    const firstModal =
+      "│ ❯ 1. Yes                       │\r\n" + "│   2. No                        │\r\n";
+    const secondModalChunk = "✶ Hashing…\r\n│ ❯ 1. Option A     │\r\n│   2. Option B     │\r\n";
+    expect(detectNewClaudeInputPendingPrompt(firstModal, secondModalChunk)).toBe(true);
   });
 });
 

--- a/ui/src/lib/activity-detection.test.ts
+++ b/ui/src/lib/activity-detection.test.ts
@@ -8,6 +8,7 @@ import {
   detectCodexStatusMessageFromOutput,
   detectClaudeInputPendingFromOutput,
   detectNewClaudeInputPendingPrompt,
+  shouldDismissClaudeInputPendingFromOutput,
 } from "./activity-detection";
 
 describe("detectActivityFromTitle", () => {
@@ -257,6 +258,20 @@ describe("detectNewClaudeInputPendingPrompt", () => {
       "│ ❯ 1. Yes                       │\r\n" + "│   2. No                        │\r\n";
     const secondModalChunk = "✶ Hashing…\r\n│ ❯ 1. Option A     │\r\n│   2. Option B     │\r\n";
     expect(detectNewClaudeInputPendingPrompt(firstModal, secondModalChunk)).toBe(true);
+  });
+});
+
+describe("shouldDismissClaudeInputPendingFromOutput", () => {
+  it("dismisses when Claude returns to its normal input prompt", () => {
+    expect(shouldDismissClaudeInputPendingFromOutput("╰─❯ ")).toBe(true);
+  });
+
+  it("does not mistake a visible modal selection arrow for dismissal", () => {
+    expect(
+      shouldDismissClaudeInputPendingFromOutput(
+        "│ ❯ 1. Yes                        │\r\n" + "│   2. No                         │\r\n",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -3,10 +3,133 @@ import {
   detectRegisteredActivityFromCommand,
   detectRegisteredActivityFromTitle,
 } from "./activity-handler";
+import { CLAUDE_INPUT_PENDING_MARKER, CODEX_INPUT_PENDING_MARKER } from "./activity-markers";
 
-export const CODEX_INPUT_PENDING_MARKER = "__codex_input_pending__";
+// Re-export so existing call sites that already import these markers from
+// `activity-detection` keep working. The canonical source is `activity-markers`
+// to keep the import graph acyclic \u2014 see the doc comment there.
+export { CLAUDE_INPUT_PENDING_MARKER, CODEX_INPUT_PENDING_MARKER };
 const MIDDLE_DOT = "\u00b7";
 const ASSISTANT_BULLET = "\u2022";
+
+/**
+ * Matches an arrow-prefixed numbered option such as `\u276f 1. Yes` /
+ * `\u276f 2. No, \u2026`. The option text is required to be non-empty so the
+ * regular Claude input prompt `\u2570\u2500\u276f ` (no number follows) is excluded.
+ */
+const CLAUDE_ARROWED_OPTION = /\u276f\s*\d+\.\s+\S/;
+
+/**
+ * Matches a numbered option line such as `1. Yes` / `  2. Yes, and don't ask
+ * again`. The leading anchor accepts start-of-line, whitespace, or the
+ * vertical box edge Claude uses to frame the modal, so options indented inside
+ * `\u2502` borders still match.
+ */
+const CLAUDE_NUMBERED_OPTION = /(?:^|[\s\u2502|])\d+\.\s+\S/gm;
+
+/**
+ * Size of the rolling window used to scan for a Claude permission modal.
+ * Claude renders the modal in alt-screen mode and redraws the entire frame
+ * every spinner tick (~150 ms). One frame is dominated by ANSI cursor
+ * positioning + colour escapes \u2014 a real WSL session that hit this bug had
+ * a 4 KB modal frame inside 29 KB of total ring-buffer output where the
+ * latest 1 KB held only the spinner footer. 16 KB comfortably covers
+ * several frames so the modal stays visible to the detector until the
+ * user answers it.
+ */
+const CLAUDE_DETECTION_WINDOW = 16384;
+
+/**
+ * Strips CSI / SGR escape sequences (e.g. `\x1b[38;5;246m`) and OSC sequences
+ * (e.g. `\x1b]133;A\x07`) so a regex can run against the printable text only.
+ *
+ * Live Claude Code modal output is more than just colour-coded text \u2014 it
+ * paints the modal frame using cursor-control escapes:
+ *
+ *   `\u276f \x1b[38;5;246m1. \x1b[38;5;153m\ucf54\ub4dc \uc791\uc131/\uc218\uc815`        \u2190 first option, literal space after "1."
+ *   `\x1b[17;3H2.\x1b[m\x1b[1C\ucf54\ub4dc\x1b[1C\ud0d0\uc0c9/\ubd84\uc11d`           \u2190 second option, CUF for spacing + CUP for row
+ *   `\x1b[18;6H\ucf54\ub4dc\ubca0\uc774\uc2a4\x1b[1C\uad6c\uc870\x1b[1C\ud30c\uc545`              \u2190 description on next row
+ *   `\x1b[19;3H3.\x1b[m\x1b[1C\ubb38\uc11c/\uc124\uba85`                     \u2190 third option
+ *
+ * Two layers of cursor escapes therefore need to be **converted to printable
+ * characters**, not just stripped, before the option regex can match:
+ *
+ *  1. CUF (`\x1b[<N>C`, cursor forward N columns) is how Claude renders the
+ *     space between the option number and its text. Stripping it without
+ *     substitution would collapse `2. \ucf54\ub4dc` into `2.\ucf54\ub4dc`, defeating the
+ *     `\d+\.\s+\S` regex.
+ *  2. CUP (`\x1b[<row>;<col>H`, cursor position) is how Claude places each
+ *     option on its own terminal row. Stripping it without substitution
+ *     concatenates every option into one long line, defeating the
+ *     `(?:^|[\s\u2502|])` line-start anchor in the numbered-option regex.
+ *
+ * Without these conversions only the first option (which uses literal
+ * spaces) matches, the count never reaches the two-options floor, and the
+ * detector silently refuses to fire on real WSL Claude sessions. The unit-
+ * test fixtures use plain text with literal newlines and spaces, so they
+ * pass without this step \u2014 every regression must be guarded by a fixture
+ * that includes real CUP/CUF escapes.
+ */
+function stripAnsi(text: string): string {
+  return (
+    text
+      .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+      // CUP \u2192 newline so options on different terminal rows end up on
+      // different text lines. Row/col values are irrelevant for detection.
+      .replace(/\x1b\[(?:\d+)?(?:;\d+)?H/g, "\n")
+      // CUF(N) \u2192 N spaces. Cap at 200 to defend against a malicious
+      // `\x1b[999999C` from blowing memory; real modals use 1\u201310.
+      .replace(/\x1b\[(\d+)C/g, (_, n) => " ".repeat(Math.min(parseInt(n, 10), 200)))
+      .replace(/\x1b\[C/g, " ")
+      .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "")
+  );
+}
+
+/**
+ * Returns true when the rolling output window currently shows a Claude Code
+ * permission / response prompt.
+ *
+ * Claude Code renders prompts like:
+ *   \u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e
+ *   \u2502 Do you want to make this edit?      \u2502
+ *   \u2502 \u276f 1. Yes                            \u2502
+ *   \u2502   2. Yes, and don't ask again       \u2502
+ *   \u2502   3. No                             \u2502
+ *   \u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f
+ *
+ * Detection requires BOTH the arrow-prefixed option AND at least two numbered
+ * lines, because the arrow alone matches the steady-state Claude input prompt
+ * once the user starts typing literal `1. text` after `\u2570\u2500\u276f ` \u2014 the two-options
+ * floor cleanly excludes that case while still firing for every real modal.
+ */
+export function detectClaudeInputPendingFromOutput(text: string): boolean {
+  const plain = stripAnsi(text);
+  if (!CLAUDE_ARROWED_OPTION.test(plain)) return false;
+  const matches = plain.match(CLAUDE_NUMBERED_OPTION);
+  return (matches?.length ?? 0) >= 2;
+}
+
+/**
+ * Returns true when the rolling window currently shows a Claude modal.
+ *
+ * IMPORTANT: do not gate on `nextText.includes(❯)`. WSL/ConPTY splits a
+ * single modal frame across many small PTY chunks; the arrow lands in
+ * chunk 1 and the numbered options arrive in later chunks via cursor
+ * positioning (`\x1b[17;3H2.`), not `\r\n`. A naive early-return on
+ * "no arrow in this chunk" would refuse to fire on every continuation
+ * chunk even though the combined buffer holds a complete modal — that
+ * is exactly the silent-fail mode reported by the user.
+ *
+ * De-duplication of repeat notifications is the call site's job (via
+ * the `CLAUDE_INPUT_PENDING_MARKER` on `activityMessage`). The marker
+ * is cleared by `TerminalView` which also resets the buffer it owns,
+ * so the detector cannot keep re-firing on stale modal residue after
+ * the user has answered.
+ */
+export function detectNewClaudeInputPendingPrompt(previousText: string, nextText: string): boolean {
+  const combinedText = `${previousText}${nextText}`.slice(-CLAUDE_DETECTION_WINDOW);
+  return detectClaudeInputPendingFromOutput(combinedText);
+}
 
 /** Known interactive apps without dedicated provider handlers. */
 const STATIC_INTERACTIVE_APPS: { title: string; command: string; name: string }[] = [

--- a/ui/src/lib/activity-detection.ts
+++ b/ui/src/lib/activity-detection.ts
@@ -26,6 +26,8 @@ const CLAUDE_ARROWED_OPTION = /\u276f\s*\d+\.\s+\S/;
  * `\u2502` borders still match.
  */
 const CLAUDE_NUMBERED_OPTION = /(?:^|[\s\u2502|])\d+\.\s+\S/gm;
+const CLAUDE_NORMAL_INPUT_PROMPT = /\u2570\u2500\u276f(?:\s|$)/;
+const CLAUDE_SELECTION_ARROW = "\u276f";
 
 /**
  * Size of the rolling window used to scan for a Claude permission modal.
@@ -129,6 +131,16 @@ export function detectClaudeInputPendingFromOutput(text: string): boolean {
 export function detectNewClaudeInputPendingPrompt(previousText: string, nextText: string): boolean {
   const combinedText = `${previousText}${nextText}`.slice(-CLAUDE_DETECTION_WINDOW);
   return detectClaudeInputPendingFromOutput(combinedText);
+}
+
+/**
+ * Returns true when a previously visible Claude modal should be considered
+ * resolved. Claude's normal prompt also contains `❯` (`╰─❯ `), so dismissal
+ * cannot be keyed only on "no arrow in the recent output".
+ */
+export function shouldDismissClaudeInputPendingFromOutput(text: string): boolean {
+  const plain = stripAnsi(text);
+  return CLAUDE_NORMAL_INPUT_PROMPT.test(plain) || !plain.includes(CLAUDE_SELECTION_ARROW);
 }
 
 /** Known interactive apps without dedicated provider handlers. */

--- a/ui/src/lib/activity-markers.ts
+++ b/ui/src/lib/activity-markers.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal sentinel values written to `instance.activityMessage` when a TUI
+ * provider is waiting for user input. They are *internal* state, never
+ * user-facing strings — the activity handlers swap them out for the
+ * appropriate icon and (optionally) a derived display message.
+ *
+ * Lives in its own module so both `activity-detection.ts` (the writer) and
+ * the per-provider handlers (the readers) can import from a leaf with no
+ * back-edges to `activity-handler.ts`. Importing the markers from
+ * `activity-detection.ts` would create a load-order cycle
+ * (`activity-handler` → `claude-activity-handler` → `activity-detection`
+ * → `activity-handler`) that races `new ClaudeActivityHandler()` against
+ * the partial activity-handler module.
+ */
+export const CODEX_INPUT_PENDING_MARKER = "__codex_input_pending__";
+export const CLAUDE_INPUT_PENDING_MARKER = "__claude_input_pending__";

--- a/ui/src/lib/claude-activity-handler.test.ts
+++ b/ui/src/lib/claude-activity-handler.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ClaudeActivityHandler } from "./claude-activity-handler";
+import { CLAUDE_INPUT_PENDING_MARKER } from "./activity-detection";
 import type { RawTerminalState } from "./activity-handler";
 
 const SEP = " \u00b7 ";
@@ -149,6 +150,66 @@ describe("ClaudeActivityHandler", () => {
     it("does NOT treat ✳ idle as a working spinner", () => {
       // Regression guard: ✳ is the idle prefix and must keep returning ✓.
       expect(handler.computeStatus(raw({ title: "\u2733 Claude Code" })).icon).toBe("✓");
+    });
+
+    // ── Input-pending overrides working state ──
+    // When Claude is parked on a permission modal mid-task, the working
+    // spinner title is still animating behind the modal and outputActive is
+    // typically true. Without an explicit input-pending branch the status
+    // pins on hourglass and the user never sees the notification badge. The
+    // marker is set by TerminalView when the modal is detected in the
+    // rolling output tail; the handler must trust it over every other
+    // signal.
+
+    it("returns success when input is pending even with outputActive true", () => {
+      expect(
+        handler.computeStatus(
+          raw({
+            activityMessage: CLAUDE_INPUT_PENDING_MARKER,
+            outputActive: true,
+            title: "✶ Working on task",
+          }),
+        ),
+      ).toEqual({ icon: "✓", color: "var(--green)" });
+    });
+
+    it("returns success when input is pending with a Braille working title", () => {
+      expect(
+        handler.computeStatus(
+          raw({
+            activityMessage: CLAUDE_INPUT_PENDING_MARKER,
+            title: "⠋ Analyzing",
+          }),
+        ).icon,
+      ).toBe("✓");
+    });
+  });
+
+  describe("computeStatusMessage when input pending", () => {
+    it("hides the internal marker and falls back to title-derived text", () => {
+      // The marker is a sentinel, never a user-facing message. When Claude
+      // is mid-task on a permission modal we still want the status line to
+      // show the surrounding context ("Editing main.rs") instead of the raw
+      // marker string.
+      expect(
+        handler.computeStatusMessage(
+          raw({
+            activityMessage: CLAUDE_INPUT_PENDING_MARKER,
+            title: "✶ Editing main.rs",
+          }),
+        ),
+      ).toBe("Editing main.rs");
+    });
+
+    it("returns undefined when input pending and no working title is available", () => {
+      expect(
+        handler.computeStatusMessage(
+          raw({
+            activityMessage: CLAUDE_INPUT_PENDING_MARKER,
+            title: "Claude Code",
+          }),
+        ),
+      ).toBeUndefined();
     });
   });
 

--- a/ui/src/lib/claude-activity-handler.ts
+++ b/ui/src/lib/claude-activity-handler.ts
@@ -1,5 +1,6 @@
-import { ShellActivityHandler } from "./shell-activity-handler";
 import type { RawTerminalState, StatusResult } from "./activity-handler";
+import { CLAUDE_INPUT_PENDING_MARKER } from "./activity-markers";
+import { ShellActivityHandler } from "./shell-activity-handler";
 
 /**
  * Star-based working spinner prefixes emitted by Claude Code while a task is
@@ -50,6 +51,10 @@ function extractTitleMessage(title: string | undefined): string | undefined {
   return stripped;
 }
 
+function isInputPending(activityMessage: string | undefined): boolean {
+  return activityMessage === CLAUDE_INPUT_PENDING_MARKER;
+}
+
 export class ClaudeActivityHandler extends ShellActivityHandler {
   shouldPreserveActivityOnExitCode(): boolean {
     return true;
@@ -81,6 +86,16 @@ export class ClaudeActivityHandler extends ShellActivityHandler {
   }
 
   computeStatus(raw: RawTerminalState): StatusResult {
+    // Input-pending overrides every other signal: a permission / response
+    // modal in the buffer is the user-actionable state, not the underlying
+    // working spinner that may still be animating behind the modal. Without
+    // this branch, the WSL Claude path leaves the status pinned at ⏳ even
+    // though Claude is parked on a y/N prompt — the user only sees the
+    // hourglass and never the notification badge.
+    if (isInputPending(raw.activityMessage)) {
+      return { icon: "✓", color: "var(--green)" };
+    }
+
     if (raw.outputActive) return { icon: "⏳", color: "var(--yellow)" };
 
     // Working spinner title (star or Braille) means Claude is actively
@@ -107,6 +122,12 @@ export class ClaudeActivityHandler extends ShellActivityHandler {
   }
 
   computeStatusMessage(raw: RawTerminalState): string | undefined {
+    // The marker is internal state, not a user-facing message. Hide it and
+    // fall back to the title-derived message so the status bar still shows
+    // useful context (e.g. "Editing main.rs") instead of the raw sentinel.
+    if (isInputPending(raw.activityMessage)) {
+      return extractTitleMessage(raw.title);
+    }
     const bullet = raw.activityMessage || undefined;
     const titleMsg = extractTitleMessage(raw.title);
     const mode = raw.statusMessageMode ?? "bullet-title";

--- a/ui/src/stores/notification-store.test.ts
+++ b/ui/src/stores/notification-store.test.ts
@@ -383,6 +383,49 @@ describe("NotificationStore", () => {
       expect(notifs[0].readAt).not.toBeNull();
     });
 
+    it("does NOT auto-dismiss requiresAction alerts even on the active workspace", () => {
+      // A Claude permission modal needs an explicit user response.
+      // Without the requiresAction exemption, the alert would be marked
+      // read the instant it lands (because the user happens to be
+      // viewing that workspace) and the badge would never light up.
+      const activeWsId = useWorkspaceStore.getState().activeWorkspaceId;
+
+      useNotificationStore.getState().addNotification({
+        terminalId: "t1",
+        workspaceId: activeWsId,
+        message: "Claude is waiting for your input",
+        requiresAction: true,
+      });
+
+      const notifs = useNotificationStore.getState().notifications;
+      expect(notifs[0].readAt).toBeNull();
+      expect(notifs[0].requiresAction).toBe(true);
+    });
+
+    it("markWorkspaceAsRead preserves requiresAction alerts", () => {
+      // Switching into the workspace shouldn't silently dismiss a
+      // still-active modal alert; only the user's explicit click or
+      // the originator clearing the underlying state should do that.
+      useNotificationStore.getState().addNotification({
+        terminalId: "t1",
+        workspaceId: "ws-1",
+        message: "Claude is waiting for your input",
+        requiresAction: true,
+      });
+      useNotificationStore.getState().addNotification({
+        terminalId: "t1",
+        workspaceId: "ws-1",
+        message: "Build done",
+      });
+
+      useNotificationStore.getState().markWorkspaceAsRead("ws-1");
+      const notifs = useNotificationStore.getState().notifications;
+      expect(
+        notifs.find((n) => n.message === "Claude is waiting for your input")?.readAt,
+      ).toBeNull();
+      expect(notifs.find((n) => n.message === "Build done")?.readAt).not.toBeNull();
+    });
+
     it("does NOT auto-dismiss in paneFocus mode when no pane is focused", () => {
       const activeWsId = useWorkspaceStore.getState().activeWorkspaceId;
       useSettingsStore.setState({

--- a/ui/src/stores/notification-store.ts
+++ b/ui/src/stores/notification-store.ts
@@ -15,6 +15,15 @@ export interface Notification {
   level: NotificationLevel;
   createdAt: number;
   readAt: number | null;
+  /**
+   * When true, this notification represents a state that needs explicit
+   * user action (e.g. answering a TUI permission modal). Such alerts are
+   * exempt from the auto-dismiss / workspace-mark-read policy so the
+   * unread badge stays visible until the user has actually responded.
+   * Cleared via `markNotificationsAsRead` with an explicit id list (user
+   * click) or by the originator when the underlying state resolves.
+   */
+  requiresAction?: boolean;
 }
 
 let notifId = 0;
@@ -27,6 +36,7 @@ interface NotificationStoreState {
     workspaceId: string;
     message: string;
     level?: NotificationLevel;
+    requiresAction?: boolean;
   }) => Notification;
   markWorkspaceAsRead: (workspaceId: string) => void;
   markNotificationsAsRead: (ids: string[]) => void;
@@ -46,12 +56,18 @@ interface NotificationStoreState {
 export const useNotificationStore = create<NotificationStoreState>()((set, get) => ({
   notifications: [],
 
-  addNotification: ({ terminalId, workspaceId, message, level }) => {
+  addNotification: ({ terminalId, workspaceId, message, level, requiresAction }) => {
     const now = Date.now();
     const dismissMode = useSettingsStore.getState().convenience.notificationDismiss;
     const activeWsId = useWorkspaceStore.getState().activeWorkspaceId;
 
+    // requiresAction alerts never auto-dismiss: they exist precisely to
+    // grab attention until the user has actually responded (e.g. a Claude
+    // permission modal). The default policy auto-clears alerts whose
+    // workspace happens to be active right now, which would hide the
+    // badge before the user could see it.
     const shouldAutoDismiss =
+      !requiresAction &&
       workspaceId === activeWsId &&
       (dismissMode === "workspace" ||
         (dismissMode === "paneFocus" && useGridStore.getState().focusedPaneIndex !== null));
@@ -64,6 +80,7 @@ export const useNotificationStore = create<NotificationStoreState>()((set, get) 
       level: level ?? "info",
       createdAt: now,
       readAt: shouldAutoDismiss ? now : null,
+      ...(requiresAction ? { requiresAction: true } : {}),
     };
     set((state) => ({
       notifications: [...state.notifications, notification],
@@ -75,7 +92,13 @@ export const useNotificationStore = create<NotificationStoreState>()((set, get) 
     const now = Date.now();
     set((state) => ({
       notifications: state.notifications.map((n) =>
-        n.workspaceId === workspaceId && n.readAt === null ? { ...n, readAt: now } : n,
+        // Skip requiresAction alerts — they only clear via explicit user
+        // click (markNotificationsAsRead) or when the originator resolves
+        // the underlying state. Otherwise opening the workspace would
+        // hide a still-active modal alert.
+        n.workspaceId === workspaceId && n.readAt === null && !n.requiresAction
+          ? { ...n, readAt: now }
+          : n,
       ),
     }));
   },


### PR DESCRIPTION
## Summary

- WSL/ConPTY Claude sessions silently failed to notify when Claude was waiting on a permission/response modal — the working spinner title kept animating behind the modal, so the title-based working→idle transition that fires `task_completed` in `claude_activity.rs` never ran. Status pinned at ⏳ and the badge never lit up.
- Detect the modal directly from the rolling PTY output (16 KB detection window + 4 KB dismissal window keyed off the `❯` arrow), set a sentinel marker on `activityMessage`, and raise a `requiresAction` notification that survives active-workspace auto-dismiss / `markWorkspaceAsRead` until the user actually clicks it or the modal resolves.
- The decisive fix lives in `stripAnsi`: Claude paints modal option rows with cursor escapes (CUP `\x1b[r;cH` for the row, CUF `\x1b[NC` for the space between number and text). A naïve strip-all-CSI pass collapsed `2.\x1b[1C코드` to `2.코드` (no whitespace) and ran every option onto one line, so only the first option matched the `\d+\.\s+\S` regex and the two-options floor was never met. Converting CUP → `\n` and CUF(N) → N spaces inside `stripAnsi` restores the structure the regex expects.

## Test plan

- [x] `npx vitest run` — 1772 tests pass, including a new regression test using a real captured WSL Claude modal bytestream
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — 0 errors (existing warnings unchanged)
- [x] Manual verification on dev (port 19281) — Claude permission modal in a WSL pane now raises the unread badge; badge clears when the modal is answered; a second modal in the same session fires a fresh notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)