### PR TITLE
파일 뷰어 '어디서나 열기' 경로 입력을 window.prompt → 인라인 입력 필드로 대체

### DIFF
--- a/ui/src/components/layout/FileViewerOverlay.test.tsx
+++ b/ui/src/components/layout/FileViewerOverlay.test.tsx
@@ -91,6 +91,80 @@ describe("FileViewerOverlay", () => {
     expect(useFileViewerStore.getState().open).toBe(false);
   });
 
+  // --- #283: inline path input (empty / "open anywhere" mode) ---
+  it("shows an autofocused inline path input when opened with no path", () => {
+    act(() => {
+      useFileViewerStore.getState().openEmptyFileViewer();
+    });
+    render(<FileViewerOverlay />);
+    const input = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveFocus();
+    // No file is loaded yet, so the viewer body must not be mounted.
+    expect(screen.queryByTestId("mock-file-viewer")).not.toBeInTheDocument();
+  });
+
+  it("loads the file when a path is typed and Enter is pressed", () => {
+    act(() => {
+      useFileViewerStore.getState().openEmptyFileViewer();
+    });
+    render(<FileViewerOverlay />);
+    const input = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "  /home/user/note.txt  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const s = useFileViewerStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.path).toBe("/home/user/note.txt");
+    // The viewer body now renders the loaded file; the input is gone.
+    expect(screen.getByTestId("mock-file-viewer")).toBeInTheDocument();
+    expect(screen.queryByTestId("file-viewer-overlay-path-input")).not.toBeInTheDocument();
+  });
+
+  it("loads the file when the load button is clicked", () => {
+    act(() => {
+      useFileViewerStore.getState().openEmptyFileViewer();
+    });
+    render(<FileViewerOverlay />);
+    const input = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "/home/user/b.txt" } });
+    fireEvent.click(screen.getByTestId("file-viewer-overlay-path-submit"));
+    expect(useFileViewerStore.getState().path).toBe("/home/user/b.txt");
+  });
+
+  it("does not load a blank path", () => {
+    act(() => {
+      useFileViewerStore.getState().openEmptyFileViewer();
+    });
+    render(<FileViewerOverlay />);
+    const input = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    // Still empty mode — input remains, nothing loaded.
+    expect(useFileViewerStore.getState().path).toBe("");
+    expect(screen.getByTestId("file-viewer-overlay-path-input")).toBeInTheDocument();
+  });
+
+  it("Escape closes the overlay while in empty (inline input) mode", () => {
+    act(() => {
+      useFileViewerStore.getState().openEmptyFileViewer();
+    });
+    render(<FileViewerOverlay />);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(useFileViewerStore.getState().open).toBe(false);
+  });
+
+  it("does not show the inline input once a file is loaded", () => {
+    act(() => {
+      useFileViewerStore.getState().openFileViewer("/home/user/a.txt");
+    });
+    render(<FileViewerOverlay />);
+    expect(screen.queryByTestId("file-viewer-overlay-path-input")).not.toBeInTheDocument();
+    expect(screen.getByTestId("mock-file-viewer")).toBeInTheDocument();
+  });
+
   it("forwards a per-path viewer instance id so a new path remounts the viewer terminal", () => {
     act(() => {
       useFileViewerStore.getState().openFileViewer("/home/user/a.txt");

--- a/ui/src/components/layout/FileViewerOverlay.tsx
+++ b/ui/src/components/layout/FileViewerOverlay.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useFileViewerStore } from "@/stores/file-viewer-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { FileViewer } from "@/components/ui/FileViewer";
+import { FocusInput } from "@/components/ui/FormControls";
 import { resolveViewer } from "@/lib/file-viewer";
 
 /**
@@ -18,10 +19,33 @@ export function FileViewerOverlay() {
   const maximized = useFileViewerStore((s) => s.maximized);
   const closeFileViewer = useFileViewerStore((s) => s.closeFileViewer);
   const toggleMaximized = useFileViewerStore((s) => s.toggleMaximized);
+  const openFileViewer = useFileViewerStore((s) => s.openFileViewer);
 
   const defaultProfile = useSettingsStore((s) => s.defaultProfile);
   const feSettings = useSettingsStore((s) => s.fileExplorer);
   const extensionViewers = useSettingsStore((s) => s.fileExplorer.extensionViewers);
+
+  // Empty-path "open anywhere" mode (#283): the overlay is open but no file is
+  // loaded yet, so we show an inline path input field at the top instead of a
+  // native window.prompt (unreliable on WebView2, not driveable via the
+  // Automation API). Submitting a non-blank path loads it in the same viewer.
+  // The input is uncontrolled (read via ref on submit) so we don't need to
+  // mirror keystrokes into React state — this also keeps the focus effect free
+  // of setState (react-hooks/set-state-in-effect).
+  const promptMode = open && path === "";
+  const pathInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus the field each time we (re)enter prompt mode. Keying the input by
+  // `promptMode` (below) remounts it empty, so no draft reset is needed.
+  useEffect(() => {
+    if (promptMode) pathInputRef.current?.focus();
+  }, [promptMode]);
+
+  const submitPath = () => {
+    // openFileViewer normalizes and rejects blank input, so a blank submit
+    // simply keeps the overlay in prompt mode.
+    openFileViewer(pathInputRef.current?.value ?? "");
+  };
 
   // When the file is shown via an external command (e.g. .txt→vi, video→mpv),
   // FileViewer renders a live TerminalView. In that mode Esc and a backdrop
@@ -81,13 +105,49 @@ export function FileViewerOverlay() {
           className="flex items-center px-3 py-2"
           style={{ borderBottom: "1px solid var(--border)" }}
         >
-          <span
-            className="flex-1 truncate text-xs"
-            style={{ color: "var(--text-primary)" }}
-            data-testid="file-viewer-overlay-path"
-          >
-            {path}
-          </span>
+          {promptMode ? (
+            <div className="flex flex-1 items-center gap-2">
+              <FocusInput
+                key="file-viewer-path-input"
+                ref={pathInputRef}
+                defaultValue=""
+                autoFocus
+                onKeyDown={(e) => {
+                  // Enter submits; Escape is handled by the global handler below
+                  // so we let it bubble (it closes the overlay).
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    submitPath();
+                  }
+                }}
+                placeholder="Open file (absolute path)…"
+                spellCheck={false}
+                autoComplete="off"
+                aria-label="File path"
+                data-testid="file-viewer-overlay-path-input"
+              />
+              <button
+                onClick={submitPath}
+                className="hover-bg-strong rounded px-2 py-1 text-xs"
+                style={{
+                  color: "var(--text-primary)",
+                  border: "1px solid var(--border)",
+                  cursor: "pointer",
+                }}
+                data-testid="file-viewer-overlay-path-submit"
+              >
+                Load
+              </button>
+            </div>
+          ) : (
+            <span
+              className="flex-1 truncate text-xs"
+              style={{ color: "var(--text-primary)" }}
+              data-testid="file-viewer-overlay-path"
+            >
+              {path}
+            </span>
+          )}
           <button
             onClick={toggleMaximized}
             className="hover-bg-strong ml-2 flex h-6 w-6 items-center justify-center rounded text-xs"
@@ -108,19 +168,29 @@ export function FileViewerOverlay() {
           </button>
         </div>
         <div className="min-h-0 flex-1 overflow-auto">
-          <FileViewer
-            path={path}
-            profile={defaultProfile}
-            // Key the viewer terminal by path so re-opening a different file
-            // (MCP/REST/Explorer can swap `path` without closing first) rebuilds
-            // the TerminalView instead of reusing the previous file's session.
-            // The session-spawn effect keys off instanceId, so a fresh id tears
-            // down the old PTY and runs the new startup command. Web viewers
-            // ignore the id, so this is harmless for them.
-            viewerInstanceId={`global-file-viewer:${path}`}
-            isFocused
-            bodyStyle={bodyStyle}
-          />
+          {promptMode ? (
+            <div
+              className="flex h-full items-center justify-center px-6 text-center text-xs"
+              style={{ color: "var(--text-secondary)" }}
+              data-testid="file-viewer-overlay-empty"
+            >
+              Enter an absolute file path above and press Enter to open it here.
+            </div>
+          ) : (
+            <FileViewer
+              path={path}
+              profile={defaultProfile}
+              // Key the viewer terminal by path so re-opening a different file
+              // (MCP/REST/Explorer can swap `path` without closing first) rebuilds
+              // the TerminalView instead of reusing the previous file's session.
+              // The session-spawn effect keys off instanceId, so a fresh id tears
+              // down the old PTY and runs the new startup command. Web viewers
+              // ignore the id, so this is harmless for them.
+              viewerInstanceId={`global-file-viewer:${path}`}
+              isFocused
+              bodyStyle={bodyStyle}
+            />
+          )}
         </div>
       </div>
     </div>,

--- a/ui/src/components/layout/FileViewerOverlay.tsx
+++ b/ui/src/components/layout/FileViewerOverlay.tsx
@@ -35,8 +35,9 @@ export function FileViewerOverlay() {
   const promptMode = open && path === "";
   const pathInputRef = useRef<HTMLInputElement>(null);
 
-  // Focus the field each time we (re)enter prompt mode. Keying the input by
-  // `promptMode` (below) remounts it empty, so no draft reset is needed.
+  // Focus the field each time we (re)enter prompt mode. The conditional render
+  // below swaps the input for the path <span> when prompt mode ends, so each new
+  // prompt session mounts a fresh empty input — no draft reset is needed.
   useEffect(() => {
     if (promptMode) pathInputRef.current?.focus();
   }, [promptMode]);
@@ -127,6 +128,7 @@ export function FileViewerOverlay() {
                 data-testid="file-viewer-overlay-path-input"
               />
               <button
+                type="button"
                 onClick={submitPath}
                 className="hover-bg-strong rounded px-2 py-1 text-xs"
                 style={{

--- a/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -280,6 +280,37 @@ describe("useKeyboardShortcuts", () => {
     promptSpy.mockRestore();
   });
 
+  it("Ctrl+Shift+O does not tear down an in-progress terminal viewer", () => {
+    // A terminal-backed viewer (.txt→vi, video→mpv) holds a live PTY session.
+    // Like Esc and a backdrop click, the "open anywhere" shortcut must not
+    // silently discard it — the user closes such viewers with the explicit ✕.
+    const fe = useSettingsStore.getState().fileExplorer;
+    useSettingsStore.setState({
+      fileExplorer: { ...fe, extensionViewers: [{ extensions: [".txt"], command: "vi" }] },
+    });
+    useFileViewerStore.setState({ open: true, path: "/tmp/notes.txt", maximized: false });
+    renderHook(() => useKeyboardShortcuts());
+
+    fireKey("O", { ctrlKey: true, shiftKey: true });
+
+    const s = useFileViewerStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.path).toBe("/tmp/notes.txt"); // unchanged — terminal session preserved
+  });
+
+  it("Ctrl+Shift+O re-prompts when a web viewer is open (no PTY to protect)", () => {
+    // Built-in web viewers (text/image/binary) have no live session, so the
+    // shortcut may reset to empty prompt mode just as Esc may close them.
+    const fe = useSettingsStore.getState().fileExplorer;
+    useSettingsStore.setState({ fileExplorer: { ...fe, extensionViewers: [] } });
+    useFileViewerStore.setState({ open: true, path: "/tmp/pic.png", maximized: false });
+    renderHook(() => useKeyboardShortcuts());
+
+    fireKey("O", { ctrlKey: true, shiftKey: true });
+
+    expect(useFileViewerStore.getState().path).toBe("");
+  });
+
   // --- Ctrl+, : settings ---
   it("Ctrl+, toggles settings modal", () => {
     renderHook(() => useKeyboardShortcuts());

--- a/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -264,27 +264,19 @@ describe("useKeyboardShortcuts", () => {
     expect(useUiStore.getState().notificationPanelOpen).toBe(false);
   });
 
-  // --- Ctrl+Shift+O: open file viewer anywhere (#279) ---
-  it("Ctrl+Shift+O opens the file viewer with the prompted path", () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("/tmp/note.txt");
+  // --- Ctrl+Shift+O: open file viewer anywhere (#279 / #283) ---
+  it("Ctrl+Shift+O opens the viewer in empty (inline path input) mode", () => {
+    // #283: no native window.prompt — the overlay opens blank and shows an
+    // inline path input field that is driveable on every platform.
+    const promptSpy = vi.spyOn(window, "prompt");
     renderHook(() => useKeyboardShortcuts());
 
     fireKey("O", { ctrlKey: true, shiftKey: true });
 
-    expect(promptSpy).toHaveBeenCalled();
+    expect(promptSpy).not.toHaveBeenCalled();
     const s = useFileViewerStore.getState();
     expect(s.open).toBe(true);
-    expect(s.path).toBe("/tmp/note.txt");
-    promptSpy.mockRestore();
-  });
-
-  it("Ctrl+Shift+O does nothing when prompt is cancelled", () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue(null);
-    renderHook(() => useKeyboardShortcuts());
-
-    fireKey("O", { ctrlKey: true, shiftKey: true });
-
-    expect(useFileViewerStore.getState().open).toBe(false);
+    expect(s.path).toBe("");
     promptSpy.mockRestore();
   });
 

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -6,6 +6,7 @@ import { useNotificationStore } from "@/stores/notification-store";
 import { useUiStore } from "@/stores/ui-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useFileViewerStore } from "@/stores/file-viewer-store";
+import { resolveViewer } from "@/lib/file-viewer";
 import { matchesKeybinding } from "@/lib/keybinding-registry";
 import { sortWorkspaces, filterVisibleWorkspaces } from "@/lib/workspace-sort";
 import { findPaneInDirection, type Direction } from "@/lib/pane-navigation";
@@ -215,7 +216,19 @@ export function useKeyboardShortcuts() {
         // platform (Windows/WebView2) and is driveable via the Automation API.
         if (matchesKeybinding(e, "fileViewer.open")) {
           e.preventDefault();
-          useFileViewerStore.getState().openEmptyFileViewer();
+          // Don't tear down an in-progress terminal viewer (.txt→vi, video→mpv):
+          // like Esc and a backdrop click (see FileViewerOverlay), the "open
+          // anywhere" shortcut must not silently discard a live PTY session —
+          // the user closes such viewers with the explicit ✕. Web viewers have
+          // no session, so re-prompting is fine.
+          const fv = useFileViewerStore.getState();
+          if (fv.open && fv.path) {
+            const { extensionViewers } = useSettingsStore.getState().fileExplorer;
+            if (resolveViewer(fv.path, extensionViewers).viewerType === "terminal") {
+              return;
+            }
+          }
+          fv.openEmptyFileViewer();
           return;
         }
 

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -209,14 +209,13 @@ export function useKeyboardShortcuts() {
 
         // fileViewer.open (default Ctrl+Shift+O): open a file anywhere in the
         // unified viewer (#279). Registered in keybinding-registry so it is
-        // user-overridable and shown in Settings. Prompts for a path and opens
-        // it in the same floating viewer used by File Explorer.
+        // user-overridable and shown in Settings. Opens the floating viewer in
+        // empty (inline path input) mode (#283) — the overlay shows a path
+        // field instead of a native window.prompt, so it works on every
+        // platform (Windows/WebView2) and is driveable via the Automation API.
         if (matchesKeybinding(e, "fileViewer.open")) {
           e.preventDefault();
-          const input = window.prompt("Open file (absolute path):", "");
-          if (input !== null) {
-            useFileViewerStore.getState().openFileViewer(input);
-          }
+          useFileViewerStore.getState().openEmptyFileViewer();
           return;
         }
 

--- a/ui/src/stores/file-viewer-store.test.ts
+++ b/ui/src/stores/file-viewer-store.test.ts
@@ -49,4 +49,32 @@ describe("file-viewer-store", () => {
     expect(s.path).toBe("/tmp/b.txt");
     expect(s.maximized).toBe(false);
   });
+
+  it("opens an empty viewer (prompt mode) with no path", () => {
+    // #283: Ctrl+Shift+O opens the overlay with a blank inline path input
+    // instead of a native window.prompt dialog.
+    const ok = useFileViewerStore.getState().openEmptyFileViewer();
+    expect(ok).toBe(true);
+    const s = useFileViewerStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.path).toBe("");
+    expect(s.maximized).toBe(false);
+  });
+
+  it("openEmptyFileViewer does not clobber a maximized request", () => {
+    useFileViewerStore.getState().openEmptyFileViewer({ maximized: true });
+    const s = useFileViewerStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.path).toBe("");
+    expect(s.maximized).toBe(true);
+  });
+
+  it("loading a path from the empty viewer fills it in", () => {
+    useFileViewerStore.getState().openEmptyFileViewer();
+    const ok = useFileViewerStore.getState().openFileViewer("/tmp/c.txt");
+    expect(ok).toBe(true);
+    const s = useFileViewerStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.path).toBe("/tmp/c.txt");
+  });
 });

--- a/ui/src/stores/file-viewer-store.ts
+++ b/ui/src/stores/file-viewer-store.ts
@@ -23,10 +23,18 @@ interface FileViewerState {
 
   /**
    * Open the viewer for `path`. Returns false (and does nothing) when the path
-   * normalizes to empty, so callers (shortcut prompt, MCP tool) can report a
+   * normalizes to empty, so callers (MCP tool, REST/automation) can report a
    * validation error.
    */
   openFileViewer: (path: string, opts?: { maximized?: boolean }) => boolean;
+  /**
+   * Open the overlay with no file loaded (#283). The overlay then shows an
+   * inline path input field instead of a native `window.prompt`, so the
+   * "open anywhere" shortcut (Ctrl+Shift+O) works on every platform and is
+   * driveable via the Automation API. Always succeeds. Call `openFileViewer`
+   * once the user submits a path.
+   */
+  openEmptyFileViewer: (opts?: { maximized?: boolean }) => boolean;
   closeFileViewer: () => void;
   toggleMaximized: () => void;
 }
@@ -42,6 +50,11 @@ export const useFileViewerStore = create<FileViewerState>()((set) => ({
     set({ open: true, path: normalized, maximized: opts?.maximized ?? false });
     return true;
   },
+  openEmptyFileViewer: (opts) => {
+    set({ open: true, path: "", maximized: opts?.maximized ?? false });
+    return true;
+  },
+
   closeFileViewer: () => set({ open: false, path: "" }),
   toggleMaximized: () => set((s) => ({ maximized: !s.maximized })),
 }));


### PR DESCRIPTION
## 개요
`#283` — 파일 뷰어 '어디서나 열기'(Ctrl+Shift+O, `fileViewer.open`)의 경로 입력을 `window.prompt`에서 오버레이 상단 인라인 입력 필드로 대체합니다.

## 배경
`#281`(전역 플로팅 파일 뷰어)의 PR 리뷰에서 `window.prompt` 사용에 다음 문제가 지적되었습니다.
- **플랫폼 신뢰성**: Windows/WebView2에서 `window.prompt` 동작이 보장되지 않음
- **자동화 불가**: 네이티브 블로킹 다이얼로그는 Automation API로 트리거/검증 불가 — '자동화 우선' 원칙과 충돌
- **UX**: 절대 경로 수동 타이핑 흐름이 번거로움

## 변경 내용
- `file-viewer-store.ts` — 빈 경로로 오버레이를 여는 `openEmptyFileViewer()` 액션 추가
- `FileViewerOverlay.tsx` — path가 빈 문자열(prompt 모드)일 때 헤더에 autofocus 입력 필드 + Load 버튼 렌더링. Enter/버튼으로 `openFileViewer` 호출. 입력은 uncontrolled(ref)로 처리하여 effect 내 setState 회피
- `useKeyboardShortcuts.ts` — `window.prompt` 제거, `openEmptyFileViewer()` 호출로 변경

## 설계 원칙 준수 (ARCHITECTURE §15)
- 공유 컴포넌트 `FocusInput`(`components/ui/FormControls`) 재사용
- 색상은 CSS 변수(`--text-primary`, `--border`), hover는 `.hover-bg-strong` 클래스 사용
- 키바인딩은 기존 `matchesKeybinding("fileViewer.open")` 경로 유지(재바인딩 가능)

## 테스트 결과
- 영향받은 4개 스위트(file-viewer-store, FileViewerOverlay, useKeyboardShortcuts, useAutomationBridge): **169 passed**
- 전체 UI 테스트: **1943 passed (80 files)**
- `tsc --noEmit`: 통과 / ESLint: 통과 / pre-commit 훅(prettier + eslint --fix): 통과
- 검증 테스트: 자동 포커스, Enter 제출, 버튼 제출, 빈 경로 거부, Escape 닫기, 파일 로드 후 입력 필드 사라짐

## 주의사항
- dev 자동화 인스턴스(포트 19281)가 실행 중이 아니어서 스크린샷/API 검증은 미수행. 이슈 fallback 지침에 따라 vitest 단위 테스트로 인라인 입력 동작을 검증했습니다.
- Automation API의 `openFileViewer`(경로 필수)는 그대로 유지 — 인라인 입력은 별도 `openEmptyFileViewer` 경로 사용으로 기존 자동화 동작 무영향.

Fixes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)
