### PR TITLE
feat: 터미널 다중 파일 경로 붙여넣기 — 구분자·따옴표 설정 지원

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -747,6 +747,13 @@ if (matchesKeybinding(e, "issueReporter.submit")) { handleSubmit(); }
 - `Ctrl+C`는 선택 영역이 없을 때만 xterm에 위임해 SIGINT를 그대로 전달한다(선택 상태로만
   판단, 키 조합을 하드코딩하지 않음).
 - 우클릭 경로(`handleContextMenu`)도 같은 헬퍼(`runTerminalPaste`)를 재사용한다.
+- **다중 파일 붙여넣기 (#325):** 클립보드에 파일이 여러 개(CF_HDROP)면 Rust
+  `smart_paste`가 `SmartPasteResult.paths`로 전체 경로 목록(WSL 프로파일이면 경로
+  변환 적용)을 반환하고, 프론트(`formatPastePaths`)가
+  `convenience.pastePathSeparator`("space" 기본 | "newline" | "comma" |
+  "semicolon") 구분자로 연결한다. `convenience.pastePathQuote`가 켜져 있으면 각
+  경로를 큰따옴표로 감싼다(공백 포함 경로 대응). 두 설정 모두 Settings UI
+  Convenience 섹션에 노출된다.
 - 이 예외는 터미널에 한정한다. 파일 탐색기 등 다른 컴포넌트의 copy/paste는 여전히
   시스템 이벤트 전용이다.
 

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -13,7 +13,13 @@ pub struct SmartPasteResult {
     /// "path" if a file/image path was resolved, "none" if no special content.
     pub paste_type: String,
     /// The path string (Windows or WSL format depending on profile), empty if paste_type is "none".
+    /// For multiple clipboard files this is the first path (backward compat).
     pub content: String,
+    /// All resolved file paths when the clipboard holds files (issue #325).
+    /// Empty for text/none results. The frontend joins these with the
+    /// user-configured separator (and optional quote wrapping).
+    #[serde(default)]
+    pub paths: Vec<String>,
 }
 
 /// Image file extensions (case-insensitive match).
@@ -37,6 +43,22 @@ pub fn is_wsl_profile(profile: &str) -> bool {
         || lower.contains("ubuntu")
         || lower.contains("debian")
         || lower.contains("linux")
+}
+
+/// Convert clipboard file paths to the target profile's path format (issue #325).
+/// WSL profiles get `/mnt/<drive>/...` paths; everything else keeps Windows paths.
+pub fn resolve_clipboard_paths(files: &[String], profile: &str) -> Vec<String> {
+    let wsl = is_wsl_profile(profile);
+    files
+        .iter()
+        .map(|f| {
+            if wsl {
+                crate::path_utils::windows_to_wsl_path(f)
+            } else {
+                f.clone()
+            }
+        })
+        .collect()
 }
 
 /// Get the default paste image directory.
@@ -132,17 +154,14 @@ fn dirs_config_path() -> Option<PathBuf> {
 fn smart_paste_platform(image_dir: &str, profile: &str) -> Result<SmartPasteResult, String> {
     use clipboard_win::{formats, get_clipboard};
 
-    // 1. Check for file paths (CF_HDROP)
+    // 1. Check for file paths (CF_HDROP) — all copied files, not just the first (issue #325)
     if let Ok(files) = get_clipboard::<Vec<String>, _>(formats::FileList) {
-        if let Some(first) = files.first() {
-            let path = if is_wsl_profile(profile) {
-                windows_to_wsl_path(first)
-            } else {
-                first.clone()
-            };
+        if !files.is_empty() {
+            let paths = resolve_clipboard_paths(&files, profile);
             return Ok(SmartPasteResult {
                 paste_type: "path".into(),
-                content: path,
+                content: paths[0].clone(),
+                paths,
             });
         }
     }
@@ -162,6 +181,7 @@ fn smart_paste_platform(image_dir: &str, profile: &str) -> Result<SmartPasteResu
                 };
                 return Ok(SmartPasteResult {
                     paste_type: "path".into(),
+                    paths: vec![content.clone()],
                     content,
                 });
             }
@@ -174,6 +194,7 @@ fn smart_paste_platform(image_dir: &str, profile: &str) -> Result<SmartPasteResu
             return Ok(SmartPasteResult {
                 paste_type: "text".into(),
                 content: text,
+                paths: Vec::new(),
             });
         }
     }
@@ -182,6 +203,7 @@ fn smart_paste_platform(image_dir: &str, profile: &str) -> Result<SmartPasteResu
     Ok(SmartPasteResult {
         paste_type: "none".into(),
         content: String::new(),
+        paths: Vec::new(),
     })
 }
 
@@ -191,6 +213,7 @@ fn smart_paste_platform(_image_dir: &str, _profile: &str) -> Result<SmartPasteRe
     Ok(SmartPasteResult {
         paste_type: "none".into(),
         content: String::new(),
+        paths: Vec::new(),
     })
 }
 
@@ -337,6 +360,55 @@ mod tests {
         );
         // UNC or relative path — just replace backslashes
         assert_eq!(windows_to_wsl_path(r"relative\path"), "relative/path");
+    }
+
+    // -- resolve_clipboard_paths (issue #325: 다중 파일 붙여넣기) --
+
+    #[test]
+    fn test_resolve_clipboard_paths_multiple_windows() {
+        let files = vec![r"C:\a\one.txt".to_string(), r"C:\b\two two.txt".to_string()];
+        let paths = resolve_clipboard_paths(&files, "PowerShell");
+        assert_eq!(paths, files);
+    }
+
+    #[test]
+    fn test_resolve_clipboard_paths_multiple_wsl() {
+        let files = vec![r"C:\a\one.txt".to_string(), r"D:\b\two.txt".to_string()];
+        let paths = resolve_clipboard_paths(&files, "WSL");
+        assert_eq!(
+            paths,
+            vec![
+                "/mnt/c/a/one.txt".to_string(),
+                "/mnt/d/b/two.txt".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_resolve_clipboard_paths_empty() {
+        let paths = resolve_clipboard_paths(&[], "PowerShell");
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_smart_paste_result_paths_serde_default() {
+        // 구버전 결과(JSON에 paths 없음)도 역직렬화 가능해야 한다 (backward compat)
+        let json = r#"{"pasteType":"path","content":"C:\\a.txt"}"#;
+        let result: SmartPasteResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.paste_type, "path");
+        assert!(result.paths.is_empty());
+    }
+
+    #[test]
+    fn test_smart_paste_result_paths_serialize_camel_case() {
+        let result = SmartPasteResult {
+            paste_type: "path".into(),
+            content: "C:\\a.txt".into(),
+            paths: vec!["C:\\a.txt".into(), "C:\\b.txt".into()],
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains(r#""paths":["C:\\a.txt","C:\\b.txt"]"#));
+        assert!(json.contains(r#""pasteType":"path""#));
     }
 
     #[test]

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -247,6 +247,19 @@ mod tests {
     }
 
     #[test]
+    fn convenience_multi_file_paste_defaults() {
+        // issue #325: 다중 파일 붙여넣기 설정 기본값
+        let conv = crate::settings::models::ConvenienceSettings::default();
+        assert_eq!(conv.paste_path_separator, "space");
+        assert!(!conv.paste_path_quote);
+        // 구버전 settings.json(필드 없음)도 기본값으로 채워진다
+        let parsed: crate::settings::models::ConvenienceSettings =
+            serde_json::from_str("{}").unwrap();
+        assert_eq!(parsed.paste_path_separator, "space");
+        assert!(!parsed.paste_path_quote);
+    }
+
+    #[test]
     fn serialize_deserialize_round_trip() {
         let settings = Settings::default();
         let json = serde_json::to_string_pretty(&settings).unwrap();

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -579,6 +579,17 @@ pub struct ConvenienceSettings {
     /// 0 = disabled (never auto-close). See issue #269.
     #[serde(default)]
     pub hidden_auto_close_seconds: u64,
+    /// Separator token between paths when pasting multiple clipboard files:
+    /// "space" (default) | "newline" | "comma" | "semicolon". See issue #325.
+    #[serde(default = "default_paste_path_separator")]
+    pub paste_path_separator: String,
+    /// Wrap each pasted file path in double quotes (useful for paths with spaces). See issue #325.
+    #[serde(default)]
+    pub paste_path_quote: bool,
+}
+
+fn default_paste_path_separator() -> String {
+    "space".to_string()
 }
 
 impl Default for ConvenienceSettings {
@@ -596,6 +607,8 @@ impl Default for ConvenienceSettings {
             smart_link_join: true,
             large_paste_warning: true,
             hidden_auto_close_seconds: 0,
+            paste_path_separator: default_paste_path_separator(),
+            paste_path_quote: false,
         }
     }
 }

--- a/ui/src/components/views/SettingsView.test.tsx
+++ b/ui/src/components/views/SettingsView.test.tsx
@@ -737,6 +737,45 @@ describe("SettingsView", () => {
     expect(useSettingsStore.getState().convenience.smartPaste).toBe(false);
   });
 
+  it("renders multi-file paste separator select and quote toggle (#325)", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+
+    await user.click(screen.getByTestId("nav-convenience"));
+    const select = screen.getByTestId("paste-path-separator-select") as HTMLSelectElement;
+    expect(select.value).toBe("space"); // 기본값
+    const quoteToggle = screen.getByTestId("paste-path-quote-toggle") as HTMLInputElement;
+    expect(quoteToggle.checked).toBe(false); // 기본값
+  });
+
+  it("changing paste path separator updates store after Save (#325)", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+
+    await user.click(screen.getByTestId("nav-convenience"));
+    const select = screen.getByTestId("paste-path-separator-select") as HTMLSelectElement;
+    await user.selectOptions(select, "newline");
+
+    // Store unchanged until Save
+    expect(useSettingsStore.getState().convenience.pastePathSeparator).toBe("space");
+
+    await user.click(screen.getByTestId("save-settings-btn"));
+    expect(useSettingsStore.getState().convenience.pastePathSeparator).toBe("newline");
+  });
+
+  it("toggling paste path quote updates store after Save (#325)", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+
+    await user.click(screen.getByTestId("nav-convenience"));
+    await user.click(screen.getByTestId("paste-path-quote-toggle"));
+
+    expect(useSettingsStore.getState().convenience.pastePathQuote).toBe(false);
+
+    await user.click(screen.getByTestId("save-settings-btn"));
+    expect(useSettingsStore.getState().convenience.pastePathQuote).toBe(true);
+  });
+
   it("does NOT update copy on select in store until Save is clicked", async () => {
     const user = userEvent.setup();
     render(<SettingsView />);

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -20,6 +20,7 @@ import type { FileExplorerSettings, ExtensionViewer } from "@/lib/tauri-api";
 import { persistSession } from "@/lib/persist-session";
 import { DEFAULT_KEYBINDINGS } from "@/lib/keybinding-registry";
 import { toSupportedCursorShape } from "@/lib/cursor-settings";
+import type { PastePathSeparator } from "@/lib/smart-text";
 import { MONOSPACED_FONTS, getSystemMonospaceFonts } from "@/lib/system-fonts";
 import { FocusInput, FocusSelect, inputStyle, inputCls } from "@/components/ui/FormControls";
 
@@ -1172,6 +1173,67 @@ function ConvenienceSection() {
               />
               <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
                 {convenience.smartPaste ? "Enabled" : "Disabled"}
+              </span>
+            </label>
+          </div>
+        </div>
+
+        {/* Multi-file paste separator (#325) */}
+        <div className="mt-3 flex items-start gap-3 py-1">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+              Multi-file Separator
+            </span>
+            <p
+              className="mt-0.5 text-[11px] leading-tight"
+              style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+            >
+              여러 파일 붙여넣기 시 경로 사이 구분자
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <select
+              data-testid="paste-path-separator-select"
+              value={convenience.pastePathSeparator}
+              onChange={(e) =>
+                updateConvenience({
+                  pastePathSeparator: e.target.value as PastePathSeparator,
+                })
+              }
+              className={inputCls}
+              style={inputStyle}
+            >
+              <option value="space">Space</option>
+              <option value="newline">Newline</option>
+              <option value="comma">Comma (,)</option>
+              <option value="semicolon">Semicolon (;)</option>
+            </select>
+          </div>
+        </div>
+
+        {/* Multi-file paste quote wrapping (#325) */}
+        <div className="mt-3 flex items-start gap-3 py-1">
+          <div className="w-36 shrink-0 pt-1">
+            <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+              Quote File Paths
+            </span>
+            <p
+              className="mt-0.5 text-[11px] leading-tight"
+              style={{ color: "var(--text-secondary)", opacity: 0.65 }}
+            >
+              붙여넣는 각 파일 경로를 큰따옴표로 감싸기 (공백 포함 경로에 유용)
+            </p>
+          </div>
+          <div className="min-w-0 flex-1">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                data-testid="paste-path-quote-toggle"
+                type="checkbox"
+                checked={convenience.pastePathQuote}
+                onChange={(e) => updateConvenience({ pastePathQuote: e.target.checked })}
+              />
+              <span className="text-[13px]" style={{ color: "var(--text-primary)" }}>
+                {convenience.pastePathQuote ? "Enabled" : "Disabled"}
               </span>
             </label>
           </div>

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -2177,6 +2177,76 @@ describe("TerminalView", () => {
     });
   });
 
+  it("pastes multiple file paths joined by the configured separator (default space)", async () => {
+    mockSmartPaste.mockResolvedValue({
+      pasteType: "path",
+      content: "C:\\test\\one.txt",
+      paths: ["C:\\test\\one.txt", "C:\\test\\two.txt"],
+    });
+
+    render(<TerminalView instanceId="t-paste-multi1" profile="PowerShell" syncGroup="" />);
+
+    await vi.waitFor(() => {
+      expect(mockAttachCustomKeyEventHandler).toHaveBeenCalled();
+    });
+
+    const event = new KeyboardEvent("keydown", { key: "v", ctrlKey: true });
+    Object.defineProperty(event, "preventDefault", { value: vi.fn() });
+    capturedKeyHandler!(event);
+
+    await vi.waitFor(() => {
+      expect(mockPaste).toHaveBeenCalledWith("C:\\test\\one.txt C:\\test\\two.txt");
+    });
+  });
+
+  it("pastes multiple file paths with newline separator and quote wrapping from settings", async () => {
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      convenience: {
+        ...useSettingsStore.getState().convenience,
+        pastePathSeparator: "newline",
+        pastePathQuote: true,
+      },
+    });
+    mockSmartPaste.mockResolvedValue({
+      pasteType: "path",
+      content: "C:\\My Files\\one.txt",
+      paths: ["C:\\My Files\\one.txt", "C:\\test\\two.txt"],
+    });
+
+    render(<TerminalView instanceId="t-paste-multi2" profile="PowerShell" syncGroup="" />);
+
+    await vi.waitFor(() => {
+      expect(mockAttachCustomKeyEventHandler).toHaveBeenCalled();
+    });
+
+    const event = new KeyboardEvent("keydown", { key: "v", ctrlKey: true });
+    Object.defineProperty(event, "preventDefault", { value: vi.fn() });
+    capturedKeyHandler!(event);
+
+    await vi.waitFor(() => {
+      expect(mockPaste).toHaveBeenCalledWith('"C:\\My Files\\one.txt"\n"C:\\test\\two.txt"');
+    });
+  });
+
+  it("falls back to content when path result has no paths array (backward compat)", async () => {
+    mockSmartPaste.mockResolvedValue({ pasteType: "path", content: "C:\\test\\file.png" });
+
+    render(<TerminalView instanceId="t-paste-multi3" profile="PowerShell" syncGroup="" />);
+
+    await vi.waitFor(() => {
+      expect(mockAttachCustomKeyEventHandler).toHaveBeenCalled();
+    });
+
+    const event = new KeyboardEvent("keydown", { key: "v", ctrlKey: true });
+    Object.defineProperty(event, "preventDefault", { value: vi.fn() });
+    capturedKeyHandler!(event);
+
+    await vi.waitFor(() => {
+      expect(mockPaste).toHaveBeenCalledWith("C:\\test\\file.png");
+    });
+  });
+
   it("skips the smart paste pipeline when smartPaste is disabled but still consumes the key", async () => {
     // Override bindings like Ctrl+Shift+V can't rely on the browser's native
     // paste event, so the keybinding handler must always consume the event.

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -25,7 +25,7 @@ import {
   markCodexTerminal,
 } from "@/lib/tauri-api";
 import { colorSchemeToXtermTheme, type WTColorScheme } from "@/lib/color-scheme";
-import { transformPasteContent, prepareSelectionForCopy } from "@/lib/smart-text";
+import { transformPasteContent, prepareSelectionForCopy, formatPastePaths } from "@/lib/smart-text";
 import { isLxShortcut } from "@/lib/lx-shortcuts";
 import { createCursorTracer } from "@/lib/cursor-trace";
 import { matchesKeybinding } from "@/lib/keybinding-registry";
@@ -174,10 +174,20 @@ function runTerminalPaste(terminal: Terminal, profile: string): void {
   smartPaste(conv.pasteImageDir, profile)
     .then((result) => {
       if (result.pasteType === "none" || !result.content) return;
-      const content = transformPasteContent(result.content, result.pasteType, {
-        removeIndent: conv.smartRemoveIndent,
-        removeLineBreak: conv.smartRemoveLineBreak,
-      });
+      // Multiple clipboard files (issue #325): join all resolved paths with
+      // the configured separator, optionally quote-wrapping each path.
+      // `paths` is absent for text pastes and older results — fall back to
+      // the single `content` transform path.
+      const content =
+        result.pasteType === "path" && result.paths && result.paths.length > 0
+          ? formatPastePaths(result.paths, {
+              separator: conv.pastePathSeparator,
+              quote: conv.pastePathQuote,
+            })
+          : transformPasteContent(result.content, result.pasteType, {
+              removeIndent: conv.smartRemoveIndent,
+              removeLineBreak: conv.smartRemoveLineBreak,
+            });
       if (shouldBlockLargePaste(content, conv.largePasteWarning)) return;
       terminal.paste(content);
     })

--- a/ui/src/lib/smart-text.test.ts
+++ b/ui/src/lib/smart-text.test.ts
@@ -6,6 +6,7 @@ import {
   transformPasteContent,
   trimSelectionTrailingWhitespace,
   prepareSelectionForCopy,
+  formatPastePaths,
 } from "./smart-text";
 import { RAW_XTERM_SELECTION, WRONG_RESULT, CLEAN_URL } from "./__fixtures__/right-pane-fixture";
 
@@ -703,5 +704,65 @@ describe("smartRemoveIndent vs MemoView Shift+Tab dedent 비교", () => {
     expect(smartRemoveIndent(input)).toBe("line1\n  \nline3");
     // Shift+Tab: 공백 줄의 2sp도 독립적으로 제거
     expect(memoShiftTabDedent(input, 2)).toBe("line1\n\nline3");
+  });
+});
+
+// ============================================================
+// formatPastePaths (issue #325: 다중 파일 경로 붙여넣기)
+// ============================================================
+describe("formatPastePaths", () => {
+  it("기본값(space, quote 끄기): 공백으로 연결", () => {
+    expect(
+      formatPastePaths(["C:\\a\\one.txt", "C:\\a\\two.txt"], { separator: "space", quote: false }),
+    ).toBe("C:\\a\\one.txt C:\\a\\two.txt");
+  });
+
+  it("파일 1개: 구분자 없이 경로 그대로", () => {
+    expect(formatPastePaths(["C:\\a\\one.txt"], { separator: "space", quote: false })).toBe(
+      "C:\\a\\one.txt",
+    );
+  });
+
+  it("newline 구분자: 줄바꿈으로 연결", () => {
+    expect(formatPastePaths(["/mnt/c/a", "/mnt/c/b"], { separator: "newline", quote: false })).toBe(
+      "/mnt/c/a\n/mnt/c/b",
+    );
+  });
+
+  it("comma 구분자: 쉼표로 연결", () => {
+    expect(formatPastePaths(["a.txt", "b.txt"], { separator: "comma", quote: false })).toBe(
+      "a.txt,b.txt",
+    );
+  });
+
+  it("semicolon 구분자: 세미콜론으로 연결", () => {
+    expect(formatPastePaths(["a.txt", "b.txt"], { separator: "semicolon", quote: false })).toBe(
+      "a.txt;b.txt",
+    );
+  });
+
+  it("quote 켜기: 각 경로를 큰따옴표로 감싼다", () => {
+    expect(
+      formatPastePaths(["C:\\My Files\\one.txt", "C:\\b.txt"], { separator: "space", quote: true }),
+    ).toBe('"C:\\My Files\\one.txt" "C:\\b.txt"');
+  });
+
+  it("quote 켜기 + 파일 1개: 한 경로만 감싼다", () => {
+    expect(formatPastePaths(["C:\\My Files\\one.txt"], { separator: "space", quote: true })).toBe(
+      '"C:\\My Files\\one.txt"',
+    );
+  });
+
+  it("빈 배열: 빈 문자열", () => {
+    expect(formatPastePaths([], { separator: "space", quote: false })).toBe("");
+  });
+
+  it("알 수 없는 구분자 토큰은 space로 처리", () => {
+    expect(
+      formatPastePaths(["a", "b"], {
+        separator: "bogus" as unknown as "space",
+        quote: false,
+      }),
+    ).toBe("a b");
   });
 });

--- a/ui/src/lib/smart-text.ts
+++ b/ui/src/lib/smart-text.ts
@@ -245,6 +245,40 @@ export function applyPasteTextTransforms(text: string, options: SmartTextOptions
   return smartRemoveLineBreak(normalized);
 }
 
+/**
+ * Separator token for joining multiple pasted file paths (issue #325).
+ * Stored as a token (not the raw char) so settings.json stays readable
+ * and the Settings UI can render a labelled dropdown.
+ */
+export type PastePathSeparator = "space" | "newline" | "comma" | "semicolon";
+
+const PASTE_PATH_SEPARATOR_CHARS: Record<PastePathSeparator, string> = {
+  space: " ",
+  newline: "\n",
+  comma: ",",
+  semicolon: ";",
+};
+
+export interface PastePathOptions {
+  /** Separator token between paths. Unknown tokens fall back to "space". */
+  separator: PastePathSeparator;
+  /** Wrap each path in double quotes (useful for paths containing spaces). */
+  quote: boolean;
+}
+
+/**
+ * Join multiple clipboard file paths into a single paste string.
+ *
+ * Used when the user copies several files in Explorer and pastes them into
+ * a terminal: each resolved path is optionally quote-wrapped, then joined
+ * with the configured separator (default: space).
+ */
+export function formatPastePaths(paths: string[], options: PastePathOptions): string {
+  const sep = PASTE_PATH_SEPARATOR_CHARS[options.separator] ?? " ";
+  const items = options.quote ? paths.map((p) => `"${p}"`) : paths;
+  return items.join(sep);
+}
+
 /** Transform paste result content shared by Ctrl+V and right-click paste. */
 export function transformPasteContent(
   content: string,

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -411,8 +411,10 @@ export interface DockSetting {
 }
 
 export interface SmartPasteResult {
-  pasteType: string; // "path" | "none"
+  pasteType: string; // "path" | "text" | "none"
   content: string;
+  /** All resolved file paths when the clipboard holds files (issue #325). */
+  paths?: string[];
 }
 
 /** Perform smart paste: check clipboard for files/images, return path or "none". */

--- a/ui/src/stores/settings-store.test.ts
+++ b/ui/src/stores/settings-store.test.ts
@@ -401,6 +401,29 @@ describe("settings-store", () => {
     expect(useSettingsStore.getState().convenience.hiddenAutoCloseSeconds).toBe(1200);
   });
 
+  it("has default multi-file paste settings (#325)", () => {
+    const { convenience } = useSettingsStore.getState();
+    expect(convenience.pastePathSeparator).toBe("space");
+    expect(convenience.pastePathQuote).toBe(false);
+  });
+
+  it("setConvenience updates multi-file paste settings (#325)", () => {
+    useSettingsStore
+      .getState()
+      .setConvenience({ pastePathSeparator: "comma", pastePathQuote: true });
+    expect(useSettingsStore.getState().convenience.pastePathSeparator).toBe("comma");
+    expect(useSettingsStore.getState().convenience.pastePathQuote).toBe(true);
+  });
+
+  it("loadFromSettings fills missing multi-file paste fields with defaults (#325)", () => {
+    useSettingsStore.getState().loadFromSettings({
+      convenience: { smartPaste: false } as any,
+    });
+    const { convenience } = useSettingsStore.getState();
+    expect(convenience.pastePathSeparator).toBe("space");
+    expect(convenience.pastePathQuote).toBe(false);
+  });
+
   it("setConvenience updates smart paste", () => {
     useSettingsStore.getState().setConvenience({ smartPaste: false });
     expect(useSettingsStore.getState().convenience.smartPaste).toBe(false);

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -15,6 +15,7 @@ import {
   type SyncCwdDefaults,
   type TerminalLocation,
 } from "../lib/sync-cwd-config";
+import type { PastePathSeparator } from "../lib/smart-text";
 
 export interface FontSettings {
   face: string;
@@ -104,6 +105,10 @@ export interface ConvenienceSettings {
    * See issue #269.
    */
   hiddenAutoCloseSeconds: number;
+  /** Separator between paths when pasting multiple clipboard files. See issue #325. */
+  pastePathSeparator: PastePathSeparator;
+  /** Wrap each pasted file path in double quotes (useful for paths with spaces). See issue #325. */
+  pastePathQuote: boolean;
 }
 
 /** Which elements to display in WorkspaceSelectorView pane rows. */
@@ -791,6 +796,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     smartLinkJoin: true,
     largePasteWarning: true,
     hiddenAutoCloseSeconds: 0,
+    pastePathSeparator: "space" as const,
+    pastePathQuote: false,
   },
   workspaceDisplay: { minimap: true, environment: true, activity: true, path: true, result: true },
   claude: {
@@ -1024,6 +1031,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
           smartLinkJoin: true,
           largePasteWarning: true,
           hiddenAutoCloseSeconds: 0,
+          pastePathSeparator: "space" as const,
+          pastePathQuote: false,
           ...(data.convenience as Partial<ConvenienceSettings>),
         }
       : undefined;


### PR DESCRIPTION
@
## 요약
Ctrl+C/V로 여러 파일을 복사해 터미널에 붙여넣을 때, 기존에는 첫 번째 파일 경로만 입력되던 것을 모든 경로가 입력되도록 확장한다.

- **Rust**: `smart_paste`가 `SmartPasteResult.paths: Vec<String>`로 전체 파일 경로를 반환 (serde default로 하위 호환). WSL 프로파일이면 각 경로를 `/mnt/...`로 변환.
- **프론트**: `formatPastePaths(paths, { separator, quote })` — 구분자로 연결하고, 옵션에 따라 각 경로를 큰따옴표로 감쌈.
- **설정**: `convenience.pastePathSeparator` (space 기본 | newline | comma | semicolon) / `convenience.pastePathQuote` (따옴표로 묶기) — 프론트·Rust 양쪽 영속화, Settings UI Convenience 섹션에 노출.
- 단일 파일·이미지 붙여넣기는 기존 동작 유지. 구버전 settings.json은 기본값으로 로드되어 마이그레이션 불필요.
- living doc 동기화: `docs/architecture/api-contracts.md` (터미널 paste 예외 절).

## 테스트
- 프론트: `npx vitest run` 전체 통과 — 82 파일 / 2,078 테스트 (신규 +18)
- 백엔드: `cargo test` 전체 통과 (라이브 클립보드 의존 테스트는 기존대로 `#[ignore]`)
- `tsc --noEmit`, prettier, eslint, `cargo fmt`/clippy 통과
- 실제 탐색기 다중 파일 복사 → 붙여넣기 수동 검증은 클립보드 의존이라 미자동화 — dev 인스턴스 확인 권장

Fixes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@