### PR TITLE
fix(file-viewer): 확장자별 viewer(vi 등) 설정이 재시작 후 로드되지 않던 버그 수정 (#342)

### DIFF
--- a/ui/src/hooks/useSessionPersistence.test.ts
+++ b/ui/src/hooks/useSessionPersistence.test.ts
@@ -21,6 +21,17 @@ vi.mock("@/lib/tauri-api", () => {
     ],
     colorSchemes: [],
     keybindings: [],
+    fileExplorer: {
+      shellProfile: "",
+      paddingTop: 8,
+      paddingRight: 8,
+      paddingBottom: 8,
+      paddingLeft: 8,
+      fontFamily: "",
+      fontSize: 13,
+      copyOnSelect: false,
+      extensionViewers: [{ extensions: [".txt"], command: "vi" }],
+    },
     layouts: [
       {
         id: "layout-1",
@@ -132,6 +143,21 @@ describe("useSessionPersistence", () => {
     expect(settingsState.profileDefaults.font.face).toBe("Fira Code");
     expect(settingsState.profileDefaults.font.size).toBe(16);
     expect(settingsState.defaultProfile).toBe("WSL");
+  });
+
+  // #342: fileExplorer (and thus extensionViewers) must be hydrated into the
+  // settings store on load. Without it the per-extension terminal viewers
+  // (e.g. .txt → vi) never resolve and the file always opens in the built-in
+  // web viewer after an app restart.
+  it("applies loaded fileExplorer.extensionViewers to settings store", async () => {
+    renderHook(() => useSessionPersistence());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const { extensionViewers } = useSettingsStore.getState().fileExplorer;
+    expect(extensionViewers).toEqual([{ extensions: [".txt"], command: "vi" }]);
   });
 
   it("applies loaded layouts and workspaces to workspace store", async () => {

--- a/ui/src/hooks/useSessionPersistence.ts
+++ b/ui/src/hooks/useSessionPersistence.ts
@@ -138,6 +138,26 @@ export function useSessionPersistence() {
                   rawSettings.issueReporter as import("@/lib/tauri-api").IssueReporterSettings,
               }
             : {}),
+          // fileExplorer carries extensionViewers (#342): without forwarding it
+          // here the store keeps its empty default, so configured per-extension
+          // viewers (e.g. .txt → vi) never resolve to the terminal viewer and
+          // the file always opens in the built-in web/text viewer after a
+          // restart. memo / syncCwdDefaults were missing for the same reason.
+          ...(rawSettings.fileExplorer
+            ? {
+                fileExplorer:
+                  rawSettings.fileExplorer as import("@/lib/tauri-api").FileExplorerSettings,
+              }
+            : {}),
+          ...(rawSettings.memo
+            ? { memo: rawSettings.memo as import("@/lib/tauri-api").MemoSettings }
+            : {}),
+          ...(rawSettings.syncCwdDefaults
+            ? {
+                syncCwdDefaults:
+                  rawSettings.syncCwdDefaults as import("@/lib/sync-cwd-config").SyncCwdDefaults,
+              }
+            : {}),
         });
 
         // Apply layouts and workspaces to workspace store


### PR DESCRIPTION
Fixes #342

## 문제
file explorer에서 확장자별 viewer로 `vi`를 지정해도 열리지 않음 (검정 화면에 커서만 깜빡임 / 또는 plain text로 표시).

## 근본 원인
앱 시작 시 설정 로드(`useSessionPersistence.ts`의 `loadFromSettings(...)` 호출)가 전달할 설정 섹션을 명시적으로 나열하는데, 그 목록에서 **`fileExplorer`(및 `memo`, `syncCwdDefaults`)가 누락**되어 있었다.

`loadFromSettings` 자체는 이 섹션들을 병합하도록 구현돼 있으나 호출부가 값을 넘기지 않아, 재시작 후 스토어의 `extensionViewers`가 항상 빈 배열로 남았다. 그 결과 `resolveViewer()`가 늘 web(텍스트) viewer로 폴백하여 지정 viewer가 동작하지 않았다.

## 변경 사항
- `ui/src/hooks/useSessionPersistence.ts` — `loadFromSettings` 호출에 `fileExplorer` / `memo` / `syncCwdDefaults` 전달 추가
- `ui/src/hooks/useSessionPersistence.test.ts` — mock에 extensionViewers 추가 + 회귀 방지 테스트 추가

## 테스트
- `useSessionPersistence.test.ts`: 14/14 통과 (신규 회귀 테스트 포함)
- file-viewer / FileViewer / FileViewerOverlay / settings-store: 134/134 통과
- 전체 프론트엔드 스위트: 83 파일 2135 테스트 통과
- `tsc --noEmit` / prettier / eslint 통과
- Rust 변경 없음

## 주의사항
- 원 신고 증상("검정화면 커서 깜빡임")과 재현된 증상("vi 미실행·text 표시")의 표현은 다르나, 둘 다 근본은 "지정 viewer로 안 열림"이며 이번 수정으로 viewer 해석/실행이 복구됨. vi 렌더링 자체는 일반 pane·WSL 양쪽에서 정상 확인.
- viewer 로드 복구 후에도 특정 프로파일(Windows 경로 + PowerShell에서 `vi`)에서 별도 문제가 남는다면 별개 후속 이슈로 다룰 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)