### PR TITLE
refactor(settings): 섹션 내부 동종 필드를 하위 그룹 카드로 묶기

### DIFF
--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -93,7 +93,7 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
 /** Card wrapper grouping related fields under an uppercase sub-header within a section. */
 function SubGroup({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div style={cardStyle} className="mt-3 p-4 first:mt-0">
+    <div style={cardStyle} className="mt-3 p-4">
       <h3
         className="mb-3 text-[12px] font-semibold uppercase tracking-wider"
         style={{ color: "var(--text-secondary)", opacity: 0.7 }}
@@ -1364,14 +1364,7 @@ function InterfaceSection() {
     <div>
       <SectionTitle>Interface</SectionTitle>
 
-      {/* Control Bar */}
-      <div style={cardStyle} className="p-4">
-        <h3
-          className="mb-3 text-[12px] font-semibold uppercase tracking-wider"
-          style={{ color: "var(--text-secondary)", opacity: 0.7 }}
-        >
-          Control Bar
-        </h3>
+      <SubGroup title="Control Bar">
         <SettingRow
           label="Hover Auto-hide"
           desc="마우스 움직임 없을 때 컨트롤 바 숨김 대기 시간 (0 = 숨기지 않음)"
@@ -1410,16 +1403,9 @@ function InterfaceSection() {
             <option value="pinned">Pinned (항상 고정 표시)</option>
           </FocusSelect>
         </SettingRow>
-      </div>
+      </SubGroup>
 
-      {/* Dock */}
-      <div style={cardStyle} className="mt-3 p-4">
-        <h3
-          className="mb-3 text-[12px] font-semibold uppercase tracking-wider"
-          style={{ color: "var(--text-secondary)", opacity: 0.7 }}
-        >
-          Dock
-        </h3>
+      <SubGroup title="Dock">
         <ToggleRow
           label="Dock Persist State"
           desc="Dock을 숨겨도 백그라운드에서 상태를 유지 (터미널 프로세스가 계속 실행됨)"
@@ -1441,16 +1427,9 @@ function InterfaceSection() {
           checked={dock.arrowFocusPane}
           onChange={(v) => updateDock({ arrowFocusPane: v })}
         />
-      </div>
+      </SubGroup>
 
-      {/* Notifications */}
-      <div style={cardStyle} className="mt-3 p-4">
-        <h3
-          className="mb-3 text-[12px] font-semibold uppercase tracking-wider"
-          style={{ color: "var(--text-secondary)", opacity: 0.7 }}
-        >
-          Notifications
-        </h3>
+      <SubGroup title="Notifications">
         <SettingRow label="Notification Dismiss" desc="알림을 읽음 처리하는 시점">
           <FocusSelect
             data-testid="notification-dismiss-select"
@@ -1467,7 +1446,7 @@ function InterfaceSection() {
             <option value="manual">알림 클릭으로만 해제</option>
           </FocusSelect>
         </SettingRow>
-      </div>
+      </SubGroup>
     </div>
   );
 }
@@ -1514,14 +1493,7 @@ function WorkspacesSection() {
     <div>
       <SectionTitle>Workspaces</SectionTitle>
 
-      {/* Display */}
-      <div style={cardStyle} className="p-4">
-        <h3
-          className="mb-3 text-[12px] font-semibold uppercase tracking-wider"
-          style={{ color: "var(--text-secondary)", opacity: 0.7 }}
-        >
-          Display
-        </h3>
+      <SubGroup title="Display">
         {displayItems.map((item, i) => (
           <div key={item.key} className={`flex items-start gap-3 py-1${i > 0 ? " mt-2" : ""}`}>
             <div className="w-36 shrink-0 pt-1">
@@ -1550,17 +1522,9 @@ function WorkspacesSection() {
             </div>
           </div>
         ))}
-      </div>
+      </SubGroup>
 
-      {/* Behavior */}
-      <div style={cardStyle} className="mt-3 p-4">
-        <h3
-          className="mb-3 text-[12px] font-semibold uppercase tracking-wider"
-          style={{ color: "var(--text-secondary)", opacity: 0.7 }}
-        >
-          Behavior
-        </h3>
-
+      <SubGroup title="Behavior">
         <SettingRow label="Path Ellipsis" desc="경로가 길 때 생략 방향 (워크스페이스 목록)">
           <FocusSelect
             data-testid="path-ellipsis-select"
@@ -1597,16 +1561,9 @@ function WorkspacesSection() {
             </span>
           </div>
         </SettingRow>
-      </div>
+      </SubGroup>
 
-      {/* Default CWD propagation */}
-      <div style={cardStyle} className="mt-3 p-4">
-        <h3
-          className="mb-3 text-[12px] font-semibold uppercase tracking-wider"
-          style={{ color: "var(--text-secondary)", opacity: 0.7 }}
-        >
-          CWD Propagation Defaults
-        </h3>
+      <SubGroup title="CWD Propagation Defaults">
         {(["workspace", "dock"] as const).map((location, i) => {
           const label = location === "workspace" ? "Workspace" : "Dock";
           const desc =
@@ -1656,7 +1613,7 @@ function WorkspacesSection() {
             </div>
           );
         })}
-      </div>
+      </SubGroup>
     </div>
   );
 }

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -90,6 +90,21 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   );
 }
 
+/** Card wrapper grouping related fields under an uppercase sub-header within a section. */
+function SubGroup({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={cardStyle} className="mt-3 p-4 first:mt-0">
+      <h3
+        className="mb-3 text-[12px] font-semibold uppercase tracking-wider"
+        style={{ color: "var(--text-secondary)", opacity: 0.7 }}
+      >
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
 function ColorSwatch({
   color,
   label,
@@ -1654,7 +1669,7 @@ function ClaudeSection() {
     <div>
       <SectionTitle>Claude Code</SectionTitle>
 
-      <div style={cardStyle} className="p-4">
+      <SubGroup title="CWD 동기화">
         {/* Sync CWD mode */}
         <div className="flex items-start gap-3 py-1.5">
           <div className="w-36 shrink-0 pt-1">
@@ -1680,7 +1695,9 @@ function ClaudeSection() {
             </FocusSelect>
           </div>
         </div>
+      </SubGroup>
 
+      <SubGroup title="세션 복원">
         {/* Restore Session */}
         <div className="flex items-start gap-3 py-1.5">
           <div className="w-36 shrink-0 pt-1">
@@ -1744,7 +1761,9 @@ function ClaudeSection() {
             </div>
           </div>
         </div>
+      </SubGroup>
 
+      <SubGroup title="상태 메시지">
         {/* Status Message Mode */}
         <div className="flex items-start gap-3 py-1.5">
           <div className="w-36 shrink-0 pt-1">
@@ -1824,7 +1843,9 @@ function ClaudeSection() {
             </div>
           </div>
         )}
+      </SubGroup>
 
+      <SubGroup title="세션 리미트 자동 복귀">
         {/* Session Limit Auto Resume (issue #312) */}
         <div className="flex items-start gap-3 py-1.5">
           <div className="w-36 shrink-0 pt-1">
@@ -1919,7 +1940,7 @@ function ClaudeSection() {
             </div>
           </>
         )}
-      </div>
+      </SubGroup>
     </div>
   );
 }
@@ -2043,7 +2064,7 @@ function FileExplorerSection() {
     <div>
       <SectionTitle>File Explorer</SectionTitle>
 
-      <div style={cardStyle} className="p-4">
+      <SubGroup title="쉘">
         {/* Shell Profile */}
         <SettingRow
           label="Shell Profile"
@@ -2063,7 +2084,9 @@ function FileExplorerSection() {
             ))}
           </FocusSelect>
         </SettingRow>
+      </SubGroup>
 
+      <SubGroup title="모양">
         {/* Font */}
         <SettingRow label="Font Family" desc="파일 목록 영역의 폰트. 비워두면 기본 폰트 상속.">
           <FocusInput
@@ -2136,7 +2159,9 @@ function FileExplorerSection() {
             </div>
           </div>
         </div>
+      </SubGroup>
 
+      <SubGroup title="동작">
         {/* Copy on Select */}
         <SettingRow label="Copy on Select" desc="파일 선택 시 자동으로 경로를 클립보드에 복사.">
           <label className="flex items-center gap-2">
@@ -2219,7 +2244,7 @@ function FileExplorerSection() {
             </button>
           </div>
         </div>
-      </div>
+      </SubGroup>
     </div>
   );
 }
@@ -2275,7 +2300,7 @@ function IssueReporterSection() {
         faceDesc="비워두면 앱 기본 폰트 상속"
       />
 
-      <div style={cardStyle} className="p-4">
+      <SubGroup title="이슈 제출">
         <SettingRow
           label="Shell"
           desc="gh CLI를 실행할 셸 접두어. 비워두면 gh를 직접 실행. 따옴표 지원."
@@ -2341,7 +2366,9 @@ function IssueReporterSection() {
             </button>
           </div>
         </div>
+      </SubGroup>
 
+      <SubGroup title="모양">
         {/* Padding */}
         <div className="flex items-start gap-3 py-1.5">
           <div className="w-36 shrink-0 pt-1">
@@ -2384,7 +2411,7 @@ function IssueReporterSection() {
             </div>
           </div>
         </div>
-      </div>
+      </SubGroup>
     </div>
   );
 }
@@ -2427,7 +2454,7 @@ function MemoSection() {
         faceDesc="비워두면 앱 기본 폰트 상속"
       />
 
-      <div style={cardStyle} className="p-4">
+      <SubGroup title="레이아웃">
         {/* Padding */}
         <div className="flex items-start gap-3 py-1.5">
           <div className="w-36 shrink-0 pt-1">
@@ -2505,7 +2532,9 @@ function MemoSection() {
             />
           </div>
         </div>
+      </SubGroup>
 
+      <SubGroup title="동작">
         {/* Paragraph Detection */}
         <div className="flex items-start gap-3 py-1.5">
           <div className="w-36 shrink-0 pt-1">
@@ -2617,7 +2646,7 @@ function MemoSection() {
             </label>
           </div>
         </div>
-      </div>
+      </SubGroup>
     </div>
   );
 }

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1211,7 +1211,8 @@ function PasteSection() {
   return (
     <div>
       <SectionTitle>Paste</SectionTitle>
-      <div style={cardStyle} className="p-4">
+
+      <SubGroup title="일반">
         <ToggleRow
           label="Smart Paste"
           desc="Ctrl+V 시 클립보드의 파일/이미지를 경로로 붙여넣기"
@@ -1220,29 +1221,18 @@ function PasteSection() {
           onChange={(v) => update({ smart: v })}
         />
 
-        <SettingRow label="Multi-file Separator" desc="여러 파일 붙여넣기 시 경로 사이 구분자">
-          <select
-            data-testid="paste-path-separator-select"
-            value={paste.pathSeparator}
-            onChange={(e) => update({ pathSeparator: e.target.value as PastePathSeparator })}
+        <SettingRow label="Image Directory" desc="이미지 저장 경로 (비워두면 기본 디렉터리 사용)">
+          <FocusInput
+            data-testid="paste-image-dir-input"
             className={inputCls}
-            style={inputStyle}
-          >
-            <option value="space">Space</option>
-            <option value="newline">Newline</option>
-            <option value="comma">Comma (,)</option>
-            <option value="semicolon">Semicolon (;)</option>
-          </select>
+            placeholder="(default: %APPDATA%\laymux\paste-images)"
+            value={paste.imageDir}
+            onChange={(e) => update({ imageDir: e.target.value })}
+          />
         </SettingRow>
+      </SubGroup>
 
-        <ToggleRow
-          label="Quote File Paths"
-          desc="붙여넣는 각 파일 경로를 큰따옴표로 감싸기 (공백 포함 경로에 유용)"
-          testid="paste-path-quote-toggle"
-          checked={paste.pathQuote}
-          onChange={(v) => update({ pathQuote: v })}
-        />
-
+      <SubGroup title="텍스트 변환">
         <ToggleRow
           label="Smart Remove Indent"
           desc="붙여넣기 시 공통 들여쓰기 제거"
@@ -1266,7 +1256,34 @@ function PasteSection() {
           checked={paste.linkJoin}
           onChange={(v) => update({ linkJoin: v })}
         />
+      </SubGroup>
 
+      <SubGroup title="다중 파일">
+        <SettingRow label="Multi-file Separator" desc="여러 파일 붙여넣기 시 경로 사이 구분자">
+          <select
+            data-testid="paste-path-separator-select"
+            value={paste.pathSeparator}
+            onChange={(e) => update({ pathSeparator: e.target.value as PastePathSeparator })}
+            className={inputCls}
+            style={inputStyle}
+          >
+            <option value="space">Space</option>
+            <option value="newline">Newline</option>
+            <option value="comma">Comma (,)</option>
+            <option value="semicolon">Semicolon (;)</option>
+          </select>
+        </SettingRow>
+
+        <ToggleRow
+          label="Quote File Paths"
+          desc="붙여넣는 각 파일 경로를 큰따옴표로 감싸기 (공백 포함 경로에 유용)"
+          testid="paste-path-quote-toggle"
+          checked={paste.pathQuote}
+          onChange={(v) => update({ pathQuote: v })}
+        />
+      </SubGroup>
+
+      <SubGroup title="안전">
         <ToggleRow
           label="Large Paste Warning"
           desc="대용량 텍스트 붙여넣기 시 확인 다이얼로그 표시"
@@ -1274,17 +1291,7 @@ function PasteSection() {
           checked={paste.largeWarning}
           onChange={(v) => update({ largeWarning: v })}
         />
-
-        <SettingRow label="Image Directory" desc="이미지 저장 경로 (비워두면 기본 디렉터리 사용)">
-          <FocusInput
-            data-testid="paste-image-dir-input"
-            className={inputCls}
-            placeholder="(default: %APPDATA%\laymux\paste-images)"
-            value={paste.imageDir}
-            onChange={(e) => update({ imageDir: e.target.value })}
-          />
-        </SettingRow>
-      </div>
+      </SubGroup>
     </div>
   );
 }


### PR DESCRIPTION
## 배경

[#340](https://github.com/kochul2000/laymux/pull/340)에서 settings를 도메인별 최상위 그룹으로 재분류했지만, **각 섹션 내부**는 여전히 같은 주제의 필드들이 한 카드에 평평하게 나열돼 시각적 구분이 없었다. 예: Claude Code 섹션의 `세션 리미트 자동 복귀 / 복귀 대기 시간 / 복귀 문구`는 하나의 주제인데 묶여 보이지 않았다.

## 변경

Interface 섹션의 Control Bar/Dock/Notifications 카드 패턴을 재사용하는 **`SubGroup`** 헬퍼(uppercase 헤더 + cardStyle)를 신설하고, 같은 주제 필드를 하위 그룹 카드로 묶었다.

| 섹션 | 하위 그룹 |
|---|---|
| **Claude Code** | CWD 동기화 / 세션 복원 / 상태 메시지 / **세션 리미트 자동 복귀** |
| **Memo** | 레이아웃(padding·indent) / 동작(단락 인식·트리플클릭·선택 복사) |
| **File Explorer** | 쉘 / 모양(폰트·padding) / 동작(copy on select·extension viewers) |
| **Issue Reporter** | 이슈 제출(shell·repositories) / 모양(padding) |

DefaultsSection은 이미 Appearance/Cursor/Advanced 하위 구조라 변경하지 않음.

## 성격

순수 JSX 래핑 — 모든 `data-testid`와 필드 동작은 동일. 동작 변경 없음.

## 검증

- tsc 0 errors · vitest **2134 passed** · prettier · vite build ✓
- dev(19281) 실측: Claude Code 섹션이 4개 하위 그룹 카드로 분리 렌더 확인 (지적된 세션 리미트 필드 3종이 한 카드로 묶임)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
