### PR TITLE
fix: isLxShortcut이 키바인딩 레지스트리를 참조하도록 개선

### DIFF
--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -18,7 +18,11 @@ import {
 } from "@/stores/settings-store";
 import type { FileExplorerSettings, ExtensionViewer } from "@/lib/tauri-api";
 import { persistSession } from "@/lib/persist-session";
-import { DEFAULT_KEYBINDINGS } from "@/lib/keybinding-registry";
+import {
+  DEFAULT_KEYBINDINGS,
+  coerceArrowWildcard,
+  usesArrowWildcard,
+} from "@/lib/keybinding-registry";
 import { toSupportedCursorShape } from "@/lib/cursor-settings";
 import type { PastePathSeparator } from "@/lib/smart-text";
 import { MONOSPACED_FONTS, getSystemMonospaceFonts } from "@/lib/system-fonts";
@@ -2925,8 +2929,14 @@ function KeybindingsSection() {
                     onKeyDown={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
-                      const str = keyEventToString(e.nativeEvent);
-                      if (!str) return;
+                      const raw = keyEventToString(e.nativeEvent);
+                      if (!raw) return;
+                      // Wildcard actions (`pane.focus` = "Alt+Arrow") bind all four
+                      // directions at once — pressing any arrow during capture keeps
+                      // the `Arrow` token instead of narrowing to a single direction.
+                      const str = usesArrowWildcard(def.defaultKeys)
+                        ? coerceArrowWildcard(raw)
+                        : raw;
                       setCapturedKeys(str);
                       // Update the keybinding in draft
                       setDraftKeybindings((prev) =>

--- a/ui/src/lib/keybinding-registry.test.ts
+++ b/ui/src/lib/keybinding-registry.test.ts
@@ -156,6 +156,25 @@ describe("keybinding-registry", () => {
       expect(matchesKeybinding(oldCopy, "terminal.copy")).toBe(false);
     });
 
+    it("should match any arrow key for 'Arrow' wildcard bindings (pane.focus)", () => {
+      expect(matchesKeybinding(makeKeyEvent("ArrowLeft", { alt: true }), "pane.focus")).toBe(true);
+      expect(matchesKeybinding(makeKeyEvent("ArrowRight", { alt: true }), "pane.focus")).toBe(true);
+      expect(matchesKeybinding(makeKeyEvent("ArrowUp", { alt: true }), "pane.focus")).toBe(true);
+      expect(matchesKeybinding(makeKeyEvent("ArrowDown", { alt: true }), "pane.focus")).toBe(true);
+      expect(matchesKeybinding(makeKeyEvent("a", { alt: true }), "pane.focus")).toBe(false);
+      expect(matchesKeybinding(makeKeyEvent("ArrowLeft"), "pane.focus")).toBe(false);
+    });
+
+    it("should respect 'Arrow' wildcard in user overrides", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [{ command: "pane.focus", keys: "Ctrl+Alt+Arrow" }],
+      });
+      expect(
+        matchesKeybinding(makeKeyEvent("ArrowLeft", { ctrl: true, alt: true }), "pane.focus"),
+      ).toBe(true);
+      expect(matchesKeybinding(makeKeyEvent("ArrowLeft", { alt: true }), "pane.focus")).toBe(false);
+    });
+
     it("should match Ctrl+C / Ctrl+V to terminal.copy / terminal.paste by default", () => {
       const copy = makeKeyEvent("c", { ctrl: true });
       const paste = makeKeyEvent("v", { ctrl: true });

--- a/ui/src/lib/keybinding-registry.test.ts
+++ b/ui/src/lib/keybinding-registry.test.ts
@@ -11,9 +11,11 @@ vi.mock("@/stores/settings-store", () => {
 
 import {
   DEFAULT_KEYBINDINGS,
+  coerceArrowWildcard,
   matchesKeybinding,
   resolveKeybinding,
   useResolvedKeybinding,
+  usesArrowWildcard,
 } from "./keybinding-registry";
 import { renderHook } from "@testing-library/react";
 
@@ -180,6 +182,44 @@ describe("keybinding-registry", () => {
       const paste = makeKeyEvent("v", { ctrl: true });
       expect(matchesKeybinding(copy, "terminal.copy")).toBe(true);
       expect(matchesKeybinding(paste, "terminal.paste")).toBe(true);
+    });
+
+    // Hand-edited settings.json may use non-canonical case (PR #336 review)
+    it("should match overrides case-insensitively (modifiers and key)", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [
+          { command: "workspace.duplicate", keys: "ctrl+shift+p" },
+          { command: "workspace.next", keys: "ctrl+alt+down" },
+          { command: "pane.focus", keys: "alt+arrow" },
+        ],
+      });
+      expect(
+        matchesKeybinding(makeKeyEvent("P", { ctrl: true, shift: true }), "workspace.duplicate"),
+      ).toBe(true);
+      expect(
+        matchesKeybinding(makeKeyEvent("ArrowDown", { ctrl: true, alt: true }), "workspace.next"),
+      ).toBe(true);
+      expect(matchesKeybinding(makeKeyEvent("ArrowLeft", { alt: true }), "pane.focus")).toBe(true);
+    });
+  });
+
+  describe("Arrow wildcard helpers (Settings capture UI)", () => {
+    it("usesArrowWildcard detects the Arrow key token", () => {
+      expect(usesArrowWildcard("Alt+Arrow")).toBe(true);
+      expect(usesArrowWildcard("Ctrl+Alt+Arrow")).toBe(true);
+      expect(usesArrowWildcard("Alt+Left")).toBe(false);
+      expect(usesArrowWildcard("Ctrl+Alt+P")).toBe(false);
+    });
+
+    it("coerceArrowWildcard replaces a direction token with Arrow", () => {
+      expect(coerceArrowWildcard("Ctrl+Alt+Left")).toBe("Ctrl+Alt+Arrow");
+      expect(coerceArrowWildcard("Alt+Up")).toBe("Alt+Arrow");
+      expect(coerceArrowWildcard("ArrowDown")).toBe("Arrow");
+    });
+
+    it("coerceArrowWildcard leaves non-arrow combos unchanged", () => {
+      expect(coerceArrowWildcard("Ctrl+Shift+G")).toBe("Ctrl+Shift+G");
+      expect(coerceArrowWildcard("Ctrl+Alt+P")).toBe("Ctrl+Alt+P");
     });
   });
 });

--- a/ui/src/lib/keybinding-registry.ts
+++ b/ui/src/lib/keybinding-registry.ts
@@ -275,15 +275,20 @@ interface ParsedShortcut {
   key: string;
 }
 
+/**
+ * Case-insensitive on modifiers and the key token, so hand-edited
+ * settings.json entries like "ctrl+shift+p" still match. The capture UI
+ * always writes canonical case; this only widens what we accept.
+ */
 function parseShortcut(shortcut: string): ParsedShortcut {
   const parts = shortcut.split("+");
-  const modifiers = new Set(parts.slice(0, -1));
+  const modifiers = new Set(parts.slice(0, -1).map((m) => m.toLowerCase()));
   const key = parts[parts.length - 1] || "";
   return {
-    ctrl: modifiers.has("Ctrl"),
-    alt: modifiers.has("Alt"),
-    shift: modifiers.has("Shift"),
-    key,
+    ctrl: modifiers.has("ctrl"),
+    alt: modifiers.has("alt"),
+    shift: modifiers.has("shift"),
+    key: normalizeKey(key),
   };
 }
 
@@ -293,6 +298,25 @@ function normalizeKey(key: string): string {
 
 /** Normalized arrow-key tokens matched by the `Arrow` wildcard (e.g. `pane.focus` = "Alt+Arrow"). */
 const ARROW_WILDCARD_KEYS = new Set(["Up", "Down", "Left", "Right"]);
+
+/** True if a combo string's key token is the `Arrow` wildcard (any arrow direction). */
+export function usesArrowWildcard(keys: string): boolean {
+  return parseShortcut(keys).key.toLowerCase() === "arrow";
+}
+
+/**
+ * Replace a captured arrow-direction token (e.g. "Ctrl+Alt+Left") with the
+ * `Arrow` wildcard ("Ctrl+Alt+Arrow"). Used by the Settings capture UI when
+ * rebinding a wildcard action like `pane.focus`, so pressing any one arrow
+ * rebinds all four directions instead of narrowing the action to a single one.
+ * Returns the input unchanged when its key token is not an arrow direction.
+ */
+export function coerceArrowWildcard(keys: string): string {
+  const parts = keys.split("+");
+  const last = parts[parts.length - 1] || "";
+  if (!ARROW_WILDCARD_KEYS.has(normalizeKey(last))) return keys;
+  return [...parts.slice(0, -1), "Arrow"].join("+");
+}
 
 /**
  * Resolve the effective key combo string for an action (user override > default).
@@ -337,8 +361,12 @@ export function matchesKeybinding(
 
   // `Arrow` is a wildcard token matching any of the four arrow keys
   // (used by directional bindings like `pane.focus` = "Alt+Arrow").
+  // Key comparison is case-insensitive so hand-edited tokens like "up"
+  // or "pageup" still match their canonical event names.
   const keyMatches =
-    parsed.key === "Arrow" ? ARROW_WILDCARD_KEYS.has(eventKey) : eventKey === parsed.key;
+    parsed.key.toLowerCase() === "arrow"
+      ? ARROW_WILDCARD_KEYS.has(eventKey)
+      : eventKey.toLowerCase() === parsed.key.toLowerCase();
 
   return (
     e.ctrlKey === parsed.ctrl &&

--- a/ui/src/lib/keybinding-registry.ts
+++ b/ui/src/lib/keybinding-registry.ts
@@ -15,6 +15,18 @@ export interface KeybindingDef {
   label: string;
   defaultKeys: string;
   group: string;
+  /**
+   * True if the (possibly user-overridden) combo must pass through xterm.js
+   * to reach the document-level handler in `useKeyboardShortcuts` while a
+   * terminal is focused (consumed by `lx-shortcuts.ts`).
+   *
+   * Declared per-definition — not derived from `group` — because the group
+   * alone doesn't decide it: `pane.focus`/`pane.propagateCwdOnce` are
+   * document-level, but `pane.delete` (plain Delete) must stay with the
+   * terminal. Terminal/Memo/Issue Reporter actions are handled inside the
+   * focused view itself and never pass through.
+   */
+  passThroughTerminal?: boolean;
 }
 
 /**
@@ -23,83 +35,178 @@ export interface KeybindingDef {
  */
 export const DEFAULT_KEYBINDINGS: KeybindingDef[] = [
   // -- Workspace --
-  { id: "workspace.1", label: "워크스페이스 1", defaultKeys: "Ctrl+Alt+1", group: "Workspace" },
-  { id: "workspace.2", label: "워크스페이스 2", defaultKeys: "Ctrl+Alt+2", group: "Workspace" },
-  { id: "workspace.3", label: "워크스페이스 3", defaultKeys: "Ctrl+Alt+3", group: "Workspace" },
-  { id: "workspace.4", label: "워크스페이스 4", defaultKeys: "Ctrl+Alt+4", group: "Workspace" },
-  { id: "workspace.5", label: "워크스페이스 5", defaultKeys: "Ctrl+Alt+5", group: "Workspace" },
-  { id: "workspace.6", label: "워크스페이스 6", defaultKeys: "Ctrl+Alt+6", group: "Workspace" },
-  { id: "workspace.7", label: "워크스페이스 7", defaultKeys: "Ctrl+Alt+7", group: "Workspace" },
-  { id: "workspace.8", label: "워크스페이스 8", defaultKeys: "Ctrl+Alt+8", group: "Workspace" },
+  {
+    id: "workspace.1",
+    label: "워크스페이스 1",
+    defaultKeys: "Ctrl+Alt+1",
+    group: "Workspace",
+    passThroughTerminal: true,
+  },
+  {
+    id: "workspace.2",
+    label: "워크스페이스 2",
+    defaultKeys: "Ctrl+Alt+2",
+    group: "Workspace",
+    passThroughTerminal: true,
+  },
+  {
+    id: "workspace.3",
+    label: "워크스페이스 3",
+    defaultKeys: "Ctrl+Alt+3",
+    group: "Workspace",
+    passThroughTerminal: true,
+  },
+  {
+    id: "workspace.4",
+    label: "워크스페이스 4",
+    defaultKeys: "Ctrl+Alt+4",
+    group: "Workspace",
+    passThroughTerminal: true,
+  },
+  {
+    id: "workspace.5",
+    label: "워크스페이스 5",
+    defaultKeys: "Ctrl+Alt+5",
+    group: "Workspace",
+    passThroughTerminal: true,
+  },
+  {
+    id: "workspace.6",
+    label: "워크스페이스 6",
+    defaultKeys: "Ctrl+Alt+6",
+    group: "Workspace",
+    passThroughTerminal: true,
+  },
+  {
+    id: "workspace.7",
+    label: "워크스페이스 7",
+    defaultKeys: "Ctrl+Alt+7",
+    group: "Workspace",
+    passThroughTerminal: true,
+  },
+  {
+    id: "workspace.8",
+    label: "워크스페이스 8",
+    defaultKeys: "Ctrl+Alt+8",
+    group: "Workspace",
+    passThroughTerminal: true,
+  },
   {
     id: "workspace.last",
     label: "마지막 워크스페이스",
     defaultKeys: "Ctrl+Alt+9",
     group: "Workspace",
+    passThroughTerminal: true,
   },
   {
     id: "workspace.next",
     label: "다음 워크스페이스",
     defaultKeys: "Ctrl+Alt+Down",
     group: "Workspace",
+    passThroughTerminal: true,
   },
   {
     id: "workspace.prev",
     label: "이전 워크스페이스",
     defaultKeys: "Ctrl+Alt+Up",
     group: "Workspace",
+    passThroughTerminal: true,
   },
-  { id: "workspace.new", label: "새 워크스페이스", defaultKeys: "Ctrl+Alt+N", group: "Workspace" },
+  {
+    id: "workspace.new",
+    label: "새 워크스페이스",
+    defaultKeys: "Ctrl+Alt+N",
+    group: "Workspace",
+    passThroughTerminal: true,
+  },
   {
     id: "workspace.duplicate",
     label: "워크스페이스 복제",
     defaultKeys: "Ctrl+Alt+D",
     group: "Workspace",
+    passThroughTerminal: true,
   },
   {
     id: "workspace.close",
     label: "워크스페이스 닫기",
     defaultKeys: "Ctrl+Alt+W",
     group: "Workspace",
+    passThroughTerminal: true,
   },
   {
     id: "workspace.rename",
     label: "워크스페이스 이름 변경",
     defaultKeys: "Ctrl+Alt+R",
     group: "Workspace",
+    passThroughTerminal: true,
   },
   // -- Pane --
-  { id: "pane.focus", label: "Pane 포커스 이동", defaultKeys: "Alt+Arrow", group: "Pane" },
+  {
+    id: "pane.focus",
+    label: "Pane 포커스 이동",
+    defaultKeys: "Alt+Arrow",
+    group: "Pane",
+    passThroughTerminal: true,
+  },
+  // pane.delete: 맨 Delete 키 — 터미널이 계속 받아야 하므로 pass-through 금지.
   { id: "pane.delete", label: "Pane 제거 (편집 모드)", defaultKeys: "Delete", group: "Pane" },
   {
     id: "pane.propagateCwdOnce",
     label: "포커스 Pane CWD 1회 전파",
     defaultKeys: "Ctrl+Alt+P",
     group: "Pane",
+    passThroughTerminal: true,
   },
   // -- UI --
-  { id: "sidebar.toggle", label: "사이드바 토글", defaultKeys: "Ctrl+Shift+B", group: "UI" },
-  { id: "notifications.toggle", label: "알림 패널 토글", defaultKeys: "Ctrl+Shift+I", group: "UI" },
+  {
+    id: "sidebar.toggle",
+    label: "사이드바 토글",
+    defaultKeys: "Ctrl+Shift+B",
+    group: "UI",
+    passThroughTerminal: true,
+  },
+  {
+    id: "notifications.toggle",
+    label: "알림 패널 토글",
+    defaultKeys: "Ctrl+Shift+I",
+    group: "UI",
+    passThroughTerminal: true,
+  },
   {
     id: "notifications.unread",
     label: "읽지 않은 알림으로 이동",
     defaultKeys: "Ctrl+Shift+U",
     group: "UI",
+    passThroughTerminal: true,
   },
   {
     id: "notifications.recent",
     label: "최근 알림 Pane으로 이동",
     defaultKeys: "Ctrl+Alt+Left",
     group: "UI",
+    passThroughTerminal: true,
   },
   {
     id: "notifications.oldest",
     label: "오래된 알림 Pane으로 이동",
     defaultKeys: "Ctrl+Alt+Right",
     group: "UI",
+    passThroughTerminal: true,
   },
-  { id: "settings.open", label: "설정 열기", defaultKeys: "Ctrl+,", group: "UI" },
-  { id: "fileViewer.open", label: "파일 뷰어 열기", defaultKeys: "Ctrl+Shift+O", group: "UI" },
+  {
+    id: "settings.open",
+    label: "설정 열기",
+    defaultKeys: "Ctrl+,",
+    group: "UI",
+    passThroughTerminal: true,
+  },
+  {
+    id: "fileViewer.open",
+    label: "파일 뷰어 열기",
+    defaultKeys: "Ctrl+Shift+O",
+    group: "UI",
+    passThroughTerminal: true,
+  },
   // -- Terminal --
   // 기본값은 OS의 시스템 클립보드 단축키(Ctrl+C / Ctrl+V)와 동일하여, 별도 설정 없이도
   // 브라우저 `copy` / `paste` 이벤트로 동작한다. 사용자가 Ctrl+Shift+C / Ctrl+Shift+V

--- a/ui/src/lib/keybinding-registry.ts
+++ b/ui/src/lib/keybinding-registry.ts
@@ -184,6 +184,9 @@ function normalizeKey(key: string): string {
   return KEY_NORMALIZE[key] ?? (key.length === 1 ? key.toUpperCase() : key);
 }
 
+/** Normalized arrow-key tokens matched by the `Arrow` wildcard (e.g. `pane.focus` = "Alt+Arrow"). */
+const ARROW_WILDCARD_KEYS = new Set(["Up", "Down", "Left", "Right"]);
+
 /**
  * Resolve the effective key combo string for an action (user override > default).
  * Returns undefined if action is not registered.
@@ -225,10 +228,15 @@ export function matchesKeybinding(
   const parsed = parseShortcut(keys);
   const eventKey = normalizeKey(e.key);
 
+  // `Arrow` is a wildcard token matching any of the four arrow keys
+  // (used by directional bindings like `pane.focus` = "Alt+Arrow").
+  const keyMatches =
+    parsed.key === "Arrow" ? ARROW_WILDCARD_KEYS.has(eventKey) : eventKey === parsed.key;
+
   return (
     e.ctrlKey === parsed.ctrl &&
     e.altKey === parsed.alt &&
     e.shiftKey === parsed.shift &&
-    eventKey === parsed.key
+    keyMatches
   );
 }

--- a/ui/src/lib/lx-shortcuts.test.ts
+++ b/ui/src/lib/lx-shortcuts.test.ts
@@ -220,5 +220,14 @@ describe("isLxShortcut", () => {
       // Old default Alt+Arrow no longer bound → not an IDE shortcut anymore
       expect(isLxShortcut(makeKeyEvent("ArrowLeft", { altKey: true }))).toBe(false);
     });
+
+    it("respects pane.propagateCwdOnce override (document-level Pane action, #324)", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [{ command: "pane.propagateCwdOnce", keys: "Ctrl+Shift+G" }],
+      });
+      expect(isLxShortcut(makeKeyEvent("G", { ctrlKey: true, shiftKey: true }))).toBe(true);
+      // Old default Ctrl+Alt+P no longer bound → must reach the shell
+      expect(isLxShortcut(makeKeyEvent("P", { ctrlKey: true, altKey: true }))).toBe(false);
+    });
   });
 });

--- a/ui/src/lib/lx-shortcuts.test.ts
+++ b/ui/src/lib/lx-shortcuts.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock settings store before importing the module under test.
+// isLxShortcut consults the keybinding registry, which reads user
+// overrides from the settings store (#332/#333).
+const mockGetState = vi.fn();
+vi.mock("@/stores/settings-store", () => ({
+  useSettingsStore: { getState: () => mockGetState() },
+}));
+
 import { isLxShortcut } from "./lx-shortcuts";
 
 function makeKeyEvent(
@@ -9,6 +18,10 @@ function makeKeyEvent(
 }
 
 describe("isLxShortcut", () => {
+  beforeEach(() => {
+    mockGetState.mockReturnValue({ keybindings: [] });
+  });
+
   // Ctrl+Alt+ArrowUp/Down: workspace navigation
   it("returns true for Ctrl+Alt+ArrowUp (previous workspace)", () => {
     expect(isLxShortcut(makeKeyEvent("ArrowUp", { ctrlKey: true, altKey: true }))).toBe(true);
@@ -140,5 +153,72 @@ describe("isLxShortcut", () => {
 
   it("returns true for Ctrl+Shift+i (lowercase, toggle notification panel)", () => {
     expect(isLxShortcut(makeKeyEvent("i", { ctrlKey: true, shiftKey: true }))).toBe(true);
+  });
+
+  // --- Keybinding registry integration (#332/#333) ---
+  describe("user overrides from keybinding registry", () => {
+    it("passes through the new combo after rebinding (e.g. workspace.duplicate → Ctrl+Shift+P)", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [{ command: "workspace.duplicate", keys: "Ctrl+Shift+P" }],
+      });
+      expect(isLxShortcut(makeKeyEvent("P", { ctrlKey: true, shiftKey: true }))).toBe(true);
+      expect(isLxShortcut(makeKeyEvent("p", { ctrlKey: true, shiftKey: true }))).toBe(true);
+    });
+
+    it("stops swallowing the old default combo after rebinding", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [{ command: "workspace.duplicate", keys: "Ctrl+Shift+P" }],
+      });
+      // Ctrl+Alt+D is no longer bound to anything → must reach the shell
+      expect(isLxShortcut(makeKeyEvent("D", { ctrlKey: true, altKey: true }))).toBe(false);
+      expect(isLxShortcut(makeKeyEvent("d", { ctrlKey: true, altKey: true }))).toBe(false);
+    });
+
+    it("respects override for workspace navigation keys", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [{ command: "workspace.next", keys: "Ctrl+Shift+Down" }],
+      });
+      expect(isLxShortcut(makeKeyEvent("ArrowDown", { ctrlKey: true, shiftKey: true }))).toBe(true);
+      expect(isLxShortcut(makeKeyEvent("ArrowDown", { ctrlKey: true, altKey: true }))).toBe(false);
+    });
+
+    it("never passes through Ctrl+single letter/digit even when rebound there (shell territory)", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [
+          { command: "workspace.new", keys: "Ctrl+N" },
+          { command: "workspace.1", keys: "Ctrl+1" },
+        ],
+      });
+      expect(isLxShortcut(makeKeyEvent("n", { ctrlKey: true }))).toBe(false);
+      expect(isLxShortcut(makeKeyEvent("1", { ctrlKey: true }))).toBe(false);
+    });
+
+    it("does not pass through terminal-scoped bindings (terminal.copy/paste own their combos)", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [
+          // Conflict: terminal.copy and sidebar.toggle both on Ctrl+Shift+C —
+          // the terminal-owned binding wins, so the key must NOT pass through.
+          { command: "terminal.copy", keys: "Ctrl+Shift+C" },
+          { command: "sidebar.toggle", keys: "Ctrl+Shift+C" },
+        ],
+      });
+      expect(isLxShortcut(makeKeyEvent("C", { ctrlKey: true, shiftKey: true }))).toBe(false);
+    });
+
+    it("does not pass through combos bound only to terminal/memo scoped actions", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [{ command: "terminal.zoomIn", keys: "Ctrl+Shift+=" }],
+      });
+      expect(isLxShortcut(makeKeyEvent("=", { ctrlKey: true, shiftKey: true }))).toBe(false);
+    });
+
+    it("respects pane.focus override while keeping Alt+Arrow wildcard semantics", () => {
+      mockGetState.mockReturnValue({
+        keybindings: [{ command: "pane.focus", keys: "Ctrl+Alt+Arrow" }],
+      });
+      expect(isLxShortcut(makeKeyEvent("ArrowLeft", { ctrlKey: true, altKey: true }))).toBe(true);
+      // Old default Alt+Arrow no longer bound → not an IDE shortcut anymore
+      expect(isLxShortcut(makeKeyEvent("ArrowLeft", { altKey: true }))).toBe(false);
+    });
   });
 });

--- a/ui/src/lib/lx-shortcuts.ts
+++ b/ui/src/lib/lx-shortcuts.ts
@@ -3,58 +3,49 @@
  * Used by TerminalView to let these events pass through xterm.js
  * so they can reach the document-level handler in useKeyboardShortcuts.
  *
- * Design principle: never capture Ctrl+single-key — those belong to the shell.
- * IDE shortcuts use Ctrl+Shift, Ctrl+Alt, or Alt+Arrow.
+ * The pass-through decision consults the keybinding registry — user
+ * overrides included — instead of a hardcoded key list (#332/#333):
+ * rebinding an action automatically moves its pass-through combo, and the
+ * old default combo is no longer swallowed by the terminal.
+ *
+ * Design principles preserved:
+ * - Never capture Ctrl+single letter/digit — those belong to the shell
+ *   (e.g. Ctrl+C → SIGINT), even if a user binds an IDE action there.
+ * - Terminal-scoped bindings (terminal.copy/paste/zoom*) are handled inside
+ *   TerminalView's own key handler and never pass through, so they win when
+ *   a user override collides with a document-level shortcut.
  */
 
-const CTRL_SHIFT_KEYS = new Set(["U", "B", "I", "O", "u", "b", "i", "o"]);
-const CTRL_ALT_KEYS = new Set([
-  "1",
-  "2",
-  "3",
-  "4",
-  "5",
-  "6",
-  "7",
-  "8",
-  "9",
-  "ArrowUp",
-  "ArrowDown",
-  "ArrowLeft",
-  "ArrowRight",
-  "N",
-  "W",
-  "R",
-  "D",
-  "P",
-  "n",
-  "w",
-  "r",
-  "d",
-  "p",
-]);
-const ALT_ARROWS = new Set(["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"]);
+import { DEFAULT_KEYBINDINGS, matchesKeybinding } from "./keybinding-registry";
+
+/**
+ * Actions dispatched by the document-level handler (useKeyboardShortcuts).
+ * These must pass through xterm.js while a terminal is focused.
+ *
+ * Selected by group: Workspace + UI are document-level, plus `pane.focus`
+ * (Alt+Arrow navigation). Intentionally excluded:
+ * - Terminal / Memo groups — handled inside the focused view itself.
+ * - `pane.delete` (plain Delete) — the terminal must keep receiving Delete.
+ * - Issue Reporter — modal-local scope, never active while a terminal is focused.
+ */
+const PASS_THROUGH_GROUPS = new Set(["Workspace", "UI"]);
+const PASS_THROUGH_EXTRA_IDS = new Set(["pane.focus"]);
+const PASS_THROUGH_ACTION_IDS: readonly string[] = DEFAULT_KEYBINDINGS.filter(
+  (d) => PASS_THROUGH_GROUPS.has(d.group) || PASS_THROUGH_EXTRA_IDS.has(d.id),
+).map((d) => d.id);
+
+/** Terminal-owned actions: their (possibly overridden) combos never pass through. */
+const TERMINAL_OWNED_ACTION_IDS: readonly string[] = DEFAULT_KEYBINDINGS.filter(
+  (d) => d.group === "Terminal",
+).map((d) => d.id);
+
+/** Ctrl+single letter/digit (no Alt/Shift) is shell territory — never pass through. */
+function isShellOwnedCombo(e: KeyboardEvent): boolean {
+  return e.ctrlKey && !e.altKey && !e.shiftKey && /^[a-zA-Z0-9]$/.test(e.key);
+}
 
 export function isLxShortcut(e: KeyboardEvent): boolean {
-  // Alt+Arrow: pane navigation
-  if (e.altKey && !e.ctrlKey && !e.shiftKey && ALT_ARROWS.has(e.key)) {
-    return true;
-  }
-
-  if (!e.ctrlKey) return false;
-
-  // Ctrl+, (settings) — no shell conflict
-  if (!e.shiftKey && !e.altKey && e.key === ",") return true;
-
-  // Ctrl+Shift+key
-  if (e.shiftKey && !e.altKey) {
-    return CTRL_SHIFT_KEYS.has(e.key);
-  }
-
-  // Ctrl+Alt: workspace switch (1~9) + workspace nav (ArrowUp/Down)
-  if (e.altKey && !e.shiftKey) {
-    return CTRL_ALT_KEYS.has(e.key);
-  }
-
-  return false;
+  if (isShellOwnedCombo(e)) return false;
+  if (TERMINAL_OWNED_ACTION_IDS.some((id) => matchesKeybinding(e, id))) return false;
+  return PASS_THROUGH_ACTION_IDS.some((id) => matchesKeybinding(e, id));
 }

--- a/ui/src/lib/lx-shortcuts.ts
+++ b/ui/src/lib/lx-shortcuts.ts
@@ -22,16 +22,14 @@ import { DEFAULT_KEYBINDINGS, matchesKeybinding } from "./keybinding-registry";
  * Actions dispatched by the document-level handler (useKeyboardShortcuts).
  * These must pass through xterm.js while a terminal is focused.
  *
- * Selected by group: Workspace + UI are document-level, plus `pane.focus`
- * (Alt+Arrow navigation). Intentionally excluded:
- * - Terminal / Memo groups — handled inside the focused view itself.
- * - `pane.delete` (plain Delete) — the terminal must keep receiving Delete.
- * - Issue Reporter — modal-local scope, never active while a terminal is focused.
+ * Membership is declared per-definition via `passThroughTerminal` in the
+ * registry — see the field's doc in `keybinding-registry.ts` for why an
+ * action is or isn't flagged. Deriving the list here (instead of keeping a
+ * parallel group/exception list) means a new document-level shortcut can't
+ * be registered without also deciding its pass-through behavior.
  */
-const PASS_THROUGH_GROUPS = new Set(["Workspace", "UI"]);
-const PASS_THROUGH_EXTRA_IDS = new Set(["pane.focus"]);
 const PASS_THROUGH_ACTION_IDS: readonly string[] = DEFAULT_KEYBINDINGS.filter(
-  (d) => PASS_THROUGH_GROUPS.has(d.group) || PASS_THROUGH_EXTRA_IDS.has(d.id),
+  (d) => d.passThroughTerminal,
 ).map((d) => d.id);
 
 /** Terminal-owned actions: their (possibly overridden) combos never pass through. */


### PR DESCRIPTION
## 요약

`ui/src/lib/lx-shortcuts.ts`의 하드코딩 키 목록(`CTRL_SHIFT_KEYS`/`CTRL_ALT_KEYS`/`ALT_ARROWS`)을 전부 제거하고, `isLxShortcut()`이 키바인딩 레지스트리(사용자 오버라이드 포함)를 동적으로 참조해 터미널 pass-through 여부를 판정하도록 변경.

- `DEFAULT_KEYBINDINGS`에서 Workspace·UI 그룹 + `pane.focus` 액션을 추려 `matchesKeybinding()`(오버라이드 우선)으로 매칭
- 재바인딩 시 새 콤보는 자동 pass-through, 옛 기본 콤보는 더 이상 키를 삼키지 않음
- 가드 2종 유지:
  - Ctrl+단일 영문/숫자(셸 소유)는 어디에 바인딩돼도 pass-through 금지 ("Ctrl+단일키는 셸 소유" 설계 원칙)
  - Terminal 그룹 바인딩(copy/paste/zoom)은 TerminalView가 직접 처리하므로 오버라이드 충돌 시에도 pass-through 안 함
- `matchesKeybinding()`에 `Arrow` 와일드카드 매칭 추가 (`pane.focus` = "Alt+Arrow")

## 테스트

- TDD: 테스트 선작성(Red) → 구현(Green)
- 오버라이드 시나리오 7건 + Arrow 와일드카드 2건 추가, 기존 기본 콤보 테스트 전부 유지
- `npx vitest run` 전체 82 파일 / 2069 테스트 통과, `tsc --noEmit`/prettier/eslint 깨끗

## 후속 과제

`useKeyboardShortcuts.ts`의 document 핸들러는 여전히 대부분 콤보를 하드코딩으로 검사함(`fileViewer.open`만 레지스트리 사용). Workspace/UI 단축키 재바인딩이 끝까지 동작하려면 document 핸들러의 레지스트리 전환이 별도 후속 작업으로 필요.

Fixes #332
Fixes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)
