### PR TITLE
fix(layout): control bar 투명화에서 좌측 pane id·propagate 아이콘 제외

### DIFF
--- a/ui/src/components/layout/PaneControlBar.test.tsx
+++ b/ui/src/components/layout/PaneControlBar.test.tsx
@@ -766,4 +766,55 @@ describe("PaneControlBar", () => {
     );
     expect(screen.queryByTestId("pane-control-cwd-propagate-once")).not.toBeInTheDocument();
   });
+
+  // -- Left icons excluded from overlay transparency (issue #341) --
+  // hover 오버레이 바는 평소 반투명이지만, 좌측 pane id 배지와 propagate 아이콘은
+  // 항상 불투명하게 보여야 한다. 두 요소를 자체 불투명 배경(.pane-bar-left-solid)을
+  // 가진 컨테이너로 감싸 부모 바의 투명화 영향을 받지 않게 한다.
+
+  it("wraps left icons (badge + propagate) in a solid-background container (issue #341)", () => {
+    render(
+      <PaneControlBar
+        currentView={terminalView}
+        actions={{ ...defaultActions, onPropagateCwdOnce: vi.fn() }}
+        hovered={true}
+        paneNumber={2}
+        workspaceId="ws-1"
+        workspaceName="WS"
+      >
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    const solid = screen.getByTestId("pane-control-bar-left-solid");
+    expect(solid.className).toContain("pane-bar-left-solid");
+    // 배지와 전파 버튼이 모두 그 안에 들어있어야 한다.
+    expect(solid.contains(screen.getByTestId("pane-number-badge"))).toBe(true);
+    expect(solid.contains(screen.getByTestId("pane-control-cwd-propagate-once"))).toBe(true);
+  });
+
+  it("renders the solid left container even with only a badge (no propagate)", () => {
+    render(
+      <PaneControlBar
+        currentView={terminalView}
+        actions={defaultActions}
+        hovered={true}
+        paneNumber={3}
+        workspaceId="ws-1"
+        workspaceName="WS"
+      >
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    const solid = screen.getByTestId("pane-control-bar-left-solid");
+    expect(solid.contains(screen.getByTestId("pane-number-badge"))).toBe(true);
+  });
+
+  it("does not render the solid left container when there are no left icons", () => {
+    render(
+      <PaneControlBar currentView={terminalView} actions={defaultActions} hovered={true}>
+        <div>content</div>
+      </PaneControlBar>,
+    );
+    expect(screen.queryByTestId("pane-control-bar-left-solid")).not.toBeInTheDocument();
+  });
 });

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -701,6 +701,25 @@ export function PaneControlBar({
     [showPropagateCwd, actions.onPropagateCwdOnce],
   );
 
+  // 좌측 아이콘(pane 번호 배지 + propagate 버튼)은 컨트롤 바 투명화(issue #320)에서
+  // 제외되어 항상 불투명하게 보여야 한다 (issue #341). 반투명 배경의 바 위에서
+  // 터미널 내용이 비쳐 흐릿해지지 않도록 자체 불투명 배경(.pane-bar-left-solid)을
+  // 가진 컨테이너로 감싼다. 좌측 아이콘이 하나도 없으면 컨테이너 자체를 렌더하지 않는다.
+  const hasLeftIcons = paneNumber != null || showPropagateCwd;
+  const leftIcons = hasLeftIcons ? (
+    <div
+      data-testid="pane-control-bar-left-solid"
+      className="pane-bar-left-solid flex shrink-0 items-center"
+    >
+      <PaneNumberBadge
+        number={paneNumber}
+        workspaceId={workspaceId}
+        workspaceName={workspaceName}
+      />
+      {leftPaneControls}
+    </div>
+  ) : null;
+
   // 자식(TerminalView 등)이 주입한 좌측 콘텐츠가 있으면 기본 BarLabel 대신 사용.
   // 둘 다 없으면 flex-1 스페이서만 렌더하여 pane 컨트롤이 오른쪽 끝에 정렬되도록 한다.
   const hasLeftContent =
@@ -784,12 +803,7 @@ export function PaneControlBar({
               borderBottom: `1px solid ${borderClr}`,
             }}
           >
-            <PaneNumberBadge
-              number={paneNumber}
-              workspaceId={workspaceId}
-              workspaceName={workspaceName}
-            />
-            {leftPaneControls}
+            {leftIcons}
             {hasBarLabel ? (
               <BarLabel viewType={currentView.type} />
             ) : leftBarContent ? (
@@ -841,12 +855,7 @@ export function PaneControlBar({
                 borderRadius: 0,
               }}
             >
-              <PaneNumberBadge
-                number={paneNumber}
-                workspaceId={workspaceId}
-                workspaceName={workspaceName}
-              />
-              {leftPaneControls}
+              {leftIcons}
               {hasBarLabel ? (
                 <BarLabel viewType={currentView.type} />
               ) : leftBarContent ? (

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -199,6 +199,16 @@
     backdrop-filter: blur(8px);
   }
 
+  /* 좌측 아이콘(pane id 배지 + propagate)은 바 투명화 대상에서 제외한다 (issue #341).
+     반투명 바 위에서 터미널 내용이 비쳐 흐릿해지지 않도록 자체 불투명 배경을 깔아
+     항상 또렷하게 보이도록 한다. 바에 hover 하면 바 전체가 불투명해지므로 이 칩은
+     주변과 매끄럽게 섞인다. */
+  .pane-bar-left-solid {
+    background: var(--bar-bg-hover);
+    border-radius: var(--radius-sm);
+    padding: 0 2px;
+  }
+
   /* Toolbar (28px header bar) */
   .ui-toolbar {
     display: flex;


### PR DESCRIPTION
## 요약
hover 컨트롤 바는 평소 반투명 배경(`--bar-bg-overlay`, alpha 0.6)을 사용해 아래 터미널 내용이 비쳐 보인다. 그 위의 좌측 pane id 배지와 propagate 아이콘도 함께 흐릿해 보이는 문제를 수정한다.

좌측 두 아이콘(pane 번호 배지 + propagate 버튼)을 자체 불투명 배경을 가진 컨테이너(`.pane-bar-left-solid`, 배경 `--bar-bg-hover`)로 감싸 부모 바의 투명화 영향을 받지 않고 항상 또렷하게 보이도록 했다. 좌측 아이콘이 없으면 컨테이너를 렌더하지 않으며, pinned 바와 hover 바 양쪽에 동일하게 적용했다.

## 변경 파일
- `ui/src/components/layout/PaneControlBar.tsx` — 좌측 아이콘을 `pane-bar-left-solid` 컨테이너로 묶는 `leftIcons` 추가
- `ui/src/index.css` — `.pane-bar-left-solid` 클래스(불투명 배경 + 둥근 모서리) 추가
- `ui/src/components/layout/PaneControlBar.test.tsx` — 테스트 3건 추가

## 테스트
- `npx vitest run`: 2137 passed (83 files), 신규 3건 포함 전부 통과

Fixes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)