### PR TITLE
feat: memo에서 Ctrl +/- 글자 크기 조절 (#301)

### DIFF
--- a/docs/adr/0004-settings-vs-ui-state-separation.md
+++ b/docs/adr/0004-settings-vs-ui-state-separation.md
@@ -13,7 +13,7 @@
 **구성은 `settings.json`, UI 상태는 localStorage** 로 엄격히 분리하고, 그 사이에 두 개의 일급 오버라이드 공간을 둔다.
 
 - `paneOverrides` — 레이아웃 **슬롯**에 귀속(예: `controlBarMode`). 슬롯 안 view 가 바뀌어도 유지.
-- `viewOverrides` — 슬롯 **콘텐츠(view)**에 귀속(예: TerminalView `fontSize`). view 타입이 바뀌면 자동 리셋.
+- `viewOverrides` — 슬롯 **콘텐츠(view)**에 귀속(예: TerminalView·MemoView `fontSize` 줌). view 타입이 바뀌면 자동 리셋.
 - 둘 다 `useOverridesStore` 에서 관리. 해석 우선순위: `profileDefaults → profile → paneOverrides → viewOverrides`.
 
 ## Consequences

--- a/ui/src/components/views/MemoView.test.tsx
+++ b/ui/src/components/views/MemoView.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoView } from "./MemoView";
 import { loadMemo, saveMemo, clipboardWriteText } from "@/lib/tauri-api";
 import { useSettingsStore } from "@/stores/settings-store";
+import { useOverridesStore } from "@/stores/overrides-store";
 
 vi.mock("@/lib/tauri-api", () => ({
   loadMemo: vi.fn().mockResolvedValue(""),
@@ -557,6 +558,80 @@ describe("MemoView", () => {
       });
       const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
       expect(textarea.style.fontSize).toBe("13px");
+    });
+  });
+
+  describe("font zoom (Ctrl +/-/0)", () => {
+    async function setupZoom(paneId = "pane-zoom") {
+      useOverridesStore.setState({ viewOverrides: {} });
+      useSettingsStore.setState({
+        memo: { ...useSettingsStore.getState().memo, fontSize: 13 },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("");
+      render(<MemoView memoKey="memo-zoom" paneId={paneId} />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      return screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
+    }
+
+    it("Ctrl+= zooms in by 1px and records a view override", async () => {
+      const textarea = await setupZoom();
+      expect(textarea.style.fontSize).toBe("13px");
+
+      fireEvent.keyDown(textarea, { key: "=", ctrlKey: true });
+      expect(textarea.style.fontSize).toBe("14px");
+      expect(useOverridesStore.getState().viewOverrides["pane-zoom"]?.fontSize).toBe(14);
+    });
+
+    it("Ctrl+- zooms out by 1px", async () => {
+      const textarea = await setupZoom();
+      fireEvent.keyDown(textarea, { key: "-", ctrlKey: true });
+      expect(textarea.style.fontSize).toBe("12px");
+      expect(useOverridesStore.getState().viewOverrides["pane-zoom"]?.fontSize).toBe(12);
+    });
+
+    it("Ctrl+0 resets to the base font size (clears override)", async () => {
+      const textarea = await setupZoom();
+      fireEvent.keyDown(textarea, { key: "=", ctrlKey: true });
+      fireEvent.keyDown(textarea, { key: "=", ctrlKey: true });
+      expect(textarea.style.fontSize).toBe("15px");
+
+      fireEvent.keyDown(textarea, { key: "0", ctrlKey: true });
+      expect(textarea.style.fontSize).toBe("13px");
+      expect(useOverridesStore.getState().viewOverrides["pane-zoom"]).toBeUndefined();
+    });
+
+    it("clamps zoom-out at the minimum font size", async () => {
+      useOverridesStore.setState({ viewOverrides: { "pane-min": { fontSize: 6 } } });
+      useSettingsStore.setState({
+        memo: { ...useSettingsStore.getState().memo, fontSize: 13 },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("");
+      render(<MemoView memoKey="memo-min" paneId="pane-min" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
+      expect(textarea.style.fontSize).toBe("6px");
+
+      fireEvent.keyDown(textarea, { key: "-", ctrlKey: true });
+      expect(textarea.style.fontSize).toBe("6px");
+      expect(useOverridesStore.getState().viewOverrides["pane-min"]?.fontSize).toBe(6);
+    });
+
+    it("override font size takes precedence over memo.fontSize", async () => {
+      useOverridesStore.setState({ viewOverrides: { "pane-ov": { fontSize: 22 } } });
+      useSettingsStore.setState({
+        memo: { ...useSettingsStore.getState().memo, fontSize: 13 },
+      });
+      vi.mocked(loadMemo).mockResolvedValue("");
+      render(<MemoView memoKey="memo-ov" paneId="pane-ov" />);
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      const textarea = screen.getByTestId("memo-textarea") as HTMLTextAreaElement;
+      expect(textarea.style.fontSize).toBe("22px");
     });
   });
 });

--- a/ui/src/components/views/MemoView.tsx
+++ b/ui/src/components/views/MemoView.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { loadMemo, saveMemo, clipboardWriteText } from "@/lib/tauri-api";
 import { useSettingsStore } from "@/stores/settings-store";
+import { useOverridesStore } from "@/stores/overrides-store";
+import { matchesKeybinding } from "@/lib/keybinding-registry";
 import { splitParagraphs } from "@/lib/memo-paragraphs";
 import { ViewShell } from "@/components/ui/ViewShell";
 import { ViewHeader } from "@/components/ui/ViewHeader";
@@ -8,12 +10,18 @@ import { ViewBody } from "@/components/ui/ViewBody";
 
 const DEBOUNCE_MS = 300;
 
+/** Font-zoom clamp — keep in lockstep with TerminalView's adjustZoom bounds. */
+const MIN_FONT_SIZE = 6;
+const MAX_FONT_SIZE = 72;
+
 interface MemoViewProps {
   memoKey: string;
+  /** View-instance key for per-pane font-zoom overrides (localStorage). */
+  paneId?: string;
   isFocused?: boolean;
 }
 
-export function MemoView({ memoKey, isFocused }: MemoViewProps) {
+export function MemoView({ memoKey, paneId, isFocused }: MemoViewProps) {
   const [text, setText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -84,9 +92,30 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
     return splitParagraphs(text, memo.paragraphCopy.minBlankLines);
   }, [text, memo.paragraphCopy.enabled, memo.paragraphCopy.minBlankLines]);
 
-  const effectiveFontSize = memo.fontSize || appFont.size;
+  // Per-view font zoom (Ctrl +/-/0) lives in overrides-store (localStorage),
+  // mirroring TerminalView so a transient zoom never pollutes settings.json.
+  const overrideFontSize = useOverridesStore((s) =>
+    paneId ? s.viewOverrides[paneId]?.fontSize : undefined,
+  );
+
+  const baseFontSize = memo.fontSize || appFont.size;
+  const effectiveFontSize = overrideFontSize ?? baseFontSize;
   const effectiveFontFamily = memo.fontFamily || appFont.face;
   const effectiveFontWeight = memo.fontWeight || appFont.weight;
+
+  // Adjust the view-instance font zoom (zoomIn/zoomOut shared). no-op without paneId.
+  const adjustZoom = useCallback(
+    (delta: number) => {
+      if (!paneId) return;
+      const overrides = useOverridesStore.getState();
+      const current = overrides.viewOverrides[paneId]?.fontSize ?? (memo.fontSize || appFont.size);
+      const next = Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, current + delta));
+      if (next !== current) {
+        overrides.setViewOverride(paneId, { fontSize: next });
+      }
+    },
+    [paneId, memo.fontSize, appFont.size],
+  );
 
   // Lazy copy on select: remember selected text, copy on deselect / blur / Ctrl+C
   const pendingCopyRef = useRef<string | null>(null);
@@ -227,6 +256,23 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // 폰트 줌: view 인스턴스 오버라이드에만 기록 (settings.json 불변).
+      if (matchesKeybinding(e, "memo.zoomIn")) {
+        e.preventDefault();
+        adjustZoom(+1);
+        return;
+      }
+      if (matchesKeybinding(e, "memo.zoomOut")) {
+        e.preventDefault();
+        adjustZoom(-1);
+        return;
+      }
+      if (matchesKeybinding(e, "memo.zoomReset")) {
+        e.preventDefault();
+        if (paneId) useOverridesStore.getState().clearViewOverride(paneId);
+        return;
+      }
+
       if (e.key !== "Tab") return;
       e.preventDefault();
 
@@ -360,7 +406,7 @@ export function MemoView({ memoKey, isFocused }: MemoViewProps) {
         }
       }
     },
-    [applyTextChange, indent],
+    [applyTextChange, indent, adjustZoom, paneId],
   );
 
   return (

--- a/ui/src/components/views/MemoView.tsx
+++ b/ui/src/components/views/MemoView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { loadMemo, saveMemo, clipboardWriteText } from "@/lib/tauri-api";
 import { useSettingsStore } from "@/stores/settings-store";
-import { useOverridesStore } from "@/stores/overrides-store";
+import { useOverridesStore, FONT_ZOOM_MIN, FONT_ZOOM_MAX } from "@/stores/overrides-store";
 import { matchesKeybinding } from "@/lib/keybinding-registry";
 import { splitParagraphs } from "@/lib/memo-paragraphs";
 import { ViewShell } from "@/components/ui/ViewShell";
@@ -9,10 +9,6 @@ import { ViewHeader } from "@/components/ui/ViewHeader";
 import { ViewBody } from "@/components/ui/ViewBody";
 
 const DEBOUNCE_MS = 300;
-
-/** Font-zoom clamp — keep in lockstep with TerminalView's adjustZoom bounds. */
-const MIN_FONT_SIZE = 6;
-const MAX_FONT_SIZE = 72;
 
 interface MemoViewProps {
   memoKey: string;
@@ -109,7 +105,7 @@ export function MemoView({ memoKey, paneId, isFocused }: MemoViewProps) {
       if (!paneId) return;
       const overrides = useOverridesStore.getState();
       const current = overrides.viewOverrides[paneId]?.fontSize ?? (memo.fontSize || appFont.size);
-      const next = Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, current + delta));
+      const next = Math.max(FONT_ZOOM_MIN, Math.min(FONT_ZOOM_MAX, current + delta));
       if (next !== current) {
         overrides.setViewOverride(paneId, { fontSize: next });
       }
@@ -269,6 +265,7 @@ export function MemoView({ memoKey, paneId, isFocused }: MemoViewProps) {
       }
       if (matchesKeybinding(e, "memo.zoomReset")) {
         e.preventDefault();
+        // paneId가 없으면 줌 오버라이드를 쓰지 않으므로 reset도 no-op (지울 대상 없음).
         if (paneId) useOverridesStore.getState().clearViewOverride(paneId);
         return;
       }

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -7,7 +7,7 @@ import { createIndentedLinkProvider } from "@/lib/indented-link-provider";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { useTerminalStore, type TerminalActivityInfo } from "@/stores/terminal-store";
 import { useSettingsStore, defaultProfileDefaults } from "@/stores/settings-store";
-import { useOverridesStore } from "@/stores/overrides-store";
+import { useOverridesStore, FONT_ZOOM_MIN, FONT_ZOOM_MAX } from "@/stores/overrides-store";
 import { toSupportedCursorShape, toXtermCursorOptions } from "@/lib/cursor-settings";
 import {
   createTerminalSession,
@@ -1017,7 +1017,7 @@ export function TerminalView({
       const currentFont = useSettingsStore
         .getState()
         .resolveFont(profile, overrides.getViewOverride(paneId));
-      const newSize = Math.max(6, Math.min(72, currentFont.size + delta));
+      const newSize = Math.max(FONT_ZOOM_MIN, Math.min(FONT_ZOOM_MAX, currentFont.size + delta));
       if (newSize !== currentFont.size) {
         overrides.setViewOverride(paneId, { fontSize: newSize });
       }

--- a/ui/src/components/views/ViewRenderer.tsx
+++ b/ui/src/components/views/ViewRenderer.tsx
@@ -212,7 +212,7 @@ export function ViewRenderer({
       const memoKey = paneId ? `memo-${paneId}` : `memo-${fallbackId}`;
       return (
         <div data-testid="view-memo" className="h-full">
-          <MemoView memoKey={memoKey} isFocused={isFocused} />
+          <MemoView memoKey={memoKey} paneId={paneId ?? fallbackId} isFocused={isFocused} />
         </div>
       );
     }

--- a/ui/src/lib/keybinding-registry.ts
+++ b/ui/src/lib/keybinding-registry.ts
@@ -118,6 +118,25 @@ export const DEFAULT_KEYBINDINGS: KeybindingDef[] = [
     defaultKeys: "Ctrl+0",
     group: "Terminal",
   },
+  // -- Memo --
+  {
+    id: "memo.zoomIn",
+    label: "메모 폰트 확대 (view 인스턴스 오버라이드)",
+    defaultKeys: "Ctrl+=",
+    group: "Memo",
+  },
+  {
+    id: "memo.zoomOut",
+    label: "메모 폰트 축소 (view 인스턴스 오버라이드)",
+    defaultKeys: "Ctrl+-",
+    group: "Memo",
+  },
+  {
+    id: "memo.zoomReset",
+    label: "메모 폰트 기본값으로 복귀",
+    defaultKeys: "Ctrl+0",
+    group: "Memo",
+  },
   // -- Issue Reporter --
   {
     id: "issueReporter.submit",

--- a/ui/src/stores/overrides-store.ts
+++ b/ui/src/stores/overrides-store.ts
@@ -24,7 +24,7 @@ export interface PaneOverrides {
 }
 
 export interface ViewOverrides {
-  /** TerminalView: Ctrl+Wheel로 조정된 폰트 크기. */
+  /** TerminalView·MemoView: Ctrl+Wheel / Ctrl +,-,0 으로 조정된 폰트 크기. */
   fontSize?: number;
 }
 

--- a/ui/src/stores/overrides-store.ts
+++ b/ui/src/stores/overrides-store.ts
@@ -19,6 +19,13 @@ import type { ControlBarMode } from "./settings-store";
 export const PANE_OVERRIDES_KEY = "laymux-pane-overrides";
 export const VIEW_OVERRIDES_KEY = "laymux-view-overrides";
 
+/**
+ * 폰트 줌(Ctrl +,-,0 / Ctrl+Wheel) 클램프 범위 — 단일 출처.
+ * `fontSize` 오버라이드를 소비하는 모든 뷰(TerminalView·MemoView)가 공유한다.
+ */
+export const FONT_ZOOM_MIN = 6;
+export const FONT_ZOOM_MAX = 72;
+
 export interface PaneOverrides {
   controlBarMode?: ControlBarMode;
 }


### PR DESCRIPTION
@
## 요약
memo 뷰에서도 터미널처럼 `Ctrl + =` / `Ctrl + -` 로 폰트 크기를 즉시 조절하고 `Ctrl + 0` 으로 기본값 복귀가 가능하도록 추가한다.

## 구현 방식
TerminalView의 줌 패턴(per-view 오버라이드)을 그대로 따랐다. 줌 값은 `useOverridesStore.viewOverrides.fontSize`(localStorage)에 기록하고 `settings.json`은 건드리지 않아 ADR 0004(설정 vs UI 상태 분리)에 부합한다. `settings.memo.fontSize`는 base 값으로 유지하고 줌은 그 위에 오버라이드를 얹는다 (`effectiveFontSize = viewOverride ?? (memo.fontSize || appFont.size)`, 6~72px 클램프).

## 변경
- `ui/src/lib/keybinding-registry.ts` — `memo.zoomIn/zoomOut/zoomReset` 키바인딩 추가
- `ui/src/components/views/MemoView.tsx` — paneId prop, 오버라이드 기반 폰트 크기 계산, 줌 핸들러
- `ui/src/components/views/ViewRenderer.tsx` — MemoView에 paneId 전달
- `ui/src/stores/overrides-store.ts` — 주석 갱신
- `docs/adr/0004-settings-vs-ui-state-separation.md` — MemoView 예시 추가
- `ui/src/components/views/MemoView.test.tsx` — 줌 테스트 5건 추가

## 테스트
- MemoView: 42건 통과 (신규 5건 포함)
- 전체 UI 스위트: 1988건 전부 통과
- tsc 타입체크 통과

Fixes #301
@