### PR TITLE
Restore IME composition underline

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -49,6 +49,7 @@
   /* utility */
   --separator-bg: rgba(255, 255, 255, 0.08); /* intentionally same as --hover-bg-strong */
   --transition-fast: 0.1s;
+  --terminal-composition-underline-color: currentColor;
 }
 
 /* Reset: Tailwind v4 @layer base already provides *, ::before, ::after { margin:0; padding:0; box-sizing:border-box }.
@@ -217,6 +218,10 @@
   white-space: pre;
   color: var(--terminal-foreground-color, #f0f0f0);
   background: var(--terminal-background-color, #0c0c0c);
+  text-decoration-line: underline;
+  text-decoration-color: var(--terminal-composition-underline-color);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
   will-change: transform;
   z-index: 2;
 }

--- a/ui/src/lib/css-tokens.test.ts
+++ b/ui/src/lib/css-tokens.test.ts
@@ -75,7 +75,11 @@ describe("CSS design tokens — font-size", () => {
 });
 
 describe("CSS design tokens — utility", () => {
-  const utilityTokens = ["--separator-bg", "--transition-fast"];
+  const utilityTokens = [
+    "--separator-bg",
+    "--transition-fast",
+    "--terminal-composition-underline-color",
+  ];
 
   it.each(utilityTokens)("defines %s in :root", (token) => {
     const regex = new RegExp(`${token.replace(/[-/]/g, "\\$&")}\\s*:`);
@@ -112,6 +116,23 @@ describe("CSS utility classes — toolbar", () => {
 describe("CSS utility classes — focus", () => {
   it("defines .ui-focus-ring:focus-visible class", () => {
     expect(cssContent).toMatch(/\.ui-focus-ring:focus-visible\s*\{/);
+  });
+});
+
+describe("CSS utility classes — terminal IME composition", () => {
+  it("underlines the active composition preview", () => {
+    expect(cssContent).toMatch(
+      /\.terminal-composition-preview\s*\{[^}]*text-decoration-line:\s*underline;/s,
+    );
+    expect(cssContent).toMatch(
+      /\.terminal-composition-preview\s*\{[^}]*text-decoration-color:\s*var\(--terminal-composition-underline-color\);/s,
+    );
+    expect(cssContent).toMatch(
+      /\.terminal-composition-preview\s*\{[^}]*text-decoration-thickness:\s*1px;/s,
+    );
+    expect(cssContent).toMatch(
+      /\.terminal-composition-preview\s*\{[^}]*text-underline-offset:\s*2px;/s,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Restore underline styling for the terminal IME composition preview
- Add CSS contract coverage for the composition preview underline token/style

Fixes #257

## Tests
- npm test -- src/lib/css-tokens.test.ts src/components/views/TerminalView.test.tsx
- npm run build
- git diff --check