### PR TITLE
공간 pane 번호 체계 추가 — pane 쉽게 지칭 (#256)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1091,6 +1091,22 @@ claude mcp add-json -s user laymux '{"type":"http","url":"http://<IP>:19280/mcp"
 - 세션 간 안정적 — 캐시 파일 키로 사용
 - 기존 ID 없는 설정은 마이그레이션 시 자동 생성
 
+### 13.7 Pane 식별자 3종 (issue #256)
+
+Pane을 가리키는 식별자는 용도가 다른 3가지가 공존한다. 혼동하지 말 것.
+
+| 식별자 | 형식 | 용도 | 안정성 |
+|---|---|---|---|
+| `terminalId` | `terminal-pane-{uuid8}` | **안정 참조** — write/focus의 1차 식별자, `LX_TERMINAL_ID` env var | 세션 간 안정 |
+| `paneIndex` | `WorkspacePane[]` 0-based 배열 인덱스 | **레이아웃 조작** — `focus_pane`/`split_pane`/`remove_pane`/`resize_pane`/`swap_panes` 파라미터 | split 삽입 순서에 종속 |
+| `paneNumber` | 화면 읽기 순서 1..N | **표시 + 사람/AI 지칭** — 컨트롤바 배지, "N번 pane으로 보내" | 레이아웃 따라 실시간 변동 |
+
+- `paneNumber`는 `ui/src/lib/pane-numbers.ts`의 `computePaneNumbers()` **단일 함수**에서 (y 우선, 동일 y는 x 오름차순; eps 0.01) 도출하는 **파생값**이다. 어디에도 저장/캐시하지 않으며 panes가 바뀌면 재계산된다.
+- `paneIndex`(배열)와 `paneNumber`(공간)는 다를 수 있다. 예: 좌우 분할 후 왼쪽을 다시 가로 분할하면 배열은 `[좌상, 좌하, 우]`지만 읽기 순서는 `좌상=1, 우=2, 좌하=3`.
+- 자동화 노출: `list_terminals`/`get_active_workspace`의 각 pane, `identify_caller`의 `pane.number`와 `neighbors.{dir}.paneNumber`, `get_grid_state`의 `focusedPaneNumber` + `panes[]` 요약(번호↔terminalId 매핑)에 포함된다.
+- 번호 직접 주소 지정: `write_to_terminal`/`read_terminal_output`/`focus_terminal`는 `terminal_id` 대신 `pane_number`(+옵션 `workspace_id`)를 받을 수 있다. 브리지 `terminals.resolveByNumber`로 호출 시점에 terminalId로 해석하며, `terminal_id`가 주어지면 항상 우선한다. 번호는 휘발성이므로 지속 참조는 `terminal_id`를 쓴다.
+- `paneNumber`는 spawn-time env var로 주입하지 않는다(레이아웃 변경 시 stale). 자기 번호가 필요하면 `identify_caller`의 `pane.number`를 라이브 조회한다.
+
 ---
 
 ## 14. Rust 코드 설계 원칙

--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -42,10 +42,31 @@ struct TerminalIdParam {
     terminal_id: String,
 }
 
+/// Target a terminal by stable ID or by spatial pane number (issue #256).
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct TerminalTargetParam {
+    /// Stable terminal ID. Provide either this or `pane_number` (terminal_id wins).
+    terminal_id: Option<String>,
+    /// Spatial pane number (1-based reading order, same as the control bar badge).
+    /// Resolved within `workspace_id` at call time. Prefer `terminal_id` for durable refs.
+    pane_number: Option<u64>,
+    /// Workspace to resolve `pane_number` in. Defaults to the active workspace.
+    workspace_id: Option<String>,
+}
+
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct WriteTerminalParam {
-    /// Terminal ID
-    terminal_id: String,
+    /// Stable terminal ID (e.g. "terminal-pane-abc12345"). Preferred — survives
+    /// layout changes. Provide either this or `pane_number`; `terminal_id` wins
+    /// if both are given.
+    terminal_id: Option<String>,
+    /// Spatial pane number (1-based, screen reading order — same as the control
+    /// bar badge). Convenient for "write to pane 3", but the number changes when
+    /// the layout changes, so it is resolved at call time. Use `terminal_id` for
+    /// durable references. Resolved within `workspace_id` (default: active workspace).
+    pane_number: Option<u64>,
+    /// Workspace to resolve `pane_number` in. Defaults to the active workspace.
+    workspace_id: Option<String>,
     /// Text to send.
     data: String,
     /// When true, C-style escape sequences in `data` are converted to real
@@ -105,8 +126,13 @@ impl std::fmt::Display for NeighborDirection {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct ReadOutputParam {
-    /// Terminal ID
-    terminal_id: String,
+    /// Stable terminal ID. Provide either this or `pane_number` (terminal_id wins).
+    terminal_id: Option<String>,
+    /// Spatial pane number (1-based reading order, same as the control bar badge).
+    /// Resolved within `workspace_id` at call time. Prefer `terminal_id` for durable refs.
+    pane_number: Option<u64>,
+    /// Workspace to resolve `pane_number` in. Defaults to the active workspace.
+    workspace_id: Option<String>,
     /// Number of lines to read (default: 100)
     lines: Option<u64>,
     /// Output format: "raw" (default, with ANSI escapes) or "text" (plain text, ANSI stripped).
@@ -384,6 +410,42 @@ impl McpHandler {
                 terminal_id
             ))])),
         }
+    }
+
+    /// Resolve a terminal target (stable ID or spatial pane number) to a terminal ID.
+    /// `terminal_id` wins when both are given; otherwise `pane_number` is resolved via
+    /// the frontend bridge within `workspace_id` (default: active workspace). Issue #256.
+    async fn resolve_terminal_id(
+        &self,
+        terminal_id: Option<&str>,
+        pane_number: Option<u64>,
+        workspace_id: Option<&str>,
+    ) -> Result<String, CallToolResult> {
+        if let Some(id) = terminal_id {
+            if !id.is_empty() {
+                return Ok(id.to_string());
+            }
+        }
+        let Some(number) = pane_number else {
+            return Err(CallToolResult::error(vec![Content::text(
+                "Provide either terminal_id or pane_number".to_string(),
+            )]));
+        };
+        let mut params = json!({ "number": number });
+        if let Some(ws) = workspace_id {
+            params["workspaceId"] = json!(ws);
+        }
+        let data = self
+            .bridge_raw("query", "terminals", "resolveByNumber", params)
+            .await?;
+        data.get("terminalId")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                CallToolResult::error(vec![Content::text(
+                    "resolveByNumber returned no terminalId".to_string(),
+                )])
+            })
     }
 
     /// Bridge request returning raw Value on success, or CallToolResult error.
@@ -739,11 +801,13 @@ impl McpHandler {
             .await
     }
 
-    /// Send input to a terminal. By default the input is submitted (Enter key)
-    /// after sending — suitable for running commands or replying to TUI prompts
-    /// (Claude Code, Codex, REPLs). Pass `enter: false` to type without
-    /// submitting (e.g. inserting text mid-line in vim, composing a multi-line
-    /// prompt before a manual submit).
+    /// Send input to a terminal. Target it with `terminal_id` (stable, preferred)
+    /// or `pane_number` (1-based screen reading order, same as the control bar
+    /// badge — convenient but changes with layout). By default the input is
+    /// submitted (Enter key) after sending — suitable for running commands or
+    /// replying to TUI prompts (Claude Code, Codex, REPLs). Pass `enter: false`
+    /// to type without submitting (e.g. inserting text mid-line in vim, composing
+    /// a multi-line prompt before a manual submit).
     /// Set `escape` to true for C-style sequences: `\\r` for Enter, `\\n` for
     /// newline, `\\u0003` for Ctrl+C. Leave `escape` false for literal text
     /// (preserves backslashes in Windows paths like `C:\\Users`).
@@ -752,13 +816,25 @@ impl McpHandler {
         &self,
         Parameters(p): Parameters<WriteTerminalParam>,
     ) -> Result<CallToolResult, ErrorData> {
+        let terminal_id = match self
+            .resolve_terminal_id(
+                p.terminal_id.as_deref(),
+                p.pane_number,
+                p.workspace_id.as_deref(),
+            )
+            .await
+        {
+            Ok(id) => id,
+            Err(e) => return Ok(e),
+        };
         let data = Self::prepare_input(&p.data, p.escape, p.enter);
-        match self.write_pty(&p.terminal_id, data.as_bytes()) {
+        match self.write_pty(&terminal_id, data.as_bytes()) {
             Ok(bytes) => Ok(json_result(&json!({
                 "written": true,
                 "bytes": bytes,
                 "bytesWritten": bytes,
                 "enter": p.enter,
+                "terminalId": terminal_id,
             }))),
             Err(e) => Ok(e),
         }
@@ -823,8 +899,19 @@ impl McpHandler {
         &self,
         Parameters(p): Parameters<ReadOutputParam>,
     ) -> Result<CallToolResult, ErrorData> {
+        let terminal_id = match self
+            .resolve_terminal_id(
+                p.terminal_id.as_deref(),
+                p.pane_number,
+                p.workspace_id.as_deref(),
+            )
+            .await
+        {
+            Ok(id) => id,
+            Err(e) => return Ok(e),
+        };
         let lines = p.lines.unwrap_or(100) as usize;
-        let (raw, buffer_size) = match self.recent_output_lines(&p.terminal_id, lines) {
+        let (raw, buffer_size) = match self.recent_output_lines(&terminal_id, lines) {
             Ok(output) => output,
             Err(e) => return Ok(e),
         };
@@ -839,17 +926,28 @@ impl McpHandler {
         })))
     }
 
-    /// Set focus to a terminal pane.
+    /// Set focus to a terminal pane, by stable terminal_id or spatial pane_number.
     #[tool]
     async fn focus_terminal(
         &self,
-        Parameters(p): Parameters<TerminalIdParam>,
+        Parameters(p): Parameters<TerminalTargetParam>,
     ) -> Result<CallToolResult, ErrorData> {
+        let terminal_id = match self
+            .resolve_terminal_id(
+                p.terminal_id.as_deref(),
+                p.pane_number,
+                p.workspace_id.as_deref(),
+            )
+            .await
+        {
+            Ok(id) => id,
+            Err(e) => return Ok(e),
+        };
         self.bridge(
             "action",
             "terminals",
             "setFocus",
-            json!({ "id": p.terminal_id }),
+            json!({ "id": terminal_id }),
         )
         .await
     }
@@ -1782,7 +1880,7 @@ mod tests {
     fn param_types_deserialize() {
         let json = r#"{"terminal_id":"t1","data":"ls\r\n"}"#;
         let p: WriteTerminalParam = serde_json::from_str(json).unwrap();
-        assert_eq!(p.terminal_id, "t1");
+        assert_eq!(p.terminal_id.as_deref(), Some("t1"));
         assert_eq!(p.data, "ls\r\n");
     }
 
@@ -1791,6 +1889,51 @@ mod tests {
         let json = r#"{"terminal_id":"t1"}"#;
         let p: ReadOutputParam = serde_json::from_str(json).unwrap();
         assert!(p.lines.is_none());
+    }
+
+    #[test]
+    fn write_terminal_accepts_pane_number_without_terminal_id() {
+        // issue #256: address a pane by spatial number instead of terminal_id.
+        let json = r#"{"pane_number":3,"data":"ls"}"#;
+        let p: WriteTerminalParam = serde_json::from_str(json).unwrap();
+        assert!(p.terminal_id.is_none());
+        assert_eq!(p.pane_number, Some(3));
+        assert!(p.workspace_id.is_none());
+    }
+
+    #[test]
+    fn write_terminal_accepts_both_terminal_id_and_pane_number() {
+        let json = r#"{"terminal_id":"t1","pane_number":2,"workspace_id":"ws-1","data":"x"}"#;
+        let p: WriteTerminalParam = serde_json::from_str(json).unwrap();
+        assert_eq!(p.terminal_id.as_deref(), Some("t1"));
+        assert_eq!(p.pane_number, Some(2));
+        assert_eq!(p.workspace_id.as_deref(), Some("ws-1"));
+    }
+
+    #[test]
+    fn write_terminal_accepts_neither_id_nor_number_at_deserialize() {
+        // Deserialization must succeed; the missing-target case is handled at call time.
+        let json = r#"{"data":"x"}"#;
+        let p: WriteTerminalParam = serde_json::from_str(json).unwrap();
+        assert!(p.terminal_id.is_none());
+        assert!(p.pane_number.is_none());
+    }
+
+    #[test]
+    fn read_output_accepts_pane_number() {
+        let json = r#"{"pane_number":1}"#;
+        let p: ReadOutputParam = serde_json::from_str(json).unwrap();
+        assert_eq!(p.pane_number, Some(1));
+        assert!(p.terminal_id.is_none());
+    }
+
+    #[test]
+    fn terminal_target_param_accepts_pane_number() {
+        let json = r#"{"pane_number":2,"workspace_id":"ws-1"}"#;
+        let p: TerminalTargetParam = serde_json::from_str(json).unwrap();
+        assert!(p.terminal_id.is_none());
+        assert_eq!(p.pane_number, Some(2));
+        assert_eq!(p.workspace_id.as_deref(), Some("ws-1"));
     }
 
     #[test]

--- a/ui/src/components/layout/PaneControlBar.test.tsx
+++ b/ui/src/components/layout/PaneControlBar.test.tsx
@@ -118,6 +118,37 @@ describe("PaneControlBar", () => {
     expect(screen.queryByTestId("pane-number-badge")).not.toBeInTheDocument();
   });
 
+  it("keeps controls right-aligned with a spacer when only the badge is on the hover bar", () => {
+    // paneNumber makes the hover bar full-width; without a flex-1 spacer the
+    // controls would collapse next to the badge on the left and overlay content.
+    const { rerender } = render(
+      <PaneControlBar
+        currentView={defaultView}
+        actions={defaultActions}
+        hovered={true}
+        paneNumber={2}
+      >
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    const bar = screen.getByTestId("pane-control-bar");
+    // full-width so the badge can sit at the left edge and controls at the right
+    expect(bar.className).toContain("left-0");
+    expect(bar.className).toContain("right-0");
+    // a flex-1 spacer (matching the pinned bar) pushes controls to the right
+    expect(Array.from(bar.children).some((c) => c.className === "flex-1")).toBe(true);
+
+    // sanity: no badge → no spacer, bar hugs the right edge instead
+    rerender(
+      <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    const compactBar = screen.getByTestId("pane-control-bar");
+    expect(compactBar.className).toContain("right-0");
+    expect(compactBar.className).not.toContain("left-0");
+  });
+
   it("bar contains view selector, split, clear, pin, minimize buttons", () => {
     render(
       <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>

--- a/ui/src/components/layout/PaneControlBar.test.tsx
+++ b/ui/src/components/layout/PaneControlBar.test.tsx
@@ -95,6 +95,29 @@ describe("PaneControlBar", () => {
     expect(screen.getByTestId("pane-control-bar")).toBeInTheDocument();
   });
 
+  it("renders the pane number badge in the bar when paneNumber is set", () => {
+    render(
+      <PaneControlBar
+        currentView={defaultView}
+        actions={defaultActions}
+        hovered={true}
+        paneNumber={4}
+      >
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    expect(screen.getByTestId("pane-number-badge")).toHaveTextContent("4");
+  });
+
+  it("does not render the badge when paneNumber is unset", () => {
+    render(
+      <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    expect(screen.queryByTestId("pane-number-badge")).not.toBeInTheDocument();
+  });
+
   it("bar contains view selector, split, clear, pin, minimize buttons", () => {
     render(
       <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -4,6 +4,7 @@ import { useOverridesStore } from "@/stores/overrides-store";
 import type { ViewInstanceConfig, ViewType } from "@/stores/types";
 import { PaneControlContext } from "./PaneControlContext";
 import { useContainerSize } from "@/hooks/useContainerSize";
+import { PaneNumberBadge } from "@/components/ui/PaneNumberBadge";
 
 /**
  * 컨트롤 바 표시 모드. 각 모드는 독립적이며 서브 상태를 갖지 않는다.
@@ -45,6 +46,8 @@ interface PaneControlBarProps {
    */
   cwdSendOn?: boolean;
   cwdReceiveOn?: boolean;
+  /** 화면 읽기 순서 기반 pane 번호(issue #256). 컨트롤바 좌측에 배지로 표시. */
+  paneNumber?: number;
   children: React.ReactNode;
 }
 
@@ -604,6 +607,7 @@ export function PaneControlBar({
   hovered,
   cwdSendOn,
   cwdReceiveOn,
+  paneNumber,
   children,
 }: PaneControlBarProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -643,7 +647,7 @@ export function PaneControlBar({
   const hasBarLabel = currentView.type !== "TerminalView" && currentView.type !== "EmptyView";
   // 자식(TerminalView 등)이 주입한 좌측 콘텐츠가 있으면 기본 BarLabel 대신 사용.
   // 둘 다 없으면 flex-1 스페이서만 렌더하여 pane 컨트롤이 오른쪽 끝에 정렬되도록 한다.
-  const hasLeftContent = hasBarLabel || leftBarContent != null;
+  const hasLeftContent = hasBarLabel || leftBarContent != null || paneNumber != null;
 
   const paneControls = useMemo(
     () =>
@@ -688,6 +692,7 @@ export function PaneControlBar({
       unregisterHeader,
       leftBarContent,
       setLeftBarContent,
+      paneNumber,
     }),
     [
       paneControls,
@@ -699,6 +704,7 @@ export function PaneControlBar({
       unregisterHeader,
       leftBarContent,
       setLeftBarContent,
+      paneNumber,
     ],
   );
 
@@ -715,6 +721,7 @@ export function PaneControlBar({
               borderBottom: `1px solid ${borderClr}`,
             }}
           >
+            <PaneNumberBadge number={paneNumber} />
             {hasBarLabel ? (
               <BarLabel viewType={currentView.type} />
             ) : leftBarContent ? (
@@ -768,6 +775,7 @@ export function PaneControlBar({
                 borderRadius: 0,
               }}
             >
+              <PaneNumberBadge number={paneNumber} />
               {hasBarLabel ? (
                 <BarLabel viewType={currentView.type} />
               ) : leftBarContent ? (

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -785,7 +785,11 @@ export function PaneControlBar({
                 >
                   {leftBarContent}
                 </div>
-              ) : null}
+              ) : (
+                // 배지만 있고 좌측 콘텐츠가 없을 때도 pinned 바와 동일하게
+                // flex-1 스페이서로 컨트롤을 오른쪽 끝에 정렬한다.
+                <div className="flex-1" />
+              )}
               {narrowBar ? (
                 <NarrowControlAnchor
                   currentView={currentView}

--- a/ui/src/components/layout/PaneControlContext.tsx
+++ b/ui/src/components/layout/PaneControlContext.tsx
@@ -27,6 +27,12 @@ export interface PaneControlContextValue {
   leftBarContent: ReactNode;
   /** 좌측 슬롯 콘텐츠 설정/해제. `null` 이면 기본 스페이서로 복귀. */
   setLeftBarContent: (node: ReactNode) => void;
+  /**
+   * 화면 읽기 순서 기반 pane 번호(issue #256). 컨트롤바 좌측에 배지로 표시한다.
+   * 배열 인덱스(`paneIndex`)가 아니라 공간 위치 번호(`paneNumber`)이며, dock 등
+   * 번호가 없는 경우 `undefined`.
+   */
+  paneNumber?: number;
 }
 
 export const PaneControlContext = createContext<PaneControlContextValue | null>(null);

--- a/ui/src/components/layout/PaneGrid.test.tsx
+++ b/ui/src/components/layout/PaneGrid.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock TerminalView to avoid Tauri IPC dependency
@@ -80,6 +80,42 @@ describe("PaneGrid", () => {
   it("renders with containerTestId", () => {
     render(<PaneGrid {...defaultProps} containerTestId="my-grid" />);
     expect(screen.getByTestId("my-grid")).toBeInTheDocument();
+  });
+
+  describe("pane number badges (issue #256)", () => {
+    // Array order [TL, BL, TR] (as splice-based splitting produces) must map to
+    // reading-order numbers TL=1, TR=2, BL=3 regardless of array index.
+    const spatialPanes: GridPane[] = [
+      { id: "TL", view: { type: "TerminalView" }, x: 0, y: 0, w: 0.5, h: 0.5 },
+      { id: "BL", view: { type: "TerminalView" }, x: 0, y: 0.5, w: 0.5, h: 0.5 },
+      { id: "TR", view: { type: "TerminalView" }, x: 0.5, y: 0, w: 0.5, h: 0.5 },
+    ];
+    const props = {
+      ...defaultProps,
+      panes: spatialPanes,
+      testIdFn: (p: GridPane) => `pane-box-${p.id}`,
+    };
+
+    beforeEach(() => {
+      // Pinned bar is always visible so the badge renders without hover.
+      useSettingsStore.setState((s) => ({
+        convenience: { ...s.convenience, defaultControlBarMode: "pinned" },
+      }));
+    });
+
+    it("shows reading-order badges when showPaneNumbers is set", () => {
+      render(<PaneGrid {...props} showPaneNumbers />);
+      const badgeIn = (id: string) =>
+        within(screen.getByTestId(`pane-box-${id}`)).getByTestId("pane-number-badge");
+      expect(badgeIn("TL")).toHaveTextContent("1");
+      expect(badgeIn("TR")).toHaveTextContent("2");
+      expect(badgeIn("BL")).toHaveTextContent("3");
+    });
+
+    it("does not show badges by default (dock reuse stays unnumbered)", () => {
+      render(<PaneGrid {...props} />);
+      expect(screen.queryByTestId("pane-number-badge")).not.toBeInTheDocument();
+    });
   });
 
   it("calls onSplitPane via PaneControlBar split button", () => {

--- a/ui/src/components/layout/PaneGrid.tsx
+++ b/ui/src/components/layout/PaneGrid.tsx
@@ -8,6 +8,7 @@ import { FocusIndicator } from "./FocusIndicator";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import { useHoverTimer } from "@/hooks/useHoverTimer";
 import { useSettingsStore } from "@/stores/settings-store";
+import { computePaneNumbers } from "@/lib/pane-numbers";
 
 export interface GridPane {
   id: string;
@@ -52,6 +53,10 @@ export interface PaneGridProps {
   // Optional: external hover override (automationHoverIndex)
   isHoveredOverride?: (paneId: string) => boolean;
 
+  // Optional: show spatial pane-number badges in the control bar (issue #256).
+  // Off by default so the dock (which reuses PaneGrid) stays unnumbered.
+  showPaneNumbers?: boolean;
+
   // PaneBoundaryHandles override props
   boundaryHandlesProps?: {
     panes?: Array<{ x: number; y: number; w: number; h: number }>;
@@ -84,6 +89,7 @@ export function PaneGrid({
   location,
   isActive = true,
   isHoveredOverride,
+  showPaneNumbers = false,
   boundaryHandlesProps,
   containerTestId,
   containerClassName = "relative h-full w-full",
@@ -93,6 +99,8 @@ export function PaneGrid({
   const size = useContainerSize(containerRef);
   const hoverIdleSeconds = useSettingsStore((s) => s.convenience.hoverIdleSeconds);
   const hover = useHoverTimer(hoverIdleSeconds);
+  // Spatial reading-order pane numbers (issue #256). Derived from geometry, never cached.
+  const paneNumbers = showPaneNumbers ? computePaneNumbers(panes) : null;
 
   return (
     <div
@@ -150,6 +158,7 @@ export function PaneGrid({
               hovered={isActive && isHovered}
               cwdSendOn={cwdSendOn}
               cwdReceiveOn={cwdReceiveOn}
+              paneNumber={paneNumbers?.get(pane.id)}
               actions={{
                 onChangeView: onSetPaneView
                   ? (config) => onSetPaneView(pane.id, config)

--- a/ui/src/components/layout/WorkspaceArea.tsx
+++ b/ui/src/components/layout/WorkspaceArea.tsx
@@ -39,6 +39,7 @@ export function WorkspaceArea() {
             key={ws.id}
             panes={ws.panes}
             isActive={isActive}
+            showPaneNumbers
             containerClassName="absolute inset-0"
             containerStyle={{ display: isActive ? undefined : "none" }}
             testIdFn={(_pane, i) => (isActive ? `workspace-pane-${i}` : undefined)}

--- a/ui/src/components/ui/PaneNumberBadge.test.tsx
+++ b/ui/src/components/ui/PaneNumberBadge.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PaneNumberBadge } from "./PaneNumberBadge";
+
+describe("PaneNumberBadge", () => {
+  it("renders the pane number", () => {
+    render(<PaneNumberBadge number={3} />);
+    const badge = screen.getByTestId("pane-number-badge");
+    expect(badge).toHaveTextContent("3");
+  });
+
+  it("renders nothing when number is undefined", () => {
+    const { container } = render(<PaneNumberBadge number={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByTestId("pane-number-badge")).toBeNull();
+  });
+});

--- a/ui/src/components/ui/PaneNumberBadge.tsx
+++ b/ui/src/components/ui/PaneNumberBadge.tsx
@@ -1,0 +1,31 @@
+/**
+ * Small badge showing a pane's spatial reading-order number (issue #256).
+ *
+ * Rendered as the leading element of a control bar's left section so humans can
+ * glance at a pane and tell an AI "send to pane N". The number is the spatial
+ * `paneNumber` (see `lib/pane-numbers.ts`), NOT the array `paneIndex`.
+ *
+ * Renders nothing when `number` is undefined (e.g. dock panes, previews).
+ */
+export function PaneNumberBadge({ number }: { number?: number }) {
+  if (number == null) return null;
+  return (
+    <span
+      data-testid="pane-number-badge"
+      className="mr-1.5 flex shrink-0 items-center justify-center font-medium tabular-nums"
+      style={{
+        minWidth: "16px",
+        height: "16px",
+        padding: "0 4px",
+        fontSize: "var(--fs-xs)",
+        lineHeight: 1,
+        color: "var(--accent)",
+        background: "var(--accent-20)",
+        borderRadius: "var(--radius-sm)",
+      }}
+      title={`Pane ${number}`}
+    >
+      {number}
+    </span>
+  );
+}

--- a/ui/src/components/ui/ViewHeader.test.tsx
+++ b/ui/src/components/ui/ViewHeader.test.tsx
@@ -76,4 +76,16 @@ describe("ViewHeader with PaneControlContext", () => {
     renderWithCtx(ctx, <ViewHeader>My View Title</ViewHeader>);
     expect(screen.getByText("My View Title")).toBeInTheDocument();
   });
+
+  it("renders the pane number badge when paneNumber is set", () => {
+    const ctx = makeCtx({ paneNumber: 2 });
+    renderWithCtx(ctx, <ViewHeader title="term">x</ViewHeader>);
+    expect(screen.getByTestId("pane-number-badge")).toHaveTextContent("2");
+  });
+
+  it("does not render the badge when paneNumber is undefined", () => {
+    const ctx = makeCtx();
+    renderWithCtx(ctx, <ViewHeader title="term">x</ViewHeader>);
+    expect(screen.queryByTestId("pane-number-badge")).not.toBeInTheDocument();
+  });
 });

--- a/ui/src/components/ui/ViewHeader.tsx
+++ b/ui/src/components/ui/ViewHeader.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { usePaneControl } from "@/components/layout/PaneControlContext";
+import { PaneNumberBadge } from "@/components/ui/PaneNumberBadge";
 
 interface ViewHeaderProps {
   /** 헤더 제목. 지정하면 통일된 스타일(--text-secondary, --fs-sm, 600)로 렌더링. */
@@ -50,6 +51,7 @@ export function ViewHeader({
       }}
     >
       <div className="flex min-w-0 flex-1 items-center">
+        <PaneNumberBadge number={ctx?.paneNumber} />
         {title && (
           <span
             style={{ color: "var(--text-secondary)", fontSize: "var(--fs-sm)", fontWeight: 600 }}

--- a/ui/src/hooks/useAutomationBridge.test.ts
+++ b/ui/src/hooks/useAutomationBridge.test.ts
@@ -1362,3 +1362,168 @@ describe("notifications.clear bridge handler", () => {
     expect(result.error).toMatch(/array/i);
   });
 });
+
+describe("spatial pane numbers (issue #256)", () => {
+  // Seed a workspace whose array order [TL, BL, TR] diverges from reading order
+  // (TL=1, TR=2, BL=3). Terminals registered for all three panes.
+  const WS_ID = "ws-num";
+  const TL = "pane-TL";
+  const BL = "pane-BL";
+  const TR = "pane-TR";
+
+  function seedDivergentWorkspace() {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: WS_ID,
+          name: "Nums",
+          panes: [
+            { id: TL, x: 0, y: 0, w: 0.5, h: 0.5, view: { type: "TerminalView" } },
+            { id: BL, x: 0, y: 0.5, w: 0.5, h: 0.5, view: { type: "TerminalView" } },
+            { id: TR, x: 0.5, y: 0, w: 0.5, h: 0.5, view: { type: "TerminalView" } },
+          ],
+        },
+      ],
+      activeWorkspaceId: WS_ID,
+    });
+    for (const id of [TL, BL, TR]) {
+      useTerminalStore.getState().registerInstance({
+        id: `terminal-${id}`,
+        profile: "WSL",
+        syncGroup: "Default",
+        workspaceId: WS_ID,
+      });
+    }
+  }
+
+  beforeEach(() => {
+    useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
+    useGridStore.setState(useGridStore.getInitialState());
+    useTerminalStore.setState(useTerminalStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  it("list_terminals exposes paneNumber in reading order regardless of array order", () => {
+    seedDivergentWorkspace();
+    const result = handleAutomationRequest({
+      requestId: "n-list",
+      category: "query",
+      target: "terminals",
+      method: "list",
+      params: {},
+    });
+    const instances = (result.data as Record<string, unknown>).instances as Array<
+      Record<string, unknown>
+    >;
+    const byId = Object.fromEntries(instances.map((i) => [i.id, i.paneNumber]));
+    expect(byId[`terminal-${TL}`]).toBe(1);
+    expect(byId[`terminal-${TR}`]).toBe(2);
+    expect(byId[`terminal-${BL}`]).toBe(3);
+  });
+
+  it("identify exposes pane.number and neighbor paneNumber", () => {
+    seedDivergentWorkspace();
+    const result = handleAutomationRequest({
+      requestId: "n-id",
+      category: "query",
+      target: "terminals",
+      method: "identify",
+      params: { id: `terminal-${TL}` },
+    });
+    const data = result.data as Record<string, unknown>;
+    const pane = data.pane as Record<string, unknown>;
+    expect(pane.number).toBe(1);
+    const neighbors = data.neighbors as Record<string, Record<string, unknown> | null>;
+    // TL's right neighbor is TR (paneNumber 2); below neighbor is BL (paneNumber 3).
+    expect(neighbors.right?.paneNumber).toBe(2);
+    expect(neighbors.below?.paneNumber).toBe(3);
+  });
+
+  it("get_active_workspace exposes paneNumber and focusedPaneNumber", () => {
+    seedDivergentWorkspace();
+    useGridStore.setState({ focusedPaneIndex: 1 }); // array index 1 = BL = number 3
+    const result = handleAutomationRequest({
+      requestId: "n-gaw",
+      category: "query",
+      target: "workspaces",
+      method: "getActive",
+      params: {},
+    });
+    const ws = (result.data as Record<string, unknown>).workspace as Record<string, unknown>;
+    expect(ws.focusedPaneNumber).toBe(3);
+    const panes = ws.panes as Array<Record<string, unknown>>;
+    const byId = Object.fromEntries(panes.map((p) => [p.id, p.paneNumber]));
+    expect(byId[TL]).toBe(1);
+    expect(byId[TR]).toBe(2);
+    expect(byId[BL]).toBe(3);
+  });
+
+  it("grid.getState exposes focusedPaneNumber and a number<->terminal summary", () => {
+    seedDivergentWorkspace();
+    useGridStore.setState({ focusedPaneIndex: 2 }); // array index 2 = TR = number 2
+    const result = handleAutomationRequest({
+      requestId: "n-grid",
+      category: "query",
+      target: "grid",
+      method: "getState",
+      params: {},
+    });
+    const data = result.data as Record<string, unknown>;
+    expect(data.focusedPaneNumber).toBe(2);
+    const panes = data.panes as Array<Record<string, unknown>>;
+    // Sorted by paneNumber ascending.
+    expect(panes.map((p) => p.paneNumber)).toEqual([1, 2, 3]);
+    expect(panes[0]).toMatchObject({ paneNumber: 1, paneId: TL, terminalId: `terminal-${TL}` });
+    expect(panes[1]).toMatchObject({ paneNumber: 2, paneId: TR });
+  });
+
+  it("resolveByNumber maps a number to a terminal id in the active workspace", () => {
+    seedDivergentWorkspace();
+    const result = handleAutomationRequest({
+      requestId: "n-res",
+      category: "query",
+      target: "terminals",
+      method: "resolveByNumber",
+      params: { number: 2 },
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.terminalId).toBe(`terminal-${TR}`);
+    expect(data.paneId).toBe(TR);
+  });
+
+  it("resolveByNumber errors for an out-of-range number", () => {
+    seedDivergentWorkspace();
+    const result = handleAutomationRequest({
+      requestId: "n-res-bad",
+      category: "query",
+      target: "terminals",
+      method: "resolveByNumber",
+      params: { number: 9 },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/No pane numbered 9/);
+  });
+
+  it("resolveByNumber errors when the pane is not a terminal", () => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: WS_ID,
+          name: "Nums",
+          panes: [{ id: "pane-empty", x: 0, y: 0, w: 1, h: 1, view: { type: "EmptyView" } }],
+        },
+      ],
+      activeWorkspaceId: WS_ID,
+    });
+    const result = handleAutomationRequest({
+      requestId: "n-res-empty",
+      category: "query",
+      target: "terminals",
+      method: "resolveByNumber",
+      params: { number: 1 },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not a terminal/);
+  });
+});

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -9,7 +9,7 @@ import { useNotificationStore, type NotificationLevel } from "@/stores/notificat
 import { useUiStore } from "@/stores/ui-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { computeWorkspaceSummary } from "@/lib/workspace-summary";
-import { computePaneNumbers } from "@/lib/pane-numbers";
+import { computePaneNumbers, GRID_EPS } from "@/lib/pane-numbers";
 import type {
   DockPosition,
   ViewInstanceConfig,
@@ -80,8 +80,7 @@ function resolveTerminalPaneIndex(terminalId: string, workspaceId: string): numb
 
 /** Check if two 1D ranges overlap (with tolerance for floating point). */
 function rangesOverlap(a: number, aLen: number, b: number, bLen: number): boolean {
-  const eps = 0.01;
-  return a < b + bLen - eps && b < a + aLen - eps;
+  return a < b + bLen - GRID_EPS && b < a + aLen - GRID_EPS;
 }
 
 type NeighborEntry = { paneIndex: number; paneNumber: number | null; terminalId: string | null };
@@ -113,28 +112,28 @@ function computeNeighbors(
 
     // Right: other starts where target ends on x-axis, y ranges overlap
     if (
-      Math.abs(other.x - (target.x + target.w)) < 0.01 &&
+      Math.abs(other.x - (target.x + target.w)) < GRID_EPS &&
       rangesOverlap(target.y, target.h, other.y, other.h)
     ) {
       if (!result.right || other.y < panes[result.right.paneIndex].y) result.right = entry;
     }
     // Left: other ends where target starts on x-axis
     if (
-      Math.abs(other.x + other.w - target.x) < 0.01 &&
+      Math.abs(other.x + other.w - target.x) < GRID_EPS &&
       rangesOverlap(target.y, target.h, other.y, other.h)
     ) {
       if (!result.left || other.y < panes[result.left.paneIndex].y) result.left = entry;
     }
     // Below: other starts where target ends on y-axis
     if (
-      Math.abs(other.y - (target.y + target.h)) < 0.01 &&
+      Math.abs(other.y - (target.y + target.h)) < GRID_EPS &&
       rangesOverlap(target.x, target.w, other.x, other.w)
     ) {
       if (!result.below || other.x < panes[result.below.paneIndex].x) result.below = entry;
     }
     // Above: other ends where target starts on y-axis
     if (
-      Math.abs(other.y + other.h - target.y) < 0.01 &&
+      Math.abs(other.y + other.h - target.y) < GRID_EPS &&
       rangesOverlap(target.x, target.w, other.x, other.w)
     ) {
       if (!result.above || other.x < panes[result.above.paneIndex].x) result.above = entry;

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -9,6 +9,7 @@ import { useNotificationStore, type NotificationLevel } from "@/stores/notificat
 import { useUiStore } from "@/stores/ui-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { computeWorkspaceSummary } from "@/lib/workspace-summary";
+import { computePaneNumbers } from "@/lib/pane-numbers";
 import type {
   DockPosition,
   ViewInstanceConfig,
@@ -83,15 +84,18 @@ function rangesOverlap(a: number, aLen: number, b: number, bLen: number): boolea
   return a < b + bLen - eps && b < a + aLen - eps;
 }
 
+type NeighborEntry = { paneIndex: number; paneNumber: number | null; terminalId: string | null };
+
 /** Compute directional neighbors for a pane in the grid. */
 function computeNeighbors(
   panes: WorkspacePane[],
   targetIndex: number,
-): Record<string, { paneIndex: number; terminalId: string | null } | null> {
+  paneNumbers: Map<string, number>,
+): Record<string, NeighborEntry | null> {
   const target = panes[targetIndex];
   if (!target) return { left: null, right: null, above: null, below: null };
 
-  const result: Record<string, { paneIndex: number; terminalId: string | null } | null> = {
+  const result: Record<string, NeighborEntry | null> = {
     left: null,
     right: null,
     above: null,
@@ -101,8 +105,9 @@ function computeNeighbors(
   for (let i = 0; i < panes.length; i++) {
     if (i === targetIndex) continue;
     const other = panes[i];
-    const entry = {
+    const entry: NeighborEntry = {
       paneIndex: i,
+      paneNumber: paneNumbers.get(other.id) ?? null,
       terminalId: other.view.type === "TerminalView" ? toTerminalId(other.id) : null,
     };
 
@@ -156,11 +161,12 @@ function findTerminalContext(terminalId: string) {
   return { terminal, workspace, pane, paneIndex, activeWorkspaceId };
 }
 
-/** Enrich a pane with its index and terminal ID (null for non-terminal panes). */
-function enrichPane(p: WorkspacePane, index: number) {
+/** Enrich a pane with its index, spatial number, and terminal ID (null for non-terminal panes). */
+function enrichPane(p: WorkspacePane, index: number, paneNumbers: Map<string, number>) {
   return {
     ...p,
     paneIndex: index,
+    paneNumber: paneNumbers.get(p.id) ?? null,
     terminalId: p.view.type === "TerminalView" ? toTerminalId(p.id) : null,
   };
 }
@@ -175,10 +181,15 @@ const handlers: HandlerMap = {
       const ws = useWorkspaceStore.getState().getActiveWorkspace();
       if (!ws) return ok({ workspace: null });
       const { focusedPaneIndex } = useGridStore.getState();
+      const paneNumbers = computePaneNumbers(ws.panes);
       const enriched = {
         ...ws,
         focusedPaneIndex,
-        panes: ws.panes.map(enrichPane),
+        focusedPaneNumber:
+          focusedPaneIndex != null
+            ? (paneNumbers.get(ws.panes[focusedPaneIndex]?.id) ?? null)
+            : null,
+        panes: ws.panes.map((p, i) => enrichPane(p, i, paneNumbers)),
       };
       return ok({ workspace: enriched });
     },
@@ -258,7 +269,24 @@ const handlers: HandlerMap = {
     getState: () => {
       const { editMode, focusedPaneIndex } = useGridStore.getState();
       const { activeWorkspaceId } = useWorkspaceStore.getState();
-      return ok({ editMode, focusedPaneIndex, activeWorkspaceId });
+      const ws = useWorkspaceStore.getState().getActiveWorkspace();
+      const paneNumbers = ws ? computePaneNumbers(ws.panes) : new Map<string, number>();
+      // Summary so an orchestrator can map paneNumber <-> terminalId in one call.
+      const panes = ws
+        ? ws.panes
+            .map((p, i) => ({
+              paneNumber: paneNumbers.get(p.id) ?? null,
+              paneIndex: i,
+              paneId: p.id,
+              terminalId: p.view.type === "TerminalView" ? toTerminalId(p.id) : null,
+            }))
+            .sort((a, b) => (a.paneNumber ?? 0) - (b.paneNumber ?? 0))
+        : [];
+      const focusedPaneNumber =
+        focusedPaneIndex != null && ws
+          ? (paneNumbers.get(ws.panes[focusedPaneIndex]?.id) ?? null)
+          : null;
+      return ok({ editMode, focusedPaneIndex, focusedPaneNumber, activeWorkspaceId, panes });
     },
     setEditMode: (p) => {
       useGridStore.getState().setEditMode(p.enabled as boolean);
@@ -307,6 +335,7 @@ const handlers: HandlerMap = {
               id: newPane.id,
               terminalId,
               paneIndex: newPaneIndex,
+              paneNumber: ws ? (computePaneNumbers(ws.panes).get(newPane.id) ?? null) : null,
               x: newPane.x,
               y: newPane.y,
               w: newPane.w,
@@ -432,14 +461,26 @@ const handlers: HandlerMap = {
     list: () => {
       const { instances } = useTerminalStore.getState();
       const { workspaces } = useWorkspaceStore.getState();
+      // Memoize per-workspace number maps so we compute each ws once.
+      const numbersByWs = new Map<string, Map<string, number>>();
       const enriched = instances.map((inst) => {
         const ws = workspaces.find((w) => w.id === inst.workspaceId);
         const paneId = toPaneId(inst.id);
         const paneIndex = ws?.panes.findIndex((p) => p.id === paneId) ?? -1;
         const pane = paneIndex >= 0 ? ws!.panes[paneIndex] : null;
+        let paneNumber: number | null = null;
+        if (ws) {
+          let numbers = numbersByWs.get(ws.id);
+          if (!numbers) {
+            numbers = computePaneNumbers(ws.panes);
+            numbersByWs.set(ws.id, numbers);
+          }
+          paneNumber = numbers.get(paneId) ?? null;
+        }
         return {
           ...inst,
           paneIndex: paneIndex >= 0 ? paneIndex : null,
+          paneNumber,
           panePosition: pane ? { x: pane.x, y: pane.y, w: pane.w, h: pane.h } : null,
         };
       });
@@ -449,10 +490,12 @@ const handlers: HandlerMap = {
       const ctx = findTerminalContext(p.id as string);
       if (!ctx) return err(`Terminal '${p.id}' not found`);
       const { terminal, workspace, pane, paneIndex, activeWorkspaceId } = ctx;
+      const paneNumber = pane ? (computePaneNumbers(workspace.panes).get(pane.id) ?? null) : null;
       return ok({
         terminal: {
           ...terminal,
           paneIndex: paneIndex >= 0 ? paneIndex : null,
+          paneNumber,
           panePosition: pane ? { x: pane.x, y: pane.y, w: pane.w, h: pane.h } : null,
         },
         workspace: {
@@ -467,6 +510,7 @@ const handlers: HandlerMap = {
       if (!ctx) return err(`Terminal '${p.id}' not found`);
       const { terminal, workspace, pane, paneIndex, activeWorkspaceId } = ctx;
       const { focusedPaneIndex } = useGridStore.getState();
+      const paneNumbers = computePaneNumbers(workspace.panes);
 
       return ok({
         terminal: {
@@ -488,6 +532,7 @@ const handlers: HandlerMap = {
           ? {
               id: pane.id,
               index: paneIndex,
+              number: paneNumbers.get(pane.id) ?? null,
               x: pane.x,
               y: pane.y,
               w: pane.w,
@@ -495,7 +540,7 @@ const handlers: HandlerMap = {
               isFocusedPane: workspace.id === activeWorkspaceId && focusedPaneIndex === paneIndex,
             }
           : null,
-        neighbors: pane ? computeNeighbors(workspace.panes, paneIndex) : null,
+        neighbors: pane ? computeNeighbors(workspace.panes, paneIndex, paneNumbers) : null,
       });
     },
     setFocus: (p) => {
@@ -521,6 +566,29 @@ const handlers: HandlerMap = {
         focused: terminalId,
         paneIndex: paneIndex >= 0 ? paneIndex : undefined,
         switchedWorkspace: switchedWorkspace ? terminal.workspaceId : undefined,
+      });
+    },
+    // Resolve a spatial pane number to a terminal ID within a workspace (issue #256).
+    // Defaults to the active workspace when workspaceId is omitted.
+    resolveByNumber: (p) => {
+      const number = p.number as number;
+      const wsId = p.workspaceId as string | undefined;
+      const { workspaces } = useWorkspaceStore.getState();
+      const ws = wsId
+        ? workspaces.find((w) => w.id === wsId)
+        : useWorkspaceStore.getState().getActiveWorkspace();
+      if (!ws) return err(wsId ? `Workspace '${wsId}' not found` : "No active workspace");
+      const paneNumbers = computePaneNumbers(ws.panes);
+      const entry = ws.panes.find((pane) => paneNumbers.get(pane.id) === number);
+      if (!entry) return err(`No pane numbered ${number} in workspace '${ws.id}'`);
+      if (entry.view.type !== "TerminalView") {
+        return err(`Pane ${number} is not a terminal (view: ${entry.view.type})`);
+      }
+      return ok({
+        terminalId: toTerminalId(entry.id),
+        paneId: entry.id,
+        paneIndex: ws.panes.indexOf(entry),
+        workspaceId: ws.id,
       });
     },
   },

--- a/ui/src/lib/pane-numbers.test.ts
+++ b/ui/src/lib/pane-numbers.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { computePaneNumbers, paneNumberFor, type NumberablePane } from "./pane-numbers";
+
+/** Build a pane with only the fields the numbering cares about. */
+function p(id: string, x: number, y: number, w = 0.5, h = 0.5): NumberablePane {
+  return { id, x, y, w, h };
+}
+
+describe("computePaneNumbers", () => {
+  it("assigns 1 to a single pane", () => {
+    const result = computePaneNumbers([p("a", 0, 0, 1, 1)]);
+    expect(result.get("a")).toBe(1);
+    expect(result.size).toBe(1);
+  });
+
+  it("numbers a left/right split left=1, right=2 (same row, x ascending)", () => {
+    const result = computePaneNumbers([p("L", 0, 0, 0.5, 1), p("R", 0.5, 0, 0.5, 1)]);
+    expect(result.get("L")).toBe(1);
+    expect(result.get("R")).toBe(2);
+  });
+
+  it("numbers a top/bottom split top=1, bottom=2 (y first)", () => {
+    const result = computePaneNumbers([p("T", 0, 0, 1, 0.5), p("B", 0, 0.5, 1, 0.5)]);
+    expect(result.get("T")).toBe(1);
+    expect(result.get("B")).toBe(2);
+  });
+
+  it("numbers a 2x2 grid in reading order (TL=1, TR=2, BL=3, BR=4)", () => {
+    const result = computePaneNumbers([
+      p("BR", 0.5, 0.5),
+      p("TL", 0, 0),
+      p("BL", 0, 0.5),
+      p("TR", 0.5, 0),
+    ]);
+    expect(result.get("TL")).toBe(1);
+    expect(result.get("TR")).toBe(2);
+    expect(result.get("BL")).toBe(3);
+    expect(result.get("BR")).toBe(4);
+  });
+
+  it("treats panes within eps (0.01) of each other on y as the same row", () => {
+    // y=0.0 and y=0.009 are the same row -> sort by x. y=0.5 is a different row.
+    const result = computePaneNumbers([
+      p("rowB", 0, 0.5),
+      p("rowA-right", 0.5, 0.009),
+      p("rowA-left", 0, 0.0),
+    ]);
+    expect(result.get("rowA-left")).toBe(1);
+    expect(result.get("rowA-right")).toBe(2);
+    expect(result.get("rowB")).toBe(3);
+  });
+
+  it("numbers by spatial reading order regardless of array order", () => {
+    // Array order [TL, BL, TR] (as produced by splice-based splitting) must still
+    // yield reading-order numbers: TL=1, TR=2, BL=3.
+    const result = computePaneNumbers([p("TL", 0, 0), p("BL", 0, 0.5), p("TR", 0.5, 0)]);
+    expect(result.get("TL")).toBe(1);
+    expect(result.get("TR")).toBe(2);
+    expect(result.get("BL")).toBe(3);
+  });
+
+  it("numbers every pane regardless of view type (numbers are positional)", () => {
+    const result = computePaneNumbers([p("a", 0, 0, 0.5, 1), p("b", 0.5, 0, 0.5, 1)]);
+    expect(result.size).toBe(2);
+  });
+
+  it("does not mutate the input array", () => {
+    const panes = [p("R", 0.5, 0), p("L", 0, 0)];
+    const snapshot = panes.map((x) => x.id);
+    computePaneNumbers(panes);
+    expect(panes.map((x) => x.id)).toEqual(snapshot);
+  });
+
+  it("returns an empty map for no panes", () => {
+    expect(computePaneNumbers([]).size).toBe(0);
+  });
+});
+
+describe("paneNumberFor", () => {
+  it("returns the number for a known pane id", () => {
+    const panes = [p("L", 0, 0, 0.5, 1), p("R", 0.5, 0, 0.5, 1)];
+    expect(paneNumberFor(panes, "R")).toBe(2);
+  });
+
+  it("returns null for an unknown pane id", () => {
+    expect(paneNumberFor([p("L", 0, 0)], "missing")).toBeNull();
+  });
+});

--- a/ui/src/lib/pane-numbers.ts
+++ b/ui/src/lib/pane-numbers.ts
@@ -24,11 +24,13 @@ export interface NumberablePane {
 }
 
 /**
- * Rows within this epsilon on the y-axis are treated as the same row.
- * Matches the floating-point tolerance used by the neighbor logic in
- * `useAutomationBridge.ts` (`rangesOverlap`).
+ * Floating-point tolerance for normalized (0-1) grid geometry comparisons.
+ * Two coordinates within this epsilon are treated as equal (same row/edge).
+ * Shared by the spatial numbering here and the neighbor adjacency logic in
+ * `useAutomationBridge.ts` (`rangesOverlap`, edge-meeting checks) so the two
+ * stay in lockstep instead of duplicating a magic number.
  */
-const EPS = 0.01;
+export const GRID_EPS = 0.01;
 
 /**
  * Compute the spatial reading-order number (1..N) for each pane.
@@ -37,7 +39,7 @@ const EPS = 0.01;
  */
 export function computePaneNumbers(panes: readonly NumberablePane[]): Map<string, number> {
   const sorted = [...panes].sort((a, b) => {
-    if (Math.abs(a.y - b.y) < EPS) return a.x - b.x;
+    if (Math.abs(a.y - b.y) < GRID_EPS) return a.x - b.x;
     return a.y - b.y;
   });
 

--- a/ui/src/lib/pane-numbers.ts
+++ b/ui/src/lib/pane-numbers.ts
@@ -1,0 +1,52 @@
+/**
+ * Spatial pane numbering (issue #256).
+ *
+ * Assigns each pane a 1-based **paneNumber** in screen reading order
+ * (top-to-bottom, then left-to-right). This is a stateless derived value used
+ * for display (control bar badge) and for humans/AIs to refer to a pane by a
+ * short number ("send to pane 3").
+ *
+ * IMPORTANT: paneNumber is NOT the array index (`paneIndex`). The
+ * `WorkspacePane[]` array order depends on split insertion order and can
+ * diverge from the visual reading order. Layout-manipulation tools keep using
+ * the array index; this module is the single source of the spatial number.
+ * Never cache the result — it is derived purely from pane geometry and is
+ * recomputed whenever the layout changes.
+ */
+
+/** Minimal shape needed to compute a spatial number. Both `WorkspacePane` and `GridPane` satisfy it. */
+export interface NumberablePane {
+  id: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * Rows within this epsilon on the y-axis are treated as the same row.
+ * Matches the floating-point tolerance used by the neighbor logic in
+ * `useAutomationBridge.ts` (`rangesOverlap`).
+ */
+const EPS = 0.01;
+
+/**
+ * Compute the spatial reading-order number (1..N) for each pane.
+ * Sort by y ascending; panes within EPS on y are the same row, sorted by x ascending.
+ * Returns a map of paneId -> number. Does not mutate the input.
+ */
+export function computePaneNumbers(panes: readonly NumberablePane[]): Map<string, number> {
+  const sorted = [...panes].sort((a, b) => {
+    if (Math.abs(a.y - b.y) < EPS) return a.x - b.x;
+    return a.y - b.y;
+  });
+
+  const numbers = new Map<string, number>();
+  sorted.forEach((pane, i) => numbers.set(pane.id, i + 1));
+  return numbers;
+}
+
+/** Convenience: the spatial number for a single pane id, or null if not found. */
+export function paneNumberFor(panes: readonly NumberablePane[], paneId: string): number | null {
+  return computePaneNumbers(panes).get(paneId) ?? null;
+}


### PR DESCRIPTION
@
## 배경 (#256)

`pane id를 쉽게 획득`해서 다른 AI에게 메시지 전달 위치를 알려줄 수 있게 한다.
기존 `terminalId`(`terminal-pane-a1b2c3d4`)는 안정적이지만 길고 불투명하고,
`paneIndex`(배열 순서)는 짧지만 split 삽입 순서에 종속되어 화면 위치와 어긋난다.

→ **화면 읽기 순서(y→x)로 매겨지는 실시간 공간 번호 `paneNumber`** 를 도입한다.
사람이 컨트롤바 배지를 보고 "3번에 보내"라고 지시하거나, AI가 number↔terminalId를
매핑해 메시지를 전달할 수 있다.

## 식별자 3종 (혼동 방지)

| 식별자 | 용도 | 안정성 |
|---|---|---|
| `terminalId` | 안정 참조 (write/focus 1차, env var) | 세션 간 안정 |
| `paneIndex` | 레이아웃 조작 (split/remove/resize) | 배열 순서 |
| `paneNumber` (신규) | 표시·사람/AI 지칭 | 화면 위치 실시간 |

`paneNumber`는 panes 기하에서 도출되는 파생값(저장/캐시 안 함). `paneIndex`와 다를 수 있다.

## 변경 사항

**Phase 1 — 계산·표시·노출**
- `lib/pane-numbers.ts`: 단일 순수 함수 `computePaneNumbers()` ((y,x) 정렬, eps 0.01).
- 컨트롤바 배지 `PaneNumberBadge`: `PaneControlContext`로 흘려 PaneControlBar 자체 바 + ViewHeader 좌측에 렌더. 워크스페이스 pane만(dock 제외, `showPaneNumbers`).
- 자동화 노출: `list_terminals` / `identify_caller`(`pane.number` + 이웃 `paneNumber`) / `get_active_workspace` / `get_grid_state`(`focusedPaneNumber` + 번호↔terminalId 요약) / `split` 응답. 신규 브리지 `terminals.resolveByNumber`.

**Phase 2 — 번호 직접 주소 지정 (MCP)**
- `write_to_terminal` / `read_terminal_output` / `focus_terminal`이 `pane_number`(+`workspace_id`)를 `terminal_id` 대안으로 수용. 둘 다 주면 `terminal_id` 우선, 호출 시점에 해석.

**문서**: `ARCHITECTURE.md §13.7`에 식별자 3종 명문화.

## 검증

- 단위/컴포넌트: 프론트 **1828 통과**, automation_server **102 통과**, tsc 클린, lint 0 에러 (TDD — 테스트 우선).
- 라이브(dev 19281):
  - split 후 배열 idx1(좌하)=`paneNumber 3`, idx2(우상)=`2` → **배열≠공간 순서 분기 확인**.
  - 스크린샷: 좌하 `3 Memo`, 우상 FileExplorer `2` 배지 표시.
  - MCP `write_to_terminal(pane_number:1)` → 좌상 #1 터미널로 정확히 해석·입력.

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@