### PR TITLE
fix: workspace.rename의 window.prompt를 인라인 입력 오버레이로 전환 (Fixes #339)

### DIFF
--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -12,6 +12,7 @@ import { SettingsView } from "@/components/views/SettingsView";
 import { NotificationPanel } from "@/components/views/NotificationPanel";
 import { ConnectionInfoModal } from "@/components/views/ConnectionInfoModal";
 import { FileViewerOverlay } from "./FileViewerOverlay";
+import { RenameWorkspaceOverlay } from "./RenameWorkspaceOverlay";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { getPaneInstanceId } from "@/lib/view-instance-id";
 import type { DockPosition, ViewType } from "@/stores/types";
@@ -400,6 +401,9 @@ export function AppLayout() {
 
       {/* Unified global file viewer (#277/#279) */}
       <FileViewerOverlay />
+
+      {/* Inline workspace rename overlay (#339) — replaces native window.prompt */}
+      <RenameWorkspaceOverlay />
     </div>
   );
 }

--- a/ui/src/components/layout/RenameWorkspaceOverlay.test.tsx
+++ b/ui/src/components/layout/RenameWorkspaceOverlay.test.tsx
@@ -88,4 +88,34 @@ describe("RenameWorkspaceOverlay", () => {
 
     expect(useRenameWorkspaceStore.getState().targetId).toBeNull();
   });
+
+  it("exposes a labelled modal dialog for screen readers", () => {
+    act(() => useRenameWorkspaceStore.getState().openRename("ws-default", "Default"));
+    render(<RenameWorkspaceOverlay />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    // The accessible name comes from the title via aria-labelledby.
+    expect(dialog).toHaveAccessibleName("Rename workspace");
+  });
+
+  it("restores focus to the previously focused element on close", () => {
+    // Simulate the rename shortcut firing while another element (e.g. a terminal)
+    // holds focus.
+    const prev = document.createElement("button");
+    document.body.appendChild(prev);
+    prev.focus();
+    expect(document.activeElement).toBe(prev);
+
+    act(() => useRenameWorkspaceStore.getState().openRename("ws-default", "Default"));
+    render(<RenameWorkspaceOverlay />);
+    // The overlay input steals focus while open.
+    expect(document.activeElement).not.toBe(prev);
+
+    act(() => useRenameWorkspaceStore.getState().closeRename());
+    // On close, focus returns to where it was before the overlay opened.
+    expect(document.activeElement).toBe(prev);
+
+    prev.remove();
+  });
 });

--- a/ui/src/components/layout/RenameWorkspaceOverlay.test.tsx
+++ b/ui/src/components/layout/RenameWorkspaceOverlay.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { RenameWorkspaceOverlay } from "./RenameWorkspaceOverlay";
+import { useRenameWorkspaceStore } from "@/stores/rename-workspace-store";
+import { useWorkspaceStore } from "@/stores/workspace-store";
+
+describe("RenameWorkspaceOverlay", () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
+    useRenameWorkspaceStore.setState({ targetId: null, currentName: "" });
+  });
+
+  it("renders nothing when closed", () => {
+    render(<RenameWorkspaceOverlay />);
+    expect(screen.queryByTestId("rename-workspace-overlay")).not.toBeInTheDocument();
+  });
+
+  it("shows the input seeded with the current name when opened", () => {
+    act(() => useRenameWorkspaceStore.getState().openRename("ws-default", "Default"));
+    render(<RenameWorkspaceOverlay />);
+    const input = screen.getByTestId("rename-workspace-overlay-input") as HTMLInputElement;
+    expect(input.value).toBe("Default");
+  });
+
+  it("renames the workspace and closes on Enter", () => {
+    act(() => useRenameWorkspaceStore.getState().openRename("ws-default", "Default"));
+    render(<RenameWorkspaceOverlay />);
+    const input = screen.getByTestId("rename-workspace-overlay-input") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "Renamed" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Renamed");
+    expect(useRenameWorkspaceStore.getState().targetId).toBeNull();
+  });
+
+  it("renames the workspace and closes on the Rename button", () => {
+    act(() => useRenameWorkspaceStore.getState().openRename("ws-default", "Default"));
+    render(<RenameWorkspaceOverlay />);
+    const input = screen.getByTestId("rename-workspace-overlay-input") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "ViaButton" } });
+    fireEvent.click(screen.getByTestId("rename-workspace-overlay-submit"));
+
+    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("ViaButton");
+    expect(useRenameWorkspaceStore.getState().targetId).toBeNull();
+  });
+
+  it("ignores a blank name (does not rename) but still closes", () => {
+    act(() => useRenameWorkspaceStore.getState().openRename("ws-default", "Default"));
+    render(<RenameWorkspaceOverlay />);
+    const input = screen.getByTestId("rename-workspace-overlay-input") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Default");
+    expect(useRenameWorkspaceStore.getState().targetId).toBeNull();
+  });
+
+  it("cancels without renaming on Escape", () => {
+    act(() => useRenameWorkspaceStore.getState().openRename("ws-default", "Default"));
+    render(<RenameWorkspaceOverlay />);
+    const input = screen.getByTestId("rename-workspace-overlay-input") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "Discarded" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Default");
+    expect(useRenameWorkspaceStore.getState().targetId).toBeNull();
+  });
+
+  it("cancels without renaming on the Cancel button", () => {
+    act(() => useRenameWorkspaceStore.getState().openRename("ws-default", "Default"));
+    render(<RenameWorkspaceOverlay />);
+
+    fireEvent.click(screen.getByTestId("rename-workspace-overlay-cancel"));
+
+    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Default");
+    expect(useRenameWorkspaceStore.getState().targetId).toBeNull();
+  });
+
+  it("cancels on backdrop click", () => {
+    act(() => useRenameWorkspaceStore.getState().openRename("ws-default", "Default"));
+    render(<RenameWorkspaceOverlay />);
+
+    fireEvent.click(screen.getByTestId("rename-workspace-overlay-backdrop"));
+
+    expect(useRenameWorkspaceStore.getState().targetId).toBeNull();
+  });
+});

--- a/ui/src/components/layout/RenameWorkspaceOverlay.tsx
+++ b/ui/src/components/layout/RenameWorkspaceOverlay.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { useRenameWorkspaceStore } from "@/stores/rename-workspace-store";
+import { useWorkspaceStore } from "@/stores/workspace-store";
+import { FocusInput } from "@/components/ui/FormControls";
+
+/**
+ * Inline workspace-rename overlay (#339). Rendered once at the app root and
+ * shown whenever `useRenameWorkspaceStore.targetId` is set — from the
+ * `workspace.rename` shortcut or the in-app rename buttons. It replaces the
+ * native `window.prompt`, which does not work on Windows/WebView2 (the #283
+ * root cause), so rename works on every platform and is driveable via the
+ * Automation API.
+ *
+ * The input is uncontrolled (read via ref on submit) and keyed by `targetId`,
+ * so opening the overlay for a different workspace remounts it with that
+ * workspace's current name.
+ */
+export function RenameWorkspaceOverlay() {
+  const targetId = useRenameWorkspaceStore((s) => s.targetId);
+  const currentName = useRenameWorkspaceStore((s) => s.currentName);
+  const closeRename = useRenameWorkspaceStore((s) => s.closeRename);
+  const renameWorkspace = useWorkspaceStore((s) => s.renameWorkspace);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus + select the field each time the overlay opens for a workspace, so
+  // the user can immediately type or overwrite the existing name.
+  useEffect(() => {
+    if (targetId !== null) inputRef.current?.select();
+  }, [targetId]);
+
+  if (targetId === null) return null;
+
+  const submit = () => {
+    const name = inputRef.current?.value.trim() ?? "";
+    if (name !== "") renameWorkspace(targetId, name);
+    closeRename();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    } else if (e.key === "Escape") {
+      // Consume Escape so global handlers don't also act on it.
+      e.preventDefault();
+      e.stopPropagation();
+      closeRename();
+    }
+  };
+
+  return createPortal(
+    <div
+      data-testid="rename-workspace-overlay"
+      className="fixed inset-0 flex items-center justify-center"
+      style={{ zIndex: 9998 }}
+    >
+      <div
+        data-testid="rename-workspace-overlay-backdrop"
+        className="absolute inset-0"
+        style={{ background: "var(--backdrop-heavy)" }}
+        onClick={closeRename}
+      />
+      <div
+        className="relative z-10 flex w-[360px] flex-col gap-3 rounded-lg p-4 shadow-2xl"
+        style={{
+          background: "var(--bg-surface, #181825)",
+          border: "1px solid var(--border, #333)",
+        }}
+      >
+        <div className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+          Rename workspace
+        </div>
+        <FocusInput
+          key={`rename-workspace-input:${targetId}`}
+          ref={inputRef}
+          defaultValue={currentName}
+          autoFocus
+          onKeyDown={onKeyDown}
+          spellCheck={false}
+          autoComplete="off"
+          aria-label="Workspace name"
+          data-testid="rename-workspace-overlay-input"
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={closeRename}
+            className="hover-bg-strong rounded px-3 py-1 text-xs"
+            style={{
+              color: "var(--text-secondary)",
+              border: "1px solid var(--border)",
+              cursor: "pointer",
+            }}
+            data-testid="rename-workspace-overlay-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            className="hover-bg-strong rounded px-3 py-1 text-xs"
+            style={{
+              color: "var(--text-primary)",
+              border: "1px solid var(--border)",
+              cursor: "pointer",
+            }}
+            data-testid="rename-workspace-overlay-submit"
+          >
+            Rename
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/ui/src/components/layout/RenameWorkspaceOverlay.tsx
+++ b/ui/src/components/layout/RenameWorkspaceOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useRenameWorkspaceStore } from "@/stores/rename-workspace-store";
 import { useWorkspaceStore } from "@/stores/workspace-store";
@@ -23,11 +23,26 @@ export function RenameWorkspaceOverlay() {
   const renameWorkspace = useWorkspaceStore((s) => s.renameWorkspace);
 
   const inputRef = useRef<HTMLInputElement>(null);
+  // Element that had focus when the overlay opened (e.g. the terminal that owned
+  // the keyboard when the rename shortcut fired). Restored on close so the next
+  // keystrokes don't fall through to <body>/the wrong pane (#354 review).
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
 
-  // Focus + select the field each time the overlay opens for a workspace, so
-  // the user can immediately type or overwrite the existing name.
-  useEffect(() => {
-    if (targetId !== null) inputRef.current?.select();
+  // On open: capture the currently focused element first, then focus + select the
+  // field so the user can immediately type or overwrite the existing name. A
+  // layout effect (not autoFocus) drives the focus so the capture provably runs
+  // before focus moves — autoFocus fires during mount, which would record the
+  // overlay input itself instead of the terminal/button to return to. On close,
+  // restore focus to the captured element.
+  useLayoutEffect(() => {
+    if (targetId === null) return;
+    restoreFocusRef.current = document.activeElement as HTMLElement | null;
+    inputRef.current?.focus();
+    inputRef.current?.select();
+    return () => {
+      restoreFocusRef.current?.focus?.();
+      restoreFocusRef.current = null;
+    };
   }, [targetId]);
 
   if (targetId === null) return null;
@@ -63,20 +78,26 @@ export function RenameWorkspaceOverlay() {
         onClick={closeRename}
       />
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rename-workspace-overlay-title"
         className="relative z-10 flex w-[360px] flex-col gap-3 rounded-lg p-4 shadow-2xl"
         style={{
           background: "var(--bg-surface, #181825)",
           border: "1px solid var(--border, #333)",
         }}
       >
-        <div className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+        <div
+          id="rename-workspace-overlay-title"
+          className="text-sm font-medium"
+          style={{ color: "var(--text-primary)" }}
+        >
           Rename workspace
         </div>
         <FocusInput
           key={`rename-workspace-input:${targetId}`}
           ref={inputRef}
           defaultValue={currentName}
-          autoFocus
           onKeyDown={onKeyDown}
           spellCheck={false}
           autoComplete="off"

--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -9,6 +9,7 @@ import { useSettingsStore } from "@/stores/settings-store";
 import { getListeningPorts, getTerminalSummaries } from "@/lib/tauri-api";
 import type { TerminalSummaryResponse } from "@/lib/tauri-api";
 import { useUiStore } from "@/stores/ui-store";
+import { useRenameWorkspaceStore } from "@/stores/rename-workspace-store";
 
 vi.mock("@/lib/persist-session", () => ({
   persistSession: vi.fn().mockResolvedValue(undefined),
@@ -112,6 +113,7 @@ describe("WorkspaceSelectorView", () => {
     useTerminalStore.setState(useTerminalStore.getInitialState());
     useSettingsStore.setState(useSettingsStore.getInitialState());
     useUiStore.setState(useUiStore.getInitialState());
+    useRenameWorkspaceStore.setState({ targetId: null, currentName: "" });
 
     // Wire getTerminalSummaries to read from the stores dynamically
     vi.mocked(getTerminalSummaries).mockImplementation(async (ids: string[]) => {
@@ -951,23 +953,29 @@ describe("WorkspaceSelectorView", () => {
     expect(screen.getByTestId("layout-menu-default-layout")).toBeInTheDocument();
   });
 
-  it("double-clicking workspace name triggers rename prompt", async () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Renamed WS");
+  it("double-clicking workspace name opens the inline rename overlay (#339)", () => {
+    // #339: no native window.prompt — opens the in-app rename overlay seeded
+    // with the workspace's id and current name.
+    const promptSpy = vi.spyOn(window, "prompt");
     render(<WorkspaceSelectorView />);
     const nameEl = screen.getByTestId("workspace-name-ws-default");
     fireEvent.doubleClick(nameEl);
-    expect(promptSpy).toHaveBeenCalledWith("Rename workspace:", "Default");
-    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Renamed-WS");
+    expect(promptSpy).not.toHaveBeenCalled();
+    const s = useRenameWorkspaceStore.getState();
+    expect(s.targetId).toBe("ws-default");
+    expect(s.currentName).toBe("Default");
     promptSpy.mockRestore();
   });
 
-  it("double-clicking workspace name does not rename when prompt is cancelled", () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue(null);
+  it("clicking the rename button opens the inline rename overlay (#339)", async () => {
+    const promptSpy = vi.spyOn(window, "prompt");
+    const user = userEvent.setup();
     render(<WorkspaceSelectorView />);
-    const nameEl = screen.getByTestId("workspace-name-ws-default");
-    fireEvent.doubleClick(nameEl);
-    expect(promptSpy).toHaveBeenCalled();
-    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Default");
+    const item = screen.getByTestId("workspace-item-ws-default");
+    await user.hover(item);
+    fireEvent.click(screen.getByTestId("workspace-rename-ws-default"));
+    expect(promptSpy).not.toHaveBeenCalled();
+    expect(useRenameWorkspaceStore.getState().targetId).toBe("ws-default");
     promptSpy.mockRestore();
   });
 
@@ -976,13 +984,11 @@ describe("WorkspaceSelectorView", () => {
     useWorkspaceStore.getState().addWorkspace("Second", "default-layout");
     const workspaces = useWorkspaceStore.getState().workspaces;
     const ws2 = workspaces[workspaces.length - 1];
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue(null);
     render(<WorkspaceSelectorView />);
     const nameEl = screen.getByTestId(`workspace-name-${ws2.id}`);
     fireEvent.doubleClick(nameEl);
     // Active workspace should still be the first one
     expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("ws-default");
-    promptSpy.mockRestore();
   });
 
   it("renameLayout changes layout name in store", () => {

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -24,6 +24,7 @@ import type { WorkspacePane } from "@/stores/types";
 import type { TerminalActivityInfo } from "@/stores/terminal-store";
 import { persistSession } from "@/lib/persist-session";
 import { useUiStore } from "@/stores/ui-store";
+import { useRenameWorkspaceStore } from "@/stores/rename-workspace-store";
 
 /** Abbreviate profile/view labels to max 3 characters. */
 const LABEL_ABBREV: Record<string, string> = {
@@ -1030,7 +1031,6 @@ export function WorkspaceSelectorView() {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace);
   const removeWorkspace = useWorkspaceStore((s) => s.removeWorkspace);
-  const renameWorkspace = useWorkspaceStore((s) => s.renameWorkspace);
   const duplicateWorkspace = useWorkspaceStore((s) => s.duplicateWorkspace);
   const addWorkspace = useWorkspaceStore((s) => s.addWorkspace);
   const reorderWorkspaces = useWorkspaceStore((s) => s.reorderWorkspaces);
@@ -1381,8 +1381,9 @@ export function WorkspaceSelectorView() {
                 }
               }}
               onRename={() => {
-                const newName = window.prompt("Rename workspace:", ws.name);
-                if (newName?.trim()) renameWorkspace(ws.id, newName.trim());
+                // Inline overlay instead of window.prompt (#339) — native
+                // prompt does not work on Windows/WebView2.
+                useRenameWorkspaceStore.getState().openRename(ws.id, ws.name);
               }}
               onTogglePaneHidden={togglePaneHidden}
               onToggleWsHidden={() => toggleWorkspaceHidden(ws.id)}

--- a/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -8,6 +8,7 @@ import { useGridStore } from "@/stores/grid-store";
 import { useUiStore } from "@/stores/ui-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useFileViewerStore } from "@/stores/file-viewer-store";
+import { useRenameWorkspaceStore } from "@/stores/rename-workspace-store";
 
 vi.mock("@/lib/tauri-api", () => ({
   loadMemo: vi.fn().mockResolvedValue(""),
@@ -36,6 +37,7 @@ describe("useKeyboardShortcuts", () => {
     useUiStore.setState(useUiStore.getInitialState());
     useSettingsStore.setState(useSettingsStore.getInitialState());
     useFileViewerStore.setState({ open: false, path: "", maximized: false });
+    useRenameWorkspaceStore.setState({ targetId: null, currentName: "" });
   });
 
   // --- Ctrl+Alt+1~9: workspace switch ---
@@ -295,24 +297,19 @@ describe("useKeyboardShortcuts", () => {
     expect(useWorkspaceStore.getState().workspaces).toHaveLength(1);
   });
 
-  it("Ctrl+Alt+R triggers rename of active workspace", () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Renamed WS");
+  it("Ctrl+Alt+R opens the inline rename overlay (no native prompt) (#339)", () => {
+    // #339: native window.prompt does not work on Windows/WebView2 — the
+    // shortcut opens the in-app rename overlay instead, seeded with the
+    // active workspace's id and current name.
+    const promptSpy = vi.spyOn(window, "prompt");
     renderHook(() => useKeyboardShortcuts());
 
     fireKey("R", { ctrlKey: true, altKey: true });
 
-    expect(promptSpy).toHaveBeenCalled();
-    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Renamed-WS");
-    promptSpy.mockRestore();
-  });
-
-  it("Ctrl+Alt+R cancels rename on null prompt", () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue(null);
-    renderHook(() => useKeyboardShortcuts());
-
-    fireKey("R", { ctrlKey: true, altKey: true });
-
-    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Default");
+    expect(promptSpy).not.toHaveBeenCalled();
+    const s = useRenameWorkspaceStore.getState();
+    expect(s.targetId).toBe("ws-default");
+    expect(s.currentName).toBe("Default");
     promptSpy.mockRestore();
   });
 
@@ -1331,14 +1328,14 @@ describe("useKeyboardShortcuts", () => {
     expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("ws-default");
   });
 
-  it("Ctrl+Alt+r (lowercase) triggers rename of active workspace", () => {
-    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Renamed WS");
+  it("Ctrl+Alt+r (lowercase) opens the inline rename overlay (#339)", () => {
+    const promptSpy = vi.spyOn(window, "prompt");
     renderHook(() => useKeyboardShortcuts());
 
     fireKey("r", { ctrlKey: true, altKey: true });
 
-    expect(promptSpy).toHaveBeenCalled();
-    expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Renamed-WS");
+    expect(promptSpy).not.toHaveBeenCalled();
+    expect(useRenameWorkspaceStore.getState().targetId).toBe("ws-default");
     promptSpy.mockRestore();
   });
 
@@ -1859,18 +1856,15 @@ describe("useKeyboardShortcuts", () => {
       document.body.removeChild(input);
     });
 
-    it("workspace.rename rebound: new combo prompts, old default is inert", () => {
-      const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Renamed WS");
+    it("workspace.rename rebound: new combo opens overlay, old default is inert", () => {
       setOverride("workspace.rename", "Ctrl+Shift+R");
       renderHook(() => useKeyboardShortcuts());
 
       fireKey("r", { ctrlKey: true, altKey: true });
-      expect(promptSpy).not.toHaveBeenCalled();
+      expect(useRenameWorkspaceStore.getState().targetId).toBeNull();
 
       fireKey("R", { ctrlKey: true, shiftKey: true });
-      expect(promptSpy).toHaveBeenCalled();
-      expect(useWorkspaceStore.getState().workspaces[0].name).toBe("Renamed-WS");
-      promptSpy.mockRestore();
+      expect(useRenameWorkspaceStore.getState().targetId).toBe("ws-default");
     });
 
     it("notifications.unread rebound: new combo jumps, old default is inert", () => {

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -6,6 +6,7 @@ import { useNotificationStore } from "@/stores/notification-store";
 import { useUiStore } from "@/stores/ui-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useFileViewerStore } from "@/stores/file-viewer-store";
+import { useRenameWorkspaceStore } from "@/stores/rename-workspace-store";
 import { resolveViewer } from "@/lib/file-viewer";
 import { matchesKeybinding } from "@/lib/keybinding-registry";
 import { propagateCwdOnceForPane } from "@/lib/propagate-cwd-once";
@@ -333,16 +334,16 @@ const SHORTCUT_HANDLERS: Record<string, (e: KeyboardEvent) => void> = {
     }
   },
 
-  // workspace.rename: rename current workspace
+  // workspace.rename: rename current workspace.
+  // Opens the inline rename overlay (#339) instead of a native window.prompt,
+  // which does not work on Windows/WebView2 (the #283 root cause) and is not
+  // driveable via the Automation API.
   "workspace.rename": (e) => {
     e.preventDefault();
-    const { workspaces, activeWorkspaceId, renameWorkspace } = useWorkspaceStore.getState();
+    const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState();
     const current = workspaces.find((ws) => ws.id === activeWorkspaceId);
     if (current) {
-      const newName = window.prompt("Rename workspace:", current.name);
-      if (newName !== null && newName.trim() !== "") {
-        renameWorkspace(activeWorkspaceId, newName.trim());
-      }
+      useRenameWorkspaceStore.getState().openRename(current.id, current.name);
     }
   },
 

--- a/ui/src/stores/rename-workspace-store.ts
+++ b/ui/src/stores/rename-workspace-store.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+
+/**
+ * Global state for the inline workspace-rename overlay (#339).
+ *
+ * Native `window.prompt` does not work on Windows/WebView2 (same root cause
+ * #283 fixed for the file viewer), so the `workspace.rename` shortcut and the
+ * in-app rename buttons funnel through this store instead. A single overlay is
+ * rendered once at the app root (see RenameWorkspaceOverlay) and shown whenever
+ * `targetId` is set. Because it is an in-app input — not a native dialog — it
+ * works on every platform and is driveable via the Automation API.
+ *
+ * This is transient UI state, not user configuration: it lives in memory only
+ * and is never persisted to settings.json.
+ */
+interface RenameWorkspaceState {
+  /** Workspace id currently being renamed, or null when the overlay is closed. */
+  targetId: string | null;
+  /** The workspace's current name, used to seed the input field. */
+  currentName: string;
+
+  /** Open the rename overlay for the given workspace. */
+  openRename: (id: string, currentName: string) => void;
+  /** Close the rename overlay without applying a change. */
+  closeRename: () => void;
+}
+
+export const useRenameWorkspaceStore = create<RenameWorkspaceState>()((set) => ({
+  targetId: null,
+  currentName: "",
+
+  openRename: (id, currentName) => set({ targetId: id, currentName }),
+  closeRename: () => set({ targetId: null, currentName: "" }),
+}));


### PR DESCRIPTION
## 배경
Fixes #339

`workspace.rename` 단축키와 워크스페이스 선택기의 rename UI가 native `window.prompt()`를 사용했는데, 이는 Windows/WebView2 환경에서 동작하지 않아 rename이 불가능했다.

## 접근 (#283 선례 재사용)
- `fileViewer.open`이 #283에서 native prompt를 제거한 패턴(임시 UI store + 루트 포털 오버레이)을 동일하게 재사용
- 단축키 경로와 선택기 UI 양쪽이 같은 `window.prompt` 버그를 공유 → 공통 인라인 오버레이로 통합
- MCP/Automation rename은 `renameWorkspace`를 직접 호출하므로 이미 정상 — 키보드/UI 경로만 수정

## 변경 파일
- `ui/src/stores/rename-workspace-store.ts` (신규) — 오버레이 대상 임시 UI 상태 (settings.json 미저장, 설정 vs 로컬 상태 분리)
- `ui/src/components/layout/RenameWorkspaceOverlay.tsx` (신규) — 루트 포털 오버레이 (Enter/버튼 제출, Esc/백드롭 취소, 빈 이름 무시)
- `ui/src/components/layout/RenameWorkspaceOverlay.test.tsx` (신규) — 8개 테스트
- `ui/src/components/layout/AppLayout.tsx` — 오버레이 마운트
- `ui/src/hooks/useKeyboardShortcuts.ts` — `openRename` 호출로 전환
- `ui/src/components/views/WorkspaceSelectorView.tsx` — 더블클릭/버튼 rename이 오버레이 호출
- 관련 테스트 갱신

## 테스트
- `npx vitest run`: 84 파일 / 2145 테스트 전부 통과
- `tsc --noEmit` 통과, eslint + prettier 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)