### PR TITLE
fix: pane 좌표 부동소수점 노이즈를 경고 없이 1.0으로 스냅

### DIFF
--- a/src-tauri/src/settings/validation.rs
+++ b/src-tauri/src/settings/validation.rs
@@ -381,13 +381,15 @@ fn normalize_pane_bounds(
     pane_path: &str,
     warnings: &mut Vec<ValidationWarning>,
 ) {
+    // Keep pre-snap originals so warnings report the value actually found in the file.
+    let (orig_x, orig_y, orig_w, orig_h) = (*x, *y, *w, *h);
     snap_to_unit(x);
     snap_to_unit(y);
     snap_to_unit(w);
     snap_to_unit(h);
 
     if !is_valid_ratio(*x) {
-        let old = *x;
+        let old = orig_x;
         *x = clamp_ratio(*x);
         warnings.push(ValidationWarning {
             path: format!("{pane_path}.x"),
@@ -399,7 +401,7 @@ fn normalize_pane_bounds(
         });
     }
     if !is_valid_ratio(*y) {
-        let old = *y;
+        let old = orig_y;
         *y = clamp_ratio(*y);
         warnings.push(ValidationWarning {
             path: format!("{pane_path}.y"),
@@ -411,7 +413,7 @@ fn normalize_pane_bounds(
         });
     }
     if !is_valid_dimension(*w) {
-        let old = *w;
+        let old = orig_w;
         *w = clamp_dimension(*w);
         warnings.push(ValidationWarning {
             path: format!("{pane_path}.w"),
@@ -423,7 +425,7 @@ fn normalize_pane_bounds(
         });
     }
     if !is_valid_dimension(*h) {
-        let old = *h;
+        let old = orig_h;
         *h = clamp_dimension(*h);
         warnings.push(ValidationWarning {
             path: format!("{pane_path}.h"),
@@ -615,7 +617,7 @@ mod tests {
     }
 
     #[test]
-    fn pane_dimension_with_fp_noise_above_1_is_silently_snapped() {
+    fn pane_bounds_fp_noise_is_silently_snapped() {
         // 리사이즈 연산 누적으로 h가 1.0000000000000009처럼 1을 미세하게 초과할 수 있다.
         // 경고 없이 1.0으로 스냅되어야 한다.
         let mut settings = Settings::default();
@@ -640,6 +642,25 @@ mod tests {
         let warnings = validate_and_repair(&mut settings);
         assert_eq!(settings.workspaces[0].panes[0].h, 1.0);
         assert!(warnings.iter().any(|w| w.path.contains(".h") && w.repaired));
+    }
+
+    #[test]
+    fn negative_noise_dimension_warning_reports_original_value() {
+        // w=-9e-16은 0.0으로 스냅된 뒤 dimension 검사(>0)에 걸려 경고가 나간다.
+        // 이때 메시지는 스냅된 0이 아니라 파일에 있던 원본 값을 보여줘야 한다.
+        let mut settings = Settings::default();
+        settings.workspaces[0].panes[0].w = -9e-16;
+        let warnings = validate_and_repair(&mut settings);
+        assert!(settings.workspaces[0].panes[0].w > 0.0);
+        let warning = warnings
+            .iter()
+            .find(|w| w.path.contains(".w"))
+            .expect("w warning expected");
+        assert!(
+            warning.message.contains("-0.0000000000000009"),
+            "message should contain original value: {}",
+            warning.message
+        );
     }
 
     #[test]

--- a/src-tauri/src/settings/validation.rs
+++ b/src-tauri/src/settings/validation.rs
@@ -320,6 +320,20 @@ const MIN_PANE_DIM: f64 = 0.01;
 /// Tolerance for floating-point comparison to avoid false positives (e.g. 0.3+0.7 = 1.0000000000000002).
 const BOUNDS_EPSILON: f64 = 1e-9;
 
+/// Snap values within epsilon of the [0, 1] boundary back onto it.
+/// Resize arithmetic can leave fp noise like 1.0000000000000009 — silently
+/// absorbing it avoids spurious "out of range" warnings on every load.
+fn snap_to_unit(v: &mut f64) {
+    if !v.is_finite() {
+        return;
+    }
+    if *v > 1.0 && *v <= 1.0 + BOUNDS_EPSILON {
+        *v = 1.0;
+    } else if *v < 0.0 && *v >= -BOUNDS_EPSILON {
+        *v = 0.0;
+    }
+}
+
 fn is_valid_ratio(v: f64) -> bool {
     v.is_finite() && (0.0..=1.0).contains(&v)
 }
@@ -367,6 +381,11 @@ fn normalize_pane_bounds(
     pane_path: &str,
     warnings: &mut Vec<ValidationWarning>,
 ) {
+    snap_to_unit(x);
+    snap_to_unit(y);
+    snap_to_unit(w);
+    snap_to_unit(h);
+
     if !is_valid_ratio(*x) {
         let old = *x;
         *x = clamp_ratio(*x);
@@ -593,6 +612,34 @@ mod tests {
         // Should NOT be modified — epsilon tolerance absorbs fp noise
         assert_eq!(pane.w, 0.7);
         assert!(!warnings.iter().any(|w| w.message.contains("범위를 초과")));
+    }
+
+    #[test]
+    fn pane_dimension_with_fp_noise_above_1_is_silently_snapped() {
+        // 리사이즈 연산 누적으로 h가 1.0000000000000009처럼 1을 미세하게 초과할 수 있다.
+        // 경고 없이 1.0으로 스냅되어야 한다.
+        let mut settings = Settings::default();
+        settings.workspaces[0].panes[0].h = 1.0 + 9e-16;
+        settings.workspaces[0].panes[0].w = 1.0 + 9e-16;
+        settings.workspaces[0].panes[0].x = -9e-16;
+        settings.workspaces[0].panes[0].y = -9e-16;
+        let warnings = validate_and_repair(&mut settings);
+        let pane = &settings.workspaces[0].panes[0];
+        assert_eq!(pane.x, 0.0);
+        assert_eq!(pane.y, 0.0);
+        assert_eq!(pane.w, 1.0);
+        assert_eq!(pane.h, 1.0);
+        assert!(warnings.is_empty(), "warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn pane_dimension_beyond_epsilon_still_warns() {
+        // epsilon(1e-9)을 넘는 초과는 여전히 경고와 함께 수정되어야 한다.
+        let mut settings = Settings::default();
+        settings.workspaces[0].panes[0].h = 1.001;
+        let warnings = validate_and_repair(&mut settings);
+        assert_eq!(settings.workspaces[0].panes[0].h, 1.0);
+        assert!(warnings.iter().any(|w| w.path.contains(".h") && w.repaired));
     }
 
     #[test]


### PR DESCRIPTION
## 문제

설정 로드 시 아래와 같은 거짓 경고가 발생:

> `workspaces[6].panes[0].h` — h 크기 1.0000000000000009이(가) 유효 범위(0.0~1.0, >0)를 벗어나 1.00로 수정했습니다.

리사이즈 연산의 부동소수점 오차 누적으로 `h`가 1.0을 9e-16만큼 초과한 것인데, 사용자에게 설정 파일 오류로 보고되고 있었다.

## 원인

`normalize_pane_bounds`에서 `x+w <= 1` 합 검사(`normalize_axis`)에는 `BOUNDS_EPSILON`(1e-9) 허용 오차가 적용되지만, 개별 필드 검사(`is_valid_ratio` / `is_valid_dimension`)는 엄격한 `<= 1.0` 비교라 fp 노이즈가 경고를 유발하는 비대칭이 있었다.

## 수정

- `snap_to_unit` 추가: `[0, 1]` 경계를 epsilon(1e-9) 이내로 벗어난 값은 **경고 없이** 0.0/1.0으로 스냅
- `normalize_pane_bounds` 진입 시 x/y/w/h에 먼저 적용 — workspace/layout/dock pane 모두 동일 경로를 타므로 한 곳 수정으로 전부 해결
- epsilon을 넘는 실제 범위 초과(예: 1.001)는 기존대로 경고와 함께 수정

## 테스트

- `pane_dimension_with_fp_noise_above_1_is_silently_snapped` — 1.0+9e-16 / -9e-16이 경고 없이 스냅되는지
- `pane_dimension_beyond_epsilon_still_warns` — 1.001은 여전히 경고와 함께 수정되는지
- 기존 validation 테스트 37개 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
