### PR TITLE
fix: 알림 메시지의 URL 클릭 시 브라우저로 열기 (#345)

### DIFF
--- a/ui/src/components/views/NotificationPanel.test.tsx
+++ b/ui/src/components/views/NotificationPanel.test.tsx
@@ -1,12 +1,18 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { NotificationPanel } from "./NotificationPanel";
 import { useNotificationStore } from "@/stores/notification-store";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useTerminalStore } from "@/stores/terminal-store";
 
+const mockOpenExternal = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/tauri-api", () => ({
+  openExternal: (...args: unknown[]) => mockOpenExternal(...args),
+}));
+
 describe("NotificationPanel", () => {
   beforeEach(() => {
+    mockOpenExternal.mockClear();
     useNotificationStore.setState(useNotificationStore.getInitialState());
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
     useTerminalStore.setState(useTerminalStore.getInitialState());
@@ -254,5 +260,49 @@ describe("NotificationPanel", () => {
 
     render(<NotificationPanel />);
     expect(screen.getByText("방금")).toBeInTheDocument();
+  });
+
+  // -- URL in notification message opens browser (issue #345) --
+
+  it("opens a URL from the notification message via openExternal when clicked", () => {
+    useNotificationStore.getState().addNotification({
+      terminalId: "t1",
+      workspaceId: "ws-default",
+      message: "Sign in at https://codex.example.com/login to continue",
+    });
+
+    render(<NotificationPanel />);
+
+    const link = screen.getByTestId("notification-url-link");
+    fireEvent.click(link);
+
+    expect(mockOpenExternal).toHaveBeenCalledTimes(1);
+    expect(mockOpenExternal).toHaveBeenCalledWith("https://codex.example.com/login");
+  });
+
+  it("does not render a URL link when message has no URL", () => {
+    useNotificationStore.getState().addNotification({
+      terminalId: "t1",
+      workspaceId: "ws-default",
+      message: "Codex task completed",
+    });
+
+    render(<NotificationPanel />);
+
+    expect(screen.queryByTestId("notification-url-link")).not.toBeInTheDocument();
+  });
+
+  it("clicking a URL notification does not throw when openExternal rejects", () => {
+    mockOpenExternal.mockRejectedValueOnce(new Error("shell open failed"));
+    useNotificationStore.getState().addNotification({
+      terminalId: "t1",
+      workspaceId: "ws-default",
+      message: "Open https://example.com/x",
+    });
+
+    render(<NotificationPanel />);
+
+    const link = screen.getByTestId("notification-url-link");
+    expect(() => fireEvent.click(link)).not.toThrow();
   });
 });

--- a/ui/src/components/views/NotificationPanel.tsx
+++ b/ui/src/components/views/NotificationPanel.tsx
@@ -2,6 +2,8 @@ import { useNotificationStore, type NotificationLevel } from "@/stores/notificat
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { formatRelativeTime } from "@/lib/workspace-summary";
+import { extractNotificationUrl } from "@/lib/notification-url";
+import { openExternal } from "@/lib/tauri-api";
 import { ViewShell } from "@/components/ui/ViewShell";
 import { ViewHeader } from "@/components/ui/ViewHeader";
 import { ViewBody } from "@/components/ui/ViewBody";
@@ -78,6 +80,7 @@ export function NotificationPanel({ workspaceId, embedded }: NotificationPanelPr
               </div>
               {wsNotifs.map((n) => {
                 const terminal = terminalInstances.find((t) => t.id === n.terminalId);
+                const url = extractNotificationUrl(n.message);
                 return (
                   <div
                     key={n.id}
@@ -97,13 +100,37 @@ export function NotificationPanel({ workspaceId, embedded }: NotificationPanelPr
                       [{terminal?.label ?? "?"}]
                     </span>
 
-                    {/* Message with level color */}
-                    <span
-                      className="flex-1 truncate text-xs"
-                      style={{ color: levelColorMap[n.level] }}
-                    >
-                      {n.message}
-                    </span>
+                    {/* Message with level color. When the message carries a
+                        URL (e.g. a Codex auth/login link), render it as a
+                        clickable link that opens the user's default browser
+                        through the Tauri opener/shell plugin — `window.open`
+                        does not work inside the Tauri webview (issue #345). */}
+                    {url ? (
+                      <button
+                        type="button"
+                        data-testid="notification-url-link"
+                        title={url}
+                        onClick={() => {
+                          openExternal(url).catch(() => {});
+                        }}
+                        className="flex-1 cursor-pointer truncate text-left text-xs underline"
+                        style={{
+                          color: levelColorMap[n.level],
+                          background: "none",
+                          border: "none",
+                          padding: 0,
+                        }}
+                      >
+                        {n.message}
+                      </button>
+                    ) : (
+                      <span
+                        className="flex-1 truncate text-xs"
+                        style={{ color: levelColorMap[n.level] }}
+                      >
+                        {n.message}
+                      </span>
+                    )}
 
                     {/* Relative time */}
                     <span className="shrink-0 text-xs" style={{ color: "var(--text-secondary)" }}>

--- a/ui/src/lib/notification-url.test.ts
+++ b/ui/src/lib/notification-url.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { extractNotificationUrl } from "./notification-url";
+
+describe("extractNotificationUrl", () => {
+  it("returns null when no URL present", () => {
+    expect(extractNotificationUrl("Codex task completed")).toBeNull();
+    expect(extractNotificationUrl("")).toBeNull();
+  });
+
+  it("extracts a bare https URL", () => {
+    expect(extractNotificationUrl("https://example.com/auth?code=abc")).toBe(
+      "https://example.com/auth?code=abc",
+    );
+  });
+
+  it("extracts an http URL", () => {
+    expect(extractNotificationUrl("Open http://localhost:1455/callback now")).toBe(
+      "http://localhost:1455/callback",
+    );
+  });
+
+  it("extracts a URL embedded in a sentence", () => {
+    expect(extractNotificationUrl("Sign in at https://codex.example.com/login to continue")).toBe(
+      "https://codex.example.com/login",
+    );
+  });
+
+  it("trims trailing sentence punctuation", () => {
+    expect(extractNotificationUrl("Visit https://example.com/page.")).toBe(
+      "https://example.com/page",
+    );
+    expect(extractNotificationUrl("See https://example.com/x!")).toBe("https://example.com/x");
+  });
+
+  it("trims an unbalanced trailing closing paren", () => {
+    expect(extractNotificationUrl("(see https://example.com/docs)")).toBe(
+      "https://example.com/docs",
+    );
+  });
+
+  it("keeps balanced parentheses inside the URL", () => {
+    expect(extractNotificationUrl("https://en.wikipedia.org/wiki/Foo_(bar)")).toBe(
+      "https://en.wikipedia.org/wiki/Foo_(bar)",
+    );
+  });
+
+  it("returns the first URL when several are present", () => {
+    expect(extractNotificationUrl("https://a.com and https://b.com")).toBe("https://a.com");
+  });
+
+  it("preserves query and fragment", () => {
+    expect(extractNotificationUrl("go https://x.io/p?a=1&b=2#frag here")).toBe(
+      "https://x.io/p?a=1&b=2#frag",
+    );
+  });
+});

--- a/ui/src/lib/notification-url.ts
+++ b/ui/src/lib/notification-url.ts
@@ -1,0 +1,41 @@
+/**
+ * Extract the first http(s) URL from a notification message.
+ *
+ * Codex (and other tools) emit notifications whose body carries a URL —
+ * e.g. an auth/login link. The notification UI surfaces that URL as a
+ * clickable link so the user can open it in their default browser via the
+ * Tauri opener/shell plugin (issue #345: plain `window.open` does not work
+ * inside the Tauri webview, so the click must route through `openExternal`).
+ *
+ * Returns the first match, or `null` when the message has no URL. Trailing
+ * punctuation that is unlikely to be part of the URL (e.g. a sentence-ending
+ * period, or an unbalanced closing bracket) is trimmed.
+ */
+export function extractNotificationUrl(message: string): string | null {
+  // Match an http(s) URL. The character class is permissive on purpose —
+  // we trim trailing punctuation afterwards rather than trying to model
+  // every edge case in the regex.
+  const match = message.match(/https?:\/\/[^\s<>"']+/i);
+  if (!match) return null;
+
+  let url = match[0];
+  // Strip trailing sentence punctuation that commonly hugs a URL in prose
+  // but is not part of it.
+  url = url.replace(/[.,;:!?]+$/, "");
+  // Strip a single unbalanced trailing closer (e.g. "(see https://x)" ).
+  const closers: Record<string, string> = { ")": "(", "]": "[", "}": "{" };
+  for (;;) {
+    const last = url[url.length - 1];
+    const opener = closers[last];
+    if (!opener) break;
+    const opens = url.split(opener).length - 1;
+    const closes = url.split(last).length - 1;
+    if (closes > opens) {
+      url = url.slice(0, -1);
+    } else {
+      break;
+    }
+  }
+
+  return url.length > 0 ? url : null;
+}


### PR DESCRIPTION
## 요약
codex 등이 보내는 알림에 로그인/인증 URL이 담겨 와도, 알림 패널(`NotificationPanel`)이 메시지를 단순 텍스트로만 렌더해 클릭해도 브라우저가 열리지 않던 문제를 수정한다.

## 근본 원인
- 알림 메시지를 `<span>` 텍스트로만 렌더 → URL 클릭 동작 없음
- Tauri webview에서는 `window.open`이 동작하지 않음. 코드베이스에 이미 존재하는 터미널 링크용 `openExternal`(`@tauri-apps/plugin-shell` `open`, capabilities `shell:allow-open`)로 라우팅하면 된다.

## 변경 사항
- `ui/src/lib/notification-url.ts` (신규) — 알림 메시지에서 첫 http(s) URL 추출 (`extractNotificationUrl`), 꼬리 구두점/불균형 괄호 정리
- `ui/src/lib/notification-url.test.ts` (신규) — 단위 테스트 9개
- `ui/src/components/views/NotificationPanel.tsx` — URL 포함 메시지를 클릭 가능한 링크로 렌더, 클릭 시 `openExternal` 호출
- `ui/src/components/views/NotificationPanel.test.tsx` — URL 클릭 동작 테스트 3개 추가

## 테스트
- 신규/관련 테스트 26개 통과
- 전체 UI 스위트 `vitest run`: 84파일 2146 테스트 전부 통과
- `tsc --noEmit`, eslint(변경 파일) 통과

## 주의
인앱 알림 패널 클릭으로 URL을 연다. Windows 데스크탑 토스트(PowerShell balloon tip) 자체 클릭은 별도 과제.

Fixes #345