### PR TITLE
Animate workspace/pane hide-mode transitions (#264)

### DIFF
--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -1716,19 +1716,34 @@ describe("WorkspaceSelectorView", () => {
       expect(screen.getByTestId("pane-eye-pane-b")).toBeInTheDocument();
     });
 
-    it("hiding a pane removes it from the list in normal mode", () => {
+    it("hiding a pane collapses it from the list in normal mode", () => {
       useUiStore.getState().togglePaneHidden("pane-a");
       render(<WorkspaceSelectorView />);
-      expect(screen.queryByTestId("pane-minimap-terminal-pane-a")).not.toBeInTheDocument();
+      const paneRow = screen.getByTestId("pane-row-pane-a");
+      expect(paneRow.className).toContain("workspace-pane-row-collapsed");
+      expect(paneRow).toHaveAttribute("aria-hidden", "true");
       expect(screen.getByText("PS")).toBeInTheDocument();
     });
 
-    it("hiding a workspace removes it from the list in normal mode", () => {
+    it("hiding a workspace collapses it from the list in normal mode", () => {
       useUiStore.getState().toggleWorkspaceHidden("ws-2");
       render(<WorkspaceSelectorView />);
-      expect(screen.queryByTestId("workspace-item-ws-2")).not.toBeInTheDocument();
+      const hidden = screen.getByTestId("workspace-item-ws-2");
+      expect(hidden.className).toContain("workspace-item-collapsed");
+      expect(hidden).toHaveAttribute("aria-hidden", "true");
       expect(screen.getByTestId("workspace-item-ws-1")).toBeInTheDocument();
       expect(screen.getByTestId("workspace-item-ws-3")).toBeInTheDocument();
+    });
+
+    it("expands hidden workspaces while hide mode is active", () => {
+      useUiStore.getState().toggleWorkspaceHidden("ws-2");
+      useUiStore.getState().toggleHideMode();
+      render(<WorkspaceSelectorView />);
+
+      const hidden = screen.getByTestId("workspace-item-ws-2");
+      expect(hidden.className).not.toContain("workspace-item-collapsed");
+      expect(hidden).not.toHaveAttribute("aria-hidden", "true");
+      expect(screen.getByTestId("workspace-eye-ws-2")).toBeInTheDocument();
     });
 
     it("active workspace is never hidden even if in hiddenWorkspaceIds", () => {

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -187,6 +187,7 @@ function WorkspaceItem({
   const wsDisplay = useSettingsStore((s) => s.workspaceDisplay);
   const claudeSettings = useSettingsStore((s) => s.claude);
   const codexSettings = useSettingsStore((s) => s.codex);
+  const isCollapsed = !hideMode && isWsHidden && !isActive;
 
   const cmdInfo = summary.lastCommand;
   const cmdStatusSettings = getStatusDisplaySettings(
@@ -210,8 +211,9 @@ function WorkspaceItem({
     <div
       data-testid={`workspace-item-${ws.id}`}
       data-active={isActive ? "true" : "false"}
-      draggable={drag.enabled}
-      onClick={hideMode ? undefined : onSelect}
+      aria-hidden={isCollapsed ? "true" : undefined}
+      draggable={drag.enabled && !isCollapsed}
+      onClick={hideMode || isCollapsed ? undefined : onSelect}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onDragStart={(e) => drag.onDragStart(e, ws.id)}
@@ -219,11 +221,13 @@ function WorkspaceItem({
       onDragLeave={(e) => drag.onDragLeave(e)}
       onDrop={(e) => drag.onDrop(e, ws.id)}
       onDragEnd={drag.onDragEnd}
-      className="relative cursor-pointer"
+      className={`workspace-item-animated relative cursor-pointer${
+        isCollapsed ? " workspace-item-collapsed" : ""
+      }`}
       style={{
         background: isActive ? "var(--accent-08)" : hovered ? "var(--active-bg)" : "transparent",
         borderLeft: isActive ? "3px solid var(--accent)" : "3px solid transparent",
-        borderBottom: "1px solid var(--border)",
+        borderBottom: isCollapsed ? "0 solid transparent" : "1px solid var(--border)",
         boxShadow:
           dropIndicator?.wsId === ws.id
             ? dropIndicator.position === "top"
@@ -234,211 +238,389 @@ function WorkspaceItem({
         paddingRight: 10,
       }}
     >
-      {/* Row 1: Index + Workspace name + terminal count + badge + close */}
-      <div data-testid={`ws-row-1-${ws.id}`} className="flex items-center justify-between">
-        <span className="flex min-w-0 items-center gap-1.5 truncate">
-          {hideMode && (
-            <button
-              data-testid={`workspace-eye-${ws.id}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleWsHidden();
-              }}
-              className="row-eye-btn shrink-0 cursor-pointer"
-              style={{
-                color: isWsHidden ? "var(--yellow)" : "var(--accent)",
-                border: "none",
-                lineHeight: 0,
-              }}
-            >
-              {isWsHidden ? <EyeOffIcon size={11} /> : <EyeIcon size={11} />}
-            </button>
-          )}
-          {/* Fade the descriptive content, but keep the eye button fully
-              visible so the yellow "hidden" cue does not wash out. */}
-          <span
-            className="flex min-w-0 items-center gap-1.5 truncate"
-            style={{ opacity: hideMode && isWsHidden ? 0.35 : undefined }}
-          >
-            <span
-              className="shrink-0 text-[10px] font-medium"
-              style={{
-                color: isActive ? "var(--accent)" : "var(--text-primary)",
-                opacity: isActive ? 0.9 : 0.6,
-                minWidth: 10,
-              }}
-              title={
-                index < 9 ? `Ctrl+Alt+${index + 1}` : index === 8 ? "Ctrl+Alt+9 (last)" : undefined
-              }
-            >
-              {index < 9 ? index + 1 : ""}
-            </span>
-            <span
-              data-testid={`workspace-name-${ws.id}`}
-              className="truncate text-sm font-medium"
-              style={{ color: isActive ? "var(--text-primary)" : "var(--text-secondary)" }}
-              onDoubleClick={(e) => {
-                e.stopPropagation();
-                onRename();
-              }}
-            >
-              {ws.name}
-            </span>
-            {summary.terminalCount > 0 && (
-              <span
-                data-testid={`terminal-count-${ws.id}`}
-                className="shrink-0 rounded px-1.5 text-[9px]"
-                style={{
-                  color: "var(--text-secondary)",
-                  background: "var(--hover-bg)",
-                  opacity: 0.7,
-                }}
-              >
-                {summary.terminalCount}
-              </span>
-            )}
-          </span>
-        </span>
-        <span
-          className="flex items-center gap-1"
-          style={{ opacity: hideMode && isWsHidden ? 0.35 : undefined }}
-        >
-          {summary.unreadCount > 0 && (
-            <CountBadge count={summary.unreadCount} testId={`unread-badge-${ws.id}`} />
-          )}
-          {hovered && (
-            <>
+      <div className="workspace-item-content">
+        {/* Row 1: Index + Workspace name + terminal count + badge + close */}
+        <div data-testid={`ws-row-1-${ws.id}`} className="flex items-center justify-between">
+          <span className="flex min-w-0 items-center gap-1.5 truncate">
+            {hideMode && (
               <button
-                data-testid={`workspace-duplicate-${ws.id}`}
+                data-testid={`workspace-eye-${ws.id}`}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onDuplicate();
+                  onToggleWsHidden();
                 }}
-                className="shrink-0 cursor-pointer rounded p-0.5 leading-none opacity-50 hover:opacity-100"
+                className="row-eye-btn shrink-0 cursor-pointer"
                 style={{
-                  color: "var(--text-secondary)",
-                  background: "transparent",
+                  color: isWsHidden ? "var(--yellow)" : "var(--accent)",
                   border: "none",
+                  lineHeight: 0,
                 }}
-                title="Duplicate workspace (Ctrl+Alt+D)"
               >
-                <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
-                  <rect
-                    x="0.5"
-                    y="2.5"
-                    width="7"
-                    height="7"
-                    rx="1"
-                    stroke="currentColor"
-                    strokeWidth="1"
-                  />
-                  <rect
-                    x="3"
-                    y="0.5"
-                    width="7"
-                    height="7"
-                    rx="1"
-                    stroke="currentColor"
-                    strokeWidth="1"
-                  />
-                </svg>
+                {isWsHidden ? <EyeOffIcon size={11} /> : <EyeIcon size={11} />}
               </button>
-              <button
-                data-testid={`workspace-rename-${ws.id}`}
-                onClick={(e) => {
+            )}
+            {/* Fade the descriptive content, but keep the eye button fully
+              visible so the yellow "hidden" cue does not wash out. */}
+            <span
+              className="flex min-w-0 items-center gap-1.5 truncate"
+              style={{ opacity: hideMode && isWsHidden ? 0.35 : undefined }}
+            >
+              <span
+                className="shrink-0 text-[10px] font-medium"
+                style={{
+                  color: isActive ? "var(--accent)" : "var(--text-primary)",
+                  opacity: isActive ? 0.9 : 0.6,
+                  minWidth: 10,
+                }}
+                title={
+                  index < 9
+                    ? `Ctrl+Alt+${index + 1}`
+                    : index === 8
+                      ? "Ctrl+Alt+9 (last)"
+                      : undefined
+                }
+              >
+                {index < 9 ? index + 1 : ""}
+              </span>
+              <span
+                data-testid={`workspace-name-${ws.id}`}
+                className="truncate text-sm font-medium"
+                style={{ color: isActive ? "var(--text-primary)" : "var(--text-secondary)" }}
+                onDoubleClick={(e) => {
                   e.stopPropagation();
                   onRename();
                 }}
-                className="shrink-0 cursor-pointer rounded p-0.5 leading-none opacity-50 hover:opacity-100"
-                style={{
-                  color: "var(--text-secondary)",
-                  background: "transparent",
-                  border: "none",
-                }}
-                title="Rename workspace (Ctrl+Alt+R)"
               >
-                <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
-                  <path
-                    d="M7.5 1.5l2 2-6 6H1.5v-2z"
-                    stroke="currentColor"
-                    strokeWidth="1"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </button>
-              {canClose && (
+                {ws.name}
+              </span>
+              {summary.terminalCount > 0 && (
+                <span
+                  data-testid={`terminal-count-${ws.id}`}
+                  className="shrink-0 rounded px-1.5 text-[9px]"
+                  style={{
+                    color: "var(--text-secondary)",
+                    background: "var(--hover-bg)",
+                    opacity: 0.7,
+                  }}
+                >
+                  {summary.terminalCount}
+                </span>
+              )}
+            </span>
+          </span>
+          <span
+            className="flex items-center gap-1"
+            style={{ opacity: hideMode && isWsHidden ? 0.35 : undefined }}
+          >
+            {summary.unreadCount > 0 && (
+              <CountBadge count={summary.unreadCount} testId={`unread-badge-${ws.id}`} />
+            )}
+            {hovered && (
+              <>
                 <button
-                  data-testid={`workspace-close-${ws.id}`}
+                  data-testid={`workspace-duplicate-${ws.id}`}
                   onClick={(e) => {
                     e.stopPropagation();
-                    onClose();
+                    onDuplicate();
                   }}
-                  className="shrink-0 cursor-pointer rounded p-0.5 leading-none opacity-50 hover:opacity-100 hover:text-[var(--red)]"
+                  className="shrink-0 cursor-pointer rounded p-0.5 leading-none opacity-50 hover:opacity-100"
                   style={{
                     color: "var(--text-secondary)",
                     background: "transparent",
                     border: "none",
                   }}
-                  title="Close workspace (Ctrl+Alt+W)"
+                  title="Duplicate workspace (Ctrl+Alt+D)"
                 >
                   <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
-                    <path
-                      d="M2.5 2.5l6 6M8.5 2.5l-6 6"
+                    <rect
+                      x="0.5"
+                      y="2.5"
+                      width="7"
+                      height="7"
+                      rx="1"
                       stroke="currentColor"
-                      strokeWidth="1.2"
-                      strokeLinecap="round"
+                      strokeWidth="1"
+                    />
+                    <rect
+                      x="3"
+                      y="0.5"
+                      width="7"
+                      height="7"
+                      rx="1"
+                      stroke="currentColor"
+                      strokeWidth="1"
                     />
                   </svg>
                 </button>
-              )}
-            </>
-          )}
-        </span>
-      </div>
+                <button
+                  data-testid={`workspace-rename-${ws.id}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRename();
+                  }}
+                  className="shrink-0 cursor-pointer rounded p-0.5 leading-none opacity-50 hover:opacity-100"
+                  style={{
+                    color: "var(--text-secondary)",
+                    background: "transparent",
+                    border: "none",
+                  }}
+                  title="Rename workspace (Ctrl+Alt+R)"
+                >
+                  <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
+                    <path
+                      d="M7.5 1.5l2 2-6 6H1.5v-2z"
+                      stroke="currentColor"
+                      strokeWidth="1"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+                {canClose && (
+                  <button
+                    data-testid={`workspace-close-${ws.id}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onClose();
+                    }}
+                    className="shrink-0 cursor-pointer rounded p-0.5 leading-none opacity-50 hover:opacity-100 hover:text-[var(--red)]"
+                    style={{
+                      color: "var(--text-secondary)",
+                      background: "transparent",
+                      border: "none",
+                    }}
+                    title="Close workspace (Ctrl+Alt+W)"
+                  >
+                    <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
+                      <path
+                        d="M2.5 2.5l6 6M8.5 2.5l-6 6"
+                        stroke="currentColor"
+                        strokeWidth="1.2"
+                        strokeLinecap="round"
+                      />
+                    </svg>
+                  </button>
+                )}
+              </>
+            )}
+          </span>
+        </div>
 
-      {/* Per-pane summaries */}
-      {panes.length >= 1 ? (
-        <div
-          data-testid={`ws-row-2-${ws.id}`}
-          className="mt-1 flex flex-col gap-0.5"
-          style={{ opacity: hideMode && isWsHidden ? 0.35 : undefined }}
-        >
-          {(() => {
-            const showMinimap = panes.length >= 1;
-            const minimapPanes = panes.map((p) => ({ x: p.x, y: p.y, w: p.w, h: p.h }));
-            const gridFocused = isActive ? useGridStore.getState().focusedPaneIndex : null;
-            return panes.map((pane, paneIdx) => {
-              const paneIndex = showMinimap ? paneIdx : -1;
-              const isFocusedPane = isActive && gridFocused === paneIdx;
-              const isPaneHidden = hiddenPaneIds.has(pane.id);
-              // In normal mode, skip hidden panes
-              if (!hideMode && isPaneHidden) return null;
-              if (pane.view.type === "TerminalView") {
-                const termId = `terminal-${pane.id}`;
-                const ts = summary.terminalSummaries.find((t) => t.id === termId);
-                if (!ts) return null;
-                const paneStatusSettings = getStatusDisplaySettings(
-                  ts.activity,
-                  claudeSettings,
-                  codexSettings,
-                );
-                const tCmdStatus =
-                  ts.lastCommand || ts.activity?.type === "interactiveApp"
-                    ? computeCommandStatus(
-                        ts.lastExitCode,
-                        ts.outputActive,
-                        ts.activityMessage,
-                        ts.activity,
-                        ts.title,
-                        paneStatusSettings.mode,
-                        paneStatusSettings.delimiter,
-                      )
-                    : null;
-                const actInfo = formatActivity(ts.activity);
+        {/* Per-pane summaries */}
+        {panes.length >= 1 ? (
+          <div
+            data-testid={`ws-row-2-${ws.id}`}
+            className="mt-1 flex flex-col gap-0.5"
+            style={{ opacity: hideMode && isWsHidden ? 0.35 : undefined }}
+          >
+            {(() => {
+              const showMinimap = panes.length >= 1;
+              const minimapPanes = panes.map((p) => ({ x: p.x, y: p.y, w: p.w, h: p.h }));
+              const gridFocused = isActive ? useGridStore.getState().focusedPaneIndex : null;
+              return panes.map((pane, paneIdx) => {
+                const paneIndex = showMinimap ? paneIdx : -1;
+                const isFocusedPane = isActive && gridFocused === paneIdx;
+                const isPaneHidden = hiddenPaneIds.has(pane.id);
+                const isPaneCollapsed = !hideMode && isPaneHidden;
+                if (pane.view.type === "TerminalView") {
+                  const termId = `terminal-${pane.id}`;
+                  const ts = summary.terminalSummaries.find((t) => t.id === termId);
+                  if (!ts) return null;
+                  const paneStatusSettings = getStatusDisplaySettings(
+                    ts.activity,
+                    claudeSettings,
+                    codexSettings,
+                  );
+                  const tCmdStatus =
+                    ts.lastCommand || ts.activity?.type === "interactiveApp"
+                      ? computeCommandStatus(
+                          ts.lastExitCode,
+                          ts.outputActive,
+                          ts.activityMessage,
+                          ts.activity,
+                          ts.title,
+                          paneStatusSettings.mode,
+                          paneStatusSettings.delimiter,
+                        )
+                      : null;
+                  const actInfo = formatActivity(ts.activity);
+                  return (
+                    <div
+                      key={pane.id}
+                      data-testid={`pane-row-${pane.id}`}
+                      aria-hidden={isPaneCollapsed ? "true" : undefined}
+                      className={`workspace-pane-row flex items-center gap-1.5 truncate text-[11px]${
+                        hideMode ? " cursor-pointer" : ""
+                      }${isPaneCollapsed ? " workspace-pane-row-collapsed" : ""}`}
+                      onClick={
+                        hideMode
+                          ? (e) => {
+                              e.stopPropagation();
+                              onTogglePaneHidden(pane.id);
+                            }
+                          : undefined
+                      }
+                      style={{
+                        paddingLeft: showMinimap && wsDisplay.minimap ? 0 : 18,
+                        ...(isFocusedPane && !hideMode
+                          ? {
+                              background: "var(--accent-12)",
+                              borderRadius: "var(--radius-md)",
+                              filter: "brightness(1.3)",
+                            }
+                          : {}),
+                      }}
+                    >
+                      {hideMode && (
+                        <button
+                          className="row-eye-btn shrink-0 cursor-pointer"
+                          data-testid={`pane-eye-${pane.id}`}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onTogglePaneHidden(pane.id);
+                          }}
+                          style={{
+                            color: isPaneHidden ? "var(--yellow)" : "var(--accent)",
+                            border: "none",
+                            lineHeight: 0,
+                          }}
+                        >
+                          {isPaneHidden ? <EyeOffIcon size={11} /> : <EyeIcon size={11} />}
+                        </button>
+                      )}
+                      <div
+                        className="flex min-w-0 flex-1 items-center gap-1.5 truncate"
+                        style={{ opacity: isPaneHidden ? 0.35 : undefined }}
+                      >
+                        {showMinimap && wsDisplay.minimap && (
+                          <span
+                            className="shrink-0"
+                            data-testid={`pane-minimap-${termId}`}
+                            style={{ opacity: isFocusedPane ? 1 : 0.5 }}
+                          >
+                            <PaneMinimap
+                              panes={minimapPanes}
+                              highlightIndex={paneIndex}
+                              width={18}
+                              height={12}
+                            />
+                          </span>
+                        )}
+                        <div className="flex min-w-0 flex-1 items-center gap-1 truncate">
+                          {wsDisplay.environment && (
+                            <span
+                              className="shrink-0 font-medium"
+                              style={{
+                                color: "var(--text-secondary)",
+                                opacity: isActive ? 0.9 : 0.7,
+                              }}
+                            >
+                              {shortLabel(ts.label)}
+                            </span>
+                          )}
+                          {wsDisplay.activity && (
+                            <span
+                              data-testid={`terminal-activity-${ts.id}`}
+                              className="shrink-0 rounded px-1 mr-1 text-[9px]"
+                              style={{
+                                color: actInfo.color,
+                                background:
+                                  ts.activity?.type === "interactiveApp"
+                                    ? ts.activity?.name === "Claude"
+                                      ? "var(--orange-15)"
+                                      : "var(--accent-12)"
+                                    : "var(--active-bg)",
+                                minWidth: 40,
+                                textAlign: "center",
+                                display: "inline-block",
+                                opacity: isActive ? 1 : 0.7,
+                              }}
+                            >
+                              {actInfo.label}
+                              {ts.outputActive ? "" : ""}
+                            </span>
+                          )}
+                          {wsDisplay.path && ts.branch && (
+                            <>
+                              <span
+                                className="shrink-0"
+                                style={{ color: "var(--green)", opacity: isActive ? 1 : 0.7 }}
+                              >
+                                {ts.branch}
+                              </span>
+                            </>
+                          )}
+                          {wsDisplay.path && ts.cwd && (
+                            <>
+                              <span
+                                className="truncate"
+                                style={{
+                                  color: isActive ? "var(--text-primary)" : "var(--text-secondary)",
+                                  opacity: isActive ? 0.7 : 0.5,
+                                  ...(pathEllipsis === "start"
+                                    ? { direction: "rtl", textAlign: "left" }
+                                    : {}),
+                                }}
+                              >
+                                <bdi>
+                                  {abbreviatePath(
+                                    isWindowsProfile(ts.profile)
+                                      ? mntPathToWindows(ts.cwd)
+                                      : ts.cwd,
+                                    pathEllipsis,
+                                  )}
+                                </bdi>
+                              </span>
+                            </>
+                          )}
+                        </div>
+                        {wsDisplay.result && tCmdStatus?.icon ? (
+                          <span
+                            data-testid={`pane-cmd-badge-${ts.id}`}
+                            className="shrink-0 ml-auto"
+                            style={{
+                              color: tCmdStatus.color,
+                              border: ts.hasUnreadNotification
+                                ? "1.5px solid var(--accent)"
+                                : "1.5px solid transparent",
+                              borderRadius: "var(--radius-md)",
+                              width: 16,
+                              height: 16,
+                              display: "inline-flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              boxSizing: "border-box",
+                              fontSize: 10,
+                              lineHeight: 1,
+                            }}
+                          >
+                            {tCmdStatus.icon}
+                          </span>
+                        ) : wsDisplay.result && ts.hasUnreadNotification ? (
+                          <span
+                            data-testid={`pane-notif-dot-${ts.id}`}
+                            className="shrink-0 ml-auto"
+                            style={{
+                              width: 6,
+                              height: 6,
+                              borderRadius: "50%",
+                              background: "var(--accent)",
+                              display: "inline-block",
+                            }}
+                          />
+                        ) : null}
+                      </div>
+                    </div>
+                  );
+                }
+                // EmptyView or other view types (IssueReporterView, MemoView, etc.)
                 return (
                   <div
                     key={pane.id}
-                    className={`flex items-center gap-1.5 truncate text-[11px]${hideMode ? " cursor-pointer" : ""}`}
+                    data-testid={`pane-row-${pane.id}`}
+                    aria-hidden={isPaneCollapsed ? "true" : undefined}
+                    className={`workspace-pane-row flex items-center gap-1.5 truncate text-[11px]${
+                      hideMode ? " cursor-pointer" : ""
+                    }${isPaneCollapsed ? " workspace-pane-row-collapsed" : ""}`}
                     onClick={
                       hideMode
                         ? (e) => {
@@ -451,9 +633,9 @@ function WorkspaceItem({
                       paddingLeft: showMinimap && wsDisplay.minimap ? 0 : 18,
                       ...(isFocusedPane && !hideMode
                         ? {
-                            background: "var(--accent-12)",
+                            background: "var(--accent-08)",
                             borderRadius: "var(--radius-md)",
-                            filter: "brightness(1.3)",
+                            color: "var(--text-primary)",
                           }
                         : {}),
                     }}
@@ -482,7 +664,7 @@ function WorkspaceItem({
                       {showMinimap && wsDisplay.minimap && (
                         <span
                           className="shrink-0"
-                          data-testid={`pane-minimap-${termId}`}
+                          data-testid={`pane-minimap-empty-${pane.id}`}
                           style={{ opacity: isFocusedPane ? 1 : 0.5 }}
                         >
                           <PaneMinimap
@@ -494,256 +676,93 @@ function WorkspaceItem({
                         </span>
                       )}
                       <div className="flex min-w-0 flex-1 items-center gap-1 truncate">
-                        {wsDisplay.environment && (
-                          <span
-                            className="shrink-0 font-medium"
-                            style={{
-                              color: "var(--text-secondary)",
-                              opacity: isActive ? 0.9 : 0.7,
-                            }}
-                          >
-                            {shortLabel(ts.label)}
-                          </span>
-                        )}
-                        {wsDisplay.activity && (
-                          <span
-                            data-testid={`terminal-activity-${ts.id}`}
-                            className="shrink-0 rounded px-1 mr-1 text-[9px]"
-                            style={{
-                              color: actInfo.color,
-                              background:
-                                ts.activity?.type === "interactiveApp"
-                                  ? ts.activity?.name === "Claude"
-                                    ? "var(--orange-15)"
-                                    : "var(--accent-12)"
-                                  : "var(--active-bg)",
-                              minWidth: 40,
-                              textAlign: "center",
-                              display: "inline-block",
-                              opacity: isActive ? 1 : 0.7,
-                            }}
-                          >
-                            {actInfo.label}
-                            {ts.outputActive ? "" : ""}
-                          </span>
-                        )}
-                        {wsDisplay.path && ts.branch && (
-                          <>
-                            <span
-                              className="shrink-0"
-                              style={{ color: "var(--green)", opacity: isActive ? 1 : 0.7 }}
-                            >
-                              {ts.branch}
-                            </span>
-                          </>
-                        )}
-                        {wsDisplay.path && ts.cwd && (
-                          <>
-                            <span
-                              className="truncate"
-                              style={{
-                                color: isActive ? "var(--text-primary)" : "var(--text-secondary)",
-                                opacity: isActive ? 0.7 : 0.5,
-                                ...(pathEllipsis === "start"
-                                  ? { direction: "rtl", textAlign: "left" }
-                                  : {}),
-                              }}
-                            >
-                              <bdi>
-                                {abbreviatePath(
-                                  isWindowsProfile(ts.profile) ? mntPathToWindows(ts.cwd) : ts.cwd,
-                                  pathEllipsis,
-                                )}
-                              </bdi>
-                            </span>
-                          </>
-                        )}
-                      </div>
-                      {wsDisplay.result && tCmdStatus?.icon ? (
                         <span
-                          data-testid={`pane-cmd-badge-${ts.id}`}
-                          className="shrink-0 ml-auto"
-                          style={{
-                            color: tCmdStatus.color,
-                            border: ts.hasUnreadNotification
-                              ? "1.5px solid var(--accent)"
-                              : "1.5px solid transparent",
-                            borderRadius: "var(--radius-md)",
-                            width: 16,
-                            height: 16,
-                            display: "inline-flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            boxSizing: "border-box",
-                            fontSize: 10,
-                            lineHeight: 1,
-                          }}
+                          className="shrink-0 font-medium"
+                          style={{ color: "var(--text-secondary)", opacity: 0.4 }}
                         >
-                          {tCmdStatus.icon}
+                          {shortLabel(pane.view.type)}
                         </span>
-                      ) : wsDisplay.result && ts.hasUnreadNotification ? (
-                        <span
-                          data-testid={`pane-notif-dot-${ts.id}`}
-                          className="shrink-0 ml-auto"
-                          style={{
-                            width: 6,
-                            height: 6,
-                            borderRadius: "50%",
-                            background: "var(--accent)",
-                            display: "inline-block",
-                          }}
-                        />
-                      ) : null}
+                      </div>
                     </div>
                   </div>
                 );
-              }
-              // EmptyView or other view types (IssueReporterView, MemoView, etc.)
-              return (
-                <div
-                  key={pane.id}
-                  className={`flex items-center gap-1.5 truncate text-[11px]${hideMode ? " cursor-pointer" : ""}`}
-                  onClick={
-                    hideMode
-                      ? (e) => {
-                          e.stopPropagation();
-                          onTogglePaneHidden(pane.id);
-                        }
-                      : undefined
-                  }
-                  style={{
-                    paddingLeft: showMinimap && wsDisplay.minimap ? 0 : 18,
-                    ...(isFocusedPane && !hideMode
-                      ? {
-                          background: "var(--accent-08)",
-                          borderRadius: "var(--radius-md)",
-                          color: "var(--text-primary)",
-                        }
-                      : {}),
-                  }}
-                >
-                  {hideMode && (
-                    <button
-                      className="row-eye-btn shrink-0 cursor-pointer"
-                      data-testid={`pane-eye-${pane.id}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onTogglePaneHidden(pane.id);
-                      }}
-                      style={{
-                        color: isPaneHidden ? "var(--yellow)" : "var(--accent)",
-                        border: "none",
-                        lineHeight: 0,
-                      }}
-                    >
-                      {isPaneHidden ? <EyeOffIcon size={11} /> : <EyeIcon size={11} />}
-                    </button>
-                  )}
-                  <div
-                    className="flex min-w-0 flex-1 items-center gap-1.5 truncate"
-                    style={{ opacity: isPaneHidden ? 0.35 : undefined }}
-                  >
-                    {showMinimap && wsDisplay.minimap && (
-                      <span
-                        className="shrink-0"
-                        data-testid={`pane-minimap-empty-${pane.id}`}
-                        style={{ opacity: isFocusedPane ? 1 : 0.5 }}
-                      >
-                        <PaneMinimap
-                          panes={minimapPanes}
-                          highlightIndex={paneIndex}
-                          width={18}
-                          height={12}
-                        />
-                      </span>
-                    )}
-                    <div className="flex min-w-0 flex-1 items-center gap-1 truncate">
-                      <span
-                        className="shrink-0 font-medium"
-                        style={{ color: "var(--text-secondary)", opacity: 0.4 }}
-                      >
-                        {shortLabel(pane.view.type)}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              );
-            });
-          })()}
-        </div>
-      ) : (
-        /* Row 2: Branch + CWD (no views or inactive) — always rendered */
+              });
+            })()}
+          </div>
+        ) : (
+          /* Row 2: Branch + CWD (no views or inactive) — always rendered */
+          <div
+            data-testid={`ws-row-2-${ws.id}`}
+            className="mt-0.5 flex items-center gap-1.5 truncate text-xs"
+            style={{ paddingLeft: 18, minHeight: "1.25rem" }}
+          >
+            {summary.branch && <span style={{ color: "var(--green)" }}>{summary.branch}</span>}
+            {summary.branch && summary.cwd && (
+              <span style={{ color: "var(--text-secondary)", opacity: 0.3 }}>·</span>
+            )}
+            {summary.cwd && (
+              <span
+                className="truncate"
+                style={{
+                  color: "var(--text-secondary)",
+                  opacity: 0.5,
+                  ...(pathEllipsis === "start" ? { direction: "rtl", textAlign: "left" } : {}),
+                }}
+              >
+                <bdi>
+                  {(() => {
+                    const cwdSource = summary.terminalSummaries.find((t) => t.cwd);
+                    const displayCwd =
+                      cwdSource && isWindowsProfile(cwdSource.profile)
+                        ? mntPathToWindows(summary.cwd)
+                        : summary.cwd;
+                    return abbreviatePath(displayCwd, pathEllipsis);
+                  })()}
+                </bdi>
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Row 3: Last command OR notification — always rendered */}
         <div
-          data-testid={`ws-row-2-${ws.id}`}
-          className="mt-0.5 flex items-center gap-1.5 truncate text-xs"
+          data-testid={`ws-row-3-${ws.id}`}
+          className="mt-0.5 truncate text-xs"
           style={{ paddingLeft: 18, minHeight: "1.25rem" }}
         >
-          {summary.branch && <span style={{ color: "var(--green)" }}>{summary.branch}</span>}
-          {summary.branch && summary.cwd && (
-            <span style={{ color: "var(--text-secondary)", opacity: 0.3 }}>·</span>
-          )}
-          {summary.cwd && (
+          {cmdInfo ? (
+            <span className="flex items-center gap-1">
+              <span data-testid={`cmd-status-${ws.id}`} style={{ color: cmdStatus?.color }}>
+                {cmdStatus?.icon}
+              </span>
+              <span className="truncate" style={{ color: "var(--text-secondary)" }}>
+                {formatCommand(
+                  cmdStatus?.text ?? cmdInfo.command,
+                  cmdStatus?.text ? ACTIVITY_MSG_TRUNCATE_LEN : undefined,
+                )}
+              </span>
+              <span style={{ color: "var(--text-secondary)", opacity: 0.4 }}>
+                · {formatRelativeTime(cmdInfo.timestamp)}
+              </span>
+            </span>
+          ) : summary.latestNotification ? (
             <span
-              className="truncate"
+              className="italic"
               style={{
-                color: "var(--text-secondary)",
-                opacity: 0.5,
-                ...(pathEllipsis === "start" ? { direction: "rtl", textAlign: "left" } : {}),
+                color:
+                  summary.latestNotification.level === "error"
+                    ? "var(--red)"
+                    : summary.latestNotification.level === "success"
+                      ? "var(--green)"
+                      : summary.latestNotification.level === "warning"
+                        ? "var(--yellow)"
+                        : "var(--accent)",
               }}
             >
-              <bdi>
-                {(() => {
-                  const cwdSource = summary.terminalSummaries.find((t) => t.cwd);
-                  const displayCwd =
-                    cwdSource && isWindowsProfile(cwdSource.profile)
-                      ? mntPathToWindows(summary.cwd)
-                      : summary.cwd;
-                  return abbreviatePath(displayCwd, pathEllipsis);
-                })()}
-              </bdi>
+              &ldquo;{summary.latestNotification.message}&rdquo;
             </span>
-          )}
+          ) : null}
         </div>
-      )}
-
-      {/* Row 3: Last command OR notification — always rendered */}
-      <div
-        data-testid={`ws-row-3-${ws.id}`}
-        className="mt-0.5 truncate text-xs"
-        style={{ paddingLeft: 18, minHeight: "1.25rem" }}
-      >
-        {cmdInfo ? (
-          <span className="flex items-center gap-1">
-            <span data-testid={`cmd-status-${ws.id}`} style={{ color: cmdStatus?.color }}>
-              {cmdStatus?.icon}
-            </span>
-            <span className="truncate" style={{ color: "var(--text-secondary)" }}>
-              {formatCommand(
-                cmdStatus?.text ?? cmdInfo.command,
-                cmdStatus?.text ? ACTIVITY_MSG_TRUNCATE_LEN : undefined,
-              )}
-            </span>
-            <span style={{ color: "var(--text-secondary)", opacity: 0.4 }}>
-              · {formatRelativeTime(cmdInfo.timestamp)}
-            </span>
-          </span>
-        ) : summary.latestNotification ? (
-          <span
-            className="italic"
-            style={{
-              color:
-                summary.latestNotification.level === "error"
-                  ? "var(--red)"
-                  : summary.latestNotification.level === "success"
-                    ? "var(--green)"
-                    : summary.latestNotification.level === "warning"
-                      ? "var(--yellow)"
-                      : "var(--accent)",
-            }}
-          >
-            &ldquo;{summary.latestNotification.message}&rdquo;
-          </span>
-        ) : null}
       </div>
     </div>
   );
@@ -1267,8 +1286,6 @@ export function WorkspaceSelectorView() {
       <div className="flex flex-1 flex-col overflow-y-auto">
         {sortedWorkspaces.map((ws, idx) => {
           const isWsHidden = hiddenWorkspaceIds.has(ws.id);
-          // In normal mode, skip hidden workspaces (but never hide the active one)
-          if (!hideMode && isWsHidden && ws.id !== activeWorkspaceId) return null;
           const isActive = ws.id === activeWorkspaceId;
           // Compute summary from frontend stores (event-driven, no polling).
           // Include lastCwd from settings as fallback for terminals that haven't

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -234,7 +234,7 @@ function WorkspaceItem({
               ? "inset 0 2px 0 0 var(--accent)"
               : "inset 0 -2px 0 0 var(--accent)"
             : "none",
-        paddingLeft: isActive ? 9 : 9,
+        paddingLeft: 9,
         paddingRight: 10,
       }}
     >

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -49,6 +49,7 @@
   /* utility */
   --separator-bg: rgba(255, 255, 255, 0.08); /* intentionally same as --hover-bg-strong */
   --transition-fast: 0.1s;
+  --transition-list-collapse: 0.18s;
   --terminal-composition-underline-color: currentColor;
 }
 
@@ -139,6 +140,49 @@
   }
   .row-eye-btn:hover {
     background: var(--hover-bg-strong);
+  }
+
+  .workspace-item-animated {
+    display: grid;
+    grid-template-rows: 1fr;
+    overflow: hidden;
+    opacity: 1;
+    transform: translateY(0);
+    transition:
+      grid-template-rows var(--transition-list-collapse) ease,
+      opacity var(--transition-list-collapse) ease,
+      transform var(--transition-list-collapse) ease,
+      border-bottom-width var(--transition-list-collapse) ease;
+  }
+  .workspace-item-content {
+    min-height: 0;
+    overflow: hidden;
+  }
+  .workspace-item-collapsed {
+    grid-template-rows: 0fr;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-4px);
+  }
+
+  .workspace-pane-row {
+    max-height: 28px;
+    opacity: 1;
+    transform: translateY(0);
+    overflow: hidden;
+    transition:
+      max-height var(--transition-list-collapse) ease,
+      opacity var(--transition-list-collapse) ease,
+      transform var(--transition-list-collapse) ease,
+      margin var(--transition-list-collapse) ease;
+  }
+  .workspace-pane-row-collapsed {
+    max-height: 0;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-3px);
+    margin-top: 0;
+    margin-bottom: 0;
   }
 
   /* Toolbar (28px header bar) */

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -50,6 +50,7 @@
   --separator-bg: rgba(255, 255, 255, 0.08); /* intentionally same as --hover-bg-strong */
   --transition-fast: 0.1s;
   --transition-list-collapse: 0.18s;
+  --pane-row-max-h: 28px;
   --terminal-composition-underline-color: currentColor;
 }
 
@@ -166,7 +167,7 @@
   }
 
   .workspace-pane-row {
-    max-height: 28px;
+    max-height: var(--pane-row-max-h);
     opacity: 1;
     transform: translateY(0);
     overflow: hidden;


### PR DESCRIPTION
## Summary
- Closes #264. Hide 모드 진입/이탈 시 hidden 워크스페이스·페인이 부드럽게 펼쳐지고 접히도록 0.18s 전환 추가.
- `workspace-item-animated` / `workspace-pane-row` 컬랩스 클래스로 grid-template-rows · opacity · transform · border-bottom-width를 단일 함수 (`isCollapsed = !hideMode && isWsHidden && !isActive`) 기반으로 토글.
- collapsed 상태에서 `aria-hidden`, drag 비활성화, click 차단으로 접근성/인터랙션도 함께 정리.

## Test plan
- [x] `npx vitest run` — 1805 passed
- [x] `cargo test` — all passed
- [x] `npx playwright test` — 70 passed
- [x] `npx tsc --noEmit` — 0 errors
- [x] `cargo check --release` — 0 errors
- [x] Dev 인스턴스 자율 검증: hide 모드 ON → workspace/pane 펼쳐짐, hide 모드 OFF → 컬랩스 확인 (스크린샷)

🤖 Generated with [Claude Code](https://claude.com/claude-code)