### PR TITLE
fix: 터미널/외부 URL 링크 클릭 시 브라우저 열기 (#345)

### DIFF
--- a/ui/src/components/views/IssueReporterView.test.tsx
+++ b/ui/src/components/views/IssueReporterView.test.tsx
@@ -324,21 +324,19 @@ describe("IssueReporterView", () => {
       expect(screen.getByTestId("issue-link")).toBeInTheDocument();
     });
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     // Click the link — should not throw even if shell open fails
     await user.click(screen.getByTestId("issue-link"));
 
     expect(mockShellOpen).toHaveBeenCalledWith("https://github.com/repo/issues/1");
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("shell.open failed"),
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to open external URL"),
+      "https://github.com/repo/issues/1",
       expect.any(Error),
     );
-    expect(windowOpenSpy).toHaveBeenCalledWith("https://github.com/repo/issues/1", "_blank");
 
-    warnSpy.mockRestore();
-    windowOpenSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("passes issueNumber on re-submit after successful creation (update mode)", async () => {

--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -5,6 +5,7 @@ import { inputStyle } from "@/components/ui/FormControls";
 import { ViewShell } from "@/components/ui/ViewShell";
 import { ViewHeader } from "@/components/ui/ViewHeader";
 import { ViewBody } from "@/components/ui/ViewBody";
+import { openExternal } from "@/lib/tauri-api";
 
 type SubmitState = "idle" | "capturing" | "submitting" | "success" | "error";
 
@@ -336,15 +337,9 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
           <a
             data-testid="issue-link"
             href={resultMsg}
-            onClick={async (e) => {
+            onClick={(e) => {
               e.preventDefault();
-              try {
-                const { open } = await import("@tauri-apps/plugin-shell");
-                await open(resultMsg);
-              } catch (e) {
-                console.warn("shell.open failed, falling back to window.open:", e);
-                window.open(resultMsg, "_blank");
-              }
+              openExternal(resultMsg).catch(() => {});
             }}
             className="mt-1 truncate text-[11px] underline"
             style={{ color: "var(--accent)", cursor: "pointer" }}

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -491,6 +491,17 @@ export function TerminalView({
       // disables reflow and truncates instead) — its real cause is resize
       // events racing ConPTY repaints, fixed by the debounced fit below.
       windowsPty: { backend: "conpty", buildNumber: 21376 },
+      // OSC 8 hyperlinks (e.g. Codex wraps URLs in escape sequences) are
+      // activated by xterm's built-in handler. Without a custom linkHandler
+      // it defaults to window.open, which only pops a useless navigation
+      // dialog inside the Tauri webview. Route them through the same
+      // openExternal path as plain-text links so they open the OS browser
+      // (issue #345).
+      linkHandler: {
+        activate: (_event, uri) => {
+          openExternal(uri).catch(() => {});
+        },
+      },
     });
 
     const fitAddon = new FitAddon();

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { open as openInDefaultApp } from "@tauri-apps/plugin-shell";
 import type { SyncCwdConfig, SyncCwdDefaults } from "./sync-cwd-config";
 import type { TerminalActivityInfo } from "@/stores/terminal-store";
 
@@ -491,11 +492,9 @@ export async function updateTerminalSyncGroup(terminalId: string, newGroup: stri
 /** Open a URL in the user's default browser via Tauri shell plugin. */
 export async function openExternal(url: string): Promise<void> {
   try {
-    const { open } = await import("@tauri-apps/plugin-shell");
-    await open(url);
+    await openInDefaultApp(url);
   } catch (e) {
-    console.warn("shell.open failed, falling back to window.open:", e);
-    window.open(url, "_blank");
+    console.error("Failed to open external URL:", url, e);
   }
 }
 


### PR DESCRIPTION
## 문제
터미널의 URL 링크나 외부 링크를 클릭해도 OS 기본 브라우저가 **전혀 열리지 않음** (codex·Claude 가리지 않음). 클릭 시 Tauri webview의 "Do you want to navigate to ...?" 다이얼로그만 뜨고 확인을 눌러도 무반응.

## 근본 원인 (라이브 진단)
1. **`openExternal`의 동적 import 실패** — `await import("@tauri-apps/plugin-shell")`가 `TypeError: Failed to fetch dynamically imported module`로 throw → `window.open` 폴백 → webview navigate 다이얼로그만 뜨고 안 열림. (권한/scope 문제 아님 — 정상 확인)
2. **OSC 8 하이퍼링크 미처리** — codex 등이 URL을 OSC 8 이스케이프로 출력. xterm 내장 핸들러가 처리하는데 커스텀 `linkHandler`가 없어 기본값 `window.open`으로 빠짐.

## 변경
- `ui/src/lib/tauri-api.ts` — `openExternal`: 동적 import → **정적 import**(메인 번들 포함). window.open 폴백 제거, 실패 시 `console.error`.
- `ui/src/components/views/TerminalView.tsx` — xterm Terminal 옵션에 **`linkHandler`** 추가 → OSC 8 링크도 `openExternal` 경유로 OS 브라우저에서 열림.
- `ui/src/components/views/IssueReporterView.tsx` — 동일한 동적 import + window.open 안티패턴을 공유 `openExternal`로 통일. (+테스트 갱신)

## 검증
- **라이브(dev 19281)**: 일반 셸에서 평문 URL 및 OSC 8 링크(`[PLAIN-SHELL-OSC8]`) 모두 OS 브라우저로 정상 오픈 확인. Claude(PS/WSL) 링크 정상.
- 전체 UI 스위트 **2138 통과**, `tsc --noEmit` 통과, eslint(변경 파일) 통과.

## 범위 밖 (별도 이슈)
codex 등 **라이브 TUI 내부**의 링크 클릭은 codex가 풀스크린 마우스 캡처/재렌더로 화면을 제어해 클릭이 전달되지 않음 — 터미널-앱 상호작용 한계로 별도 이슈에서 다룸(수정자키+클릭 우회 등).

Fixes #345