### PR TITLE
fix: EmptyView 오버플로 시 상단 잘림 해결 (#298)

### DIFF
--- a/ui/src/components/views/EmptyView.test.tsx
+++ b/ui/src/components/views/EmptyView.test.tsx
@@ -27,6 +27,33 @@ vi.mock("@/lib/tauri-api", () => ({
   sendOsNotification: vi.fn().mockResolvedValue(undefined),
 }));
 
+/**
+ * Install a ResizeObserver stub that reports a fixed content-box size, so the
+ * size-adaptive behavior (#298) can be exercised in jsdom. Returns a restore fn.
+ */
+function mockResizeObserverSize(width: number, height: number): () => void {
+  const original = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = class {
+    private cb: ResizeObserverCallback;
+    constructor(cb: ResizeObserverCallback) {
+      this.cb = cb;
+    }
+    observe(target: Element) {
+      setTimeout(() => {
+        this.cb(
+          [{ target, contentRect: { width, height } } as unknown as ResizeObserverEntry],
+          this as unknown as ResizeObserver,
+        );
+      }, 0);
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  return () => {
+    globalThis.ResizeObserver = original;
+  };
+}
+
 describe("EmptyView", () => {
   beforeEach(() => {
     useSettingsStore.setState(useSettingsStore.getInitialState());
@@ -127,28 +154,7 @@ describe("EmptyView", () => {
 
   it("hides the guidance header when the pane is too short (issue #298)", async () => {
     // Report a content-box height below the compact threshold so the header drops.
-    const original = globalThis.ResizeObserver;
-    globalThis.ResizeObserver = class {
-      private cb: ResizeObserverCallback;
-      constructor(cb: ResizeObserverCallback) {
-        this.cb = cb;
-      }
-      observe(target: Element) {
-        setTimeout(() => {
-          this.cb(
-            [
-              {
-                target,
-                contentRect: { width: 150, height: 100 },
-              } as unknown as ResizeObserverEntry,
-            ],
-            this as unknown as ResizeObserver,
-          );
-        }, 0);
-      }
-      unobserve() {}
-      disconnect() {}
-    } as unknown as typeof ResizeObserver;
+    const restore = mockResizeObserverSize(400, 100);
     try {
       render(<EmptyView />);
       // Option list stays visible — only the guidance is dropped.
@@ -158,7 +164,25 @@ describe("EmptyView", () => {
         expect(screen.queryByText(/Press number key to quick-select/)).not.toBeInTheDocument();
       });
     } finally {
-      globalThis.ResizeObserver = original;
+      restore();
+    }
+  });
+
+  it("drops card chrome and hint when the pane is too narrow (issue #298)", async () => {
+    // Narrow but tall: cards shed their category tag + drag handle and the
+    // header hint is hidden, but the title and the option list stay visible.
+    const restore = mockResizeObserverSize(120, 600);
+    try {
+      render(<EmptyView />);
+      expect(screen.getByTestId("empty-view-memo")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryAllByText("⠿")).toHaveLength(0);
+        expect(screen.queryByText(/Press number key to quick-select/)).not.toBeInTheDocument();
+      });
+      // Title still shown because the pane is tall enough.
+      expect(screen.getByText("Select a view")).toBeInTheDocument();
+    } finally {
+      restore();
     }
   });
 

--- a/ui/src/components/views/EmptyView.test.tsx
+++ b/ui/src/components/views/EmptyView.test.tsx
@@ -125,6 +125,23 @@ describe("EmptyView", () => {
     expect(onSelect).toHaveBeenCalledWith({ type: "MemoView" });
   });
 
+  it("does not clip top content when overflowing (issue #298)", () => {
+    // The scroll container must NOT use justify-center: combined with
+    // overflow-y-auto it pushes the top of tall content above the scroll
+    // origin, making the first items unreachable. Centering is done by an
+    // inner my-auto wrapper that collapses to 0 on overflow instead.
+    render(<EmptyView />);
+    const container = screen.getByTestId("empty-view");
+    expect(container.className).not.toContain("justify-center");
+    expect(container.className).toContain("overflow-y-auto");
+
+    // Header and options live inside a my-auto wrapper.
+    const header = screen.getByText("Select a view");
+    const wrapper = header.closest(".my-auto");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).toContainElement(screen.getByTestId("empty-view-memo"));
+  });
+
   it("respects stored viewOrder", () => {
     // Set custom order: memo first
     useSettingsStore.setState({ viewOrder: ["memo", "settings", "ws-selector"] });

--- a/ui/src/components/views/EmptyView.test.tsx
+++ b/ui/src/components/views/EmptyView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { EmptyView } from "./EmptyView";
@@ -184,6 +184,16 @@ describe("EmptyView", () => {
     } finally {
       restore();
     }
+  });
+
+  it("gives each option label min-w-0 so truncate works on the flex child (issue #298)", () => {
+    // jsdom does not lay out, so guard the class contract instead: a flex child
+    // needs min-w-0 for `truncate` to clip rather than overflow the card.
+    render(<EmptyView />);
+    const button = screen.getByTestId("empty-view-memo");
+    const label = within(button).getByText("Memo");
+    expect(label.className).toContain("min-w-0");
+    expect(label.className).toContain("truncate");
   });
 
   it("does not clip top content when overflowing (issue #298)", () => {

--- a/ui/src/components/views/EmptyView.test.tsx
+++ b/ui/src/components/views/EmptyView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { EmptyView } from "./EmptyView";
@@ -123,6 +123,43 @@ describe("EmptyView", () => {
 
     await user.click(screen.getByTestId("empty-view-memo"));
     expect(onSelect).toHaveBeenCalledWith({ type: "MemoView" });
+  });
+
+  it("hides the guidance header when the pane is too short (issue #298)", async () => {
+    // Report a content-box height below the compact threshold so the header drops.
+    const original = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      private cb: ResizeObserverCallback;
+      constructor(cb: ResizeObserverCallback) {
+        this.cb = cb;
+      }
+      observe(target: Element) {
+        setTimeout(() => {
+          this.cb(
+            [
+              {
+                target,
+                contentRect: { width: 150, height: 100 },
+              } as unknown as ResizeObserverEntry,
+            ],
+            this as unknown as ResizeObserver,
+          );
+        }, 0);
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+    try {
+      render(<EmptyView />);
+      // Option list stays visible — only the guidance is dropped.
+      expect(screen.getByTestId("empty-view-memo")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByText("Select a view")).not.toBeInTheDocument();
+        expect(screen.queryByText(/Press number key to quick-select/)).not.toBeInTheDocument();
+      });
+    } finally {
+      globalThis.ResizeObserver = original;
+    }
   });
 
   it("does not clip top content when overflowing (issue #298)", () => {

--- a/ui/src/components/views/EmptyView.tsx
+++ b/ui/src/components/views/EmptyView.tsx
@@ -101,8 +101,10 @@ function EmptyViewCard({
           {shortcutNum <= 9 ? shortcutNum : ""}
         </span>
 
-        {/* Label */}
-        <span className="flex-1 truncate text-xs font-medium">{option.label}</span>
+        {/* Label — min-w-0 is required for truncate to work on a flex child,
+            otherwise the default min-width:auto keeps the nowrap label at its
+            intrinsic width and it overflows the card instead of clipping. */}
+        <span className="min-w-0 flex-1 truncate text-xs font-medium">{option.label}</span>
 
         {/* Category tag + drag handle drop out at narrow widths (see #298) —
             they wrap and overflow the card, crowding out the label. */}

--- a/ui/src/components/views/EmptyView.tsx
+++ b/ui/src/components/views/EmptyView.tsx
@@ -283,39 +283,44 @@ export function EmptyView({ onSelectView, context: _context = "pane", isFocused 
       ref={containerRef}
       tabIndex={-1}
       data-testid="empty-view"
-      className="empty-view-scroll flex h-full flex-col items-center justify-center gap-3 overflow-y-auto p-6 outline-none"
+      className="empty-view-scroll flex h-full flex-col items-center overflow-y-auto p-6 outline-none"
       style={{ color: "var(--text-secondary)" }}
     >
-      {/* Header */}
-      <div className="mb-2 text-center">
-        <p className="text-sm font-medium" style={{ color: "var(--text-primary)", opacity: 0.7 }}>
-          Select a view
-        </p>
-        <p className="mt-0.5 text-[10px]" style={{ opacity: 0.4 }}>
-          Press number key to quick-select · Drag to reorder
-        </p>
-      </div>
+      {/* Content wrapper: my-auto centers vertically when there is spare room,
+          but collapses to 0 on overflow so the top stays scroll-reachable
+          (justify-center would clip the top instead). See issue #298. */}
+      <div className="my-auto flex w-full flex-col items-center gap-3">
+        {/* Header */}
+        <div className="mb-2 text-center">
+          <p className="text-sm font-medium" style={{ color: "var(--text-primary)", opacity: 0.7 }}>
+            Select a view
+          </p>
+          <p className="mt-0.5 text-[10px]" style={{ opacity: 0.4 }}>
+            Press number key to quick-select · Drag to reorder
+          </p>
+        </div>
 
-      {/* Options list */}
-      <div className="flex w-full max-w-[240px] flex-col gap-1">
-        {options.map((opt, i) => (
-          <EmptyViewCard
-            key={opt.key}
-            option={opt}
-            index={i}
-            hovered={hoveredIdx === i}
-            dragging={dragIdx === i}
-            dropPosition={
-              dropInfo && dropInfo.index === i && dragIdx !== i ? dropInfo.position : null
-            }
-            onSelect={() => handleSelect(i)}
-            onHover={(entering) => setHoveredIdx(entering ? i : null)}
-            onDragStart={() => handleDragStart(i)}
-            onDragOver={(e) => handleDragOver(e, i)}
-            onDragEnd={handleDragEnd}
-            onDrop={handleDrop}
-          />
-        ))}
+        {/* Options list */}
+        <div className="flex w-full max-w-[240px] flex-col gap-1">
+          {options.map((opt, i) => (
+            <EmptyViewCard
+              key={opt.key}
+              option={opt}
+              index={i}
+              hovered={hoveredIdx === i}
+              dragging={dragIdx === i}
+              dropPosition={
+                dropInfo && dropInfo.index === i && dragIdx !== i ? dropInfo.position : null
+              }
+              onSelect={() => handleSelect(i)}
+              onHover={(entering) => setHoveredIdx(entering ? i : null)}
+              onDragStart={() => handleDragStart(i)}
+              onDragOver={(e) => handleDragOver(e, i)}
+              onDragEnd={handleDragEnd}
+              onDrop={handleDrop}
+            />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/ui/src/components/views/EmptyView.tsx
+++ b/ui/src/components/views/EmptyView.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useCallback, useRef, useState } from "react";
 import type { ViewInstanceConfig } from "@/stores/types";
 import { useSettingsStore } from "@/stores/settings-store";
+import { useContainerSize } from "@/hooks/useContainerSize";
+
+/**
+ * Content-box height (px) below which the "Select a view" guidance header is
+ * hidden. When the pane is this short every vertical pixel matters, so we drop
+ * the title + hint and give the space to the option list instead. See #298.
+ */
+const COMPACT_HEADER_HIDE_HEIGHT = 220;
 
 export type EmptyViewContext = "pane" | "dock";
 
@@ -192,6 +200,12 @@ export function EmptyView({ onSelectView, context: _context = "pane", isFocused 
   const setViewOrder = useSettingsStore((s) => s.setViewOrder);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
 
+  // When the pane is too short, hide the guidance header to free up room for
+  // the option list. contentRect height excludes the container padding, so the
+  // threshold is stable regardless of what we render. See #298.
+  const { h: contentHeight } = useContainerSize(containerRef);
+  const hideHeader = contentHeight > 0 && contentHeight < COMPACT_HEADER_HIDE_HEIGHT;
+
   // Grab DOM focus when this pane becomes focused (e.g. via Alt+Arrow navigation)
   useEffect(() => {
     if (isFocused) {
@@ -290,15 +304,20 @@ export function EmptyView({ onSelectView, context: _context = "pane", isFocused 
           but collapses to 0 on overflow so the top stays scroll-reachable
           (justify-center would clip the top instead). See issue #298. */}
       <div className="my-auto flex w-full flex-col items-center gap-3">
-        {/* Header */}
-        <div className="mb-2 text-center">
-          <p className="text-sm font-medium" style={{ color: "var(--text-primary)", opacity: 0.7 }}>
-            Select a view
-          </p>
-          <p className="mt-0.5 text-[10px]" style={{ opacity: 0.4 }}>
-            Press number key to quick-select · Drag to reorder
-          </p>
-        </div>
+        {/* Header — hidden when the pane is too short (see #298) */}
+        {!hideHeader && (
+          <div className="mb-2 text-center">
+            <p
+              className="text-sm font-medium"
+              style={{ color: "var(--text-primary)", opacity: 0.7 }}
+            >
+              Select a view
+            </p>
+            <p className="mt-0.5 text-[10px]" style={{ opacity: 0.4 }}>
+              Press number key to quick-select · Drag to reorder
+            </p>
+          </div>
+        )}
 
         {/* Options list */}
         <div className="flex w-full max-w-[240px] flex-col gap-1">

--- a/ui/src/components/views/EmptyView.tsx
+++ b/ui/src/components/views/EmptyView.tsx
@@ -10,6 +10,14 @@ import { useContainerSize } from "@/hooks/useContainerSize";
  */
 const COMPACT_HEADER_HIDE_HEIGHT = 220;
 
+/**
+ * Content-box width (px) below which option cards drop their secondary chrome
+ * (category tag, drag handle) and the header hint. At narrow widths these wrap
+ * onto extra lines and overflow the card, so we collapse to a clean single-line
+ * label + shortcut layout instead. See #298.
+ */
+const NARROW_WIDTH_THRESHOLD = 170;
+
 export type EmptyViewContext = "pane" | "dock";
 
 interface EmptyViewProps {
@@ -32,6 +40,7 @@ function EmptyViewCard({
   hovered,
   dragging,
   dropPosition,
+  narrow,
   onSelect,
   onHover,
   onDragStart,
@@ -44,6 +53,7 @@ function EmptyViewCard({
   hovered: boolean;
   dragging: boolean;
   dropPosition: "top" | "bottom" | null;
+  narrow: boolean;
   onSelect: () => void;
   onHover: (entering: boolean) => void;
   onDragStart: () => void;
@@ -92,28 +102,34 @@ function EmptyViewCard({
         </span>
 
         {/* Label */}
-        <span className="flex-1 text-xs font-medium">{option.label}</span>
+        <span className="flex-1 truncate text-xs font-medium">{option.label}</span>
 
-        {/* Category tag */}
-        <span
-          className="shrink-0 text-[9px] uppercase tracking-wider"
-          style={{ color: "var(--text-secondary)", opacity: 0.4 }}
-        >
-          {option.category}
-        </span>
+        {/* Category tag + drag handle drop out at narrow widths (see #298) —
+            they wrap and overflow the card, crowding out the label. */}
+        {!narrow && (
+          <>
+            {/* Category tag */}
+            <span
+              className="shrink-0 text-[9px] uppercase tracking-wider"
+              style={{ color: "var(--text-secondary)", opacity: 0.4 }}
+            >
+              {option.category}
+            </span>
 
-        {/* Drag handle — right edge */}
-        <span
-          className="shrink-0 pl-2 pr-0.5 text-[10px]"
-          style={{
-            color: "var(--text-secondary)",
-            opacity: 0.25,
-            cursor: "grab",
-            userSelect: "none",
-          }}
-        >
-          ⠿
-        </span>
+            {/* Drag handle — right edge */}
+            <span
+              className="shrink-0 pl-2 pr-0.5 text-[10px]"
+              style={{
+                color: "var(--text-secondary)",
+                opacity: 0.25,
+                cursor: "grab",
+                userSelect: "none",
+              }}
+            >
+              ⠿
+            </span>
+          </>
+        )}
       </button>
     </div>
   );
@@ -200,11 +216,14 @@ export function EmptyView({ onSelectView, context: _context = "pane", isFocused 
   const setViewOrder = useSettingsStore((s) => s.setViewOrder);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
 
-  // When the pane is too short, hide the guidance header to free up room for
-  // the option list. contentRect height excludes the container padding, so the
-  // threshold is stable regardless of what we render. See #298.
-  const { h: contentHeight } = useContainerSize(containerRef);
+  // Adapt to the pane size. contentRect excludes the container padding, so both
+  // thresholds stay stable regardless of what we render. See #298.
+  //  - too short  → drop the guidance header to free vertical room
+  //  - too narrow → cards drop their category tag + drag handle, and the header
+  //                 hint is hidden (they otherwise wrap and overflow)
+  const { w: contentWidth, h: contentHeight } = useContainerSize(containerRef);
   const hideHeader = contentHeight > 0 && contentHeight < COMPACT_HEADER_HIDE_HEIGHT;
+  const narrow = contentWidth > 0 && contentWidth < NARROW_WIDTH_THRESHOLD;
 
   // Grab DOM focus when this pane becomes focused (e.g. via Alt+Arrow navigation)
   useEffect(() => {
@@ -313,9 +332,11 @@ export function EmptyView({ onSelectView, context: _context = "pane", isFocused 
             >
               Select a view
             </p>
-            <p className="mt-0.5 text-[10px]" style={{ opacity: 0.4 }}>
-              Press number key to quick-select · Drag to reorder
-            </p>
+            {!narrow && (
+              <p className="mt-0.5 text-[10px]" style={{ opacity: 0.4 }}>
+                Press number key to quick-select · Drag to reorder
+              </p>
+            )}
           </div>
         )}
 
@@ -328,6 +349,7 @@ export function EmptyView({ onSelectView, context: _context = "pane", isFocused 
               index={i}
               hovered={hoveredIdx === i}
               dragging={dragIdx === i}
+              narrow={narrow}
               dropPosition={
                 dropInfo && dropInfo.index === i && dragIdx !== i ? dropInfo.position : null
               }


### PR DESCRIPTION
## 문제 (#298)

EmptyView를 작은 pane에 표시할 때 레이아웃이 깨지는 문제들:

1. **높이가 작을 때 상단 잘림** — 옵션 목록이 pane 높이를 초과하면 콘텐츠가 세로 중앙 정렬로 위로 밀려나 "Select a view" 헤더 등 최상단 항목이 잘리고 스크롤로도 접근 불가.
2. **높이가 작을 때 안내 헤더가 공간 낭비** — 짧은 pane에서 제목 + 단축키 힌트가 실익 없이 공간만 차지.
3. **폭이 좁을 때 카드 깨짐** — 카테고리 태그가 카드 밖으로 넘쳐 라벨과 겹치고, 라벨이 2줄로 줄바꿈, 힌트가 여러 줄로 쪼개짐.

## 수정

### 1. 상단 잘림 해결
- 스크롤 컨테이너에서 `justify-center` 제거, 콘텐츠를 `my-auto` 래퍼로 감쌈.
- `my-auto`는 여유 공간이 있으면 중앙 정렬, 오버플로 시 margin이 0으로 수렴 → 상단이 항상 스크롤 접근 가능.

### 2. 높이가 작으면 안내 헤더 숨김
- `useContainerSize`로 content-box 높이 측정, 임계값(220px) 미만이면 헤더 미렌더링.

### 3. 폭이 좁으면 카드 chrome 숨김
- content-box 폭 임계값(170px) 미만이면 카드의 카테고리 태그·드래그 핸들과 헤더 힌트를 숨기고, 라벨에 `truncate` 적용 → 단축번호 + 라벨 단일 줄 레이아웃.

`contentRect` 높이/폭은 padding을 제외하므로 렌더링 내용과 무관하게 임계값이 안정적임(토글 오실레이션 없음).

## 검증

- `EmptyView.test.tsx` 16개 통과 (회귀 테스트 추가: 상단 비-클리핑 / 짧으면 헤더 숨김 / 좁으면 카드 chrome·힌트 숨김)
- `tsc --noEmit`, `eslint` 통과
- laymux-dev 실행 후 EmptyView pane을 분할해 스크린샷으로 검증:
  - 상단 잘림: 수정 전 헤더 잘림 → 수정 후 정상 표시 + 스크롤 가능
  - 높이 0.25: 헤더 숨김, 옵션 상단부터 표시
  - 폭 0.12: 카테고리 태그·드래그 핸들·힌트 제거, 라벨 단일 줄 정리 (이전엔 태그 오버플로 + 2줄 깨짐)

Fixes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)
