### PR TITLE
fix: File Explorer가 CWD를 못 받아 경로/목록이 안 보이는 현상 수정 (#274)

### DIFF
--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -134,6 +134,24 @@ pub fn read_file_for_viewer(
     }
 }
 
+/// Resolve the current user's home directory as a path string.
+///
+/// Used by the File Explorer as a fallback CWD when no syncGroup CWD or
+/// restored `lastCwd` is available, so the explorer is never stuck showing
+/// "..." with an empty listing.
+pub fn home_directory() -> Option<String> {
+    std::env::var("USERPROFILE")
+        .or_else(|_| std::env::var("HOME"))
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Return the current user's home directory path.
+#[tauri::command]
+pub fn get_home_directory() -> Result<String, String> {
+    home_directory().ok_or_else(|| "Could not determine home directory".to_string())
+}
+
 /// A single directory entry returned by `list_directory`.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -274,6 +292,18 @@ mod tests {
     #[test]
     fn base64_encode_hello() {
         assert_eq!(base64_encode(b"Hello"), "SGVsbG8=");
+    }
+
+    #[test]
+    fn home_directory_resolves_to_existing_path() {
+        // The home directory must resolve to a non-empty, existing path so the
+        // File Explorer always has a valid fallback CWD (issue #274).
+        let home = home_directory().expect("home directory should resolve in test env");
+        assert!(!home.is_empty());
+        assert!(
+            std::path::Path::new(&home).exists(),
+            "resolved home dir should exist: {home}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,6 +151,7 @@ pub fn run() {
             commands::load_window_geometry,
             commands::read_file_for_viewer,
             commands::list_directory,
+            commands::get_home_directory,
             commands::get_automation_info,
             commands::load_settings_validated,
             commands::reset_settings,

--- a/ui/src/components/views/FileExplorerView.test.tsx
+++ b/ui/src/components/views/FileExplorerView.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { FileExplorerView } from "./FileExplorerView";
-import { clipboardWriteText, readFileForViewer, listDirectory } from "@/lib/tauri-api";
+import {
+  clipboardWriteText,
+  readFileForViewer,
+  listDirectory,
+  getHomeDirectory,
+} from "@/lib/tauri-api";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useTerminalStore } from "@/stores/terminal-store";
 
@@ -16,6 +21,7 @@ vi.mock("@/lib/tauri-api", () => ({
     .fn()
     .mockResolvedValue({ kind: "text", content: "file content", truncated: false }),
   listDirectory: vi.fn().mockResolvedValue([]),
+  getHomeDirectory: vi.fn().mockResolvedValue("/home/fallback"),
   onTerminalCwdChanged: vi
     .fn()
     .mockImplementation(
@@ -69,6 +75,8 @@ describe("FileExplorerView", () => {
     vi.mocked(clipboardWriteText).mockClear();
     vi.mocked(readFileForViewer).mockClear();
     vi.mocked(listDirectory).mockClear();
+    vi.mocked(getHomeDirectory).mockClear();
+    vi.mocked(getHomeDirectory).mockResolvedValue("/home/fallback");
     mockListDir();
     useSettingsStore.setState(useSettingsStore.getInitialState());
     useTerminalStore.setState({ instances: [] });
@@ -430,14 +438,30 @@ describe("FileExplorerView", () => {
     expect(screen.getByTestId("file-explorer-viewer-image")).toBeInTheDocument();
   });
 
-  it("shows empty state when no CWD available", async () => {
-    render(<FileExplorerView {...defaultProps} lastCwd="" />);
+  it("falls back to home directory when no CWD available (#274)", async () => {
+    // No lastCwd, no syncGroup terminal with cwd, cwdReceive off:
+    // explorer must NOT be stuck at "..." / "Empty directory" — it falls back to home.
+    render(<FileExplorerView {...defaultProps} lastCwd="" syncGroup="" cwdReceive={false} />);
     await act(async () => {
       await vi.runAllTimersAsync();
     });
 
-    // No CWD → should not be stuck at Loading
+    expect(getHomeDirectory).toHaveBeenCalled();
+    // Path bar shows the resolved home dir, not "..."
+    expect(screen.getByTestId("file-explorer-path-bar")).toHaveTextContent("/home/fallback");
+    // Directory listing was fetched for the home dir
+    expect(listDirectory).toHaveBeenCalledWith("/home/fallback");
     expect(screen.getByTestId("file-explorer-list")).toBeInTheDocument();
+  });
+
+  it("does not call home fallback when a CWD is available", async () => {
+    render(<FileExplorerView {...defaultProps} />);
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(getHomeDirectory).not.toHaveBeenCalled();
+    expect(listDirectory).toHaveBeenCalledWith("/home/user");
   });
 
   it("shows .. entry at top of file list", async () => {

--- a/ui/src/components/views/FileExplorerView.tsx
+++ b/ui/src/components/views/FileExplorerView.tsx
@@ -221,8 +221,10 @@ export function FileExplorerView({
       if (cancelled) return;
       setCurrentCwd(cwd);
       refreshListing(cwd);
+      // Only initialize history (and reset the index to 0) when it is still
+      // empty; if entries already exist, leave navigation state untouched.
       setHistory((prev) => (prev.length ? prev : [cwd]));
-      setHistoryIndex((prev) => (prev === 0 ? 0 : prev));
+      setHistoryIndex((prev) => (history.length ? prev : 0));
     };
 
     const initialCwd = lastCwd || initialGroupCwd;

--- a/ui/src/components/views/FileExplorerView.tsx
+++ b/ui/src/components/views/FileExplorerView.tsx
@@ -5,6 +5,7 @@ import {
   clipboardWriteText,
   readFileForViewer,
   listDirectory,
+  getHomeDirectory,
   onTerminalCwdChanged,
   handleLxMessage,
   type DirEntry,
@@ -214,17 +215,45 @@ export function FileExplorerView({
 
   // --- Initial listing ---
   useEffect(() => {
+    let cancelled = false;
+
+    const applyInitialCwd = (cwd: string) => {
+      if (cancelled) return;
+      setCurrentCwd(cwd);
+      refreshListing(cwd);
+      setHistory((prev) => (prev.length ? prev : [cwd]));
+      setHistoryIndex((prev) => (prev === 0 ? 0 : prev));
+    };
+
     const initialCwd = lastCwd || initialGroupCwd;
     if (initialCwd) {
-      setCurrentCwd(initialCwd);
-      refreshListing(initialCwd);
-      if (!history.length) {
-        setHistory([initialCwd]);
-        setHistoryIndex(0);
-      }
-    } else {
-      setLoading(false);
+      applyInitialCwd(initialCwd);
+      return;
     }
+
+    // No lastCwd and no syncGroup CWD available. Rather than getting stuck
+    // showing "..." with an empty listing (#274), fall back to the user's
+    // home directory so the explorer always has a valid, navigable path.
+    getHomeDirectory()
+      .then((home) => {
+        if (cancelled || !home) {
+          if (!cancelled) setLoading(false);
+          return;
+        }
+        // If a syncGroup CWD arrived while we were resolving, prefer it.
+        if (currentCwdRef.current) {
+          setLoading(false);
+          return;
+        }
+        applyInitialCwd(home);
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -417,6 +417,11 @@ export async function listDirectory(path: string, wslDistro?: string): Promise<D
   return invoke("list_directory", { path, wslDistro: wslDistro ?? null });
 }
 
+/** Resolve the user's home directory (fallback CWD for File Explorer). */
+export async function getHomeDirectory(): Promise<string> {
+  return invoke("get_home_directory");
+}
+
 /** Read a file and classify it for the file viewer. */
 export async function readFileForViewer(
   path: string,


### PR DESCRIPTION
@
## 문제 (#274)

File Explorer에서 경로 표시줄에 `"..."`, 목록에 `"Empty directory"`만 표시되는 회귀.

## 근본 원인

File Explorer가 CWD를 전혀 받아오지 못함. CWD 획득 경로 3가지가 모두 비어있을 수 있었음:

1. **`cwdReceive` 기본값이 `false`** — `DEFAULT_SYNC_CWD_DEFAULTS`가 workspace/dock 모두 `{ send: false, receive: false }`. `FileExplorerView`의 `onTerminalCwdChanged` 구독 effect가 `if (!cwdReceive || !syncGroup) return;`로 즉시 빠져나가 syncGroup 터미널의 CWD 변경을 수신 못 함.
2. 남은 경로 `lastCwd`(세션 복원 시만), `initialGroupCwd`(마운트 시점에 같은 syncGroup 터미널이 이미 cwd 보유 시만)도 비어있을 수 있음.
3. 셋 다 비면 `currentCwd=""` → `"..."` + `"Empty directory"`에 영구 정지.

## 수정

초기 CWD를 못 얻으면 사용자 홈 디렉터리로 폴백. 폴백 경로는 실제 경로이므로 상/하위 탐색도 정상 동작. resolve 중 syncGroup CWD가 도착하면 그쪽을 우선.

## 변경 파일

- `src-tauri/src/commands/file_ops.rs` — `home_directory()` 헬퍼 + `get_home_directory` Tauri 커맨드 + 단위 테스트
- `src-tauri/src/lib.rs` — `get_home_directory` 핸들러 등록
- `ui/src/lib/tauri-api.ts` — `getHomeDirectory()` 래퍼
- `ui/src/components/views/FileExplorerView.tsx` — 초기 listing effect 홈 폴백 (언마운트 cancel 처리)
- `ui/src/components/views/FileExplorerView.test.tsx` — 재현/검증 테스트 2건

## 테스트

- 프론트엔드: `FileExplorerView.test.tsx` 33건 통과(신규 2건), `ViewRenderer`+`lib` 650건 통과
- 백엔드: `cargo test --lib file_ops` 4건 통과(신규 1건)
- `cargo fmt --check`, ESLint, Prettier 통과

## 주의사항

- 단위 테스트는 통과했으나 **dev 인스턴스(19281) 실제 스크린샷/API 검증 미수행** (dev 미실행). UI 최종 확인은 dev 빌드에서 File Explorer 패널 열어 경로 표시줄 확인 필요.
- 더 근본적 수정은 `cwdReceive` 기본값 활성화이나, 이는 사용자 설정 기본값(`syncCwdDefaults`) 정책 변경이라 의도적으로 폴백 방식으로 안전하게 해결.

Fixes #274
@