### PR TITLE
memo 에서 copy 버튼 제거

### DIFF
--- a/ui/src/components/views/MemoView.test.tsx
+++ b/ui/src/components/views/MemoView.test.tsx
@@ -124,8 +124,8 @@ describe("MemoView", () => {
     expect(textarea.value).toBe("");
   });
 
-  describe("paragraph copy feature", () => {
-    it("renders paragraph overlay when enabled and text has paragraphs", async () => {
+  describe("no paragraph copy button (issue #266)", () => {
+    it("never renders the paragraph overlay or copy button, even with paragraphs", async () => {
       useSettingsStore.setState({
         ...useSettingsStore.getState(),
         memo: {
@@ -139,71 +139,32 @@ describe("MemoView", () => {
         await vi.runAllTimersAsync();
       });
 
-      // Should render paragraph overlay container
-      const overlay = screen.getByTestId("paragraph-overlay");
-      expect(overlay).toBeInTheDocument();
-
-      // Should have 2 paragraph regions
-      const regions = screen.getAllByTestId(/^paragraph-region-/);
-      expect(regions).toHaveLength(2);
-    });
-
-    it("does not render paragraph overlay when feature is disabled", async () => {
-      useSettingsStore.setState({
-        ...useSettingsStore.getState(),
-        memo: {
-          ...useSettingsStore.getState().memo,
-          paragraphCopy: { enabled: false, minBlankLines: 2 },
-        },
-      });
-      vi.mocked(loadMemo).mockResolvedValue("abc\n\n\ndef");
-      render(<MemoView memoKey="pane-disabled" />);
-      await act(async () => {
-        await vi.runAllTimersAsync();
-      });
-
+      // The copy-button overlay must be gone entirely.
       expect(screen.queryByTestId("paragraph-overlay")).not.toBeInTheDocument();
+      expect(screen.queryAllByTestId(/^paragraph-region-/)).toHaveLength(0);
+      expect(screen.queryAllByTestId(/^paragraph-copy-btn-/)).toHaveLength(0);
+      expect(screen.queryAllByTestId(/^paragraph-highlight-/)).toHaveLength(0);
     });
 
-    it("does not render paragraph overlay when only one paragraph exists", async () => {
+    it("does not write to the clipboard on paragraph hover/move", async () => {
       useSettingsStore.setState({
         ...useSettingsStore.getState(),
         memo: {
           ...useSettingsStore.getState().memo,
           paragraphCopy: { enabled: true, minBlankLines: 2 },
-        },
-      });
-      vi.mocked(loadMemo).mockResolvedValue("abc\ndef");
-      render(<MemoView memoKey="pane-single" />);
-      await act(async () => {
-        await vi.runAllTimersAsync();
-      });
-
-      expect(screen.queryByTestId("paragraph-overlay")).not.toBeInTheDocument();
-    });
-
-    it("overlay does not block textarea input (pointer-events-none)", async () => {
-      useSettingsStore.setState({
-        ...useSettingsStore.getState(),
-        memo: {
-          ...useSettingsStore.getState().memo,
-          paragraphCopy: { enabled: true, minBlankLines: 2 },
+          copyOnSelect: false,
         },
       });
       vi.mocked(loadMemo).mockResolvedValue("abc\n\n\ndef");
-      render(<MemoView memoKey="pane-no-block" />);
+      render(<MemoView memoKey="pane-no-copy" />);
       await act(async () => {
         await vi.runAllTimersAsync();
       });
+      vi.mocked(clipboardWriteText).mockClear();
 
-      // Overlay should have pointer-events-none
-      const overlay = screen.getByTestId("paragraph-overlay");
-      expect(overlay.className).toContain("pointer-events-none");
-
-      // Textarea should still be interactable
       const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
-      fireEvent.change(textarea, { target: { value: "typed text" } });
-      expect(textarea.value).toBe("typed text");
+      fireEvent.mouseMove(textarea, { clientX: 5, clientY: 5 });
+      expect(clipboardWriteText).not.toHaveBeenCalled();
     });
   });
 
@@ -431,30 +392,6 @@ describe("MemoView", () => {
       // Click on second memo's textarea (outside first memo's textarea)
       fireEvent.mouseDown(textareas[1], { bubbles: true });
       expect(clipboardWriteText).toHaveBeenCalledWith("aaa");
-    });
-  });
-
-  describe("copy button hover highlight", () => {
-    it("renders highlight overlay when copy button is hovered", async () => {
-      useSettingsStore.setState({
-        ...useSettingsStore.getState(),
-        memo: {
-          ...useSettingsStore.getState().memo,
-          paragraphCopy: { enabled: true, minBlankLines: 2 },
-        },
-      });
-      vi.mocked(loadMemo).mockResolvedValue("abc\n\n\ndef");
-      render(<MemoView memoKey="pane-highlight" />);
-      await act(async () => {
-        await vi.runAllTimersAsync();
-      });
-
-      // Should have paragraph overlay
-      expect(screen.getByTestId("paragraph-overlay")).toBeInTheDocument();
-
-      // Initially no highlight
-      expect(screen.queryByTestId("paragraph-highlight-0")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("paragraph-highlight-1")).not.toBeInTheDocument();
     });
   });
 

--- a/ui/src/components/views/MemoView.tsx
+++ b/ui/src/components/views/MemoView.tsx
@@ -78,38 +78,15 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
   const memo = useSettingsStore((s) => s.memo);
   const appFont = useSettingsStore((s) => s.appFont);
 
-  // Paragraph copy feature
+  // Paragraph detection: drives triple-click paragraph select.
   const paragraphs = useMemo(() => {
     if (!memo.paragraphCopy.enabled) return [];
     return splitParagraphs(text, memo.paragraphCopy.minBlankLines);
   }, [text, memo.paragraphCopy.enabled, memo.paragraphCopy.minBlankLines]);
 
-  const showParagraphOverlay = memo.paragraphCopy.enabled && paragraphs.length > 1;
-
-  // Paragraph hover detection via textarea mouse position
-  const [hoveredParagraph, setHoveredParagraph] = useState<number | null>(null);
   const effectiveFontSize = memo.fontSize || appFont.size;
   const effectiveFontFamily = memo.fontFamily || appFont.face;
   const effectiveFontWeight = memo.fontWeight || appFont.weight;
-  const lineHeight = effectiveFontSize * 1.6; // fontSize * lineHeight
-
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent<HTMLTextAreaElement>) => {
-      if (!showParagraphOverlay) return;
-      const textarea = textareaRef.current;
-      if (!textarea) return;
-      const rect = textarea.getBoundingClientRect();
-      const y = e.clientY - rect.top + textarea.scrollTop - memo.paddingTop;
-      const line = Math.floor(y / lineHeight);
-      const idx = paragraphs.findIndex((p) => line >= p.startLine && line <= p.endLine);
-      setHoveredParagraph(idx >= 0 ? idx : null);
-    },
-    [showParagraphOverlay, paragraphs, memo.paddingTop, lineHeight],
-  );
-
-  const handleMouseLeave = useCallback(() => {
-    setHoveredParagraph(null);
-  }, []);
 
   // Lazy copy on select: remember selected text, copy on deselect / blur / Ctrl+C
   const pendingCopyRef = useRef<string | null>(null);
@@ -389,7 +366,7 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
   return (
     <ViewShell testId="memo-view">
       <ViewHeader testId="memo-header" title="Memo" />
-      <ViewBody variant="full" onMouseLeave={handleMouseLeave}>
+      <ViewBody variant="full">
         <textarea
           ref={textareaRef}
           data-testid="memo-textarea"
@@ -397,7 +374,6 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
           onChange={handleChange}
           onPaste={handlePaste}
           onKeyDown={handleKeyDown}
-          onMouseMove={handleMouseMove}
           onClick={handleClick}
           className="h-full w-full resize-none border-none outline-none"
           style={{
@@ -411,151 +387,7 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
           }}
           spellCheck={false}
         />
-        {showParagraphOverlay && (
-          <ParagraphOverlay
-            paragraphs={paragraphs}
-            paddingTop={memo.paddingTop}
-            paddingRight={memo.paddingRight}
-            hoveredIndex={hoveredParagraph}
-            textareaRef={textareaRef}
-            fontSize={effectiveFontSize}
-          />
-        )}
       </ViewBody>
     </ViewShell>
-  );
-}
-
-// --- Paragraph overlay ---
-
-interface ParagraphOverlayProps {
-  paragraphs: { text: string; startLine: number; endLine: number }[];
-  paddingTop: number;
-  paddingRight: number;
-  hoveredIndex: number | null;
-  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
-  fontSize?: number;
-}
-
-function ParagraphOverlay({
-  paragraphs,
-  paddingTop,
-  paddingRight,
-  hoveredIndex,
-  textareaRef,
-  fontSize = 13,
-}: ParagraphOverlayProps) {
-  const [copied, setCopied] = useState<number | null>(null);
-  const [copyBtnHoveredIdx, setCopyBtnHoveredIdx] = useState<number | null>(null);
-  const lineHeight = fontSize * 1.6; // fontSize * lineHeight
-  const [containerHeight, setContainerHeight] = useState(0);
-
-  const handleCopy = (e: React.MouseEvent, index: number) => {
-    e.preventDefault();
-    e.stopPropagation();
-    const para = paragraphs[index];
-    clipboardWriteText(para.text).catch(() => {});
-    setCopied(index);
-    setTimeout(() => setCopied(null), 1500);
-    // Return focus to textarea after copy
-    textareaRef.current?.focus();
-  };
-
-  // Track overlay container height via callback ref + ResizeObserver
-  const roRef = useRef<ResizeObserver | null>(null);
-  const overlayCallbackRef = useCallback((node: HTMLDivElement | null) => {
-    if (roRef.current) {
-      roRef.current.disconnect();
-      roRef.current = null;
-    }
-    if (!node) return;
-    setContainerHeight(node.clientHeight);
-    const ro = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        setContainerHeight(entry.contentRect.height);
-      }
-    });
-    ro.observe(node);
-    roRef.current = ro;
-  }, []);
-
-  // Calculate scroll offset
-  const [scrollTop, setScrollTop] = useState(0);
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-    const onScroll = () => setScrollTop(textarea.scrollTop);
-    textarea.addEventListener("scroll", onScroll);
-    return () => textarea.removeEventListener("scroll", onScroll);
-  }, [textareaRef]);
-
-  // Pre-compute clamped positions outside of JSX render
-  const clampedTops = useMemo(() => {
-    const btnHeight = 22;
-    const minTop = 4;
-    const maxTop = containerHeight - btnHeight - 4;
-    return paragraphs.map((para) => {
-      const rawTop = paddingTop + para.startLine * lineHeight - scrollTop;
-      return containerHeight > 0 ? Math.max(minTop, Math.min(rawTop, maxTop)) : rawTop;
-    });
-  }, [paragraphs, paddingTop, lineHeight, scrollTop, containerHeight]);
-
-  return (
-    <div
-      ref={overlayCallbackRef}
-      data-testid="paragraph-overlay"
-      className="pointer-events-none absolute inset-0 overflow-hidden"
-    >
-      {/* Highlight overlay when copy button is hovered */}
-      {copyBtnHoveredIdx !== null && paragraphs[copyBtnHoveredIdx] && (
-        <div
-          data-testid={`paragraph-highlight-${copyBtnHoveredIdx}`}
-          className="absolute left-0 right-0"
-          style={{
-            top: paddingTop + paragraphs[copyBtnHoveredIdx].startLine * lineHeight - scrollTop,
-            height:
-              (paragraphs[copyBtnHoveredIdx].endLine -
-                paragraphs[copyBtnHoveredIdx].startLine +
-                1) *
-              lineHeight,
-            background: "var(--accent-12)",
-            borderRadius: "var(--radius-sm, 4px)",
-            pointerEvents: "none",
-          }}
-        />
-      )}
-      {paragraphs.map((_para, i) => {
-        return (
-          <div
-            key={i}
-            data-testid={`paragraph-region-${i}`}
-            className="absolute"
-            style={{ top: clampedTops[i], right: 0 }}
-          >
-            {hoveredIndex === i && (
-              <button
-                data-testid={`paragraph-copy-btn-${i}`}
-                className="pointer-events-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px]"
-                style={{
-                  marginRight: paddingRight + 4,
-                  background: "var(--bg-overlay)",
-                  color: "var(--text-secondary)",
-                  border: "1px solid var(--border)",
-                  cursor: "pointer",
-                  zIndex: 10,
-                  opacity: 0.9,
-                }}
-                onMouseDown={(e) => handleCopy(e, i)}
-                onMouseEnter={() => setCopyBtnHoveredIdx(i)}
-                onMouseLeave={() => setCopyBtnHoveredIdx(null)}
-                title="단락 복사"
-              >
-                {copied === i ? "Copied!" : "Copy"}
-              </button>
-            )}
-          </div>
-        );
-      })}
-    </div>
   );
 }

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -2398,17 +2398,17 @@ function MemoSection() {
           </div>
         </div>
 
-        {/* Paragraph Copy */}
+        {/* Paragraph Detection */}
         <div className="flex items-start gap-3 py-1.5">
           <div className="w-36 shrink-0 pt-1">
             <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
-              단락 복사
+              단락 인식
             </span>
             <p
               className="mt-0.5 text-[11px] leading-tight"
               style={{ color: "var(--text-secondary)", opacity: 0.65 }}
             >
-              N줄 이상 빈 줄로 구분된 단락에 복사 버튼 표시
+              N줄 이상 빈 줄로 단락을 구분 (트리플클릭 단락 선택에 사용)
             </p>
           </div>
           <div className="min-w-0 flex-1">


### PR DESCRIPTION
@
## 개요
메모(MemoView)에서 단락 hover 시 나타나던 "Copy" 버튼 오버레이를 제거합니다. 오히려 사용에 방해가 된다는 피드백 반영.

Fixes #266

## 변경 사항
- `ui/src/components/views/MemoView.tsx` — hover 시 표시되던 Copy 버튼 오버레이(`ParagraphOverlay`)와 관련 hover 상태/핸들러(`hoveredParagraph`, `copyBtnHoveredIdx`, `handleMouseMove`/`handleMouseLeave`, `showParagraphOverlay`), `onMouseLeave`/`onMouseMove` 바인딩 정리
- `ui/src/components/views/MemoView.test.tsx` — copy 버튼/오버레이가 어떤 단락 상태에서도 렌더링되지 않고 hover/mouse-move 시 클립보드에 쓰지 않음을 검증하는 테스트로 교체
- `ui/src/components/views/SettingsView.tsx` — 버튼 제거에 맞춰 "단락 복사" 설정 라벨을 "단락 인식"(트리플클릭 단락 선택 용도)으로 변경

## 유지한 부분
- `paragraphCopy` 설정과 `splitParagraphs` 로직은 트리플클릭 단락 선택 기능이 의존하므로 의도적으로 유지 (버튼·오버레이만 제거)

## 테스트
- `MemoView.test.tsx`: 37 passed
- UI 전체 unit: 72 파일 / 1774 테스트 통과
- tsc --noEmit, ESLint, pre-commit 훅 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@