### PR TITLE
fix: smart copy가 명령 안에 박힌 wrap된 URL을 복원하도록

### DIFF
--- a/ui/src/lib/smart-text.test.ts
+++ b/ui/src/lib/smart-text.test.ts
@@ -229,6 +229,52 @@ describe("smartRemoveLineBreak", () => {
     const input = "https://example.com\nis a great site";
     expect(smartRemoveLineBreak(input)).toBe("https://example.com\nis a great site");
   });
+
+  it("명령 안에 박힌 URL이 줄바꿈으로 쪼개져도 명령 구조는 보존하며 URL만 복원한다", () => {
+    // 셸 prefix 'curl "' 의 single space 는 명령 문법이므로 보존하고,
+    // 따옴표 안 URL이 wrap 으로 쪼개진 부분만 이어붙인다 (전체가 URL이 아니므로
+    // Phase2 collapse 는 발동하지 않는다).
+    const input = 'curl "https://example.com/very/long/pa\n  th?x=1"';
+    expect(smartRemoveLineBreak(input)).toBe('curl "https://example.com/very/long/path?x=1"');
+  });
+
+  it("Claude Code TUI 입력창처럼 들여쓰기된 연속 줄로 쪼개진 URL 목록을 명령 안에서 복원한다", () => {
+    // dev 재현(cols 118): Claude Code 의 ! bash 입력창은 긴 줄을 자체 레이아웃으로
+    // 그려서 연속 줄을 isWrapped=false + 2칸 들여쓰기로 만든다. getSelection 은 이를
+    // 개행으로 분리하고 들여쓰기를 남긴다. 명령 prefix 의 single space 는 보존하고
+    // URL 토큰을 쪼갠 wrap 만 이어붙여야 한다.
+    const input =
+      '!  gws auth login --scopes "openid,email,profile,https://www.googleapis.com/auth/userinfo.email,https://www.googleap\n' +
+      "  is.com/auth/userinfo.profile,https://www.googleapis.com/auth/calendar,https://www.googleapis.com/auth/cloud-platfo\n" +
+      "  rm,https://www.googleapis.com/auth/documents,https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth\n" +
+      "  /gmail.modify,https://www.googleapis.com/auth/presentations,https://www.googleapis.com/auth/pubsub,https://www.goo\n" +
+      "  gleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/tasks,https://www.googleapis.com/auth/script.project\n" +
+      '  s,https://www.googleapis.com/auth/script.deployments,https://www.googleapis.com/auth/script.processes"';
+    const expected =
+      '!  gws auth login --scopes "openid,email,profile,' +
+      "https://www.googleapis.com/auth/userinfo.email," +
+      "https://www.googleapis.com/auth/userinfo.profile," +
+      "https://www.googleapis.com/auth/calendar," +
+      "https://www.googleapis.com/auth/cloud-platform," +
+      "https://www.googleapis.com/auth/documents," +
+      "https://www.googleapis.com/auth/drive," +
+      "https://www.googleapis.com/auth/gmail.modify," +
+      "https://www.googleapis.com/auth/presentations," +
+      "https://www.googleapis.com/auth/pubsub," +
+      "https://www.googleapis.com/auth/spreadsheets," +
+      "https://www.googleapis.com/auth/tasks," +
+      "https://www.googleapis.com/auth/script.projects," +
+      "https://www.googleapis.com/auth/script.deployments," +
+      'https://www.googleapis.com/auth/script.processes"';
+    expect(smartRemoveLineBreak(input)).toBe(expected);
+  });
+
+  it("스킴으로 시작하는 연속 줄(별도 URL/줄바꿈 직후 URL)은 이전 토큰에 강제로 붙이지 않는다", () => {
+    // 줄바꿈 직후 https:// 로 시작하면 wrap 된 URL 꼬리가 아니라 새 URL 이므로
+    // 앞 prose 토큰에 이어붙이지 않는다. (prose 가 섞여 Phase2 collapse 도 미발동)
+    const input = "see this:\n  https://example.com/a";
+    expect(smartRemoveLineBreak(input)).toBe("see this:\n  https://example.com/a");
+  });
 });
 
 // ============================================================
@@ -538,6 +584,25 @@ describe("prepareSelectionForCopy", () => {
       smartRemoveLineBreak: true,
     });
     expect(result).toBe("hello\nworld");
+  });
+
+  it("명령(첫 줄 들여쓰기 0) 안의 wrap 된 URL 목록을 copy 파이프라인 전체에서 복원한다", () => {
+    // 첫 줄 들여쓰기가 0이라 smartRemoveIndent 의 공통 최소 인덴트는 0 → 미작동.
+    // 따라서 연속 줄의 2칸 들여쓰기는 smartRemoveLineBreak 의 wrap 복원이 직접 벗겨야 한다.
+    // (xterm getSelection 은 TUI 연속 줄을 개행 + 들여쓰기 + trailing pad 로 만든다.)
+    const raw =
+      'gws --scopes "https://api.example.com/auth/aaa,https://api.exam   \n' +
+      '  ple.com/auth/bbb,https://api.example.com/auth/ccc"            \n' +
+      "                                                                 \n";
+    const expected =
+      'gws --scopes "https://api.example.com/auth/aaa,' +
+      "https://api.example.com/auth/bbb," +
+      'https://api.example.com/auth/ccc"';
+    const result = prepareSelectionForCopy(raw, {
+      smartRemoveIndent: true,
+      smartRemoveLineBreak: true,
+    });
+    expect(result).toBe(expected);
   });
 });
 

--- a/ui/src/lib/smart-text.test.ts
+++ b/ui/src/lib/smart-text.test.ts
@@ -275,6 +275,20 @@ describe("smartRemoveLineBreak", () => {
     const input = "see this:\n  https://example.com/a";
     expect(smartRemoveLineBreak(input)).toBe("see this:\n  https://example.com/a");
   });
+
+  it("URL 줄 다음에 단일 단어 산문이 와도 글루하지 않는다 (false-positive 가드, PR #303 리뷰)", () => {
+    // continuation 'Thanks' 는 단일 무공백 토큰이지만 URL-구조문자(/:?=&%#@)가 없는
+    // 평문 단어 → wrap 꼬리가 아니다. '...page' 에 붙여 'pageThanks' 가 되면 안 된다.
+    const input = "See https://example.com/page\nThanks";
+    expect(smartRemoveLineBreak(input)).toBe("See https://example.com/page\nThanks");
+  });
+
+  it("줄 끝 pad 가 남아 있어도 명령 안 wrap URL 을 병합한다 (paste 경로 견고성, PR #303 리뷰)", () => {
+    // applyPasteTextTransforms 는 trimSelectionTrailingWhitespace 없이 호출되므로
+    // 줄 끝 pad 가 남을 수 있다. tail/continuation 계산이 이를 견뎌야 한다.
+    const input = 'curl "https://example.com/very/long/pa   \n  th?x=1"   ';
+    expect(smartRemoveLineBreak(input)).toBe('curl "https://example.com/very/long/path?x=1"');
+  });
 });
 
 // ============================================================

--- a/ui/src/lib/smart-text.ts
+++ b/ui/src/lib/smart-text.ts
@@ -123,8 +123,20 @@ export function smartRemoveIndent(text: string): string {
  *     segment contains an `http(s)://` scheme;
  *   - the continuation (after indent strip) is a single whitespace-free token —
  *     prose like `hello world` has internal spaces and is left alone;
+ *   - the continuation contains a URL-structural char (`/ : ? = & % # @`) — a
+ *     plain prose word like `Thanks` after a URL line is NOT a wrapped tail, so
+ *     `See https://x.com/page\nThanks` is left alone. `.` and `,` are excluded
+ *     because they are common in prose. Limitation: a URL wrapped mid-segment
+ *     onto a purely alphanumeric tail (`...com/pa` + `th`) is not merged here —
+ *     when the whole selection is one URL, the Phase-2 collapse still repairs
+ *     it; embedded in a command it stays broken. This favours leaving a visible
+ *     break over silently gluing prose, which corrupts text unrecoverably.
  *   - the continuation does NOT itself start a new scheme — `https://b.com` on
  *     its own line is a separate URL, not a wrapped tail.
+ *
+ * `tail` and `continuation` are computed with trailing pad stripped so the
+ * decision holds on the paste path too, where smartRemoveLineBreak runs without
+ * a prior trimSelectionTrailingWhitespace.
  */
 function mergeWrappedUrlLines(text: string): string {
   if (!/\r?\n/.test(text)) return text;
@@ -133,14 +145,20 @@ function mergeWrappedUrlLines(text: string): string {
 
   let result = lines[0];
   for (let i = 1; i < lines.length; i++) {
-    const continuation = lines[i].replace(/^[ \t]+/, "");
-    const tail = /\S*$/.exec(result)?.[0] ?? "";
+    const continuation = lines[i].replace(/^[ \t]+/, "").replace(/[ \t]+$/, "");
+    const resultTrimmedEnd = result.replace(/[ \t]+$/, "");
+    const tail = /\S*$/.exec(resultTrimmedEnd)?.[0] ?? "";
     const isWrappedUrlTail =
       continuation.length > 0 &&
       /^\S+$/.test(continuation) &&
+      /[/:?=&%#@]/.test(continuation) &&
       !/^https?:\/\//.test(continuation) &&
       /https?:\/\//.test(tail);
-    result += isWrappedUrlTail ? continuation : eol + lines[i];
+    if (isWrappedUrlTail) {
+      result = resultTrimmedEnd + continuation;
+    } else {
+      result += eol + lines[i];
+    }
   }
   return result;
 }

--- a/ui/src/lib/smart-text.ts
+++ b/ui/src/lib/smart-text.ts
@@ -103,27 +103,67 @@ export function smartRemoveIndent(text: string): string {
 }
 
 /**
- * Detect if the entire text (when all whitespace is removed) forms a single URL,
- * AND every internal whitespace run looks like terminal padding / wrap leftover
- * rather than natural-language word separation. If both hold, return the
- * whitespace-stripped form. Otherwise return the input unchanged.
+ * Rejoin a URL token that terminal / TUI wrapping split across lines, dropping
+ * each continuation line's leading indent.
+ *
+ * Why this is needed beyond the whole-text-is-a-URL collapse below: full-screen
+ * TUIs (e.g. Claude Code's input box) render a long line with their OWN layout
+ * — a constant left indent on every continuation row, broken with explicit
+ * cursor moves rather than terminal auto-wrap. xterm therefore stores those
+ * rows as separate, non-`isWrapped` lines, so `getSelection()` joins them with
+ * newlines and keeps the indent. The result is a command like
+ *   `gws --scopes "https://a.com/x,https://a.com/y,..."`
+ * coming back with newlines + 2-space gaps wedged inside the URLs. Such a
+ * selection is not a single URL, so it never reached the collapse path.
+ *
+ * A line break is treated as a wrap artefact (removed, continuation indent
+ * stripped) only when ALL of these hold, which keeps prose and bare URL lists
+ * intact:
+ *   - the text so far ends inside a URL run — its trailing whitespace-free
+ *     segment contains an `http(s)://` scheme;
+ *   - the continuation (after indent strip) is a single whitespace-free token —
+ *     prose like `hello world` has internal spaces and is left alone;
+ *   - the continuation does NOT itself start a new scheme — `https://b.com` on
+ *     its own line is a separate URL, not a wrapped tail.
+ */
+function mergeWrappedUrlLines(text: string): string {
+  if (!/\r?\n/.test(text)) return text;
+  const eol = text.includes("\r\n") ? "\r\n" : "\n";
+  const lines = text.split(/\r?\n/);
+
+  let result = lines[0];
+  for (let i = 1; i < lines.length; i++) {
+    const continuation = lines[i].replace(/^[ \t]+/, "");
+    const tail = /\S*$/.exec(result)?.[0] ?? "";
+    const isWrappedUrlTail =
+      continuation.length > 0 &&
+      /^\S+$/.test(continuation) &&
+      !/^https?:\/\//.test(continuation) &&
+      /https?:\/\//.test(tail);
+    result += isWrappedUrlTail ? continuation : eol + lines[i];
+  }
+  return result;
+}
+
+/**
+ * Repair URLs broken by terminal / TUI line wrapping.
+ *
+ * Two passes:
+ *   1. `mergeWrappedUrlLines` rejoins a URL token split across lines (the TUI
+ *      input-box case above) while preserving prose and bare URL lists.
+ *   2. If, after merging, the whole text (with all whitespace removed) forms a
+ *      single URL AND every internal whitespace run looks like terminal padding
+ *      / wrap leftover, return the whitespace-stripped form. A lone ASCII space
+ *      between tokens is treated as prose and preserved, so inputs like
+ *        "https://x.com hello world"   (single-line URL + prose)
+ *        "https://x.com\nhello world"  (URL on line 1, prose on line 2)
+ *      survive intact. The shapes that collapse:
+ *        a. Multi-line URL split by terminal hard-wrap.
+ *        b. Multi-line URL with leading indent + trailing buffer-pad per line.
+ *        c. Single-line URL where an upstream paste target stripped newlines but
+ *           left leading-indent + trailing-pad as ≥2-char internal gaps, or tabs.
  *
  * "Padding-like" run = contains a newline / CR / tab, or is ≥2 ASCII spaces.
- * A lone ASCII space between tokens is treated as prose and preserved, so
- * inputs like
- *
- *     "https://x.com hello world"            (single-line URL + prose)
- *     "https://x.com\nhello world"           (URL on line 1, prose on line 2)
- *
- * survive intact on both copy and paste paths. The shapes that DO collapse:
- *
- *     1. Multi-line URL split by terminal hard-wrap (the newline run is the
- *        only whitespace, possibly fused with indent/pad spaces around it).
- *     2. Multi-line URL with leading indent + trailing buffer-pad on each line.
- *     3. Single-line URL where an upstream paste target stripped newlines but
- *        left leading-indent + trailing-pad as ≥2-char internal gaps, or
- *        tabs.
- *
  * URLs forbid raw whitespace, so collapsing is safe once we have decided the
  * input is URL-shaped and the gaps look like artefacts.
  *
@@ -134,17 +174,19 @@ export function smartRemoveIndent(text: string): string {
 export function smartRemoveLineBreak(text: string): string {
   if (!text) return text;
 
-  const joined = text.replace(/\s+/g, "");
-  if (!/^https?:\/\/\S+$/.test(joined)) return text;
+  const merged = mergeWrappedUrlLines(text);
+
+  const joined = merged.replace(/\s+/g, "");
+  if (!/^https?:\/\/\S+$/.test(joined)) return merged;
 
   // Only collapse when every internal whitespace run looks like terminal
   // padding / wrap leftover. A lone ASCII space is the prose signature.
-  const trimmed = text.replace(/^\s+/, "").replace(/\s+$/, "");
+  const trimmed = merged.replace(/^\s+/, "").replace(/\s+$/, "");
   const internalRuns = trimmed.match(/\s+/g) ?? [];
   const allRunsLookLikePadding = internalRuns.every(
     (run) => run.length >= 2 || /[\t\r\n]/.test(run),
   );
-  if (!allRunsLookLikePadding) return text;
+  if (!allRunsLookLikePadding) return merged;
 
   return joined;
 }


### PR DESCRIPTION
## 문제

`! gws auth login --scopes "...,https://...,https://..."` 같은 긴 명령을 smart copy 하면 줄바꿈이 일부만 복원되어 `googleapis  .com`(공백 2개)·중간 개행이 섞인 채 깨져서 복사됨.

## 근본 원인 (dev 라이브 재현)

해당 화면은 **Claude Code TUI의 `!` bash 입력창**. dev(cols 118)에서 버퍼를 덤프해 확인:

- Claude Code는 긴 입력을 **터미널 autowrap이 아니라 자체 레이아웃(커서 이동)**으로 그림 → 연속 줄이 xterm 버퍼에 **`isWrapped=false` + 앞 2칸 들여쓰기 + 끝 pad 공백**으로 저장됨.
- `getSelection()`이 이 줄들을 `\r\n`으로 분리해 이어붙이고 들여쓰기를 남김 → 명령 안 URL이 개행/공백2 아티팩트로 깨짐.
- 기존 `smartRemoveLineBreak`는 **셀렉션 전체가 순수 URL일 때만** 작동 → 명령에 박힌 URL은 미복원. (`smartRemoveIndent`도 첫 줄 들여쓰기 0이라 공통 최소=0으로 무력화)

→ `isWrapped` 기반 재구성은 불가(claude가 wrapped로 표시 안 함). URL-aware 복원만 유효.

## 수정

`smartRemoveLineBreak`에 **Phase 1: `mergeWrappedUrlLines`** 추가 — 줄바꿈으로 쪼개진 URL 토큰만 이어붙임. 산문·별도 URL 목록 보존을 위해 모두 충족 시에만 합침:

- 직전 텍스트가 URL 안에서 끝남 (마지막 공백없는 구간에 `http(s)://`)
- 다음 줄이 들여쓰기 제거 후 **공백 없는 단일 토큰** (`hello world` 등 산문 제외)
- 다음 줄이 `https://`로 새로 시작하지 않음 (별도 URL 보존)

전체가 순수 URL인 경우의 기존 collapse(Phase 2)는 유지.

## 검증

- 유닛 테스트 **81개 통과** (실제 재현 데이터 기반 신규 4개 + 기존 산문/URL-목록 보존 무회귀), TerminalView 114개 통과, 타입체크·eslint·prettier 클린.
- **라이브 e2e (dev, Claude Code 입력창 재현)**: 실제 버퍼 → getSelection 재구성 → 소스 transform 통과 결과가 **단일 줄, CR/LF·내부 공백2 없음, scope URL 14개 전부 온전, `script.processes"`로 정확히 종료**.

남는 차이는 claude가 표시하는 `!  gws` 앞 2칸뿐(URL 무관 TUI 문자라 미수정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)