### PR TITLE
fix: MCP activity 응답 중첩 제거로 Codex 감지 복구

### DIFF
--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -650,6 +650,7 @@ impl McpHandler {
     /// Enrich a JSON array of objects by injecting activity state from backend detection.
     /// `id_field` is the JSON key containing the terminal ID (e.g. "id" or "terminalId").
     /// `activity_field` is the key to insert (e.g. "activity" or "terminalActivity").
+    /// The inserted value is the flat `TerminalActivity` shape, not `TerminalStateInfo`.
     fn enrich_with_activity(
         app_state: &crate::state::AppState,
         items: &mut Vec<Value>,
@@ -663,7 +664,7 @@ impl McpHandler {
                     if let Some(obj) = item.as_object_mut() {
                         obj.insert(
                             activity_field.to_string(),
-                            serde_json::to_value(state_info).unwrap_or(json!(null)),
+                            serde_json::to_value(&state_info.activity).unwrap_or(json!(null)),
                         );
                     }
                 }
@@ -2262,5 +2263,38 @@ mod tests {
         let data = json!({ "workspaces": [], "activeWorkspaceId": null });
         let summary = workspace_list_summary(&data);
         assert_eq!(summary["workspaces"].as_array().map(|a| a.len()), Some(0));
+    }
+
+    #[test]
+    fn enrich_with_activity_injects_flat_activity_shape() {
+        let state = crate::state::AppState::new();
+        let terminal_id = "terminal-pane-codex";
+        let mut buffer = crate::output_buffer::TerminalOutputBuffer::default();
+        buffer.push(b"\x1b]0;OpenAI Codex\x07");
+        state
+            .output_buffers
+            .lock()
+            .unwrap()
+            .insert(terminal_id.to_string(), buffer);
+        state.terminals.lock().unwrap().insert(
+            terminal_id.to_string(),
+            crate::terminal::TerminalSession::new(
+                terminal_id.to_string(),
+                crate::terminal::TerminalConfig::default(),
+            ),
+        );
+
+        let mut items = vec![json!({ "id": terminal_id })];
+        McpHandler::enrich_with_activity(&state, &mut items, "id", "activity");
+
+        assert_eq!(
+            items[0]["activity"],
+            json!({ "type": "interactiveApp", "name": "Codex" }),
+            "MCP list_terminals must expose activity directly, not activity.activity"
+        );
+        assert!(
+            items[0]["activity"].get("activity").is_none(),
+            "nested activity.activity breaks clients that read the documented shape"
+        );
     }
 }


### PR DESCRIPTION
@
## 문제
`list_terminals` / `workspace://active` / `terminal://{id}` / `get_active_workspace` 응답에서 activity 주입 시 `TerminalStateInfo` 전체를 넣어 한 겹 중첩되었다:

```json
"activity": { "activity": { "type": "interactiveApp", "name": "Codex" } }
```

`get_terminal_states`는 `{type, name}` flat shape로 올바르게 나오는 반면, 위 경로들은 문서화된 shape와 달라 클라이언트가 Codex 등 `interactiveApp` 상태를 인식하지 못했다.

## 수정
- `enrich_with_activity`가 `state_info.activity`만 flat하게 직렬화하도록 변경. `TerminalStateInfo`는 `activity` 단일 필드만 가지므로 손실되는 데이터 없음.
- 헬퍼 한 곳 수정으로 5개 호출 지점(`list_terminals`, `terminal://{id}`, `workspace://active`, `get_active_workspace`)이 모두 교정됨.
- `activity.activity` 중첩이 재발하지 않도록 회귀 테스트 추가.

## 검증
- `cargo test -p laymux --lib automation_server::mcp::tests` 통과
- `cargo test -p laymux --lib codex` 통과
- `cargo fmt --check` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@