### PR TITLE
feat(memo): 선택 시 복사 기본값 켬으로 변경

### DIFF
--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -863,7 +863,7 @@ pub struct MemoSettings {
     #[serde(default)]
     pub paragraph_copy: MemoParagraphCopySettings,
     /// Automatically copy selected text to clipboard (like terminal copyOnSelect).
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub copy_on_select: bool,
     /// Triple-click to select entire paragraph (requires paragraph_copy enabled).
     #[serde(default = "default_true", alias = "dblClickParagraphSelect")]
@@ -894,7 +894,7 @@ impl Default for MemoSettings {
             padding_bottom: 8,
             padding_left: 8,
             paragraph_copy: MemoParagraphCopySettings::default(),
-            copy_on_select: false,
+            copy_on_select: true,
             triple_click_paragraph_select: true,
             indent_size: 2,
             font_family: String::new(),

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -424,7 +424,7 @@ const DEFAULT_MEMO: MemoSettings = {
   paddingBottom: 8,
   paddingLeft: 8,
   paragraphCopy: { enabled: true, minBlankLines: 2 },
-  copyOnSelect: false,
+  copyOnSelect: true,
   tripleClickParagraphSelect: true,
   indentSize: 2,
   fontFamily: "",


### PR DESCRIPTION
## 변경

Memo 뷰의 **선택 시 복사(`copyOnSelect`)** 기본값을 `false` → `true`로 변경한다. 터미널과 동일하게 드래그 선택만으로 클립보드에 복사된다.

- `ui` settings-store: `DEFAULT_MEMO.copyOnSelect = true`
- `rust` models: `MemoSettings.copy_on_select` 기본값 `true` (`#[serde(default = "default_true")]` + `impl Default`). 구 `settings.json`에 필드가 없어도 켜진 값으로 채워진다.

기존에 명시적으로 `copyOnSelect: false`를 저장한 사용자는 그 값을 유지한다(기본값만 변경).

## 검증

- tsc 0 · vitest (MemoView + settings-store) 134 passed · prettier ✓
- cargo `settings` 테스트 65 passed (round-trip 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
