### PR TITLE
feat: 파일 뷰어 상시 주소줄 — 오픈 후에도 다른 경로로 이동 가능

### DIFF
--- a/ui/src/components/layout/FileViewerOverlay.test.tsx
+++ b/ui/src/components/layout/FileViewerOverlay.test.tsx
@@ -158,6 +158,19 @@ describe("FileViewerOverlay", () => {
     expect(useFileViewerStore.getState().open).toBe(false);
   });
 
+  it("Escape closes the overlay even when the address bar input is focused in prompt mode", () => {
+    act(() => {
+      useFileViewerStore.getState().openEmptyFileViewer();
+    });
+    render(<FileViewerOverlay />);
+    const input = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    input.focus();
+    // In prompt mode there is no draft to revert, so the bar's keydown handler
+    // must NOT consume Escape — it bubbles to the global handler and closes.
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(useFileViewerStore.getState().open).toBe(false);
+  });
+
   // --- #327 / #326: persistent address bar ---
   it("shows the current path in an editable address bar once a file is loaded (#327)", () => {
     act(() => {

--- a/ui/src/components/layout/FileViewerOverlay.test.tsx
+++ b/ui/src/components/layout/FileViewerOverlay.test.tsx
@@ -116,9 +116,11 @@ describe("FileViewerOverlay", () => {
     const s = useFileViewerStore.getState();
     expect(s.open).toBe(true);
     expect(s.path).toBe("/home/user/note.txt");
-    // The viewer body now renders the loaded file; the input is gone.
+    // The viewer body now renders the loaded file; the address bar stays at the
+    // top showing the loaded path (#327).
     expect(screen.getByTestId("mock-file-viewer")).toBeInTheDocument();
-    expect(screen.queryByTestId("file-viewer-overlay-path-input")).not.toBeInTheDocument();
+    const bar = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    expect(bar.value).toBe("/home/user/note.txt");
   });
 
   it("loads the file when the load button is clicked", () => {
@@ -156,13 +158,88 @@ describe("FileViewerOverlay", () => {
     expect(useFileViewerStore.getState().open).toBe(false);
   });
 
-  it("does not show the inline input once a file is loaded", () => {
+  // --- #327 / #326: persistent address bar ---
+  it("shows the current path in an editable address bar once a file is loaded (#327)", () => {
     act(() => {
       useFileViewerStore.getState().openFileViewer("/home/user/a.txt");
     });
     render(<FileViewerOverlay />);
-    expect(screen.queryByTestId("file-viewer-overlay-path-input")).not.toBeInTheDocument();
+    const input = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe("/home/user/a.txt");
+    // The bar must not steal focus from the loaded viewer (terminal apps etc.).
+    expect(input).not.toHaveFocus();
     expect(screen.getByTestId("mock-file-viewer")).toBeInTheDocument();
+  });
+
+  it("navigates to another file when a new path is typed and Enter is pressed (#326)", () => {
+    act(() => {
+      useFileViewerStore.getState().openFileViewer("/home/user/a.txt");
+    });
+    render(<FileViewerOverlay />);
+    const input = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "/home/user/b.txt" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(useFileViewerStore.getState().path).toBe("/home/user/b.txt");
+    expect(screen.getByTestId("mock-file-viewer").getAttribute("data-path")).toBe(
+      "/home/user/b.txt",
+    );
+  });
+
+  it("preserves maximized state when navigating via the address bar", () => {
+    act(() => {
+      useFileViewerStore.getState().openFileViewer("/home/user/a.txt", { maximized: true });
+    });
+    render(<FileViewerOverlay />);
+    const input = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "/home/user/b.txt" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(useFileViewerStore.getState().path).toBe("/home/user/b.txt");
+    expect(useFileViewerStore.getState().maximized).toBe(true);
+  });
+
+  it("keeps the current file and restores the bar when a blank path is submitted", () => {
+    act(() => {
+      useFileViewerStore.getState().openFileViewer("/home/user/a.txt");
+    });
+    render(<FileViewerOverlay />);
+    const input = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(useFileViewerStore.getState().path).toBe("/home/user/a.txt");
+    expect(input.value).toBe("/home/user/a.txt");
+  });
+
+  it("Escape inside the address bar reverts the draft without closing the overlay", () => {
+    act(() => {
+      useFileViewerStore.getState().openFileViewer("/home/user/a.txt");
+    });
+    render(<FileViewerOverlay />);
+    const input = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    input.focus();
+    fireEvent.change(input, { target: { value: "/tmp/draft.txt" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    // The overlay stays open (Escape was consumed by the bar) and the draft is
+    // reverted to the currently loaded path.
+    expect(useFileViewerStore.getState().open).toBe(true);
+    expect(input.value).toBe("/home/user/a.txt");
+  });
+
+  it("updates the address bar when the path is swapped externally (MCP re-open)", () => {
+    act(() => {
+      useFileViewerStore.getState().openFileViewer("/home/user/a.txt");
+    });
+    const { rerender } = render(<FileViewerOverlay />);
+    act(() => {
+      useFileViewerStore.getState().openFileViewer("/home/user/b.txt");
+    });
+    rerender(<FileViewerOverlay />);
+    const input = screen.getByTestId("file-viewer-overlay-path-input") as HTMLInputElement;
+    expect(input.value).toBe("/home/user/b.txt");
   });
 
   it("forwards a per-path viewer instance id so a new path remounts the viewer terminal", () => {

--- a/ui/src/components/layout/FileViewerOverlay.tsx
+++ b/ui/src/components/layout/FileViewerOverlay.tsx
@@ -25,27 +25,55 @@ export function FileViewerOverlay() {
   const feSettings = useSettingsStore((s) => s.fileExplorer);
   const extensionViewers = useSettingsStore((s) => s.fileExplorer.extensionViewers);
 
-  // Empty-path "open anywhere" mode (#283): the overlay is open but no file is
-  // loaded yet, so we show an inline path input field at the top instead of a
-  // native window.prompt (unreliable on WebView2, not driveable via the
-  // Automation API). Submitting a non-blank path loads it in the same viewer.
-  // The input is uncontrolled (read via ref on submit) so we don't need to
-  // mirror keystrokes into React state — this also keeps the focus effect free
-  // of setState (react-hooks/set-state-in-effect).
+  // Persistent address bar (#327 / #326): the path input at the top is always
+  // shown. With no file loaded yet ("open anywhere" mode, #283) it starts empty
+  // and autofocused; once a file is open it shows the current path and the user
+  // can type another path + Enter to navigate without closing first (#326).
+  // The input is uncontrolled (read via ref on submit) and keyed by `path`, so
+  // an external path swap (MCP/REST/Explorer) remounts it with the new value —
+  // no keystroke mirroring into React state is needed.
   const promptMode = open && path === "";
   const pathInputRef = useRef<HTMLInputElement>(null);
 
-  // Focus the field each time we (re)enter prompt mode. The conditional render
-  // below swaps the input for the path <span> when prompt mode ends, so each new
-  // prompt session mounts a fresh empty input — no draft reset is needed.
+  // Focus the field each time we (re)enter prompt mode. Once a file is loaded
+  // the bar must NOT steal focus (terminal viewers own the keyboard), so this
+  // only fires for the empty prompt session.
   useEffect(() => {
     if (promptMode) pathInputRef.current?.focus();
   }, [promptMode]);
 
   const submitPath = () => {
-    // openFileViewer normalizes and rejects blank input, so a blank submit
-    // simply keeps the overlay in prompt mode.
-    openFileViewer(pathInputRef.current?.value ?? "");
+    // openFileViewer normalizes and rejects blank input; `maximized` is carried
+    // over so navigating from a maximized viewer stays maximized.
+    const ok = openFileViewer(pathInputRef.current?.value ?? "", { maximized });
+    if (pathInputRef.current) {
+      // Sync the bar with the store: on success this shows the normalized path,
+      // on a blank/invalid submit it restores the currently loaded path (or
+      // stays empty in prompt mode). On success also release the keyboard so
+      // the opened viewer (e.g. a terminal app) gets it.
+      pathInputRef.current.value = useFileViewerStore.getState().path;
+      if (ok) pathInputRef.current.blur();
+    }
+  };
+
+  const onPathInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submitPath();
+      return;
+    }
+    if (e.key === "Escape" && !promptMode) {
+      // While a file is loaded, Escape in the bar only cancels the draft —
+      // revert to the current path and blur. Consume the event so the global
+      // Escape handler below doesn't also dismiss the overlay. In prompt mode
+      // we let it bubble: there is nothing to revert, so Escape closes.
+      e.preventDefault();
+      e.stopPropagation();
+      if (pathInputRef.current) {
+        pathInputRef.current.value = path;
+        pathInputRef.current.blur();
+      }
+    }
   };
 
   // When the file is shown via an external command (e.g. .txt→vi, video→mpv),
@@ -106,50 +134,35 @@ export function FileViewerOverlay() {
           className="flex items-center px-3 py-2"
           style={{ borderBottom: "1px solid var(--border)" }}
         >
-          {promptMode ? (
-            <div className="flex flex-1 items-center gap-2">
-              <FocusInput
-                key="file-viewer-path-input"
-                ref={pathInputRef}
-                defaultValue=""
-                autoFocus
-                onKeyDown={(e) => {
-                  // Enter submits; Escape is handled by the global handler below
-                  // so we let it bubble (it closes the overlay).
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    submitPath();
-                  }
-                }}
-                placeholder="Open file (absolute path)…"
-                spellCheck={false}
-                autoComplete="off"
-                aria-label="File path"
-                data-testid="file-viewer-overlay-path-input"
-              />
-              <button
-                type="button"
-                onClick={submitPath}
-                className="hover-bg-strong rounded px-2 py-1 text-xs"
-                style={{
-                  color: "var(--text-primary)",
-                  border: "1px solid var(--border)",
-                  cursor: "pointer",
-                }}
-                data-testid="file-viewer-overlay-path-submit"
-              >
-                Load
-              </button>
-            </div>
-          ) : (
-            <span
-              className="flex-1 truncate text-xs"
-              style={{ color: "var(--text-primary)" }}
-              data-testid="file-viewer-overlay-path"
+          <div className="flex flex-1 items-center gap-2">
+            <FocusInput
+              // Keyed by path: an external swap (MCP/REST/Explorer) remounts the
+              // uncontrolled input with the new path as its value.
+              key={`file-viewer-path-input:${path}`}
+              ref={pathInputRef}
+              defaultValue={path}
+              autoFocus={promptMode}
+              onKeyDown={onPathInputKeyDown}
+              placeholder="Open file (absolute path)…"
+              spellCheck={false}
+              autoComplete="off"
+              aria-label="File path"
+              data-testid="file-viewer-overlay-path-input"
+            />
+            <button
+              type="button"
+              onClick={submitPath}
+              className="hover-bg-strong rounded px-2 py-1 text-xs"
+              style={{
+                color: "var(--text-primary)",
+                border: "1px solid var(--border)",
+                cursor: "pointer",
+              }}
+              data-testid="file-viewer-overlay-path-submit"
             >
-              {path}
-            </span>
-          )}
+              Open
+            </button>
+          </div>
           <button
             onClick={toggleMaximized}
             className="hover-bg-strong ml-2 flex h-6 w-6 items-center justify-center rounded text-xs"

--- a/ui/src/components/layout/FileViewerOverlay.tsx
+++ b/ui/src/components/layout/FileViewerOverlay.tsx
@@ -51,6 +51,10 @@ export function FileViewerOverlay() {
       // on a blank/invalid submit it restores the currently loaded path (or
       // stays empty in prompt mode). On success also release the keyboard so
       // the opened viewer (e.g. a terminal app) gets it.
+      // Note: when the submit changes `path`, the keyed input remounts and these
+      // writes hit the detached old node (harmless — the new node mounts with the
+      // new path, unfocused). They only matter when NO remount happens: a blank /
+      // invalid submit (restore the bar) or re-submitting the same path (blur).
       pathInputRef.current.value = useFileViewerStore.getState().path;
       if (ok) pathInputRef.current.blur();
     }
@@ -89,7 +93,11 @@ export function FileViewerOverlay() {
   useEffect(() => {
     if (!open || isTerminalViewer) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
+      // The address bar consumes Escape (draft revert) with preventDefault +
+      // stopPropagation. stopPropagation alone only works because this listener
+      // is in the bubble phase, so also honor defaultPrevented as a defensive
+      // contract that survives the listener ever moving to capture.
+      if (e.key === "Escape" && !e.defaultPrevented) {
         e.preventDefault();
         closeFileViewer();
       }


### PR DESCRIPTION
## 변경 요약
파일 뷰어 최상단에 **상시 주소줄**을 제공한다 (#327). 파일이 열린 뒤에도 주소줄에 새 경로를 입력하고 Enter(또는 Open 버튼)를 누르면 즉시 다른 파일로 이동할 수 있다 (#326).

- 빈 상태(Ctrl+Shift+O "open anywhere")는 기존대로 빈 주소줄 + 자동 포커스
- 이동 시 maximized 상태 유지, 빈/공백 입력 제출 시 현재 파일 유지 + 경로 복원
- 파일이 열린 상태의 주소줄 Esc는 초안만 되돌리고 오버레이는 닫지 않음 (전역 Esc와 충돌 방지)
- 외부 경로 교체(MCP/REST/Explorer) 시 `key={path}` 리마운트로 주소줄 자동 동기화
- 파일이 열린 상태에서는 주소줄이 autoFocus하지 않아 터미널 뷰어(vi/mpv 등) 포커스를 빼앗지 않음

## 변경 파일
- `ui/src/components/layout/FileViewerOverlay.tsx`
- `ui/src/components/layout/FileViewerOverlay.test.tsx` (TDD 신규 6건 + 기존 2건 갱신)

## 테스트
- 전체 프론트엔드 스위트 `npx vitest run`: 82 파일 / 2065 테스트 전부 통과
- eslint / prettier / tsc --noEmit 클린

## 주의사항
- 버튼 라벨 "Load" → "Open" (testid `file-viewer-overlay-path-submit` 유지)
- 읽기 전용 경로 span의 testid `file-viewer-overlay-path` 제거됨 — 외부 자동화가 사용 중이었다면 `file-viewer-overlay-path-input`의 value를 읽도록 변경 필요

Fixes #327
Fixes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)