### PR TITLE
[2, [1, 1]] 같은 레이아웃에서 리사이즈 시 빈칸이 생기는 버그 수정

### DIFF
--- a/ui/src/components/layout/PaneBoundaryHandles.test.tsx
+++ b/ui/src/components/layout/PaneBoundaryHandles.test.tsx
@@ -65,4 +65,74 @@ describe("PaneBoundaryHandles", () => {
     // After merge: 1 pane (smaller absorbed by larger)
     expect(useWorkspaceStore.getState().getActiveWorkspace()!.panes).toHaveLength(1);
   });
+
+  it("drags one merged vertical handle to resize all panes on the split side", () => {
+    const panes = [
+      { x: 0, y: 0, w: 0.5, h: 1 },
+      { x: 0.5, y: 0, w: 0.5, h: 0.5 },
+      { x: 0.5, y: 0.5, w: 0.5, h: 0.5 },
+    ];
+
+    render(
+      <PaneBoundaryHandles
+        containerWidth={1000}
+        containerHeight={600}
+        panes={panes}
+        getLatestPanes={() => panes}
+        onResizePane={(index, delta) => {
+          panes[index] = { ...panes[index], ...delta };
+        }}
+      />,
+    );
+
+    const handles = screen.getAllByTestId(/^boundary-handle/);
+    const verticalHandles = handles.filter((handle) => handle.style.cursor === "col-resize");
+    expect(verticalHandles).toHaveLength(1);
+
+    fireEvent.mouseDown(verticalHandles[0], { clientX: 500, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 600, clientY: 100 });
+    fireEvent.mouseUp(document);
+
+    expect(panes[0].w).toBeCloseTo(0.6);
+    expect(panes[1].x).toBeCloseTo(0.6);
+    expect(panes[1].w).toBeCloseTo(0.4);
+    expect(panes[2].x).toBeCloseTo(0.6);
+    expect(panes[2].w).toBeCloseTo(0.4);
+  });
+
+  it("keeps all panes touching after dragging the [2, [1, 1]] boundary (no visual gap)", () => {
+    // Reproduces the bug where only the segment under the cursor moved while the
+    // other stacked pane stayed in place, leaving an empty band.
+    const panes = [
+      { x: 0, y: 0, w: 0.5, h: 1 },
+      { x: 0.5, y: 0, w: 0.5, h: 0.5 },
+      { x: 0.5, y: 0.5, w: 0.5, h: 0.5 },
+    ];
+
+    render(
+      <PaneBoundaryHandles
+        containerWidth={1000}
+        containerHeight={600}
+        panes={panes}
+        getLatestPanes={() => panes}
+        onResizePane={(index, delta) => {
+          panes[index] = { ...panes[index], ...delta };
+        }}
+      />,
+    );
+
+    const verticalHandle = screen
+      .getAllByTestId(/^boundary-handle/)
+      .find((h) => h.style.cursor === "col-resize")!;
+
+    fireEvent.mouseDown(verticalHandle, { clientX: 500, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 650, clientY: 100 });
+    fireEvent.mouseUp(document);
+
+    const leftRight = panes[0].x + panes[0].w;
+    expect(panes[1].x).toBeCloseTo(leftRight);
+    expect(panes[2].x).toBeCloseTo(leftRight);
+    expect(panes[1].x + panes[1].w).toBeCloseTo(1);
+    expect(panes[2].x + panes[2].w).toBeCloseTo(1);
+  });
 });

--- a/ui/src/hooks/usePaneResize.test.ts
+++ b/ui/src/hooks/usePaneResize.test.ts
@@ -53,6 +53,110 @@ describe("usePaneResize", () => {
       expect(boundaries.length).toBeGreaterThanOrEqual(2);
     });
 
+    it("merges adjacent vertical boundary segments so stacked panes resize together", () => {
+      const panes: WorkspacePane[] = [
+        { id: "left", x: 0, y: 0, w: 0.5, h: 1, view: { type: "EmptyView" } },
+        { id: "right-top", x: 0.5, y: 0, w: 0.5, h: 0.5, view: { type: "EmptyView" } },
+        { id: "right-bottom", x: 0.5, y: 0.5, w: 0.5, h: 0.5, view: { type: "EmptyView" } },
+      ];
+
+      const boundaries = findPaneBoundaries(panes);
+      const vertical = boundaries.filter((bd) => bd.direction === "vertical");
+
+      expect(vertical).toHaveLength(1);
+      expect(vertical[0].position).toBeCloseTo(0.5);
+      expect(vertical[0].start).toBeCloseTo(0);
+      expect(vertical[0].end).toBeCloseTo(1);
+      expect(vertical[0].leftPaneIndices).toEqual([0]);
+      expect(vertical[0].rightPaneIndices.sort()).toEqual([1, 2]);
+    });
+
+    it("merges adjacent horizontal boundary segments so side-by-side panes resize together", () => {
+      const panes: WorkspacePane[] = [
+        { id: "top-left", x: 0, y: 0, w: 0.5, h: 0.5, view: { type: "EmptyView" } },
+        { id: "top-right", x: 0.5, y: 0, w: 0.5, h: 0.5, view: { type: "EmptyView" } },
+        { id: "bottom", x: 0, y: 0.5, w: 1, h: 0.5, view: { type: "EmptyView" } },
+      ];
+
+      const boundaries = findPaneBoundaries(panes);
+      const horizontal = boundaries.filter((bd) => bd.direction === "horizontal");
+
+      expect(horizontal).toHaveLength(1);
+      expect(horizontal[0].position).toBeCloseTo(0.5);
+      expect(horizontal[0].start).toBeCloseTo(0);
+      expect(horizontal[0].end).toBeCloseTo(1);
+      expect(horizontal[0].leftPaneIndices.sort()).toEqual([0, 1]);
+      expect(horizontal[0].rightPaneIndices).toEqual([2]);
+    });
+
+    it("merges three or more adjacent vertical segments into a single boundary", () => {
+      // Layout [2, [1, 1, 1]] — left full-height, right split into three stacked panes
+      const panes: WorkspacePane[] = [
+        { id: "left", x: 0, y: 0, w: 0.5, h: 1, view: { type: "EmptyView" } },
+        { id: "r-top", x: 0.5, y: 0, w: 0.5, h: 1 / 3, view: { type: "EmptyView" } },
+        { id: "r-mid", x: 0.5, y: 1 / 3, w: 0.5, h: 1 / 3, view: { type: "EmptyView" } },
+        { id: "r-bot", x: 0.5, y: 2 / 3, w: 0.5, h: 1 / 3, view: { type: "EmptyView" } },
+      ];
+
+      const vertical = findPaneBoundaries(panes).filter((bd) => bd.direction === "vertical");
+
+      expect(vertical).toHaveLength(1);
+      expect(vertical[0].start).toBeCloseTo(0);
+      expect(vertical[0].end).toBeCloseTo(1);
+      expect(vertical[0].leftPaneIndices).toEqual([0]);
+      expect(vertical[0].rightPaneIndices.sort()).toEqual([1, 2, 3]);
+    });
+
+    it("merges segments even when sub-split sizes are uneven", () => {
+      // Right side split into uneven heights (e.g., user resized the inner boundary)
+      const panes: WorkspacePane[] = [
+        { id: "left", x: 0, y: 0, w: 0.5, h: 1, view: { type: "EmptyView" } },
+        { id: "right-top", x: 0.5, y: 0, w: 0.5, h: 0.7, view: { type: "EmptyView" } },
+        { id: "right-bottom", x: 0.5, y: 0.7, w: 0.5, h: 0.3, view: { type: "EmptyView" } },
+      ];
+
+      const vertical = findPaneBoundaries(panes).filter((bd) => bd.direction === "vertical");
+
+      expect(vertical).toHaveLength(1);
+      expect(vertical[0].start).toBeCloseTo(0);
+      expect(vertical[0].end).toBeCloseTo(1);
+      expect(vertical[0].leftPaneIndices).toEqual([0]);
+      expect(vertical[0].rightPaneIndices.sort()).toEqual([1, 2]);
+    });
+
+    it("merges 2x2 grid boundary so dragging moves all four panes together", () => {
+      const panes: WorkspacePane[] = [
+        { id: "tl", x: 0, y: 0, w: 0.5, h: 0.5, view: { type: "EmptyView" } },
+        { id: "tr", x: 0.5, y: 0, w: 0.5, h: 0.5, view: { type: "EmptyView" } },
+        { id: "bl", x: 0, y: 0.5, w: 0.5, h: 0.5, view: { type: "EmptyView" } },
+        { id: "br", x: 0.5, y: 0.5, w: 0.5, h: 0.5, view: { type: "EmptyView" } },
+      ];
+
+      const vertical = findPaneBoundaries(panes).filter((bd) => bd.direction === "vertical");
+
+      expect(vertical).toHaveLength(1);
+      expect(vertical[0].leftPaneIndices.sort()).toEqual([0, 2]);
+      expect(vertical[0].rightPaneIndices.sort()).toEqual([1, 3]);
+    });
+
+    it("keeps same-position boundary segments separate when their ranges are disconnected", () => {
+      const panes: WorkspacePane[] = [
+        { id: "left-top", x: 0, y: 0, w: 0.5, h: 0.25, view: { type: "EmptyView" } },
+        { id: "right-top", x: 0.5, y: 0, w: 0.5, h: 0.25, view: { type: "EmptyView" } },
+        { id: "middle", x: 0, y: 0.25, w: 1, h: 0.5, view: { type: "EmptyView" } },
+        { id: "left-bottom", x: 0, y: 0.75, w: 0.5, h: 0.25, view: { type: "EmptyView" } },
+        { id: "right-bottom", x: 0.5, y: 0.75, w: 0.5, h: 0.25, view: { type: "EmptyView" } },
+      ];
+
+      const vertical = findPaneBoundaries(panes).filter((bd) => bd.direction === "vertical");
+
+      expect(vertical).toHaveLength(2);
+      expect(vertical.map((bd) => [bd.start, bd.end])).toEqual([
+        [0, 0.25],
+        [0.75, 1],
+      ]);
+    });
+
     it("returns empty for single pane", () => {
       const panes: WorkspacePane[] = [
         { id: "p1", x: 0, y: 0, w: 1, h: 1, view: { type: "EmptyView" } },

--- a/ui/src/hooks/usePaneResize.ts
+++ b/ui/src/hooks/usePaneResize.ts
@@ -20,6 +20,45 @@ export interface PaneBoundary {
 
 const EPSILON = 0.001;
 
+function pushUnique(indices: number[], value: number): void {
+  if (!indices.includes(value)) indices.push(value);
+}
+
+function mergeBoundarySegments(boundaries: PaneBoundary[]): PaneBoundary[] {
+  const sorted = [...boundaries].sort((a, b) => {
+    if (a.direction !== b.direction) return a.direction.localeCompare(b.direction);
+    if (Math.abs(a.position - b.position) >= EPSILON) return a.position - b.position;
+    return a.start - b.start;
+  });
+
+  const merged: PaneBoundary[] = [];
+
+  for (const boundary of sorted) {
+    const current = merged[merged.length - 1];
+    const canMerge =
+      current &&
+      current.direction === boundary.direction &&
+      Math.abs(current.position - boundary.position) < EPSILON &&
+      boundary.start <= current.end + EPSILON;
+
+    if (!canMerge) {
+      merged.push({
+        ...boundary,
+        leftPaneIndices: [...boundary.leftPaneIndices],
+        rightPaneIndices: [...boundary.rightPaneIndices],
+      });
+      continue;
+    }
+
+    current.start = Math.min(current.start, boundary.start);
+    current.end = Math.max(current.end, boundary.end);
+    for (const idx of boundary.leftPaneIndices) pushUnique(current.leftPaneIndices, idx);
+    for (const idx of boundary.rightPaneIndices) pushUnique(current.rightPaneIndices, idx);
+  }
+
+  return merged;
+}
+
 /**
  * Find all shared boundaries between panes.
  */
@@ -54,8 +93,8 @@ export function findPaneBoundaries(panes: GridRect[]): PaneBoundary[] {
                 Math.abs(bd.end - overlapEnd) < EPSILON,
             );
             if (existing) {
-              if (!existing.leftPaneIndices.includes(i)) existing.leftPaneIndices.push(i);
-              if (!existing.rightPaneIndices.includes(j)) existing.rightPaneIndices.push(j);
+              pushUnique(existing.leftPaneIndices, i);
+              pushUnique(existing.rightPaneIndices, j);
             } else {
               boundaries.push({
                 direction: "vertical",
@@ -84,8 +123,8 @@ export function findPaneBoundaries(panes: GridRect[]): PaneBoundary[] {
                 Math.abs(bd.end - overlapEnd) < EPSILON,
             );
             if (existing) {
-              if (!existing.leftPaneIndices.includes(j)) existing.leftPaneIndices.push(j);
-              if (!existing.rightPaneIndices.includes(i)) existing.rightPaneIndices.push(i);
+              pushUnique(existing.leftPaneIndices, j);
+              pushUnique(existing.rightPaneIndices, i);
             } else {
               boundaries.push({
                 direction: "vertical",
@@ -120,8 +159,8 @@ export function findPaneBoundaries(panes: GridRect[]): PaneBoundary[] {
                 Math.abs(bd.end - overlapEnd) < EPSILON,
             );
             if (existing) {
-              if (!existing.leftPaneIndices.includes(i)) existing.leftPaneIndices.push(i);
-              if (!existing.rightPaneIndices.includes(j)) existing.rightPaneIndices.push(j);
+              pushUnique(existing.leftPaneIndices, i);
+              pushUnique(existing.rightPaneIndices, j);
             } else {
               boundaries.push({
                 direction: "horizontal",
@@ -150,8 +189,8 @@ export function findPaneBoundaries(panes: GridRect[]): PaneBoundary[] {
                 Math.abs(bd.end - overlapEnd) < EPSILON,
             );
             if (existing) {
-              if (!existing.leftPaneIndices.includes(j)) existing.leftPaneIndices.push(j);
-              if (!existing.rightPaneIndices.includes(i)) existing.rightPaneIndices.push(i);
+              pushUnique(existing.leftPaneIndices, j);
+              pushUnique(existing.rightPaneIndices, i);
             } else {
               boundaries.push({
                 direction: "horizontal",
@@ -168,7 +207,7 @@ export function findPaneBoundaries(panes: GridRect[]): PaneBoundary[] {
     }
   }
 
-  return boundaries;
+  return mergeBoundarySegments(boundaries);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `findPaneBoundaries`가 인접한 페인 쌍마다 별도의 경계 레코드를 반환해, `[2, [1, 1]]`처럼 한쪽이 분할된 레이아웃에서 사용자가 본 단일 경계선을 드래그해도 커서가 걸친 세그먼트의 페인만 이동하고 나머지 적층 페인은 그대로 남아 빈칸이 발생.
- 같은 position을 공유하며 끝점이 맞닿은 세그먼트들을 하나의 `PaneBoundary`로 병합해, 단일 핸들로 양쪽 모든 페인이 함께 움직이도록 수정.
- `[2, [1, 1]]`, `[2, [1, 1, 1]]`, 비균등 서브 분할, 2x2 그리드 케이스에 대한 단위 테스트와 드래그 후 페인이 여전히 모서리에 맞물려 있는지 확인하는 통합 테스트 추가.

## Test plan
- [x] `npx vitest run src/hooks/usePaneResize.test.ts src/components/layout/PaneBoundaryHandles.test.tsx` — 27 tests pass
- [x] `npx vitest run` (UI 전체) — 1785 tests pass
- [x] `npx prettier --check` / `npx eslint` (lint-staged 자동) — 통과
- [ ] 수동: `[2, [1, 1]]` 레이아웃을 만든 뒤 가운데 세로 경계를 드래그해 좌/우(상·하 포함)가 모두 같이 움직이고 빈칸이 생기지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)