### PR TITLE
feat: hover 컨트롤 바에 마우스 오버 시 불투명 복귀

### DIFF
--- a/ui/src/components/layout/PaneControlBar.test.tsx
+++ b/ui/src/components/layout/PaneControlBar.test.tsx
@@ -150,25 +150,28 @@ describe("PaneControlBar", () => {
   });
 
   // -- Overlay transparency (issue #320) --
-  // hover 오버레이 바가 터미널 내용을 가리지 않도록 기본값으로 반투명 처리한다.
+  // hover 오버레이 바는 평소엔 반투명(.pane-hover-bar)이고, 바 자체에 마우스가
+  // 올라가면 CSS :hover 로 불투명 복귀한다. 인라인 background/backdropFilter 를
+  // 쓰면 CSS :hover 가 인라인 스타일을 못 이기므로 클래스로만 스타일링한다.
 
-  it("hover overlay bar uses the semi-transparent overlay token (issue #320)", () => {
+  it("hover overlay bar uses the translucent .pane-hover-bar class (issue #320)", () => {
     render(
       <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
         <div>content</div>
       </PaneControlBar>,
     );
     const bar = screen.getByTestId("pane-control-bar");
-    expect(bar.style.background).toBe("var(--bar-bg-overlay)");
+    expect(bar.className).toContain("pane-hover-bar");
   });
 
-  it("hover overlay bar does not blur the content beneath it (issue #320)", () => {
+  it("hover overlay bar has no inline background/blur that would defeat CSS :hover (issue #320)", () => {
     render(
       <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
         <div>content</div>
       </PaneControlBar>,
     );
     const bar = screen.getByTestId("pane-control-bar");
+    expect(bar.style.background).toBe("");
     expect(bar.style.backdropFilter).toBe("");
   });
 

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -64,8 +64,6 @@ const BAR_H = "var(--bar-h)";
 const BTN_H = "var(--btn-h)";
 const BTN_MIN_W = "var(--btn-min-w)";
 const barBg = "var(--bg-surface)";
-// hover 오버레이는 콘텐츠 위에 뜨므로 반투명 토큰 사용 — 아래 내용이 비쳐야 한다 (issue #320)
-const barBgOverlay = "var(--bar-bg-overlay)";
 const borderClr = "var(--border)";
 const sepClr = "var(--separator-bg)";
 
@@ -809,13 +807,11 @@ export function PaneControlBar({
           {!isPinned && !hasViewHeader && mode !== "minimized" && showBar && (
             <div
               data-testid="pane-control-bar"
-              className={`absolute top-0 z-20 flex items-center pr-1 ${
+              className={`pane-hover-bar absolute top-0 z-20 flex items-center pr-1 ${
                 hasLeftContent || narrowBar ? "left-0 right-0 pl-2" : "right-0 pl-0.5"
               }`}
               style={{
                 minHeight: BAR_H,
-                // 반투명 배경 + blur 없음: 컨트롤 바 아래 터미널 내용이 보여야 한다 (issue #320)
-                background: barBgOverlay,
                 borderBottom: `1px solid ${sepClr}`,
                 ...(!hasLeftContent && !narrowBar ? { borderLeft: `1px solid ${sepClr}` } : {}),
                 borderRadius: 0,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -188,6 +188,17 @@
     margin-bottom: 0;
   }
 
+  /* hover 모드 오버레이 컨트롤 바: 평소엔 반투명(아래 터미널 내용이 비침, issue #320),
+     바 자체에 마우스가 올라가면 조작 대상이므로 불투명으로 복귀 */
+  .pane-hover-bar {
+    background: var(--bar-bg-overlay);
+    transition: background var(--transition-fast);
+  }
+  .pane-hover-bar:hover {
+    background: var(--bar-bg-hover);
+    backdrop-filter: blur(8px);
+  }
+
   /* Toolbar (28px header bar) */
   .ui-toolbar {
     display: flex;

--- a/ui/src/lib/css-tokens.test.ts
+++ b/ui/src/lib/css-tokens.test.ts
@@ -102,6 +102,18 @@ describe("CSS utility classes — hover", () => {
   });
 });
 
+describe("CSS utility classes — pane hover bar", () => {
+  it("defines .pane-hover-bar with the translucent overlay background", () => {
+    expect(cssContent).toMatch(/\.pane-hover-bar\s*\{[^}]*background:\s*var\(--bar-bg-overlay\);/s);
+  });
+
+  it("restores the opaque background on .pane-hover-bar:hover", () => {
+    expect(cssContent).toMatch(
+      /\.pane-hover-bar:hover\s*\{[^}]*background:\s*var\(--bar-bg-hover\);/s,
+    );
+  });
+});
+
 describe("CSS utility classes — separator", () => {
   it("defines .ui-sep class", () => {
     expect(cssContent).toMatch(/\.ui-sep\s*\{/);


### PR DESCRIPTION
## 요약
- #320 에서 hover 오버레이 컨트롤 바를 반투명 처리해 아래 터미널 내용이 보이게 했지만, 바 자체를 조작할 때는 컨트롤 가독성이 필요하다.
- 바에 마우스가 올라가면 불투명(`--bar-bg-hover`) + blur(8px) 로 복귀하도록 `.pane-hover-bar` CSS 클래스를 추가했다.
- CSS `:hover` 가 인라인 스타일을 못 이기므로, 인라인 `background` 를 클래스로 이동 (UI 원칙 §15: 호버는 CSS 클래스).

## 검증
- 단위 테스트 85개 통과 (클래스 적용 + 인라인 스타일 부재 + CSS 규칙 존재 가드)
- dev(19281) 인스턴스에서 hover 시뮬레이션 + 스크린샷으로 반투명 상태 확인
- prettier / eslint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)