### PR TITLE
fix: pane 컨트롤 바 hover 오버레이를 반투명으로 변경

### DIFF
--- a/ui/src/components/layout/PaneControlBar.test.tsx
+++ b/ui/src/components/layout/PaneControlBar.test.tsx
@@ -149,6 +149,29 @@ describe("PaneControlBar", () => {
     expect(compactBar.className).not.toContain("left-0");
   });
 
+  // -- Overlay transparency (issue #320) --
+  // hover 오버레이 바가 터미널 내용을 가리지 않도록 기본값으로 반투명 처리한다.
+
+  it("hover overlay bar uses the semi-transparent overlay token (issue #320)", () => {
+    render(
+      <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    const bar = screen.getByTestId("pane-control-bar");
+    expect(bar.style.background).toBe("var(--bar-bg-overlay)");
+  });
+
+  it("hover overlay bar does not blur the content beneath it (issue #320)", () => {
+    render(
+      <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    const bar = screen.getByTestId("pane-control-bar");
+    expect(bar.style.backdropFilter).toBe("");
+  });
+
   it("bar contains view selector, split, clear, pin, minimize buttons", () => {
     render(
       <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -64,7 +64,8 @@ const BAR_H = "var(--bar-h)";
 const BTN_H = "var(--btn-h)";
 const BTN_MIN_W = "var(--btn-min-w)";
 const barBg = "var(--bg-surface)";
-const barBgHover = "var(--bar-bg-hover)";
+// hover 오버레이는 콘텐츠 위에 뜨므로 반투명 토큰 사용 — 아래 내용이 비쳐야 한다 (issue #320)
+const barBgOverlay = "var(--bar-bg-overlay)";
 const borderClr = "var(--border)";
 const sepClr = "var(--separator-bg)";
 
@@ -813,8 +814,8 @@ export function PaneControlBar({
               }`}
               style={{
                 minHeight: BAR_H,
-                background: barBgHover,
-                backdropFilter: "blur(8px)",
+                // 반투명 배경 + blur 없음: 컨트롤 바 아래 터미널 내용이 보여야 한다 (issue #320)
+                background: barBgOverlay,
                 borderBottom: `1px solid ${sepClr}`,
                 ...(!hasLeftContent && !narrowBar ? { borderLeft: `1px solid ${sepClr}` } : {}),
                 borderRadius: 0,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -28,6 +28,8 @@
   --backdrop-heavy: rgba(0, 0, 0, 0.5);
   --hover-bg-subtle: rgba(255, 255, 255, 0.03);
   --bar-bg-hover: rgba(24, 24, 37, 0.96);
+  /* pane 컨트롤 바 hover 오버레이 — 아래 콘텐츠가 비치도록 반투명 (issue #320) */
+  --bar-bg-overlay: rgba(24, 24, 37, 0.6);
 
   /* dimensions */
   --bar-h: 28px;

--- a/ui/src/lib/css-tokens.test.ts
+++ b/ui/src/lib/css-tokens.test.ts
@@ -39,6 +39,7 @@ describe("CSS design tokens — hover overlay", () => {
     "--backdrop-light",
     "--backdrop-heavy",
     "--bar-bg-hover",
+    "--bar-bg-overlay",
   ];
 
   it.each(hoverTokens)("defines %s in :root", (token) => {
@@ -133,6 +134,16 @@ describe("CSS utility classes — terminal IME composition", () => {
     expect(cssContent).toMatch(
       /\.terminal-composition-preview\s*\{[^}]*text-underline-offset:\s*2px;/s,
     );
+  });
+});
+
+describe("CSS design tokens — control bar overlay opacity (issue #320)", () => {
+  it("--bar-bg-overlay is semi-transparent (alpha <= 0.75) so content beneath stays visible", () => {
+    const match = cssContent.match(
+      /--bar-bg-overlay\s*:\s*rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*([\d.]+)\s*\)/,
+    );
+    expect(match).not.toBeNull();
+    expect(parseFloat(match![1])).toBeLessThanOrEqual(0.75);
   });
 });
 


### PR DESCRIPTION
## 요약
- pane 컨트롤 바 hover 오버레이가 거의 불투명(`rgba(24,24,37,0.96)` + `backdrop-filter: blur(8px)`)이라 아래 터미널 내용이 가려지는 문제 수정
- 반투명 토큰 `--bar-bg-overlay: rgba(24, 24, 37, 0.6)` 추가, hover 오버레이 배경 교체 및 blur 제거
- pinned 바는 레이아웃 공간을 차지해 내용을 가리지 않으므로 기존 불투명 유지, narrow 모드 플로팅 메뉴도 드롭다운 가독성 위해 유지

## 테스트
- 회귀 테스트 추가 (반투명 토큰 사용 + blur 미적용, 토큰 alpha ≤ 0.75 검증)
- 전체 프론트엔드 스위트 `npx vitest run`: 81 files / 2026 tests 통과

Fixes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)