### PR TITLE
feat: explorer 주소창 편집 가능 — 입력/붙여넣기/Enter, 파일이면 부모이동+즉시 open (#278)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -215,7 +215,7 @@ View:     viewOverrides[paneId]        (localStorage: "laymux-view-overrides")
 | `SettingsView` | Dock only (또는 모달) | 설정 화면 |
 | `TerminalView` | 자유 | WSL / PowerShell 실행 |
 | `MemoView` | 자유 | 간단한 텍스트 메모장. 내용은 `cache/memo.json`에 pane별로 저장 |
-| `FileExplorerView` | 자유 | CWD 동기화 기반 파일 탐색기. 백그라운드 셸로 `ls` 실행, 파일 뷰어(텍스트/이미지/터미널) 지원 |
+| `FileExplorerView` | 자유 | CWD 동기화 기반 파일 탐색기. Rust `list_directory`로 디렉터리 나열, 편집 가능한 주소창(경로 직접 입력/붙여넣기 → `stat_path`로 검증 후 디렉터리 이동 또는 파일이면 부모 이동+통합 뷰어 open, #278), 파일 뷰어(텍스트/이미지/터미널) 지원 |
 | `EmptyView` | 자유 | View 미지정 상태. 실행할 View 선택 UI |
 
 ### 6.2 EmptyView

--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -64,13 +64,8 @@ pub fn read_file_for_viewer(
     path: String,
     max_bytes: Option<usize>,
 ) -> Result<FileViewerContent, String> {
-    // Resolve WSL paths on Windows
-    let distro = if cfg!(windows) && path.starts_with('/') && !path.starts_with("/mnt/") {
-        path_utils::get_default_wsl_distro()
-    } else {
-        None
-    };
-    let resolved = path_utils::resolve_path_for_windows(&path, distro.as_deref());
+    // Resolve WSL/Windows paths with the shared inference rule (#282).
+    let resolved = path_utils::resolve_address_path(&path, None);
     let file_path = std::path::Path::new(&resolved);
     let ext = file_path
         .extension()
@@ -152,14 +147,7 @@ pub struct PathInfo {
 /// without treating "not found" as a hard error.
 #[tauri::command]
 pub fn stat_path(path: String, wsl_distro: Option<String>) -> PathInfo {
-    let distro = wsl_distro.or_else(|| {
-        if cfg!(windows) && path.starts_with('/') && !path.starts_with("/mnt/") {
-            path_utils::get_default_wsl_distro()
-        } else {
-            None
-        }
-    });
-    let resolved = path_utils::resolve_path_for_windows(&path, distro.as_deref());
+    let resolved = path_utils::resolve_address_path(&path, wsl_distro.as_deref());
     match std::fs::metadata(&resolved) {
         Ok(meta) => PathInfo {
             exists: true,
@@ -204,16 +192,8 @@ pub struct DirEntry {
 /// List directory contents and return structured metadata for each entry.
 #[tauri::command]
 pub fn list_directory(path: String, wsl_distro: Option<String>) -> Result<Vec<DirEntry>, String> {
-    // On Windows, resolve Linux paths to UNC paths
-    let distro = wsl_distro.or_else(|| {
-        // Auto-detect WSL distro if path looks like a Linux path
-        if cfg!(windows) && path.starts_with('/') && !path.starts_with("/mnt/") {
-            path_utils::get_default_wsl_distro()
-        } else {
-            None
-        }
-    });
-    let resolved = path_utils::resolve_path_for_windows(&path, distro.as_deref());
+    // Resolve WSL/Windows paths with the shared inference rule (#282).
+    let resolved = path_utils::resolve_address_path(&path, wsl_distro.as_deref());
     let dir_path = std::path::Path::new(&resolved);
     let entries = std::fs::read_dir(dir_path).map_err(|e| format!("Cannot read directory: {e}"))?;
 

--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -134,6 +134,44 @@ pub fn read_file_for_viewer(
     }
 }
 
+/// Filesystem facts about a path, used by the File Explorer address bar (#278)
+/// to decide whether a typed/pasted path should navigate (directory) or open a
+/// file (navigate to parent + open in the shared viewer).
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PathInfo {
+    pub exists: bool,
+    pub is_directory: bool,
+}
+
+/// Resolve an address-bar path (handling WSL/Windows translation the same way as
+/// `list_directory`) and report whether it exists and is a directory.
+///
+/// Never errors on a missing path — a non-existent path simply returns
+/// `{ exists: false, is_directory: false }` so the frontend can show feedback
+/// without treating "not found" as a hard error.
+#[tauri::command]
+pub fn stat_path(path: String, wsl_distro: Option<String>) -> PathInfo {
+    let distro = wsl_distro.or_else(|| {
+        if cfg!(windows) && path.starts_with('/') && !path.starts_with("/mnt/") {
+            path_utils::get_default_wsl_distro()
+        } else {
+            None
+        }
+    });
+    let resolved = path_utils::resolve_path_for_windows(&path, distro.as_deref());
+    match std::fs::metadata(&resolved) {
+        Ok(meta) => PathInfo {
+            exists: true,
+            is_directory: meta.is_dir(),
+        },
+        Err(_) => PathInfo {
+            exists: false,
+            is_directory: false,
+        },
+    }
+}
+
 /// Resolve the current user's home directory as a path string.
 ///
 /// Used by the File Explorer as a fallback CWD when no syncGroup CWD or
@@ -304,6 +342,34 @@ mod tests {
             std::path::Path::new(&home).exists(),
             "resolved home dir should exist: {home}"
         );
+    }
+
+    #[test]
+    fn stat_path_reports_directory() {
+        let dir = std::env::temp_dir();
+        let info = stat_path(dir.to_string_lossy().into_owned(), None);
+        assert!(info.exists, "temp dir should exist");
+        assert!(info.is_directory, "temp dir should be a directory");
+    }
+
+    #[test]
+    fn stat_path_reports_file() {
+        let mut file = std::env::temp_dir();
+        file.push(format!("laymux_stat_path_test_{}.txt", std::process::id()));
+        std::fs::write(&file, b"hi").expect("write temp file");
+        let info = stat_path(file.to_string_lossy().into_owned(), None);
+        assert!(info.exists, "temp file should exist");
+        assert!(!info.is_directory, "temp file should not be a directory");
+        let _ = std::fs::remove_file(&file);
+    }
+
+    #[test]
+    fn stat_path_missing_is_not_an_error() {
+        let mut missing = std::env::temp_dir();
+        missing.push("laymux_stat_path_definitely_missing_xyz_123");
+        let info = stat_path(missing.to_string_lossy().into_owned(), None);
+        assert!(!info.exists, "missing path should report exists=false");
+        assert!(!info.is_directory);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,6 +151,7 @@ pub fn run() {
             commands::load_window_geometry,
             commands::read_file_for_viewer,
             commands::list_directory,
+            commands::stat_path,
             commands::get_home_directory,
             commands::get_automation_info,
             commands::load_settings_validated,

--- a/src-tauri/src/path_utils.rs
+++ b/src-tauri/src/path_utils.rs
@@ -186,6 +186,27 @@ pub fn resolve_path_for_windows(path: &str, wsl_distro: Option<&str>) -> String 
     path.to_string()
 }
 
+/// Resolve a path supplied to a file command (address bar, listing, viewer) to a
+/// Windows-accessible path, applying one shared WSL-distro inference rule:
+///
+/// - an explicit `wsl_distro` always wins;
+/// - otherwise, on Windows, a Linux-looking path (`/...` that is not `/mnt/...`)
+///   auto-detects the default distro so `\\wsl.localhost\<distro>\...` resolves.
+///
+/// Centralizing this keeps `stat_path`, `list_directory`, and
+/// `read_file_for_viewer` from drifting — if their distro inference diverged, a
+/// path could `stat` as existing yet fail to open (or vice versa). (#282)
+pub fn resolve_address_path(path: &str, wsl_distro: Option<&str>) -> String {
+    let distro = wsl_distro.map(str::to_string).or_else(|| {
+        if cfg!(windows) && path.starts_with('/') && !path.starts_with("/mnt/") {
+            get_default_wsl_distro()
+        } else {
+            None
+        }
+    });
+    resolve_path_for_windows(path, distro.as_deref())
+}
+
 /// Extract WSL distro name from a raw path (before normalization).
 /// Handles `//wsl.localhost/<distro>/path` and `//wsl$/<distro>/path` formats.
 pub fn extract_wsl_distro_from_path(path: &str) -> Option<String> {
@@ -356,6 +377,28 @@ mod tests {
             resolve_path_for_windows("/home/user", Some("Ubuntu")),
             "\\\\wsl.localhost\\Ubuntu\\home\\user"
         );
+    }
+
+    #[test]
+    fn resolve_address_path_explicit_distro_unc() {
+        // An explicit distro wins and yields a UNC path (same as the underlying
+        // resolve_path_for_windows) — shared by stat_path/list_directory.
+        assert_eq!(
+            resolve_address_path("/home/user", Some("Ubuntu")),
+            "\\\\wsl.localhost\\Ubuntu\\home\\user"
+        );
+    }
+
+    #[test]
+    fn resolve_address_path_mnt_to_windows() {
+        // /mnt/x paths need no distro and map straight to a drive path.
+        assert_eq!(resolve_address_path("/mnt/c/Users", None), "C:\\Users");
+    }
+
+    #[test]
+    fn resolve_address_path_windows_passthrough() {
+        // Already-Windows paths pass through unchanged regardless of distro.
+        assert_eq!(resolve_address_path("C:\\Users", None), "C:\\Users");
     }
 
     #[test]

--- a/ui/src/components/views/FileExplorerView.tsx
+++ b/ui/src/components/views/FileExplorerView.tsx
@@ -6,12 +6,18 @@ import {
   clipboardWriteText,
   listDirectory,
   getHomeDirectory,
+  statPath,
   onTerminalCwdChanged,
   handleLxMessage,
   type DirEntry,
 } from "@/lib/tauri-api";
 // convertFileSrc no longer needed — images are returned as data URLs
-import { joinPath, parentPath } from "@/lib/file-explorer-parse";
+import {
+  joinPath,
+  parentPath,
+  normalizeAddressInput,
+  resolveAddressNavigation,
+} from "@/lib/file-explorer-parse";
 import { ViewShell } from "@/components/ui/ViewShell";
 import { ViewHeader } from "@/components/ui/ViewHeader";
 import { ViewBody } from "@/components/ui/ViewBody";
@@ -47,6 +53,12 @@ export function FileExplorerView({
   const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
   const [focusIndex, setFocusIndex] = useState(0);
   const [lastClickIndex, setLastClickIndex] = useState(0);
+
+  // --- Editable address bar (#278) ---
+  const [addressEditing, setAddressEditing] = useState(false);
+  const [addressValue, setAddressValue] = useState("");
+  const [addressError, setAddressError] = useState(false);
+  const addressInputRef = useRef<HTMLInputElement>(null);
 
   // --- History stack for back/forward navigation ---
   const [history, setHistory] = useState<string[]>(lastCwd ? [lastCwd] : []);
@@ -324,6 +336,77 @@ export function FileExplorerView({
     [navigateToDir, openFile],
   );
 
+  // --- Address bar: begin editing (click/focus) ---
+  const beginAddressEdit = useCallback(() => {
+    setAddressValue(currentCwdRef.current);
+    setAddressError(false);
+    setAddressEditing(true);
+  }, []);
+
+  // --- Address bar: cancel editing (Esc / blur) → revert to current path ---
+  const cancelAddressEdit = useCallback(() => {
+    setAddressEditing(false);
+    setAddressError(false);
+  }, []);
+
+  // --- Address bar: commit (Enter) ---
+  // Validates the typed/pasted path against the Rust backend, then either
+  // navigates to a directory, or navigates to a file's parent + opens the file
+  // in the shared viewer. Invalid paths keep the editor open and flag an error.
+  const commitAddress = useCallback(async () => {
+    const normalized = normalizeAddressInput(addressValue);
+    if (!normalized) {
+      setAddressError(true);
+      return;
+    }
+    let info: { exists: boolean; isDirectory: boolean };
+    try {
+      info = await statPath(normalized);
+    } catch {
+      info = { exists: false, isDirectory: false };
+    }
+    const action = resolveAddressNavigation(normalized, info);
+    if (action.kind === "invalid") {
+      setAddressError(true);
+      return;
+    }
+    setAddressEditing(false);
+    setAddressError(false);
+    if (action.kind === "navigate") {
+      navigateTo(action.dir);
+    } else {
+      // File: move into its directory AND open it in the shared viewer (#278).
+      navigateTo(action.dir);
+      openFileViewer(action.file);
+    }
+  }, [addressValue, navigateTo, openFileViewer]);
+
+  // --- Focus the input when entering edit mode ---
+  useEffect(() => {
+    if (addressEditing) {
+      const input = addressInputRef.current;
+      if (input) {
+        input.focus();
+        input.select();
+      }
+    }
+  }, [addressEditing]);
+
+  const handleAddressKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // Keep arrow/typing keys from reaching the list's keyboard handler.
+      e.stopPropagation();
+      if (e.key === "Enter") {
+        e.preventDefault();
+        void commitAddress();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        cancelAddressEdit();
+      }
+    },
+    [commitAddress, cancelAddressEdit],
+  );
+
   // --- Scroll focused item into view ---
   const scrollToIndex = useCallback((index: number) => {
     const list = listRef.current;
@@ -525,9 +608,39 @@ export function FileExplorerView({
         >
           →
         </button>
-        <span className="text-xs truncate ml-1" style={{ color: "var(--text-primary)" }}>
-          {currentCwd || "..."}
-        </span>
+        {addressEditing ? (
+          <input
+            ref={addressInputRef}
+            type="text"
+            className="text-xs ml-1 flex-1 min-w-0 outline-none rounded px-1"
+            style={{
+              background: "var(--bg-base)",
+              color: "var(--text-primary)",
+              border: addressError ? "1px solid var(--red)" : "1px solid var(--accent)",
+            }}
+            value={addressValue}
+            spellCheck={false}
+            autoComplete="off"
+            data-testid="file-explorer-address-input"
+            aria-invalid={addressError}
+            onChange={(e) => {
+              setAddressValue(e.target.value);
+              if (addressError) setAddressError(false);
+            }}
+            onKeyDown={handleAddressKeyDown}
+            onBlur={cancelAddressEdit}
+          />
+        ) : (
+          <span
+            className="text-xs truncate ml-1 flex-1 min-w-0 cursor-text"
+            style={{ color: "var(--text-primary)" }}
+            data-testid="file-explorer-address"
+            title="Click to edit path"
+            onClick={beginAddressEdit}
+          >
+            {currentCwd || "..."}
+          </span>
+        )}
       </ViewHeader>
 
       <ViewBody ref={listRef} style={listStyle} testId="file-explorer-list">

--- a/ui/src/components/views/FileExplorerView.tsx
+++ b/ui/src/components/views/FileExplorerView.tsx
@@ -59,6 +59,10 @@ export function FileExplorerView({
   const [addressValue, setAddressValue] = useState("");
   const [addressError, setAddressError] = useState(false);
   const addressInputRef = useRef<HTMLInputElement>(null);
+  // Monotonic token for the in-flight address commit. Bumped on every commit
+  // start and on cancel (Esc/blur), so a slow `statPath` that resolves after the
+  // user moved on can detect it is stale and skip navigating. (#282)
+  const commitSeqRef = useRef(0);
 
   // --- History stack for back/forward navigation ---
   const [history, setHistory] = useState<string[]>(lastCwd ? [lastCwd] : []);
@@ -345,6 +349,8 @@ export function FileExplorerView({
 
   // --- Address bar: cancel editing (Esc / blur) → revert to current path ---
   const cancelAddressEdit = useCallback(() => {
+    // Invalidate any in-flight commit so a late statPath can't navigate.
+    commitSeqRef.current += 1;
     setAddressEditing(false);
     setAddressError(false);
   }, []);
@@ -359,12 +365,17 @@ export function FileExplorerView({
       setAddressError(true);
       return;
     }
+    const seq = (commitSeqRef.current += 1);
     let info: { exists: boolean; isDirectory: boolean };
     try {
       info = await statPath(normalized);
     } catch {
       info = { exists: false, isDirectory: false };
     }
+    // Stale guard: if the user cancelled (Esc/blur) or fired a newer commit
+    // while statPath was in flight, discard this result so it can't navigate
+    // or open a viewer behind the user's back. (#282)
+    if (seq !== commitSeqRef.current) return;
     const action = resolveAddressNavigation(normalized, info);
     if (action.kind === "invalid") {
       setAddressError(true);
@@ -636,7 +647,17 @@ export function FileExplorerView({
             style={{ color: "var(--text-primary)" }}
             data-testid="file-explorer-address"
             title="Click to edit path"
+            role="button"
+            tabIndex={0}
+            aria-label="Edit path"
             onClick={beginAddressEdit}
+            onKeyDown={(e) => {
+              // Keyboard users enter edit mode with Enter/Space (#282 a11y).
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                beginAddressEdit();
+              }
+            }}
           >
             {currentCwd || "..."}
           </span>

--- a/ui/src/lib/file-explorer-parse.test.ts
+++ b/ui/src/lib/file-explorer-parse.test.ts
@@ -74,6 +74,13 @@ describe("parentPath", () => {
   it("handles windows paths", () => {
     expect(parentPath("C:\\Users\\me\\project")).toBe("C:\\Users\\me");
   });
+
+  it("returns the drive root (with trailing separator) for a file at drive root", () => {
+    // "C:\foo.txt"'s parent is the drive root "C:\", not "C:" — the latter is a
+    // drive-relative cwd on Windows and would not navigate predictably.
+    expect(parentPath("C:\\foo.txt")).toBe("C:\\");
+    expect(parentPath("C:\\dir")).toBe("C:\\");
+  });
 });
 
 describe("normalizeAddressInput", () => {
@@ -145,6 +152,14 @@ describe("resolveAddressNavigation", () => {
       kind: "open-file",
       dir: "C:\\Users\\me",
       file: "C:\\Users\\me\\notes.txt",
+    });
+  });
+
+  it("opens a file at the drive root, navigating to the drive root itself", () => {
+    expect(resolveAddressNavigation("C:\\foo.txt", { exists: true, isDirectory: false })).toEqual({
+      kind: "open-file",
+      dir: "C:\\",
+      file: "C:\\foo.txt",
     });
   });
 

--- a/ui/src/lib/file-explorer-parse.test.ts
+++ b/ui/src/lib/file-explorer-parse.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { shellEscape, joinPath, parentPath } from "./file-explorer-parse";
+import {
+  shellEscape,
+  joinPath,
+  parentPath,
+  normalizeAddressInput,
+  resolveAddressNavigation,
+} from "./file-explorer-parse";
 
 describe("shellEscape", () => {
   it("wraps simple string in single quotes", () => {
@@ -67,5 +73,84 @@ describe("parentPath", () => {
 
   it("handles windows paths", () => {
     expect(parentPath("C:\\Users\\me\\project")).toBe("C:\\Users\\me");
+  });
+});
+
+describe("normalizeAddressInput", () => {
+  it("trims surrounding whitespace", () => {
+    expect(normalizeAddressInput("  /home/user  ")).toBe("/home/user");
+  });
+
+  it("strips a single pair of wrapping double quotes", () => {
+    expect(normalizeAddressInput('"C:\\Users\\me"')).toBe("C:\\Users\\me");
+  });
+
+  it("strips a single pair of wrapping single quotes", () => {
+    expect(normalizeAddressInput("'/home/user/file name.txt'")).toBe("/home/user/file name.txt");
+  });
+
+  it("strips quotes after trimming whitespace", () => {
+    expect(normalizeAddressInput('  "/home/user"  ')).toBe("/home/user");
+  });
+
+  it("removes a single trailing path separator (but keeps roots)", () => {
+    expect(normalizeAddressInput("/home/user/")).toBe("/home/user");
+    expect(normalizeAddressInput("C:\\Users\\me\\")).toBe("C:\\Users\\me");
+  });
+
+  it("preserves unix root", () => {
+    expect(normalizeAddressInput("/")).toBe("/");
+  });
+
+  it("preserves windows drive root trailing separator", () => {
+    expect(normalizeAddressInput("C:\\")).toBe("C:\\");
+  });
+
+  it("returns empty string for blank input", () => {
+    expect(normalizeAddressInput("   ")).toBe("");
+    expect(normalizeAddressInput("")).toBe("");
+  });
+});
+
+describe("resolveAddressNavigation", () => {
+  it("rejects empty input", () => {
+    expect(resolveAddressNavigation("", { exists: true, isDirectory: true })).toEqual({
+      kind: "invalid",
+    });
+  });
+
+  it("rejects a non-existent path", () => {
+    expect(
+      resolveAddressNavigation("/no/such/path", { exists: false, isDirectory: false }),
+    ).toEqual({ kind: "invalid" });
+  });
+
+  it("navigates to a directory", () => {
+    expect(resolveAddressNavigation("/home/user", { exists: true, isDirectory: true })).toEqual({
+      kind: "navigate",
+      dir: "/home/user",
+    });
+  });
+
+  it("navigates to the parent and opens the file when input is a file", () => {
+    expect(
+      resolveAddressNavigation("/home/user/notes.txt", { exists: true, isDirectory: false }),
+    ).toEqual({ kind: "open-file", dir: "/home/user", file: "/home/user/notes.txt" });
+  });
+
+  it("opens a windows file, navigating to its directory", () => {
+    expect(
+      resolveAddressNavigation("C:\\Users\\me\\notes.txt", { exists: true, isDirectory: false }),
+    ).toEqual({
+      kind: "open-file",
+      dir: "C:\\Users\\me",
+      file: "C:\\Users\\me\\notes.txt",
+    });
+  });
+
+  it("normalizes the input before deciding (quoted file)", () => {
+    expect(
+      resolveAddressNavigation('  "/home/user/a.txt"  ', { exists: true, isDirectory: false }),
+    ).toEqual({ kind: "open-file", dir: "/home/user", file: "/home/user/a.txt" });
   });
 });

--- a/ui/src/lib/file-explorer-parse.ts
+++ b/ui/src/lib/file-explorer-parse.ts
@@ -20,3 +20,67 @@ export function parentPath(path: string): string {
   if (lastSep <= 0) return sep; // root
   return trimmed.slice(0, lastSep);
 }
+
+/**
+ * Normalize a path typed or pasted into the File Explorer address bar.
+ *
+ * - trims surrounding whitespace,
+ * - strips one layer of wrapping quotes (drag-and-drop / shell copy often yields
+ *   quoted paths — same convenience as the file viewer's {@link normalizeViewerPath}),
+ * - removes a single trailing separator while preserving roots ("/" and "C:\\").
+ *
+ * Returns "" for blank input so callers can treat it as "do nothing".
+ */
+export function normalizeAddressInput(raw: string): string {
+  if (typeof raw !== "string") return "";
+  let p = raw.trim();
+  if (p.length === 0) return "";
+  // Strip one layer of matching wrapping quotes (single or double).
+  if (
+    (p.startsWith('"') && p.endsWith('"') && p.length >= 2) ||
+    (p.startsWith("'") && p.endsWith("'") && p.length >= 2)
+  ) {
+    p = p.slice(1, -1).trim();
+  }
+  if (p.length === 0) return "";
+
+  // Drop a single trailing separator unless the result would be a root.
+  const sep = p.includes("\\") ? "\\" : "/";
+  if (p.endsWith(sep) && p.length > 1) {
+    const trimmed = p.slice(0, -1);
+    // Keep windows drive roots like "C:\" intact (trimming would give "C:").
+    const isDriveRoot = /^[A-Za-z]:$/.test(trimmed);
+    if (!isDriveRoot) p = trimmed;
+  }
+  return p;
+}
+
+/** Filesystem facts about an address-bar path, resolved by the Rust backend. */
+export interface AddressPathInfo {
+  exists: boolean;
+  isDirectory: boolean;
+}
+
+/** Decision for what an address-bar submission should do. */
+export type AddressNavigation =
+  | { kind: "invalid" }
+  | { kind: "navigate"; dir: string }
+  | { kind: "open-file"; dir: string; file: string };
+
+/**
+ * Decide what to do when the user submits a path in the address bar.
+ *
+ * - empty / non-existent → `invalid` (caller shows feedback, does not navigate),
+ * - directory → `navigate` to it,
+ * - file → `open-file`: navigate to the file's parent directory AND open the file
+ *   in the shared viewer (issue #278 convenience).
+ *
+ * Pure: filesystem facts are supplied via {@link AddressPathInfo} so this can be
+ * unit-tested without touching the backend.
+ */
+export function resolveAddressNavigation(raw: string, info: AddressPathInfo): AddressNavigation {
+  const path = normalizeAddressInput(raw);
+  if (!path || !info.exists) return { kind: "invalid" };
+  if (info.isDirectory) return { kind: "navigate", dir: path };
+  return { kind: "open-file", dir: parentPath(path), file: path };
+}

--- a/ui/src/lib/file-explorer-parse.ts
+++ b/ui/src/lib/file-explorer-parse.ts
@@ -1,3 +1,5 @@
+import { normalizeViewerPath } from "./file-viewer";
+
 /** Escape a string for safe use as a single-quoted shell argument. */
 export function shellEscape(s: string): string {
   // Wrap in single quotes; escape embedded single quotes as '\''
@@ -18,30 +20,24 @@ export function parentPath(path: string): string {
   const trimmed = path.endsWith(sep) ? path.slice(0, -1) : path;
   const lastSep = trimmed.lastIndexOf(sep);
   if (lastSep <= 0) return sep; // root
+  // Windows drive root: the parent of "C:\foo" is "C:\" (drive root), not "C:"
+  // — a bare "C:" is a drive-relative cwd and would not navigate predictably.
+  if (trimmed[lastSep - 1] === ":") return trimmed.slice(0, lastSep + 1);
   return trimmed.slice(0, lastSep);
 }
 
 /**
  * Normalize a path typed or pasted into the File Explorer address bar.
  *
- * - trims surrounding whitespace,
- * - strips one layer of wrapping quotes (drag-and-drop / shell copy often yields
- *   quoted paths — same convenience as the file viewer's {@link normalizeViewerPath}),
- * - removes a single trailing separator while preserving roots ("/" and "C:\\").
+ * Builds on the shared {@link normalizeViewerPath} core (trim + strip one layer
+ * of wrapping quotes — drag-and-drop / shell copy often yields quoted paths) and
+ * additionally removes a single trailing separator while preserving roots
+ * ("/" and "C:\\"). Sharing the core keeps the two entry points from drifting.
  *
  * Returns "" for blank input so callers can treat it as "do nothing".
  */
 export function normalizeAddressInput(raw: string): string {
-  if (typeof raw !== "string") return "";
-  let p = raw.trim();
-  if (p.length === 0) return "";
-  // Strip one layer of matching wrapping quotes (single or double).
-  if (
-    (p.startsWith('"') && p.endsWith('"') && p.length >= 2) ||
-    (p.startsWith("'") && p.endsWith("'") && p.length >= 2)
-  ) {
-    p = p.slice(1, -1).trim();
-  }
+  let p = normalizeViewerPath(raw);
   if (p.length === 0) return "";
 
   // Drop a single trailing separator unless the result would be a root.

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -417,6 +417,21 @@ export async function listDirectory(path: string, wslDistro?: string): Promise<D
   return invoke("list_directory", { path, wslDistro: wslDistro ?? null });
 }
 
+/** Filesystem facts about a path (used by the File Explorer address bar, #278). */
+export interface PathInfo {
+  exists: boolean;
+  isDirectory: boolean;
+}
+
+/**
+ * Resolve a path (WSL/Windows translation handled by the backend) and report
+ * whether it exists and is a directory. Never throws on a missing path —
+ * returns `{ exists: false }` so the caller can show validation feedback.
+ */
+export async function statPath(path: string, wslDistro?: string): Promise<PathInfo> {
+  return invoke("stat_path", { path, wslDistro: wslDistro ?? null });
+}
+
 /** Resolve the user's home directory (fallback CWD for File Explorer). */
 export async function getHomeDirectory(): Promise<string> {
   return invoke("get_home_directory");


### PR DESCRIPTION
@
## 요약
explorer 주소창을 편집 가능하게 하고, 경로 입력/붙여넣기 후 Enter로 이동한다. 파일 경로면 부모 디렉터리로 이동한 뒤 통일 뷰어로 즉시 연다.

> **스택 PR**: base가 `fix/277-279-file-viewer`(#281)이다. #281의 통일 뷰어(`openFileViewer`)를 재사용하기 때문. #281 머지 후 이 PR을 머지하거나, base를 main으로 재지정.

## 변경 사항
- `ui/src/lib/file-explorer-parse.ts` — 순수 로직: `normalizeAddressInput`(트림/따옴표/후행 구분자 제거), `resolveAddressNavigation`(디렉터리→navigate / 파일→부모이동+open / 무효→invalid)
- `ui/src/components/views/FileExplorerView.tsx` — 주소창을 편집 input으로 전환. 클릭 시 편집, Enter 커밋, Esc/blur 취소(원래 경로 복원), 무효 경로는 빨간 테두리(`--red`) 피드백
- `ui/src/lib/tauri-api.ts` — `statPath()` + `PathInfo` 타입
- `src-tauri/src/commands/file_ops.rs` — `stat_path` 커맨드(WSL/Windows 경로 변환, 없는 경로는 `exists:false`) + Rust 테스트 3개
- `src-tauri/src/lib.rs` — 커맨드 등록
- `ARCHITECTURE.md` — FileExplorerView 설명 갱신

## 통일 뷰어 재사용
파일 입력 시 새 뷰어를 만들지 않고 `useFileViewerStore.openFileViewer(file)`를 호출. `resolveAddressNavigation`이 `open-file`이면 `navigateTo(parent)` 후 `openFileViewer(file)`로 #277/#279 통합 오버레이를 연다.

## CWD 설계 준수
디렉터리 이동은 기존 `navigateTo` 재사용 → history push + syncGroup CWD 전파(`sync-cwd`) 그대로 동작. 백그라운드 셸 없이 파일시스템 접근은 Rust(`stat_path`)로 처리.

## 테스트
- 프론트: vitest 1912 통과, `tsc --noEmit`/eslint clean, `vite build` 성공
- 백엔드: `cargo test stat_path` 3개 통과

## 주의
- 시각적 스크린샷 검증은 dev 인스턴스 미실행으로 미수행(단위 테스트+타입체크+빌드로 검증). 실제 화면 확인 권장
- WSL distro는 기존 `list_directory`와 동일하게 백엔드 auto-detect에 의존

Fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@