### PR TITLE
Fix CWD send/receive indicators to mirror syncCwdDefaults

### DIFF
--- a/ui/src/components/layout/Dock.test.tsx
+++ b/ui/src/components/layout/Dock.test.tsx
@@ -422,6 +422,82 @@ describe("Dock", () => {
     expect(onSetPaneView).toHaveBeenCalledWith("dp-1", expect.objectContaining({ cwdSend: true }));
   });
 
+  it("single-pane FileExplorer uses fileExplorer.shellProfile for CWD defaults", () => {
+    const onSetPaneView = vi.fn();
+    useSettingsStore.setState((s) => ({
+      fileExplorer: { ...s.fileExplorer, shellProfile: "WSL" },
+      profiles: s.profiles.map((p) =>
+        p.name === "WSL"
+          ? { ...p, syncCwd: { send: true, receive: true } }
+          : p.name === "PowerShell"
+            ? { ...p, syncCwd: { send: false, receive: false } }
+            : p,
+      ),
+    }));
+
+    render(
+      <Dock
+        position="bottom"
+        activeView="FileExplorerView"
+        views={[]}
+        panes={[
+          {
+            id: "dp-files",
+            view: { type: "FileExplorerView", profile: "PowerShell" },
+            x: 0,
+            y: 0,
+            w: 1,
+            h: 1,
+          },
+        ]}
+        onSetPaneView={onSetPaneView}
+      />,
+    );
+
+    fireEvent.mouseEnter(screen.getByTestId("dock-bottom"));
+    expect(screen.getByTestId("pane-control-cwd-send").getAttribute("title")).toBe("CWD Send (on)");
+    fireEvent.click(screen.getByTestId("pane-control-cwd-send"));
+    expect(onSetPaneView).toHaveBeenCalledWith(
+      "dp-files",
+      expect.objectContaining({ cwdSend: false }),
+    );
+  });
+
+  it("updates single-pane CWD indicators when dock syncCwdDefaults changes", () => {
+    render(
+      <Dock
+        position="bottom"
+        activeView="TerminalView"
+        views={[]}
+        panes={[
+          {
+            id: "dp-1",
+            view: { type: "TerminalView", profile: "PowerShell" },
+            x: 0,
+            y: 0,
+            w: 1,
+            h: 1,
+          },
+        ]}
+        onSetPaneView={vi.fn()}
+      />,
+    );
+
+    fireEvent.mouseEnter(screen.getByTestId("dock-bottom"));
+    expect(screen.getByTestId("pane-control-cwd-send").getAttribute("title")).toBe(
+      "CWD Send (off)",
+    );
+
+    act(() => {
+      useSettingsStore.getState().setSyncCwdDefaults({ dock: { send: true, receive: true } });
+    });
+
+    expect(screen.getByTestId("pane-control-cwd-send").getAttribute("title")).toBe("CWD Send (on)");
+    expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
+      "CWD Receive (on)",
+    );
+  });
+
   it("split-pane dock shows CWD send/receive OFF by default", () => {
     render(
       <Dock
@@ -455,6 +531,55 @@ describe("Dock", () => {
     );
     expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
       "CWD Receive (off)",
+    );
+  });
+
+  it("split-pane FileExplorer uses fileExplorer.shellProfile for CWD defaults", () => {
+    const onSetPaneView = vi.fn();
+    useSettingsStore.setState((s) => ({
+      fileExplorer: { ...s.fileExplorer, shellProfile: "WSL" },
+      profiles: s.profiles.map((p) =>
+        p.name === "WSL"
+          ? { ...p, syncCwd: { send: true, receive: true } }
+          : p.name === "PowerShell"
+            ? { ...p, syncCwd: { send: false, receive: false } }
+            : p,
+      ),
+    }));
+
+    render(
+      <Dock
+        position="left"
+        activeView={null}
+        views={[]}
+        panes={[
+          {
+            id: "dp-files",
+            view: { type: "FileExplorerView", profile: "PowerShell" },
+            x: 0,
+            y: 0,
+            w: 1,
+            h: 0.5,
+          },
+          {
+            id: "dp-term",
+            view: { type: "TerminalView", profile: "PowerShell" },
+            x: 0,
+            y: 0.5,
+            w: 1,
+            h: 0.5,
+          },
+        ]}
+        onSetPaneView={onSetPaneView}
+      />,
+    );
+
+    fireEvent.mouseEnter(screen.getByTestId("dock-pane-dp-files"));
+    expect(screen.getByTestId("pane-control-cwd-send").getAttribute("title")).toBe("CWD Send (on)");
+    fireEvent.click(screen.getByTestId("pane-control-cwd-send"));
+    expect(onSetPaneView).toHaveBeenCalledWith(
+      "dp-files",
+      expect.objectContaining({ cwdSend: false }),
     );
   });
 });

--- a/ui/src/components/layout/Dock.test.tsx
+++ b/ui/src/components/layout/Dock.test.tsx
@@ -363,4 +363,98 @@ describe("Dock", () => {
     fireEvent.click(screen.getByTestId("pane-control-split-v"));
     expect(onSplitPane).toHaveBeenCalledWith("dp-1", "vertical");
   });
+
+  // -- CWD toggle defaults follow syncCwdDefaults --
+  //
+  // 기본 syncCwdDefaults는 workspace/dock 모두 { send: false, receive: false } 이다.
+  // 신규 dock 페인이 cwdSend/cwdReceive override 없이 표시될 때 OFF 아이콘이 나와야 한다.
+
+  it("single-pane dock shows CWD send/receive OFF by default (syncCwdDefaults.dock=off)", () => {
+    render(
+      <Dock
+        position="bottom"
+        activeView="TerminalView"
+        views={[]}
+        panes={[
+          {
+            id: "dp-1",
+            view: { type: "TerminalView", profile: "PowerShell" },
+            x: 0,
+            y: 0,
+            w: 1,
+            h: 1,
+          },
+        ]}
+        onSetPaneView={vi.fn()}
+      />,
+    );
+    fireEvent.mouseEnter(screen.getByTestId("dock-bottom"));
+    expect(screen.getByTestId("pane-control-cwd-send").getAttribute("title")).toBe(
+      "CWD Send (off)",
+    );
+    expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
+      "CWD Receive (off)",
+    );
+  });
+
+  it("single-pane dock toggling CWD send from default-off sets cwdSend=true", () => {
+    const onSetPaneView = vi.fn();
+    render(
+      <Dock
+        position="bottom"
+        activeView="TerminalView"
+        views={[]}
+        panes={[
+          {
+            id: "dp-1",
+            view: { type: "TerminalView", profile: "PowerShell" },
+            x: 0,
+            y: 0,
+            w: 1,
+            h: 1,
+          },
+        ]}
+        onSetPaneView={onSetPaneView}
+      />,
+    );
+    fireEvent.mouseEnter(screen.getByTestId("dock-bottom"));
+    fireEvent.click(screen.getByTestId("pane-control-cwd-send"));
+    expect(onSetPaneView).toHaveBeenCalledWith("dp-1", expect.objectContaining({ cwdSend: true }));
+  });
+
+  it("split-pane dock shows CWD send/receive OFF by default", () => {
+    render(
+      <Dock
+        position="left"
+        activeView={null}
+        views={[]}
+        panes={[
+          {
+            id: "dp-1",
+            view: { type: "TerminalView", profile: "PowerShell" },
+            x: 0,
+            y: 0,
+            w: 1,
+            h: 0.5,
+          },
+          {
+            id: "dp-2",
+            view: { type: "TerminalView", profile: "PowerShell" },
+            x: 0,
+            y: 0.5,
+            w: 1,
+            h: 0.5,
+          },
+        ]}
+        onSetPaneView={vi.fn()}
+      />,
+    );
+    fireEvent.mouseEnter(screen.getByTestId("dock-pane-dp-1"));
+    expect(screen.getByTestId("pane-control-cwd-send").getAttribute("title")).toBe(
+      "CWD Send (off)",
+    );
+    expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
+      "CWD Receive (off)",
+    );
+  });
 });

--- a/ui/src/components/layout/Dock.tsx
+++ b/ui/src/components/layout/Dock.tsx
@@ -1,12 +1,13 @@
 import type { DockPosition, DockPane, ViewType, ViewInstanceConfig } from "@/stores/types";
 import { useDockStore } from "@/stores/dock-store";
-import { useSettingsStore, FALLBACK_PROFILE } from "@/stores/settings-store";
+import { useSettingsStore } from "@/stores/settings-store";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useGridStore } from "@/stores/grid-store";
 import { ViewRenderer } from "@/components/views/ViewRenderer";
 import { PaneControlBar } from "./PaneControlBar";
 import { PaneGrid } from "./PaneGrid";
 import { useHoverTimer } from "@/hooks/useHoverTimer";
+import { useCwdDefaultsResolver } from "./useCwdDefaultsResolver";
 
 interface DockProps {
   position: DockPosition;
@@ -53,8 +54,7 @@ export function Dock({
   });
 
   const singleHover = useHoverTimer(hoverIdleSeconds);
-  const defaultProfile = useSettingsStore((s) => s.defaultProfile);
-  const resolveSyncCwdForProfile = useSettingsStore((s) => s.resolveSyncCwdForProfile);
+  const resolveCwdDefaults = useCwdDefaultsResolver("dock");
 
   // Split panes rendering — delegates to shared PaneGrid
   if (hasSplitPanes) {
@@ -77,12 +77,7 @@ export function Dock({
   const singleView = panes[0]?.view;
   const hasSingleCwdView =
     singleView?.type === "TerminalView" || singleView?.type === "FileExplorerView";
-  const singleCwdDefaults = hasSingleCwdView
-    ? resolveSyncCwdForProfile(
-        (singleView?.profile as string) || defaultProfile || FALLBACK_PROFILE,
-        "dock",
-      )
-    : null;
+  const singleCwdDefaults = hasSingleCwdView && singleView ? resolveCwdDefaults(singleView) : null;
   const singleCwdSendOn = singleCwdDefaults
     ? ((singleView?.cwdSend as boolean | undefined) ?? singleCwdDefaults.send)
     : undefined;
@@ -210,8 +205,7 @@ function DockGrid({
 }) {
   const focusedDock = useDockStore((s) => s.focusedDock);
   const focusedDockPaneId = useDockStore((s) => s.focusedDockPaneId);
-  const defaultProfile = useSettingsStore((s) => s.defaultProfile);
-  const resolveSyncCwdForProfile = useSettingsStore((s) => s.resolveSyncCwdForProfile);
+  const resolveCwdDefaults = useCwdDefaultsResolver("dock");
 
   return (
     <PaneGrid
@@ -228,10 +222,7 @@ function DockGrid({
       onSetPaneView={onSetPaneView}
       onSplitPane={onSplitPane}
       onRemovePane={onRemovePane}
-      getCwdDefaults={(view: ViewInstanceConfig) => {
-        const profileName = (view.profile as string) || defaultProfile || FALLBACK_PROFILE;
-        return resolveSyncCwdForProfile(profileName, "dock");
-      }}
+      getCwdDefaults={resolveCwdDefaults}
       workspaceId={activeWorkspaceId}
       workspaceName={activeWsName}
       emptyViewContext="dock"

--- a/ui/src/components/layout/Dock.tsx
+++ b/ui/src/components/layout/Dock.tsx
@@ -1,6 +1,6 @@
 import type { DockPosition, DockPane, ViewType, ViewInstanceConfig } from "@/stores/types";
 import { useDockStore } from "@/stores/dock-store";
-import { useSettingsStore } from "@/stores/settings-store";
+import { useSettingsStore, FALLBACK_PROFILE } from "@/stores/settings-store";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useGridStore } from "@/stores/grid-store";
 import { ViewRenderer } from "@/components/views/ViewRenderer";
@@ -53,6 +53,8 @@ export function Dock({
   });
 
   const singleHover = useHoverTimer(hoverIdleSeconds);
+  const defaultProfile = useSettingsStore((s) => s.defaultProfile);
+  const resolveSyncCwdForProfile = useSettingsStore((s) => s.resolveSyncCwdForProfile);
 
   // Split panes rendering — delegates to shared PaneGrid
   if (hasSplitPanes) {
@@ -72,6 +74,22 @@ export function Dock({
 
   // Single-pane rendering (original behavior + split button on hover)
   const singlePaneId = panes[0]?.id;
+  const singleView = panes[0]?.view;
+  const hasSingleCwdView =
+    singleView?.type === "TerminalView" || singleView?.type === "FileExplorerView";
+  const singleCwdDefaults = hasSingleCwdView
+    ? resolveSyncCwdForProfile(
+        (singleView?.profile as string) || defaultProfile || FALLBACK_PROFILE,
+        "dock",
+      )
+    : null;
+  const singleCwdSendOn = singleCwdDefaults
+    ? ((singleView?.cwdSend as boolean | undefined) ?? singleCwdDefaults.send)
+    : undefined;
+  const singleCwdReceiveOn = singleCwdDefaults
+    ? ((singleView?.cwdReceive as boolean | undefined) ?? singleCwdDefaults.receive)
+    : undefined;
+
   return (
     <div
       data-testid={`dock-${position}`}
@@ -111,6 +129,8 @@ export function Dock({
           paneId={singlePaneId}
           currentView={panes[0]?.view ?? { type: activeView ?? "EmptyView" }}
           hovered={singleHover.hoveredId !== null}
+          cwdSendOn={singleCwdSendOn}
+          cwdReceiveOn={singleCwdReceiveOn}
           actions={{
             onSplitH:
               onSplitPane && singlePaneId
@@ -127,24 +147,21 @@ export function Dock({
                     : undefined
                 : undefined,
             onToggleCwdSend:
-              singlePaneId &&
-              onSetPaneView &&
-              (panes[0]?.view.type === "TerminalView" || panes[0]?.view.type === "FileExplorerView")
-                ? () =>
-                    onSetPaneView(singlePaneId, {
-                      ...panes[0].view,
-                      cwdSend: !((panes[0].view.cwdSend as boolean) ?? true),
-                    })
+              singlePaneId && onSetPaneView && hasSingleCwdView && singleCwdDefaults
+                ? () => {
+                    const current =
+                      (panes[0].view.cwdSend as boolean | undefined) ?? singleCwdDefaults.send;
+                    onSetPaneView(singlePaneId, { ...panes[0].view, cwdSend: !current });
+                  }
                 : undefined,
             onToggleCwdReceive:
-              singlePaneId &&
-              onSetPaneView &&
-              (panes[0]?.view.type === "TerminalView" || panes[0]?.view.type === "FileExplorerView")
-                ? () =>
-                    onSetPaneView(singlePaneId, {
-                      ...panes[0].view,
-                      cwdReceive: !((panes[0].view.cwdReceive as boolean) ?? true),
-                    })
+              singlePaneId && onSetPaneView && hasSingleCwdView && singleCwdDefaults
+                ? () => {
+                    const current =
+                      (panes[0].view.cwdReceive as boolean | undefined) ??
+                      singleCwdDefaults.receive;
+                    onSetPaneView(singlePaneId, { ...panes[0].view, cwdReceive: !current });
+                  }
                 : undefined,
           }}
         >
@@ -193,6 +210,8 @@ function DockGrid({
 }) {
   const focusedDock = useDockStore((s) => s.focusedDock);
   const focusedDockPaneId = useDockStore((s) => s.focusedDockPaneId);
+  const defaultProfile = useSettingsStore((s) => s.defaultProfile);
+  const resolveSyncCwdForProfile = useSettingsStore((s) => s.resolveSyncCwdForProfile);
 
   return (
     <PaneGrid
@@ -209,7 +228,10 @@ function DockGrid({
       onSetPaneView={onSetPaneView}
       onSplitPane={onSplitPane}
       onRemovePane={onRemovePane}
-      getCwdDefaults={() => ({ send: true, receive: true })}
+      getCwdDefaults={(view: ViewInstanceConfig) => {
+        const profileName = (view.profile as string) || defaultProfile || FALLBACK_PROFILE;
+        return resolveSyncCwdForProfile(profileName, "dock");
+      }}
       workspaceId={activeWorkspaceId}
       workspaceName={activeWsName}
       emptyViewContext="dock"

--- a/ui/src/components/layout/PaneControlBar.test.tsx
+++ b/ui/src/components/layout/PaneControlBar.test.tsx
@@ -443,4 +443,131 @@ describe("PaneControlBar", () => {
     expect(screen.getByTestId("pane-control-bar")).toBeInTheDocument();
     expect(screen.getByTestId("injected-left")).toHaveTextContent("HOVER_INFO");
   });
+
+  // -- CWD send/receive toggle indicators --
+  //
+  // 표시 상태는 호출자가 계산한 effective state(cwdSendOn / cwdReceiveOn)를 따른다.
+  // viewConfig.cwdSend / cwdReceive를 직접 보면 syncCwdDefaults(workspace=false, dock=false)
+  // 기본값이 적용되는 신규 페인에서 "꺼져 있는데 켜진 아이콘"이 표시된다 (issue: cwd-propagation-default-icon).
+
+  const terminalView = { type: "TerminalView" as const, profile: "PowerShell" };
+  const fileExplorerView = { type: "FileExplorerView" as const };
+
+  it("shows CWD send button ON when cwdSendOn=true (regardless of viewConfig)", () => {
+    render(
+      <PaneControlBar
+        currentView={terminalView}
+        actions={{ ...defaultActions, onToggleCwdSend: vi.fn() }}
+        cwdSendOn={true}
+        hovered={true}
+      >
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    const btn = screen.getByTestId("pane-control-cwd-send");
+    expect(btn.getAttribute("title")).toBe("CWD Send (on)");
+  });
+
+  it("shows CWD send button OFF when cwdSendOn=false (regardless of viewConfig)", () => {
+    render(
+      <PaneControlBar
+        currentView={terminalView}
+        actions={{ ...defaultActions, onToggleCwdSend: vi.fn() }}
+        cwdSendOn={false}
+        hovered={true}
+      >
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    const btn = screen.getByTestId("pane-control-cwd-send");
+    expect(btn.getAttribute("title")).toBe("CWD Send (off)");
+  });
+
+  it("shows CWD receive button ON when cwdReceiveOn=true", () => {
+    render(
+      <PaneControlBar
+        currentView={terminalView}
+        actions={{ ...defaultActions, onToggleCwdReceive: vi.fn() }}
+        cwdReceiveOn={true}
+        hovered={true}
+      >
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
+      "CWD Receive (on)",
+    );
+  });
+
+  it("shows CWD receive button OFF when cwdReceiveOn=false", () => {
+    render(
+      <PaneControlBar
+        currentView={terminalView}
+        actions={{ ...defaultActions, onToggleCwdReceive: vi.fn() }}
+        cwdReceiveOn={false}
+        hovered={true}
+      >
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
+      "CWD Receive (off)",
+    );
+  });
+
+  it("ignores viewConfig.cwdSend; effective state comes from cwdSendOn prop only", () => {
+    // viewConfig.cwdSend is undefined (no per-pane override). Caller passed cwdSendOn=false
+    // because syncCwdDefaults.workspace.send = false. The bar must show OFF, not ON.
+    render(
+      <PaneControlBar
+        currentView={terminalView}
+        actions={{ ...defaultActions, onToggleCwdSend: vi.fn() }}
+        cwdSendOn={false}
+        hovered={true}
+      >
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    expect(screen.getByTestId("pane-control-cwd-send").getAttribute("title")).toBe(
+      "CWD Send (off)",
+    );
+  });
+
+  it("displays CWD toggles for FileExplorerView too", () => {
+    render(
+      <PaneControlBar
+        currentView={fileExplorerView}
+        actions={{
+          ...defaultActions,
+          onToggleCwdSend: vi.fn(),
+          onToggleCwdReceive: vi.fn(),
+        }}
+        cwdSendOn={false}
+        cwdReceiveOn={false}
+        hovered={true}
+      >
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    expect(screen.getByTestId("pane-control-cwd-send").getAttribute("title")).toBe(
+      "CWD Send (off)",
+    );
+    expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
+      "CWD Receive (off)",
+    );
+  });
+
+  it("hides CWD send button when no onToggleCwdSend action provided", () => {
+    render(
+      <PaneControlBar
+        currentView={terminalView}
+        actions={defaultActions}
+        cwdSendOn={false}
+        hovered={true}
+      >
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    expect(screen.queryByTestId("pane-control-cwd-send")).not.toBeInTheDocument();
+  });
 });

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -35,6 +35,16 @@ interface PaneControlBarProps {
   currentView: ViewInstanceConfig;
   actions: PaneControlBarActions;
   hovered: boolean;
+  /**
+   * Effective CWD send/receive state for indicator display.
+   *
+   * Computed by the caller from `viewConfig.cwdSend ?? resolveSyncCwd(...)` so the
+   * indicator stays in sync with what the backend actually applies. Do NOT fall back
+   * to `currentView.cwdSend ?? true` here — that ignores `syncCwdDefaults` (default off)
+   * and shows an "on" icon for a propagation that the backend treats as off.
+   */
+  cwdSendOn?: boolean;
+  cwdReceiveOn?: boolean;
   children: React.ReactNode;
 }
 
@@ -160,6 +170,8 @@ function BarContent({
   actions,
   mode,
   onSetMode,
+  cwdSendOn,
+  cwdReceiveOn,
   expanded = true,
   wrapped = false,
   vertical = false,
@@ -170,6 +182,8 @@ function BarContent({
   actions: PaneControlBarActions;
   mode: ControlBarMode;
   onSetMode: (m: ControlBarMode) => void;
+  cwdSendOn?: boolean;
+  cwdReceiveOn?: boolean;
   expanded?: boolean;
   wrapped?: boolean;
   vertical?: boolean;
@@ -200,7 +214,10 @@ function BarContent({
           {(currentView.type === "TerminalView" || currentView.type === "FileExplorerView") &&
             actions.onToggleCwdSend &&
             (() => {
-              const isOn = (currentView.cwdSend ?? true) as boolean;
+              // Effective state must come from the caller (resolveSyncCwd + per-pane override).
+              // Falling back to `currentView.cwdSend ?? true` here lies about the actual
+              // propagation state when no per-pane override exists and the default is off.
+              const isOn = cwdSendOn ?? false;
               return (
                 <>
                   <Separator />
@@ -239,7 +256,7 @@ function BarContent({
           {(currentView.type === "TerminalView" || currentView.type === "FileExplorerView") &&
             actions.onToggleCwdReceive &&
             (() => {
-              const isOn = (currentView.cwdReceive ?? true) as boolean;
+              const isOn = cwdReceiveOn ?? false;
               return (
                 <BarBtn
                   testId="pane-control-cwd-receive"
@@ -409,12 +426,16 @@ function NarrowControlMenu({
   actions,
   mode,
   onSetMode,
+  cwdSendOn,
+  cwdReceiveOn,
   position,
 }: {
   currentView: ViewInstanceConfig;
   actions: PaneControlBarActions;
   mode: ControlBarMode;
   onSetMode: (m: ControlBarMode) => void;
+  cwdSendOn?: boolean;
+  cwdReceiveOn?: boolean;
   position: { top: number; right: number };
 }) {
   return (
@@ -437,6 +458,8 @@ function NarrowControlMenu({
         actions={actions}
         mode={mode}
         onSetMode={onSetMode}
+        cwdSendOn={cwdSendOn}
+        cwdReceiveOn={cwdReceiveOn}
         vertical
         showMinimize={false}
       />
@@ -451,6 +474,8 @@ function NarrowControlAnchor({
   menuOpen,
   onToggleMenu,
   onSetMode,
+  cwdSendOn,
+  cwdReceiveOn,
 }: {
   currentView: ViewInstanceConfig;
   actions: PaneControlBarActions;
@@ -458,6 +483,8 @@ function NarrowControlAnchor({
   menuOpen: boolean;
   onToggleMenu: () => void;
   onSetMode: (m: ControlBarMode) => void;
+  cwdSendOn?: boolean;
+  cwdReceiveOn?: boolean;
 }) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [menuPosition, setMenuPosition] = useState({ top: 0, right: 0 });
@@ -508,6 +535,8 @@ function NarrowControlAnchor({
           actions={actions}
           mode={mode}
           onSetMode={onSetMode}
+          cwdSendOn={cwdSendOn}
+          cwdReceiveOn={cwdReceiveOn}
           position={menuPosition}
         />
       )}
@@ -573,6 +602,8 @@ export function PaneControlBar({
   currentView,
   actions,
   hovered,
+  cwdSendOn,
+  cwdReceiveOn,
   children,
 }: PaneControlBarProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -624,11 +655,20 @@ export function PaneControlBar({
           menuOpen={narrowMenuOpen}
           onToggleMenu={() => setNarrowMenuOpen((open) => !open)}
           onSetMode={setMode}
+          cwdSendOn={cwdSendOn}
+          cwdReceiveOn={cwdReceiveOn}
         />
       ) : (
-        <BarContent currentView={currentView} actions={actions} mode={mode} onSetMode={setMode} />
+        <BarContent
+          currentView={currentView}
+          actions={actions}
+          mode={mode}
+          onSetMode={setMode}
+          cwdSendOn={cwdSendOn}
+          cwdReceiveOn={cwdReceiveOn}
+        />
       ),
-    [currentView, actions, mode, setMode, narrowBar, narrowMenuOpen],
+    [currentView, actions, mode, setMode, narrowBar, narrowMenuOpen, cwdSendOn, cwdReceiveOn],
   );
 
   const registerHeader = useCallback(() => setHasViewHeader(true), []);
@@ -692,6 +732,8 @@ export function PaneControlBar({
                 menuOpen={narrowMenuOpen}
                 onToggleMenu={() => setNarrowMenuOpen((open) => !open)}
                 onSetMode={setMode}
+                cwdSendOn={cwdSendOn}
+                cwdReceiveOn={cwdReceiveOn}
               />
             ) : (
               <BarContent
@@ -699,6 +741,8 @@ export function PaneControlBar({
                 actions={actions}
                 mode={mode}
                 onSetMode={setMode}
+                cwdSendOn={cwdSendOn}
+                cwdReceiveOn={cwdReceiveOn}
               />
             )}
           </div>
@@ -742,6 +786,8 @@ export function PaneControlBar({
                   menuOpen={narrowMenuOpen}
                   onToggleMenu={() => setNarrowMenuOpen((open) => !open)}
                   onSetMode={setMode}
+                  cwdSendOn={cwdSendOn}
+                  cwdReceiveOn={cwdReceiveOn}
                 />
               ) : (
                 <BarContent
@@ -749,6 +795,8 @@ export function PaneControlBar({
                   actions={actions}
                   mode={mode}
                   onSetMode={setMode}
+                  cwdSendOn={cwdSendOn}
+                  cwdReceiveOn={cwdReceiveOn}
                 />
               )}
             </div>

--- a/ui/src/components/layout/PaneGrid.test.tsx
+++ b/ui/src/components/layout/PaneGrid.test.tsx
@@ -111,4 +111,119 @@ describe("PaneGrid", () => {
     expect(pane0.getAttribute("data-pane-index")).toBe("0");
     expect(pane1.getAttribute("data-pane-index")).toBe("1");
   });
+
+  // -- CWD toggle indicator reflects getCwdDefaults --
+  //
+  // 기본값(off)인 신규 페인에서도 viewConfig에 cwdSend/cwdReceive override가 없으면
+  // PaneControlBar 표시는 OFF여야 한다. (Regression: 표시는 ?? true로 폴백되어 ON으로 보였다)
+
+  it("shows CWD send/receive as OFF when getCwdDefaults returns {send:false, receive:false} and no override", () => {
+    const onePane: GridPane[] = [
+      {
+        id: "pane-x",
+        view: { type: "TerminalView", profile: "PowerShell" },
+        x: 0,
+        y: 0,
+        w: 1,
+        h: 1,
+      },
+    ];
+    render(
+      <PaneGrid
+        {...defaultProps}
+        panes={onePane}
+        onSetPaneView={vi.fn()}
+        getCwdDefaults={() => ({ send: false, receive: false })}
+      />,
+    );
+    fireEvent.mouseEnter(screen.getByTestId("test-pane-0"));
+    expect(screen.getByTestId("pane-control-cwd-send").getAttribute("title")).toBe(
+      "CWD Send (off)",
+    );
+    expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
+      "CWD Receive (off)",
+    );
+  });
+
+  it("shows CWD send/receive as ON when getCwdDefaults returns true and no override", () => {
+    const onePane: GridPane[] = [
+      {
+        id: "pane-x",
+        view: { type: "TerminalView", profile: "PowerShell" },
+        x: 0,
+        y: 0,
+        w: 1,
+        h: 1,
+      },
+    ];
+    render(
+      <PaneGrid
+        {...defaultProps}
+        panes={onePane}
+        onSetPaneView={vi.fn()}
+        getCwdDefaults={() => ({ send: true, receive: true })}
+      />,
+    );
+    fireEvent.mouseEnter(screen.getByTestId("test-pane-0"));
+    expect(screen.getByTestId("pane-control-cwd-send").getAttribute("title")).toBe("CWD Send (on)");
+    expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
+      "CWD Receive (on)",
+    );
+  });
+
+  it("per-pane override beats getCwdDefaults (override=false, defaults=true → OFF)", () => {
+    const onePane: GridPane[] = [
+      {
+        id: "pane-x",
+        view: { type: "TerminalView", profile: "PowerShell", cwdSend: false, cwdReceive: false },
+        x: 0,
+        y: 0,
+        w: 1,
+        h: 1,
+      },
+    ];
+    render(
+      <PaneGrid
+        {...defaultProps}
+        panes={onePane}
+        onSetPaneView={vi.fn()}
+        getCwdDefaults={() => ({ send: true, receive: true })}
+      />,
+    );
+    fireEvent.mouseEnter(screen.getByTestId("test-pane-0"));
+    expect(screen.getByTestId("pane-control-cwd-send").getAttribute("title")).toBe(
+      "CWD Send (off)",
+    );
+    expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
+      "CWD Receive (off)",
+    );
+  });
+
+  it("toggling CWD send from default-off (no override) sets cwdSend=true", () => {
+    const onSetPaneView = vi.fn();
+    const onePane: GridPane[] = [
+      {
+        id: "pane-x",
+        view: { type: "TerminalView", profile: "PowerShell" },
+        x: 0,
+        y: 0,
+        w: 1,
+        h: 1,
+      },
+    ];
+    render(
+      <PaneGrid
+        {...defaultProps}
+        panes={onePane}
+        onSetPaneView={onSetPaneView}
+        getCwdDefaults={() => ({ send: false, receive: false })}
+      />,
+    );
+    fireEvent.mouseEnter(screen.getByTestId("test-pane-0"));
+    fireEvent.click(screen.getByTestId("pane-control-cwd-send"));
+    expect(onSetPaneView).toHaveBeenCalledWith(
+      "pane-x",
+      expect.objectContaining({ cwdSend: true }),
+    );
+  });
 });

--- a/ui/src/components/layout/PaneGrid.tsx
+++ b/ui/src/components/layout/PaneGrid.tsx
@@ -108,6 +108,17 @@ export function PaneGrid({
         const hasCwdView =
           pane.view.type === "TerminalView" || pane.view.type === "FileExplorerView";
 
+        // Effective CWD send/receive: per-pane override beats getCwdDefaults cascade.
+        // This is the same precedence the backend applies via ViewRenderer → resolveSyncCwd,
+        // so the indicator and the actual propagation stay in sync.
+        const cwdDefaults = hasCwdView && getCwdDefaults ? getCwdDefaults(pane.view) : null;
+        const cwdSendOn = cwdDefaults
+          ? ((pane.view.cwdSend as boolean | undefined) ?? cwdDefaults.send)
+          : undefined;
+        const cwdReceiveOn = cwdDefaults
+          ? ((pane.view.cwdReceive as boolean | undefined) ?? cwdDefaults.receive)
+          : undefined;
+
         return (
           <div
             key={pane.id}
@@ -137,6 +148,8 @@ export function PaneGrid({
               paneId={pane.id}
               currentView={pane.view}
               hovered={isActive && isHovered}
+              cwdSendOn={cwdSendOn}
+              cwdReceiveOn={cwdReceiveOn}
               actions={{
                 onChangeView: onSetPaneView
                   ? (config) => onSetPaneView(pane.id, config)
@@ -149,19 +162,18 @@ export function PaneGrid({
                 onDelete:
                   panes.length > 1 && onRemovePane ? () => onRemovePane(pane.id) : undefined,
                 onToggleCwdSend:
-                  hasCwdView && onSetPaneView && getCwdDefaults
+                  hasCwdView && onSetPaneView && cwdDefaults
                     ? () => {
-                        const defaults = getCwdDefaults(pane.view);
-                        const current = (pane.view.cwdSend as boolean | undefined) ?? defaults.send;
+                        const current =
+                          (pane.view.cwdSend as boolean | undefined) ?? cwdDefaults.send;
                         onSetPaneView(pane.id, { ...pane.view, cwdSend: !current });
                       }
                     : undefined,
                 onToggleCwdReceive:
-                  hasCwdView && onSetPaneView && getCwdDefaults
+                  hasCwdView && onSetPaneView && cwdDefaults
                     ? () => {
-                        const defaults = getCwdDefaults(pane.view);
                         const current =
-                          (pane.view.cwdReceive as boolean | undefined) ?? defaults.receive;
+                          (pane.view.cwdReceive as boolean | undefined) ?? cwdDefaults.receive;
                         onSetPaneView(pane.id, { ...pane.view, cwdReceive: !current });
                       }
                     : undefined,

--- a/ui/src/components/layout/WorkspaceArea.tsx
+++ b/ui/src/components/layout/WorkspaceArea.tsx
@@ -2,9 +2,9 @@ import { useState } from "react";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useGridStore } from "@/stores/grid-store";
 import { useDockStore } from "@/stores/dock-store";
-import { useSettingsStore, FALLBACK_PROFILE, type TerminalLocation } from "@/stores/settings-store";
-import type { ViewInstanceConfig } from "@/stores/types";
+import type { TerminalLocation } from "@/stores/settings-store";
 import { PaneGrid } from "./PaneGrid";
+import { useCwdDefaultsResolver } from "./useCwdDefaultsResolver";
 
 export function WorkspaceArea() {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
@@ -16,9 +16,8 @@ export function WorkspaceArea() {
   const setPaneView = useWorkspaceStore((s) => s.setPaneView);
   const splitPane = useWorkspaceStore((s) => s.splitPane);
   const removePane = useWorkspaceStore((s) => s.removePane);
-  const defaultProfile = useSettingsStore((s) => s.defaultProfile);
-  const resolveSyncCwdForProfile = useSettingsStore((s) => s.resolveSyncCwdForProfile);
   const location: TerminalLocation = "workspace";
+  const resolveCwdDefaults = useCwdDefaultsResolver(location);
 
   // Lazy mount: only render panes for workspaces that have been activated at least once.
   // Prevents unnecessary TerminalView/WebGL initialization for never-visited workspaces,
@@ -55,10 +54,7 @@ export function WorkspaceArea() {
             }
             onSplitPane={isActive ? (paneId, dir) => splitPane(idxOf(paneId), dir) : undefined}
             onRemovePane={isActive ? (paneId) => removePane(idxOf(paneId)) : undefined}
-            getCwdDefaults={(view: ViewInstanceConfig) => {
-              const profileName = (view.profile as string) || defaultProfile || FALLBACK_PROFILE;
-              return resolveSyncCwdForProfile(profileName, location);
-            }}
+            getCwdDefaults={resolveCwdDefaults}
             isHoveredOverride={
               isActive && automationHoverIndex !== null
                 ? (paneId) => automationHoverIndex === idxOf(paneId)

--- a/ui/src/components/layout/useCwdDefaultsResolver.ts
+++ b/ui/src/components/layout/useCwdDefaultsResolver.ts
@@ -1,0 +1,59 @@
+import { useCallback } from "react";
+import { resolveSyncCwd, type SyncCwdPair } from "@/lib/sync-cwd-config";
+import type { TerminalLocation } from "@/stores/settings-store";
+import {
+  defaultProfileDefaults,
+  FALLBACK_PROFILE,
+  useSettingsStore,
+} from "@/stores/settings-store";
+import type { ViewInstanceConfig } from "@/stores/types";
+
+function getCwdProfileName(
+  view: ViewInstanceConfig,
+  defaultProfile: string,
+  fileExplorerShellProfile: string,
+): string {
+  if (view.type === "FileExplorerView") {
+    return fileExplorerShellProfile || defaultProfile || FALLBACK_PROFILE;
+  }
+  return (view.profile as string) || defaultProfile || FALLBACK_PROFILE;
+}
+
+/**
+ * Resolve the effective CWD defaults used by pane controls.
+ *
+ * The subscriptions are intentionally explicit. A stored resolver function that
+ * calls get() would not re-render existing panes when syncCwd settings change.
+ */
+export function useCwdDefaultsResolver(
+  location: TerminalLocation,
+): (view: ViewInstanceConfig) => SyncCwdPair {
+  const defaultProfile = useSettingsStore((s) => s.defaultProfile);
+  const fileExplorerShellProfile = useSettingsStore((s) => s.fileExplorer?.shellProfile ?? "");
+  const profiles = useSettingsStore((s) => s.profiles ?? []);
+  const profileDefaultsSyncCwd = useSettingsStore(
+    (s) => s.profileDefaults?.syncCwd ?? defaultProfileDefaults.syncCwd,
+  );
+  const syncCwdDefaults = useSettingsStore((s) => s.syncCwdDefaults);
+
+  return useCallback(
+    (view: ViewInstanceConfig) => {
+      const profileName = getCwdProfileName(view, defaultProfile, fileExplorerShellProfile);
+      return resolveSyncCwd({
+        profileName,
+        location,
+        profileSyncCwd: profiles.find((p) => p.name === profileName)?.syncCwd,
+        profileDefaultsSyncCwd,
+        syncCwdDefaults,
+      });
+    },
+    [
+      defaultProfile,
+      fileExplorerShellProfile,
+      location,
+      profileDefaultsSyncCwd,
+      profiles,
+      syncCwdDefaults,
+    ],
+  );
+}

--- a/ui/src/components/views/ViewRenderer.test.tsx
+++ b/ui/src/components/views/ViewRenderer.test.tsx
@@ -164,7 +164,8 @@ describe("ViewRenderer", () => {
     expect(onSelectView).not.toHaveBeenCalled();
   });
 
-  it("FileExplorerView defaults cwdSend and cwdReceive to true regardless of location", () => {
+  it("FileExplorerView defaults cwdSend/cwdReceive from syncCwdDefaults (dock=off by default)", () => {
+    // 기본 syncCwdDefaults.dock = { send: false, receive: false } → 표시·적용 모두 off
     render(
       <ViewRenderer
         viewType="FileExplorerView"
@@ -175,17 +176,24 @@ describe("ViewRenderer", () => {
       />,
     );
     const last = fileExplorerProps.at(-1);
-    expect(last?.cwdSend).toBe(true);
-    expect(last?.cwdReceive).toBe(true);
+    expect(last?.cwdSend).toBe(false);
+    expect(last?.cwdReceive).toBe(false);
   });
 
-  it("FileExplorerView defaults to true even without explicit location", () => {
+  it("FileExplorerView honors custom syncCwdDefaults.dock", () => {
+    useSettingsStore.setState((s) => ({
+      syncCwdDefaults: {
+        ...s.syncCwdDefaults,
+        dock: { send: true, receive: true },
+      },
+    }));
     render(
       <ViewRenderer
         viewType="FileExplorerView"
         viewConfig={{ type: "FileExplorerView" }}
         workspaceId="ws-1"
         paneId="pane-1"
+        location="dock"
       />,
     );
     const last = fileExplorerProps.at(-1);

--- a/ui/src/components/views/ViewRenderer.tsx
+++ b/ui/src/components/views/ViewRenderer.tsx
@@ -87,14 +87,18 @@ function FileExplorerViewWithSyncCwd({
   workspaceId,
   paneId,
   isFocused,
+  location,
 }: {
   viewConfig?: ViewInstanceConfig;
   workspaceId?: string;
   paneId?: string;
   isFocused?: boolean;
+  location: TerminalLocation;
 }) {
   const defaultProfile = useSettingsStore((s) => s.defaultProfile);
   const fileExplorerSettings = useSettingsStore((s) => s.fileExplorer);
+  const profileDefaultsSyncCwd = useSettingsStore((s) => s.profileDefaults.syncCwd);
+  const syncCwdDefaults = useSettingsStore((s) => s.syncCwdDefaults);
   const fallbackId = useId();
 
   const configSyncGroup = (viewConfig?.syncGroup as string) ?? "";
@@ -104,10 +108,18 @@ function FileExplorerViewWithSyncCwd({
 
   // Use file explorer's shellProfile setting, or fall back to defaultProfile
   const profileName = fileExplorerSettings.shellProfile || defaultProfile || FALLBACK_PROFILE;
-
-  // FileExplorerView is CWD-based: default to true unless explicitly disabled in viewConfig
-  const cwdSend = (viewConfig?.cwdSend as boolean | undefined) ?? true;
-  const cwdReceive = (viewConfig?.cwdReceive as boolean | undefined) ?? true;
+  const profileSyncCwd = useSettingsStore(
+    (s) => s.profiles.find((p) => p.name === profileName)?.syncCwd,
+  );
+  const resolvedDefaults = resolveSyncCwd({
+    profileName,
+    location,
+    profileSyncCwd,
+    profileDefaultsSyncCwd,
+    syncCwdDefaults,
+  });
+  const cwdSend = (viewConfig?.cwdSend as boolean | undefined) ?? resolvedDefaults.send;
+  const cwdReceive = (viewConfig?.cwdReceive as boolean | undefined) ?? resolvedDefaults.receive;
 
   return (
     <FileExplorerView
@@ -211,6 +223,7 @@ export function ViewRenderer({
             workspaceId={workspaceId}
             paneId={paneId}
             isFocused={isFocused}
+            location={location}
           />
         </div>
       );


### PR DESCRIPTION
## Summary

- 신규 페인의 CWD Send/Receive 아이콘이 `syncCwdDefaults`(기본 off)와 무관하게 항상 켜진 모양으로 표시되던 문제 수정. 켜진 것처럼 보이는 아이콘을 누르면 실제로는 off→on으로 토글되어 사용자 의도와 반대로 동작했다.
- 원인: 표시·토글·백엔드 적용이 서로 다른 폴백을 사용했다. `ViewRenderer`는 `resolveSyncCwd` cascade를 따랐지만(workspace=false, dock=false), `PaneControlBar`의 아이콘 표시는 `viewConfig.cwdSend ?? true`로, `Dock`의 single-pane 토글과 `DockGrid.getCwdDefaults`는 하드코딩 `true`로 폴백했다.
- 해결: `PaneControlBar`에 `cwdSendOn` / `cwdReceiveOn` props를 추가해 호출자가 effective 상태를 계산해 넘기도록 했다. `PaneGrid`, `Dock` single-pane 경로, `DockGrid.getCwdDefaults`는 모두 `resolveSyncCwd` + per-pane override로 계산해 백엔드 적용과 단일 진실의 원천을 공유한다. `FileExplorerViewWithSyncCwd`의 `?? true` 폴백도 같은 경로로 통일.
- ARCHITECTURE §15 "원시 상태 분리 → 계산 함수로 표시 도출" 준수.

## Test plan

- [x] `npx vitest run` — 전체 UI 1791개 단위/통합 테스트 통과
- [x] `npm run build` — 빌드 통과
- [x] `npx tsc --noEmit` — 타입 검사 통과
- [x] `PaneControlBar.test.tsx` — `cwdSendOn` / `cwdReceiveOn` props에 따른 아이콘 title 변경 검증 (7건 추가)
- [x] `PaneGrid.test.tsx` — `getCwdDefaults`가 false/true일 때 아이콘 OFF/ON 표시, per-pane override 우선, default-off에서 토글 시 cwdSend=true 검증 (4건 추가)
- [x] `Dock.test.tsx` — single-pane / split-pane 모두 dock syncCwdDefaults(기본 off) 반영, default-off에서 토글 시 cwdSend=true 검증 (3건 추가)
- [x] `ViewRenderer.test.tsx` — FileExplorerView의 default가 `?? true`가 아니라 `syncCwdDefaults`를 따르는지 검증으로 수정
- [ ] dev 인스턴스에서 신규 페인 열고 hover 시 CWD 아이콘이 off(흐릿) 상태로 표시되는지 시각 확인
- [ ] settings에서 `syncCwdDefaults.workspace = { send: true, receive: true }`로 바꾼 뒤 신규 페인이 on 상태로 표시되는지 확인
- [ ] 토글 클릭 시 의도와 같은 방향(off→on, on→off)으로 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)