### PR TITLE
fix: 패널 드래그 리사이즈 시 터미널 스크롤백 손상 수정 (#285)

### DIFF
--- a/src-tauri/src/automation_server/handlers_bridge.rs
+++ b/src-tauri/src/automation_server/handlers_bridge.rs
@@ -1,4 +1,4 @@
-use axum::extract::{Path, State as AxumState};
+use axum::extract::{Path, Query, State as AxumState};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
@@ -301,6 +301,43 @@ pub async fn panes_remove(
         "panes",
         "remove",
         serde_json::json!({ "paneIndex": index }),
+    )
+    .await
+    {
+        Ok(data) => (StatusCode::OK, Json(data)),
+        Err(e) => e,
+    }
+}
+
+/// Resize a pane by a width/height delta (fraction of the grid). Used to
+/// drive fine-grained, drag-like resize sequences for reflow verification
+/// (issue #285). Body: { "dw": <f64>, "dh": <f64> } — either optional.
+pub async fn panes_resize(
+    AxumState(state): AxumState<ServerState>,
+    Path(index): Path<usize>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let mut delta = serde_json::json!({});
+    if let Some(dw) = body.get("dw").and_then(|v| v.as_f64()) {
+        delta["w"] = serde_json::json!(dw);
+    }
+    if let Some(dh) = body.get("dh").and_then(|v| v.as_f64()) {
+        delta["h"] = serde_json::json!(dh);
+    }
+    if delta.as_object().map(|o| o.is_empty()).unwrap_or(true) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(err_json(
+                "at least one of 'dw' or 'dh' (number) is required",
+            )),
+        );
+    }
+    match bridge_request(
+        &state,
+        "action",
+        "panes",
+        "resize",
+        serde_json::json!({ "paneIndex": index, "delta": delta }),
     )
     .await
     {
@@ -635,6 +672,26 @@ pub async fn terminals_set_focus(
     )
     .await
     {
+        Ok(data) => (StatusCode::OK, Json(data)),
+        Err(e) => e,
+    }
+}
+
+/// Dump xterm's reflowed line buffer (text + isWrapped) for a terminal.
+/// Reflects xterm's own wrapping model after a resize — used to verify
+/// ConPTY scrollback reflow on width changes (issue #285) without screenshots.
+pub async fn terminal_buffer_dump(
+    AxumState(state): AxumState<ServerState>,
+    Path(id): Path<String>,
+    Query(q): Query<BufferDumpQuery>,
+) -> impl IntoResponse {
+    let mut params = serde_json::json!({ "id": id });
+    // Forward the line cap to the frontend (0 = whole buffer). Without this the
+    // JS handler always falls back to its default, so `?limit=` was ignored.
+    if let Some(limit) = q.limit {
+        params["limit"] = serde_json::json!(limit);
+    }
+    match bridge_request(&state, "query", "terminals", "dumpBuffer", params).await {
         Ok(data) => (StatusCode::OK, Json(data)),
         Err(e) => e,
     }

--- a/src-tauri/src/automation_server/mod.rs
+++ b/src-tauri/src/automation_server/mod.rs
@@ -193,6 +193,7 @@ pub fn build_router(state: ServerState, subscriptions: SharedSubscriptionRegistr
         .route("/api/v1/grid/hover", post(grid_simulate_hover))
         .route("/api/v1/panes/split", post(panes_split))
         .route("/api/v1/panes/{index}", delete(panes_remove))
+        .route("/api/v1/panes/{index}/resize", post(panes_resize))
         .route("/api/v1/panes/{index}/view", put(panes_set_view))
         .route("/api/v1/docks", get(docks_list))
         .route(
@@ -221,6 +222,7 @@ pub fn build_router(state: ServerState, subscriptions: SharedSubscriptionRegistr
         .route("/api/v1/terminals", get(terminals_list))
         .route("/api/v1/terminals/{id}/write", post(terminal_write))
         .route("/api/v1/terminals/{id}/output", get(terminal_output))
+        .route("/api/v1/terminals/{id}/buffer", get(terminal_buffer_dump))
         .route("/api/v1/memos", get(memos_list))
         .route("/api/v1/memos/{key}", get(memo_get))
         .route("/api/v1/notifications", get(notifications_list))

--- a/src-tauri/src/automation_server/types.rs
+++ b/src-tauri/src/automation_server/types.rs
@@ -36,6 +36,12 @@ pub struct OutputQuery {
 }
 
 #[derive(Deserialize)]
+pub struct BufferDumpQuery {
+    /// Max lines to return (trailing slice). 0 = whole buffer. Omitted = frontend default.
+    pub limit: Option<usize>,
+}
+
+#[derive(Deserialize)]
 pub struct SwitchWorkspaceBody {
     pub id: String,
 }
@@ -158,6 +164,7 @@ pub const REGISTERED_ROUTES: &[(&str, &str)] = &[
     ("POST", "/api/v1/grid/hover"),
     ("POST", "/api/v1/panes/split"),
     ("DELETE", "/api/v1/panes/{index}"),
+    ("POST", "/api/v1/panes/{index}/resize"),
     ("PUT", "/api/v1/panes/{index}/view"),
     ("GET", "/api/v1/docks"),
     ("POST", "/api/v1/docks/layout-mode/toggle"),
@@ -171,6 +178,7 @@ pub const REGISTERED_ROUTES: &[(&str, &str)] = &[
     ("GET", "/api/v1/terminals"),
     ("POST", "/api/v1/terminals/{id}/write"),
     ("GET", "/api/v1/terminals/{id}/output"),
+    ("GET", "/api/v1/terminals/{id}/buffer"),
     ("GET", "/api/v1/memos"),
     ("GET", "/api/v1/memos/{key}"),
     ("GET", "/api/v1/notifications"),

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -2466,6 +2466,78 @@ describe("TerminalView", () => {
     }
   });
 
+  // -- Regression: rapid resize burst (pane-divider drag) must coalesce (#285) --
+  //
+  // Dragging a pane divider emits a ResizeObserver entry every frame. Reflowing
+  // (fit → terminal.resize → xterm buffer reflow) on each intermediate width
+  // races xterm's synchronous reflow against ConPTY's async resize repaints and
+  // corrupts scrollback (duplicated / merged lines). The fix debounces the fit
+  // so a whole drag burst collapses into a single reflow after it settles.
+  it("coalesces a rapid resize burst into a single fit (issue #285)", async () => {
+    type Observer = {
+      target: Element | null;
+      callback: (entries: ResizeObserverEntry[], obs: ResizeObserver) => void;
+    };
+    const observers: Observer[] = [];
+    const originalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      private obs: Observer;
+      constructor(cb: (entries: ResizeObserverEntry[], obs: ResizeObserver) => void) {
+        this.obs = { target: null, callback: cb };
+        observers.push(this.obs);
+      }
+      observe(target: Element) {
+        this.obs.target = target;
+        setTimeout(() => {
+          this.obs.callback(
+            [
+              {
+                target,
+                contentRect: { width: 800, height: 600 },
+              } as unknown as ResizeObserverEntry,
+            ],
+            this as unknown as ResizeObserver,
+          );
+        }, 0);
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      render(<TerminalView instanceId="t-resize-coalesce" profile="PowerShell" syncGroup="" />);
+      await vi.waitFor(() => {
+        expect(mockCreateTerminalSession).toHaveBeenCalled();
+      });
+
+      const obs = observers[0];
+      const target = obs.target as Element;
+
+      // Ignore the synchronous creation fit; measure only the drag burst.
+      mockFit.mockClear();
+
+      // Simulate a divider drag: many distinct widths in one synchronous burst.
+      act(() => {
+        for (let w = 790; w >= 700; w -= 5) {
+          obs.callback(
+            [{ target, contentRect: { width: w, height: 600 } } as unknown as ResizeObserverEntry],
+            {} as ResizeObserver,
+          );
+        }
+      });
+
+      // Debounced: no per-frame fit fires synchronously during the burst.
+      expect(mockFit).not.toHaveBeenCalled();
+
+      // After the burst settles, exactly one fit runs for the whole drag.
+      await vi.waitFor(() => {
+        expect(mockFit).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+
   // -- Regression: reflow triggers fired while inactive workspace is hidden --
   //
   // WorkspaceArea hides inactive workspaces via `display: none`. The font /

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -2542,6 +2542,78 @@ describe("TerminalView", () => {
     }
   });
 
+  // -- Regression: pending debounced fit cancelled when container hides (#285 P2) --
+  //
+  // A normal resize schedules the trailing fit, then the workspace/pane can go
+  // display:none (0×0) before the 80ms debounce expires. If the pending timer
+  // is not cancelled it fires fitAddon.fit() against the hidden container,
+  // pushing cols/rows=0 through the PTY and garbling the pane on return.
+  it("cancels a pending debounced fit when the container becomes hidden (issue #285 P2)", async () => {
+    type Observer = {
+      target: Element | null;
+      callback: (entries: ResizeObserverEntry[], obs: ResizeObserver) => void;
+    };
+    const observers: Observer[] = [];
+    const originalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      private obs: Observer;
+      constructor(cb: (entries: ResizeObserverEntry[], obs: ResizeObserver) => void) {
+        this.obs = { target: null, callback: cb };
+        observers.push(this.obs);
+      }
+      observe(target: Element) {
+        this.obs.target = target;
+        setTimeout(() => {
+          this.obs.callback(
+            [
+              {
+                target,
+                contentRect: { width: 800, height: 600 },
+              } as unknown as ResizeObserverEntry,
+            ],
+            this as unknown as ResizeObserver,
+          );
+        }, 0);
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      render(<TerminalView instanceId="t-resize-hide" profile="PowerShell" syncGroup="" />);
+      await vi.waitFor(() => {
+        expect(mockCreateTerminalSession).toHaveBeenCalled();
+      });
+
+      const obs = observers[0];
+      const target = obs.target as Element;
+      mockFit.mockClear();
+
+      // 1) A normal size change schedules the debounced fit.
+      act(() => {
+        obs.callback(
+          [{ target, contentRect: { width: 760, height: 600 } } as unknown as ResizeObserverEntry],
+          {} as ResizeObserver,
+        );
+      });
+
+      // 2) Before the 80ms debounce fires, the pane is hidden (display:none → 0×0).
+      act(() => {
+        obs.callback(
+          [{ target, contentRect: { width: 0, height: 0 } } as unknown as ResizeObserverEntry],
+          {} as ResizeObserver,
+        );
+      });
+
+      // 3) Wait past the debounce window: the pending fit must NOT have fired
+      //    (cancelled on hide), so no fit runs against the 0×0 container.
+      await new Promise((r) => setTimeout(r, 150));
+      expect(mockFit).not.toHaveBeenCalled();
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+
   // -- Regression: reflow triggers fired while inactive workspace is hidden --
   //
   // WorkspaceArea hides inactive workspaces via `display: none`. The font /

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -161,9 +161,13 @@ vi.mock("@xterm/addon-serialize", () => ({
 
 const mockRegisterTerminalSerializer = vi.fn();
 const mockUnregisterTerminalSerializer = vi.fn();
+const mockRegisterTerminalInspector = vi.fn();
+const mockUnregisterTerminalInspector = vi.fn();
 vi.mock("@/lib/terminal-serialize-registry", () => ({
   registerTerminalSerializer: (...args: unknown[]) => mockRegisterTerminalSerializer(...args),
   unregisterTerminalSerializer: (...args: unknown[]) => mockUnregisterTerminalSerializer(...args),
+  registerTerminalInspector: (...args: unknown[]) => mockRegisterTerminalInspector(...args),
+  unregisterTerminalInspector: (...args: unknown[]) => mockUnregisterTerminalInspector(...args),
 }));
 
 // Mock tauri API

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -1469,6 +1469,15 @@ export function TerminalView({
     const resizeObserver = new ResizeObserver((entries) => {
       const { width, height } = entries[0].contentRect;
       const isNowHidden = width === 0 || height === 0;
+      // A pending debounced fit must never run against a hidden container.
+      // WorkspaceArea/PaneGrid hide inactive panes via display:none, firing a
+      // 0×0 entry; if a drag just scheduled a fit, fitting on the 0×0 box would
+      // push cols/rows=0 through the PTY and garble the pane on return. Cancel
+      // the pending fit the moment the container goes hidden (issue #285 P2).
+      if (isNowHidden && resizeFitTimer !== undefined) {
+        clearTimeout(resizeFitTimer);
+        resizeFitTimer = undefined;
+      }
       if (width > 0 && height > 0 && !sessionCreated) {
         sessionCreated = true;
         prevW = Math.round(width);
@@ -1654,7 +1663,14 @@ export function TerminalView({
           // so xterm reflow + the PTY resize happen ONCE after the drag settles,
           // never interleaving with ConPTY's per-resize repaints (issue #285).
           if (resizeFitTimer !== undefined) clearTimeout(resizeFitTimer);
-          resizeFitTimer = setTimeout(applyFit, RESIZE_FIT_DEBOUNCE_MS);
+          resizeFitTimer = setTimeout(() => {
+            resizeFitTimer = undefined;
+            // Re-check at fire time: the container may have gone hidden after
+            // this was scheduled (race with the 0×0 cancel above). Skip — the
+            // hide→show recovery path re-fits on return (issue #285 P2).
+            if (cancelled || isContainerHiddenRef.current) return;
+            applyFit();
+          }, RESIZE_FIT_DEBOUNCE_MS);
         }
       }
       prevWasHidden = isNowHidden;

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -73,6 +73,16 @@ import { usePaneControl } from "@/components/layout/PaneControlContext";
 /** Default silence timeout for output idle detection (ms). */
 const OUTPUT_IDLE_TIMEOUT_MS = 5000;
 
+/**
+ * Trailing debounce (ms) before reflowing the terminal after a container-size
+ * change. A pane-divider drag emits a ResizeObserver burst (one entry per
+ * frame); reflowing on each intermediate width races xterm's synchronous
+ * buffer reflow against ConPTY's async resize repaints and corrupts scrollback
+ * (issue #285). Coalescing into a single fit after the drag settles removes the
+ * interleaving. Kept short so a settled resize still feels immediate.
+ */
+const RESIZE_FIT_DEBOUNCE_MS = 80;
+
 /** Byte-size threshold for the large paste warning dialog. */
 const LARGE_PASTE_THRESHOLD = 5120;
 
@@ -429,6 +439,11 @@ export function TerminalView({
       rescaleOverlappingGlyphs: true,
       overviewRuler: { width: overviewRulerWidth },
       scrollback: 10000,
+      // ConPTY backend with buildNumber >= 21376 enables xterm's own buffer
+      // reflow so scrollback re-wraps correctly on a width change. The #285
+      // scrollback corruption is NOT caused by this value (verified: 21375
+      // disables reflow and truncates instead) — its real cause is resize
+      // events racing ConPTY repaints, fixed by the debounced fit below.
       windowsPty: { backend: "conpty", buildNumber: 21376 },
     });
 
@@ -1446,6 +1461,8 @@ export function TerminalView({
     let prevW = 0;
     let prevH = 0;
     let webglTimer: ReturnType<typeof setTimeout> | undefined;
+    // Trailing-debounce handle for container-size reflow (see RESIZE_FIT_DEBOUNCE_MS).
+    let resizeFitTimer: ReturnType<typeof setTimeout> | undefined;
     const resizeObserver = new ResizeObserver((entries) => {
       const { width, height } = entries[0].contentRect;
       const isNowHidden = width === 0 || height === 0;
@@ -1566,23 +1583,46 @@ export function TerminalView({
         }
         prevW = w;
         prevH = h;
-        fitAddon.fit();
-        if (recoveringFromHidden || consumeDirty) {
-          // See `prevWasHidden` / `reflowDirtyRef` definitions: the WebGL
-          // atlas can go stale while the container is display:none (a DPR
-          // or font change that fires on a 0-size terminal cannot rebuild
-          // anything), so re-rasterise on the hide → show transition.
-          // Safe no-op without WebGL renderer.
-          try {
-            (terminal as unknown as { clearTextureAtlas?: () => void }).clearTextureAtlas?.();
-          } catch {
-            /* older xterm builds / mocks may lack this method */
+
+        // The actual reflow, factored out so the common drag path can debounce
+        // it while one-shot recovery events run promptly.
+        const applyFit = () => {
+          if (cancelled) return;
+          fitAddon.fit();
+          if (recoveringFromHidden || consumeDirty) {
+            // See `prevWasHidden` / `reflowDirtyRef` definitions: the WebGL
+            // atlas can go stale while the container is display:none (a DPR
+            // or font change that fires on a 0-size terminal cannot rebuild
+            // anything), so re-rasterise on the hide → show transition.
+            // Safe no-op without WebGL renderer.
+            try {
+              (terminal as unknown as { clearTextureAtlas?: () => void }).clearTextureAtlas?.();
+            } catch {
+              /* older xterm builds / mocks may lack this method */
+            }
+            terminal.refresh(0, terminal.rows - 1);
+            reflowDirtyRef.current = false;
           }
-          terminal.refresh(0, terminal.rows - 1);
-          reflowDirtyRef.current = false;
+          bindHelperTextareaEvents();
+          scheduleOverlayCaretUpdate();
+        };
+
+        if (recoveringFromHidden || consumeDirty) {
+          // Hide→show recovery / pending dirty reflow are single, important
+          // events — apply now and cancel any in-flight drag debounce so the
+          // atlas rebuild is not skipped.
+          if (resizeFitTimer !== undefined) {
+            clearTimeout(resizeFitTimer);
+            resizeFitTimer = undefined;
+          }
+          applyFit();
+        } else {
+          // Plain container-size change (e.g. dragging a pane divider): debounce
+          // so xterm reflow + the PTY resize happen ONCE after the drag settles,
+          // never interleaving with ConPTY's per-resize repaints (issue #285).
+          if (resizeFitTimer !== undefined) clearTimeout(resizeFitTimer);
+          resizeFitTimer = setTimeout(applyFit, RESIZE_FIT_DEBOUNCE_MS);
         }
-        bindHelperTextareaEvents();
-        scheduleOverlayCaretUpdate();
       }
       prevWasHidden = isNowHidden;
       isContainerHiddenRef.current = isNowHidden;
@@ -1594,6 +1634,7 @@ export function TerminalView({
     return () => {
       cancelled = true;
       if (webglTimer !== undefined) clearTimeout(webglTimer);
+      if (resizeFitTimer !== undefined) clearTimeout(resizeFitTimer);
       if (terminalReflowFrameRef.current !== null) {
         cancelAnimationFrame(terminalReflowFrameRef.current);
         terminalReflowFrameRef.current = null;

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -67,6 +67,9 @@ import { loadTerminalOutputCache } from "@/lib/tauri-api";
 import {
   registerTerminalSerializer,
   unregisterTerminalSerializer,
+  registerTerminalInspector,
+  unregisterTerminalInspector,
+  type TerminalBufferLine,
 } from "@/lib/terminal-serialize-registry";
 import { usePaneControl } from "@/components/layout/PaneControlContext";
 
@@ -1502,6 +1505,36 @@ export function TerminalView({
         }
         registerTerminalSerializer(instanceId, () => serializeAddon.serialize());
 
+        // Register buffer inspector for automated reflow verification (issue #285).
+        // Exposes xterm's reflowed line model (text + isWrapped) so the
+        // Automation API can confirm width-change reflow without screenshots.
+        const dumpBuffer = (limit: number) => {
+          const buf = terminal.buffer.active;
+          const total = buf.length;
+          const start = limit > 0 ? Math.max(0, total - limit) : 0;
+          const lines: TerminalBufferLine[] = [];
+          for (let i = start; i < total; i++) {
+            const line = buf.getLine(i);
+            if (!line) continue;
+            lines.push({
+              index: i,
+              text: line.translateToString(true),
+              isWrapped: line.isWrapped,
+            });
+          }
+          return {
+            cols: terminal.cols,
+            rows: terminal.rows,
+            length: total,
+            baseY: buf.baseY,
+            lines,
+          };
+        };
+        if (paneId) {
+          registerTerminalInspector(paneId, dumpBuffer);
+        }
+        registerTerminalInspector(instanceId, dumpBuffer);
+
         fitAddon.fit();
         openedRef.current = true;
         scheduleOverlayCaretUpdate();
@@ -1665,8 +1698,10 @@ export function TerminalView({
       setSyncOutputCursorVisibility(false);
       if (paneId) {
         unregisterTerminalSerializer(paneId);
+        unregisterTerminalInspector(paneId);
       }
       unregisterTerminalSerializer(instanceId);
+      unregisterTerminalInspector(instanceId);
       unlistenOutput?.();
       closeTerminalSession(instanceId).catch(() => {});
       terminal.dispose();

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -10,6 +10,7 @@ import { useUiStore } from "@/stores/ui-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useFileViewerStore } from "@/stores/file-viewer-store";
 import { computeWorkspaceSummary } from "@/lib/workspace-summary";
+import { getTerminalInspector } from "@/lib/terminal-serialize-registry";
 import { computePaneNumbers, GRID_EPS } from "@/lib/pane-numbers";
 import type {
   DockPosition,
@@ -567,6 +568,17 @@ const handlers: HandlerMap = {
         paneIndex: paneIndex >= 0 ? paneIndex : undefined,
         switchedWorkspace: switchedWorkspace ? terminal.workspaceId : undefined,
       });
+    },
+    // Dump xterm's reflowed buffer (text + isWrapped per line) for automated
+    // reflow verification (issue #285). Reads the live xterm line model, not the
+    // PTY ring buffer, so it reflects wrapping state after a width change.
+    dumpBuffer: (p) => {
+      const terminalId = p.id as string;
+      if (!findTerminalInstance(terminalId)) return err(`Terminal '${terminalId}' not found`);
+      const inspector = getTerminalInspector(toPaneId(terminalId));
+      if (!inspector) return err(`Terminal '${terminalId}' has no live buffer`);
+      const limit = typeof p.limit === "number" ? p.limit : 300;
+      return ok(inspector(limit));
     },
     // Resolve a spatial pane number to a terminal ID within a workspace (issue #256).
     // Defaults to the active workspace when workspaceId is omitted.

--- a/ui/src/lib/terminal-serialize-registry.ts
+++ b/ui/src/lib/terminal-serialize-registry.ts
@@ -13,3 +13,45 @@ export function unregisterTerminalSerializer(paneId: string): void {
 export function getTerminalSerializeMap(): ReadonlyMap<string, SerializeFn> {
   return new Map(registry);
 }
+
+/**
+ * Buffer inspector registry — exposes xterm's *reflowed* buffer for automated
+ * verification (issue #285). Unlike the PTY ring buffer, this reflects xterm's
+ * own line model after a resize, including the `isWrapped` flag that decides
+ * whether ConPTY hard-wrapped rows re-join on a width change. Keyed by paneId.
+ */
+export interface TerminalBufferLine {
+  /** Absolute line index in the active buffer (0 = top of scrollback). */
+  index: number;
+  /** Line text with trailing whitespace trimmed. */
+  text: string;
+  /** xterm's wrap flag: true means this row continues the previous logical line. */
+  isWrapped: boolean;
+}
+
+export interface TerminalBufferDump {
+  cols: number;
+  rows: number;
+  /** Total lines in the active buffer (scrollback + viewport). */
+  length: number;
+  /** Scrollback rows above the viewport (buffer.baseY). */
+  baseY: number;
+  /** Lines returned (a trailing slice when the buffer exceeds `limit`). */
+  lines: TerminalBufferLine[];
+}
+
+type BufferDumpFn = (limit: number) => TerminalBufferDump;
+
+const inspectRegistry = new Map<string, BufferDumpFn>();
+
+export function registerTerminalInspector(paneId: string, fn: BufferDumpFn): void {
+  inspectRegistry.set(paneId, fn);
+}
+
+export function unregisterTerminalInspector(paneId: string): void {
+  inspectRegistry.delete(paneId);
+}
+
+export function getTerminalInspector(paneId: string): BufferDumpFn | undefined {
+  return inspectRegistry.get(paneId);
+}


### PR DESCRIPTION
## 개요
패널 분할선을 **극단적으로 좁혔다가 넓히는 등 연속 드래그**를 하면 터미널
스크롤백이 손상되던 문제(#285)를 수정합니다 — 줄 중복·병합, 좌측 클러스터링.

Fixes #285

## 근본 원인 (초기 진단 정정)
이 PR의 초기 버전은 `windowsPty.buildNumber`(21376→21375)를 원인으로 지목했으나,
dev 인스턴스 실측 결과 **buildNumber는 원인이 아님**을 확인했습니다(21375는 오히려
reflow를 비활성화해 단일 리사이즈에서도 내용을 잘라먹어 더 나쁨). 해당 변경
(`terminal-reflow.ts`)은 되돌리고 main의 21376을 유지합니다.

실제 원인:
- 드래그 중 `ResizeObserver`가 매 프레임 `fitAddon.fit() → terminal.resize()`를 호출.
- xterm의 buffer **reflow는 동기**, `write()`(=ConPTY의 resize repaint)는 **비동기 parse**.
- 디바운스가 없어, 다음 프레임의 동기 reflow가 직전 repaint의 parse와 **경합**하며
  스크롤백 라인이 중복·병합됨.

## 수정
- `ResizeObserver`의 컨테이너 크기 변경 경로에 **80ms trailing 디바운스** 추가.
  드래그 burst를 정착 후 **1회 reflow**로 합쳐 reflow와 repaint가 겹치지 않게 함.
- `hide→show` 복구, dirty reflow 등 1회성 이벤트는 즉시 적용(디바운스 우회)하여
  기존 동작(#232 atlas rebuild 등) 보존.

## 검증
- **재현**: Automation API를 확장(`GET /terminals/{id}/buffer` 버퍼 덤프,
  `POST /panes/{index}/resize` 미세 리사이즈)해, "출력 스트리밍 중 resize 난사"로
  손상을 재현(중복 3·병합 1). *(별도 커밋)*
- **수정 후**: 동일 테스트에서 **중복 0·병합 0**, 강한 스트레스(250줄·180 resize) 반복도 0/0.
- 드래그 burst가 `fit()` 1회로 합쳐지는 **회귀 테스트** 추가.
- 프론트 전체 **1946 tests 통과**, `tsc`/`cargo check` 클린.

## 커밋
1. `fix:` 디바운스 수정 + 회귀 테스트 (실제 #285 수정)
2. `test(automation):` 버퍼 덤프·미세 resize 엔드포인트 (검증 인프라, 재사용 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
