### PR TITLE
test: useResolvedKeybinding 훅 단위 테스트 추가 (PR #331 리뷰 후속)

### DIFF
--- a/ui/src/lib/keybinding-registry.test.ts
+++ b/ui/src/lib/keybinding-registry.test.ts
@@ -1,12 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock settings store before importing the module under test
+// Mock settings store before importing the module under test.
+// 훅(useResolvedKeybinding)도 테스트하므로 selector 호출이 가능한 함수형 mock 으로 만든다.
 const mockGetState = vi.fn();
-vi.mock("@/stores/settings-store", () => ({
-  useSettingsStore: { getState: () => mockGetState() },
-}));
+vi.mock("@/stores/settings-store", () => {
+  const useSettingsStore = <T>(selector: (s: unknown) => T): T => selector(mockGetState());
+  useSettingsStore.getState = () => mockGetState();
+  return { useSettingsStore };
+});
 
-import { DEFAULT_KEYBINDINGS, matchesKeybinding, resolveKeybinding } from "./keybinding-registry";
+import {
+  DEFAULT_KEYBINDINGS,
+  matchesKeybinding,
+  resolveKeybinding,
+  useResolvedKeybinding,
+} from "./keybinding-registry";
+import { renderHook } from "@testing-library/react";
 
 function makeKeyEvent(
   key: string,
@@ -65,6 +74,28 @@ describe("keybinding-registry", () => {
 
     it("should return undefined for unknown action", () => {
       expect(resolveKeybinding("unknown.action")).toBeUndefined();
+    });
+  });
+
+  // PR #331 리뷰 1번: 툴팁 등 렌더링에 쓰는 키 콤보는 keybindings 구독 기반 훅으로
+  // 읽어야 재바인딩 시 즉시 갱신된다 (resolveKeybinding 은 getState 1회 읽기).
+  describe("useResolvedKeybinding", () => {
+    it("should return default keys when no override", () => {
+      const { result } = renderHook(() => useResolvedKeybinding("pane.propagateCwdOnce"));
+      expect(result.current).toBe("Ctrl+Alt+P");
+    });
+
+    it("should return user override when present", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [{ command: "pane.propagateCwdOnce", keys: "Ctrl+Shift+P" }],
+      });
+      const { result } = renderHook(() => useResolvedKeybinding("pane.propagateCwdOnce"));
+      expect(result.current).toBe("Ctrl+Shift+P");
+    });
+
+    it("should return undefined for unknown action", () => {
+      const { result } = renderHook(() => useResolvedKeybinding("unknown.action"));
+      expect(result.current).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## 개요

PR #331 리뷰 1번 반영으로 추가된 `useResolvedKeybinding` 훅(9da263f, #331 에 병합됨)의 단위 테스트를 보강한다. #331 에는 컴포넌트 레벨 reactivity 테스트만 있고 훅 자체의 단위 테스트가 없었다.

## 변경

- `ui/src/lib/keybinding-registry.test.ts`
  - `useResolvedKeybinding` 테스트 3건: 기본 콤보 해석 / 사용자 오버라이드 우선 / 미등록 액션 → undefined
  - settings-store mock 을 selector 호출이 가능한 함수형으로 전환 (기존 `getState` 전용 객체 mock 으로는 훅 테스트 불가)

## 테스트

`npx vitest run` — 83 files / 2080 tests 전부 통과.

🤖 자동 반영 (Claude Code /loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)