### PR TITLE
feat: 다국어 지원(한글/영어) 1차 — i18n 인프라·시작 로케일 감지·언어 설정 (Fixes #350)

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -11,6 +11,16 @@
 
 `settings.json`은 **사용자가 의도적으로 편집·공유하는 구성**만 담는다. 재시작 간 유지돼야 하지만 구성이 아닌 UI 상태(컨트롤 바 모드, 폰트 줌 등)는 localStorage에 저장되는 인스턴스 오버라이드 레이어([overview.md](./overview.md) §4.2)에 들어간다.
 
+### 다국어(i18n) — 언어 설정
+
+UI 다국어는 **react-i18next** 로 구현한다(이슈 #350).
+
+- **설정 키:** `settings.json` 의 최상위 `language: "system" | "ko" | "en"` (Rust `Settings.language: String`, camelCase). 첫 실행 기본값은 `"system"`. serde `#[serde(default = "default_language")]` 로 구버전(키 없음) settings.json 도 `"system"` 으로 파싱된다(하위호환 목적 default 만 유지). 프론트 SSOT 는 `settings-store` 의 `language` 필드 + `setLanguage` 액션.
+- **로케일 해석:** `ui/src/i18n/resolve-language.ts` 의 순수 함수 `resolveLanguage(setting, navigatorLang)` 가 단일 진실원. `"system"` 이면 `navigator.language` 가 `ko*` (대소문자 무시)일 때 한글, 그 외/빈 값은 영어로 폴백. `"ko"`/`"en"` 은 그대로. 명시적 시작 모달은 두지 않는다.
+- **초기화/동기화:** `ui/src/i18n/index.ts` 가 import 시점에 i18next 를 동기 초기화(resources 번들, `fallbackLng:"ko"`, `interpolation.escapeValue:false`). 실제 언어는 설정 로드 후 `useLanguageSync` 훅이 `language` 변경을 구독해 `applyLanguage()`(→ `i18n.changeLanguage()`)로 적용. `main.tsx` 가 `import "./i18n"` 로 부트.
+- **사전 구조:** `ui/src/i18n/locales/{ko,en}.json`. 네임스페이스 `common` · `settings` · `workspace`. 키는 `t("ns:path.to.key")`, 보간은 `{{name}}`.
+- **현재 번역 범위(슬라이스):** `WorkspaceSelectorView` + SettingsView "Startup" 의 Language 카드만 `t()` 전환됨. 나머지 화면의 전체 번역은 후속 작업.
+
 ### 접근 방법
 
 - 모달로 열기 (기본)

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -241,6 +241,27 @@ mod tests {
     }
 
     #[test]
+    fn default_language_is_system() {
+        let settings = Settings::default();
+        assert_eq!(settings.language, "system");
+    }
+
+    #[test]
+    fn language_round_trip_and_backcompat() {
+        // Explicit value survives a round trip.
+        let mut settings = Settings::default();
+        settings.language = "en".into();
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("\"language\":\"en\""));
+        let parsed: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.language, "en");
+
+        // 구버전 settings.json(language 없음)도 기본값("system")으로 채워진다.
+        let legacy: Settings = serde_json::from_str("{}").unwrap();
+        assert_eq!(legacy.language, "system");
+    }
+
+    #[test]
     fn default_issue_reporter_settings() {
         let settings = Settings::default();
         assert_eq!(settings.issue_reporter.shell, "");

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -1008,6 +1008,11 @@ fn default_true() -> bool {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
+    /// App UI language: "system" (OS locale), "ko", or "en". Opaque to the
+    /// backend — resolved on the frontend. `#[serde(default)]` keeps existing
+    /// settings.json (without this key) parsing cleanly.
+    #[serde(default = "default_language")]
+    pub language: String,
     #[serde(default)]
     pub color_schemes: Vec<ColorScheme>,
     #[serde(default)]
@@ -1068,9 +1073,14 @@ fn default_profile() -> String {
     "PowerShell".into()
 }
 
+fn default_language() -> String {
+    "system".into()
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Self {
+            language: default_language(),
             color_schemes: Vec::new(),
             profiles: vec![
                 Profile {

--- a/src-tauri/tests/e2e_test.rs
+++ b/src-tauri/tests/e2e_test.rs
@@ -20,6 +20,7 @@ fn settings_round_trip_with_full_config() {
     let path = dir.path().join("settings.json");
 
     let settings = Settings {
+        language: "system".into(),
         color_schemes: vec![ColorScheme {
             name: "Solarized Dark".into(),
             foreground: "#839496".into(),

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,8 +16,10 @@
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "html2canvas": "^1.4.1",
+        "i18next": "^26.3.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-i18next": "^17.0.8",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -299,7 +301,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3149,6 +3150,15 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -3160,6 +3170,34 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.3.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.1.tgz",
+      "integrity": "sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ignore": {
@@ -4079,6 +4117,33 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.8.tgz",
+      "integrity": "sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.2.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -4462,7 +4527,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4545,6 +4610,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/utrie": {
@@ -4714,6 +4788,15 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,8 +24,10 @@
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "html2canvas": "^1.4.1",
+    "i18next": "^26.3.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-i18next": "^17.0.8",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { saveBeforeClose } from "@/lib/persist-session";
 import { createCloseHandler } from "@/lib/window-close-handler";
 import { useWindowGeometry, captureWindowGeometry } from "@/hooks/useWindowGeometry";
 import { useAppFocus } from "@/hooks/useAppFocus";
+import { useLanguageSync } from "@/hooks/useLanguageSync";
 import { SettingsRecoveryModal } from "@/components/views/SettingsRecoveryModal";
 import { closeTerminalSession } from "@/lib/tauri-api";
 import { useTerminalStore } from "@/stores/terminal-store";
@@ -19,6 +20,7 @@ export function App() {
   useAutomationBridge();
   useWindowGeometry();
   useAppFocus();
+  useLanguageSync();
 
   const [recoveryDismissed, setRecoveryDismissed] = useState(false);
 
@@ -27,7 +29,9 @@ export function App() {
   useEffect(() => {
     let cancelled = false;
     const closeOpenTerminalSessions = async () => {
-      const terminalIds = Array.from(new Set(useTerminalStore.getState().instances.map((i) => i.id)));
+      const terminalIds = Array.from(
+        new Set(useTerminalStore.getState().instances.map((i) => i.id)),
+      );
       await Promise.allSettled(terminalIds.map((id) => closeTerminalSession(id)));
     };
     import("@tauri-apps/api/window")

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, createContext, useContext, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { useUiStore } from "@/stores/ui-store";
 import {
   useSettingsStore,
@@ -15,6 +16,7 @@ import {
   type AntialiasingMode,
   type ColorScheme,
   type Keybinding,
+  type LanguageSetting,
 } from "@/stores/settings-store";
 import type { FileExplorerSettings, ExtensionViewer } from "@/lib/tauri-api";
 import { persistSession } from "@/lib/persist-session";
@@ -161,7 +163,12 @@ function useMonospacedFonts() {
   return installed;
 }
 
+const LANGUAGE_OPTIONS: LanguageSetting[] = ["system", "ko", "en"];
+
 function StartupSection() {
+  const { t } = useTranslation(["settings", "common"]);
+  const language = useSettingsStore((s) => s.language);
+  const setLanguage = useSettingsStore((s) => s.setLanguage);
   const storeDefaultProfile = useSettingsStore((s) => s.defaultProfile);
   const setDefaultProfile = useSettingsStore((s) => s.setDefaultProfile);
   const profiles = useSettingsStore((s) => s.profiles);
@@ -180,7 +187,38 @@ function StartupSection() {
 
   return (
     <div>
-      <SectionTitle>Startup</SectionTitle>
+      <SectionTitle>{t("settings:startup.title")}</SectionTitle>
+
+      {/* Language — applies immediately (live i18n effect), so it is not draft-gated. */}
+      <div className="mb-3" style={cardStyle}>
+        <div className="px-4 py-2">
+          <div className="flex items-center justify-between">
+            <div>
+              <h4 className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>
+                {t("settings:startup.language.title")}
+              </h4>
+              <p
+                className="mt-0.5 text-[11px]"
+                style={{ color: "var(--text-secondary)", opacity: 0.6 }}
+              >
+                {t("settings:startup.language.description")}
+              </p>
+            </div>
+            <FocusSelect
+              data-testid="language-select"
+              value={language}
+              onChange={(e) => setLanguage(e.target.value as LanguageSetting)}
+              className="w-44 rounded px-2 py-1.5 text-xs"
+            >
+              {LANGUAGE_OPTIONS.map((lng) => (
+                <option key={lng} value={lng}>
+                  {t(`common:language.${lng}`)}
+                </option>
+              ))}
+            </FocusSelect>
+          </div>
+        </div>
+      </div>
 
       {/* App Theme */}
       <div className="mb-3" style={cardStyle}>

--- a/ui/src/components/views/WorkspaceSelectorView.i18n.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.i18n.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { WorkspaceSelectorView } from "./WorkspaceSelectorView";
+import i18n from "@/i18n";
+
+vi.mock("@/lib/persist-session", () => ({
+  persistSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock("@/lib/tauri-api", () => ({
+  getListeningPorts: vi.fn().mockResolvedValue([]),
+  getTerminalSummaries: vi.fn().mockResolvedValue([]),
+  markNotificationsRead: vi.fn().mockResolvedValue(0),
+}));
+
+describe("WorkspaceSelectorView i18n", () => {
+  afterEach(async () => {
+    await act(async () => {
+      await i18n.changeLanguage("en");
+    });
+  });
+
+  it("renders English labels when language is en", async () => {
+    await act(async () => {
+      await i18n.changeLanguage("en");
+    });
+    render(<WorkspaceSelectorView />);
+    expect(screen.getByTestId("workspace-selector-header")).toHaveTextContent("New Workspace");
+    expect(screen.getByText("Workspaces")).toBeInTheDocument();
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+  });
+
+  it("renders Korean labels when language is ko", async () => {
+    await act(async () => {
+      await i18n.changeLanguage("ko");
+    });
+    render(<WorkspaceSelectorView />);
+    expect(screen.getByTestId("workspace-selector-header")).toHaveTextContent("새 워크스페이스");
+    expect(screen.getByText("워크스페이스")).toBeInTheDocument();
+    expect(screen.getByText("알림")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useGridStore } from "@/stores/grid-store";
 import { useNotificationStore } from "@/stores/notification-store";
@@ -184,6 +185,7 @@ function WorkspaceItem({
   onTogglePaneHidden: (paneId: string) => void;
   onToggleWsHidden: () => void;
 }) {
+  const { t } = useTranslation("workspace");
   const [hovered, setHovered] = useState(false);
   const wsDisplay = useSettingsStore((s) => s.workspaceSelector.display);
   const claudeSettings = useSettingsStore((s) => s.claude);
@@ -334,7 +336,7 @@ function WorkspaceItem({
                       background: "transparent",
                       border: "none",
                     }}
-                    title={isWsHidden ? "Show workspace" : "Hide workspace"}
+                    title={isWsHidden ? t("item.showWorkspace") : t("item.hideWorkspace")}
                   >
                     {isWsHidden ? <EyeOffIcon size={11} /> : <EyeIcon size={11} />}
                   </button>
@@ -351,7 +353,7 @@ function WorkspaceItem({
                     background: "transparent",
                     border: "none",
                   }}
-                  title="Duplicate workspace (Ctrl+Alt+D)"
+                  title={t("item.duplicateWorkspace")}
                 >
                   <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
                     <rect
@@ -386,7 +388,7 @@ function WorkspaceItem({
                     background: "transparent",
                     border: "none",
                   }}
-                  title="Rename workspace (Ctrl+Alt+R)"
+                  title={t("item.renameWorkspace")}
                 >
                   <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
                     <path
@@ -410,7 +412,7 @@ function WorkspaceItem({
                       background: "transparent",
                       border: "none",
                     }}
-                    title="Close workspace (Ctrl+Alt+W)"
+                    title={t("item.closeWorkspace")}
                   >
                     <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
                       <path
@@ -811,6 +813,7 @@ function LayoutCard({
   onSetDefault: () => void;
   onOverwrite: () => void;
 }) {
+  const { t } = useTranslation("workspace");
   const [hovered, setHovered] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
@@ -908,7 +911,7 @@ function LayoutCard({
                 lineHeight: "14px",
               }}
             >
-              default
+              {t("layout.default")}
             </span>
           )}
           {hovered && isDefault && (
@@ -934,7 +937,7 @@ function LayoutCard({
             color: "var(--text-secondary)",
             border: "none",
           }}
-          title="Layout options"
+          title={t("layout.options")}
         >
           <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
             <circle cx="6" cy="2.5" r="1.2" />
@@ -962,9 +965,9 @@ function LayoutCard({
             }}
             className="cursor-pointer px-3 py-1 text-left text-[11px]"
             style={{ color: "var(--text-primary)", background: "transparent", border: "none" }}
-            title="Save current workspace pane layout to this template"
+            title={t("layout.overwriteTitle")}
           >
-            Overwrite
+            {t("layout.overwrite")}
           </button>
           <button
             onClick={() => {
@@ -973,9 +976,9 @@ function LayoutCard({
             }}
             className="cursor-pointer px-3 py-1 text-left text-[11px]"
             style={{ color: "var(--text-primary)", background: "transparent", border: "none" }}
-            title="Rename this layout"
+            title={t("layout.renameTitle")}
           >
-            Rename
+            {t("layout.rename")}
           </button>
           <button
             onClick={() => {
@@ -984,9 +987,9 @@ function LayoutCard({
             }}
             className="cursor-pointer px-3 py-1 text-left text-[11px]"
             style={{ color: "var(--text-primary)", background: "transparent", border: "none" }}
-            title="Create a copy of this layout"
+            title={t("layout.duplicateTitle")}
           >
-            Duplicate
+            {t("layout.duplicate")}
           </button>
           {!isDefault && (
             <button
@@ -996,24 +999,24 @@ function LayoutCard({
               }}
               className="cursor-pointer px-3 py-1 text-left text-[11px]"
               style={{ color: "var(--text-primary)", background: "transparent", border: "none" }}
-              title="Use this layout when creating new workspaces"
+              title={t("layout.setDefaultTitle")}
             >
-              Set as Default
+              {t("layout.setDefault")}
             </button>
           )}
           {canDelete && (
             <button
               onClick={() => {
-                if (window.confirm(`Delete layout "${layout.name}"?`)) {
+                if (window.confirm(t("layout.deleteConfirm", { name: layout.name }))) {
                   onDelete();
                 }
                 setMenuOpen(false);
               }}
               className="cursor-pointer px-3 py-1 text-left text-[11px]"
               style={{ color: "var(--red)", background: "transparent", border: "none" }}
-              title="Permanently delete this layout"
+              title={t("layout.deleteTitle")}
             >
-              Delete
+              {t("layout.delete")}
             </button>
           )}
         </div>
@@ -1023,6 +1026,7 @@ function LayoutCard({
 }
 
 export function WorkspaceSelectorView() {
+  const { t } = useTranslation("workspace");
   const [showNotifPanel, setShowNotifPanel] = useState(false);
   const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(null);
   const selectorRef = useRef<HTMLDivElement>(null);
@@ -1189,7 +1193,7 @@ export function WorkspaceSelectorView() {
       tabIndex={-1}
       onBlur={handleSelectorBlur}
     >
-      <ViewHeader testId="workspace-selector-header" title="New Workspace" />
+      <ViewHeader testId="workspace-selector-header" title={t("newWorkspace")} />
       {/* New Workspace: Layout picker */}
       <div className="shrink-0" data-testid="new-workspace-panel">
         <div className="flex flex-col">
@@ -1201,7 +1205,7 @@ export function WorkspaceSelectorView() {
               canDelete={layouts.length > 1}
               onClick={() => handleCreateWithLayout(layout.id)}
               onRename={() => {
-                const name = window.prompt("Rename layout:", layout.name);
+                const name = window.prompt(t("layout.renamePrompt"), layout.name);
                 if (name?.trim()) renameLayout(layout.id, name.trim());
               }}
               onDuplicate={() => duplicateLayout(layout.id, `${layout.name} Copy`)}
@@ -1221,7 +1225,7 @@ export function WorkspaceSelectorView() {
         className="px-2 pb-1 flex items-center justify-between"
         style={{ borderBottom: "1px solid var(--border)" }}
       >
-        <SectionLabel>Workspaces</SectionLabel>
+        <SectionLabel>{t("workspaces")}</SectionLabel>
         <span className="flex items-center gap-1">
           <button
             data-testid="hide-mode-toggle"
@@ -1242,7 +1246,7 @@ export function WorkspaceSelectorView() {
               fontWeight: hideMode ? 600 : 400,
               opacity: hideMode ? 1 : 0.7,
             }}
-            title={hideMode ? "Apply and exit hide mode" : "Enter hide mode"}
+            title={hideMode ? t("hideMode.apply") : t("hideMode.enter")}
           >
             {hideMode ? (
               <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
@@ -1280,9 +1284,7 @@ export function WorkspaceSelectorView() {
               opacity: 0.7,
             }}
             title={
-              workspaceSortOrder === "manual"
-                ? "Sort: Manual (drag to reorder)"
-                : "Sort: Notification (most recent first)"
+              workspaceSortOrder === "manual" ? t("sort.manualTitle") : t("sort.notificationTitle")
             }
           >
             <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
@@ -1300,7 +1302,7 @@ export function WorkspaceSelectorView() {
                 </>
               )}
             </svg>
-            {workspaceSortOrder === "manual" ? "Manual" : "Notif"}
+            {workspaceSortOrder === "manual" ? t("sort.manual") : t("sort.notification")}
           </button>
         </span>
       </div>
@@ -1432,7 +1434,7 @@ export function WorkspaceSelectorView() {
         className="hover-bg flex shrink-0 cursor-pointer items-center justify-between px-2 pt-1 pb-1"
         style={{ borderTop: "1px solid var(--border)", borderBottom: "1px solid var(--border)" }}
       >
-        <SectionLabel>{showNotifPanel ? "Hide Notifications" : "Notifications"}</SectionLabel>
+        <SectionLabel>{showNotifPanel ? t("hideNotifications") : t("notifications")}</SectionLabel>
         {totalUnread > 0 && <CountBadge count={totalUnread} />}
       </div>
 

--- a/ui/src/hooks/useLanguageSync.ts
+++ b/ui/src/hooks/useLanguageSync.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useSettingsStore } from "@/stores/settings-store";
+import { applyLanguage } from "@/i18n";
+
+/**
+ * Keep i18next's active language in sync with the `language` setting.
+ *
+ * Runs on mount (applies the startup/loaded value) and whenever the user
+ * changes the language in settings. `applyLanguage` resolves "system" against
+ * the browser locale before calling `i18n.changeLanguage`.
+ */
+export function useLanguageSync(): void {
+  const language = useSettingsStore((s) => s.language);
+  useEffect(() => {
+    applyLanguage(language);
+  }, [language]);
+}

--- a/ui/src/hooks/useSessionPersistence.ts
+++ b/ui/src/hooks/useSessionPersistence.ts
@@ -63,6 +63,7 @@ export function useSessionPersistence() {
 
         // Apply to settings store
         useSettingsStore.getState().loadFromSettings({
+          ...(rawSettings.language ? { language: rawSettings.language } : {}),
           defaultProfile: rawSettings.defaultProfile,
           profileDefaults: sProfileDefaults as Parameters<
             ReturnType<typeof useSettingsStore.getState>["loadFromSettings"]

--- a/ui/src/i18n/index.ts
+++ b/ui/src/i18n/index.ts
@@ -1,0 +1,50 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import ko from "./locales/ko.json";
+import en from "./locales/en.json";
+import { resolveLanguage, type LanguageSetting, type ResolvedLanguage } from "./resolve-language";
+
+export { resolveLanguage };
+export type { LanguageSetting, ResolvedLanguage };
+
+/** Namespaces shipped in each locale bundle. */
+export const namespaces = ["common", "settings", "workspace"] as const;
+
+export const resources = {
+  ko,
+  en,
+} as const;
+
+/**
+ * i18next is initialized synchronously at module import (resources are bundled,
+ * no async backend). The concrete startup language is applied later from the
+ * loaded settings via `applyLanguage` — until then we use the fallback so the
+ * first paint is never blank.
+ */
+i18n.use(initReactI18next).init({
+  resources,
+  // Resolved language is applied from settings after load; start at the fallback.
+  lng: "ko",
+  fallbackLng: "ko",
+  ns: namespaces as unknown as string[],
+  defaultNS: "common",
+  interpolation: {
+    // React already escapes values — double-escaping breaks interpolated text.
+    escapeValue: false,
+  },
+});
+
+/**
+ * Resolve a user language setting against the browser locale and apply it to
+ * i18next. Returns the resolved concrete language for callers that need it.
+ */
+export function applyLanguage(setting: LanguageSetting): ResolvedLanguage {
+  const navigatorLang = typeof navigator !== "undefined" ? navigator.language : undefined;
+  const resolved = resolveLanguage(setting, navigatorLang);
+  if (i18n.language !== resolved) {
+    void i18n.changeLanguage(resolved);
+  }
+  return resolved;
+}
+
+export default i18n;

--- a/ui/src/i18n/index.ts
+++ b/ui/src/i18n/index.ts
@@ -17,14 +17,20 @@ export const resources = {
 
 /**
  * i18next is initialized synchronously at module import (resources are bundled,
- * no async backend). The concrete startup language is applied later from the
- * loaded settings via `applyLanguage` — until then we use the fallback so the
- * first paint is never blank.
+ * no async backend). The user's explicit language is applied later from the
+ * loaded settings via `applyLanguage`; until then we resolve `"system"` against
+ * the browser locale so the very first paint already matches the OS language
+ * (no Korean→English flash for new/English-OS users). Settings load then
+ * re-applies any explicit "ko"/"en" override on top of this.
  */
+const initialLanguage = resolveLanguage(
+  "system",
+  typeof navigator !== "undefined" ? navigator.language : undefined,
+);
+
 i18n.use(initReactI18next).init({
   resources,
-  // Resolved language is applied from settings after load; start at the fallback.
-  lng: "ko",
+  lng: initialLanguage,
   fallbackLng: "ko",
   ns: namespaces as unknown as string[],
   defaultNS: "common",

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1,0 +1,57 @@
+{
+  "common": {
+    "language": {
+      "system": "System",
+      "ko": "한국어",
+      "en": "English"
+    }
+  },
+  "settings": {
+    "startup": {
+      "title": "Startup",
+      "language": {
+        "title": "Language",
+        "description": "App UI display language (System follows the OS locale)"
+      }
+    }
+  },
+  "workspace": {
+    "newWorkspace": "New Workspace",
+    "workspaces": "Workspaces",
+    "notifications": "Notifications",
+    "hideNotifications": "Hide Notifications",
+    "sort": {
+      "manual": "Manual",
+      "notification": "Notif",
+      "manualTitle": "Sort: Manual (drag to reorder)",
+      "notificationTitle": "Sort: Notification (most recent first)"
+    },
+    "hideMode": {
+      "enter": "Enter hide mode",
+      "apply": "Apply and exit hide mode"
+    },
+    "layout": {
+      "options": "Layout options",
+      "overwrite": "Overwrite",
+      "rename": "Rename",
+      "duplicate": "Duplicate",
+      "setDefault": "Set as Default",
+      "delete": "Delete",
+      "default": "default",
+      "overwriteTitle": "Save current workspace pane layout to this template",
+      "renameTitle": "Rename this layout",
+      "duplicateTitle": "Create a copy of this layout",
+      "setDefaultTitle": "Use this layout when creating new workspaces",
+      "deleteTitle": "Permanently delete this layout",
+      "deleteConfirm": "Delete layout \"{{name}}\"?",
+      "renamePrompt": "Rename layout:"
+    },
+    "item": {
+      "showWorkspace": "Show workspace",
+      "hideWorkspace": "Hide workspace",
+      "duplicateWorkspace": "Duplicate workspace (Ctrl+Alt+D)",
+      "renameWorkspace": "Rename workspace (Ctrl+Alt+R)",
+      "closeWorkspace": "Close workspace (Ctrl+Alt+W)"
+    }
+  }
+}

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -1,0 +1,57 @@
+{
+  "common": {
+    "language": {
+      "system": "시스템",
+      "ko": "한국어",
+      "en": "English"
+    }
+  },
+  "settings": {
+    "startup": {
+      "title": "시작",
+      "language": {
+        "title": "언어",
+        "description": "앱 UI 표시 언어 (시스템은 OS 로케일을 따름)"
+      }
+    }
+  },
+  "workspace": {
+    "newWorkspace": "새 워크스페이스",
+    "workspaces": "워크스페이스",
+    "notifications": "알림",
+    "hideNotifications": "알림 숨기기",
+    "sort": {
+      "manual": "수동",
+      "notification": "알림순",
+      "manualTitle": "정렬: 수동 (드래그하여 재정렬)",
+      "notificationTitle": "정렬: 알림순 (최근 항목 우선)"
+    },
+    "hideMode": {
+      "enter": "숨김 모드 진입",
+      "apply": "적용하고 숨김 모드 종료"
+    },
+    "layout": {
+      "options": "레이아웃 옵션",
+      "overwrite": "덮어쓰기",
+      "rename": "이름 변경",
+      "duplicate": "복제",
+      "setDefault": "기본값으로 설정",
+      "delete": "삭제",
+      "default": "기본",
+      "overwriteTitle": "현재 워크스페이스 pane 레이아웃을 이 템플릿에 저장",
+      "renameTitle": "이 레이아웃 이름 변경",
+      "duplicateTitle": "이 레이아웃 복사본 만들기",
+      "setDefaultTitle": "새 워크스페이스 생성 시 이 레이아웃 사용",
+      "deleteTitle": "이 레이아웃 영구 삭제",
+      "deleteConfirm": "레이아웃 \"{{name}}\"을(를) 삭제할까요?",
+      "renamePrompt": "레이아웃 이름 변경:"
+    },
+    "item": {
+      "showWorkspace": "워크스페이스 표시",
+      "hideWorkspace": "워크스페이스 숨김",
+      "duplicateWorkspace": "워크스페이스 복제 (Ctrl+Alt+D)",
+      "renameWorkspace": "워크스페이스 이름 변경 (Ctrl+Alt+R)",
+      "closeWorkspace": "워크스페이스 닫기 (Ctrl+Alt+W)"
+    }
+  }
+}

--- a/ui/src/i18n/resolve-language.test.ts
+++ b/ui/src/i18n/resolve-language.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { resolveLanguage } from "./resolve-language";
+
+describe("resolveLanguage", () => {
+  it("returns explicit ko regardless of navigator locale", () => {
+    expect(resolveLanguage("ko", "en-US")).toBe("ko");
+    expect(resolveLanguage("ko", undefined)).toBe("ko");
+  });
+
+  it("returns explicit en regardless of navigator locale", () => {
+    expect(resolveLanguage("en", "ko-KR")).toBe("en");
+    expect(resolveLanguage("en", undefined)).toBe("en");
+  });
+
+  it("system maps ko* locales to Korean", () => {
+    expect(resolveLanguage("system", "ko")).toBe("ko");
+    expect(resolveLanguage("system", "ko-KR")).toBe("ko");
+    expect(resolveLanguage("system", "KO-kr")).toBe("ko");
+  });
+
+  it("system maps non-ko locales to English", () => {
+    expect(resolveLanguage("system", "en-US")).toBe("en");
+    expect(resolveLanguage("system", "ja-JP")).toBe("en");
+    expect(resolveLanguage("system", "fr")).toBe("en");
+  });
+
+  it("system falls back to English for missing/empty locale", () => {
+    expect(resolveLanguage("system", undefined)).toBe("en");
+    expect(resolveLanguage("system", null)).toBe("en");
+    expect(resolveLanguage("system", "")).toBe("en");
+  });
+});

--- a/ui/src/i18n/resolve-language.ts
+++ b/ui/src/i18n/resolve-language.ts
@@ -1,0 +1,25 @@
+/** Supported UI languages (resolved, concrete). */
+export type ResolvedLanguage = "ko" | "en";
+
+/** User-facing language setting. "system" defers to the OS/browser locale. */
+export type LanguageSetting = "system" | ResolvedLanguage;
+
+/**
+ * Resolve the concrete UI language from the user's setting and the browser locale.
+ *
+ * - Explicit "ko"/"en" wins.
+ * - "system" inspects `navigatorLang` (e.g. `navigator.language`): a `ko*`
+ *   locale (case-insensitive) maps to Korean, everything else falls back to
+ *   English. A missing/empty locale also falls back to English.
+ *
+ * Pure function — no globals — so it is unit-testable without a DOM.
+ */
+export function resolveLanguage(
+  setting: LanguageSetting,
+  navigatorLang: string | undefined | null,
+): ResolvedLanguage {
+  if (setting === "ko" || setting === "en") return setting;
+  // setting === "system"
+  const lang = (navigatorLang ?? "").toLowerCase();
+  return lang.startsWith("ko") ? "ko" : "en";
+}

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -70,6 +70,7 @@ async function persistSessionCore(): Promise<void> {
 
   // Build the base settings object (matches the Tauri Settings type).
   const base: Settings = {
+    language: settingsState.language,
     defaultProfile: settingsState.defaultProfile,
     profileDefaults: {
       ...settingsState.profileDefaults,

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -268,6 +268,8 @@ export interface ProfileDefaults {
 }
 
 export interface Settings {
+  /** App UI language: "system" (OS locale), "ko", or "en". */
+  language?: import("@/stores/settings-store").LanguageSetting;
   colorSchemes: ColorScheme[];
   profiles: Profile[];
   keybindings: Keybinding[];

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./index.css";
+import "./i18n";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/ui/src/stores/settings-store.test.ts
+++ b/ui/src/stores/settings-store.test.ts
@@ -14,6 +14,33 @@ describe("settings-store", () => {
     expect(profileDefaults.stabilizeInteractiveCursor).toBe(true);
   });
 
+  it("defaults language to system", () => {
+    expect(useSettingsStore.getState().language).toBe("system");
+  });
+
+  it("setLanguage updates the language setting", () => {
+    useSettingsStore.getState().setLanguage("en");
+    expect(useSettingsStore.getState().language).toBe("en");
+    useSettingsStore.getState().setLanguage("ko");
+    expect(useSettingsStore.getState().language).toBe("ko");
+  });
+
+  it("loadFromSettings applies a valid language", () => {
+    useSettingsStore.getState().loadFromSettings({ language: "en" });
+    expect(useSettingsStore.getState().language).toBe("en");
+  });
+
+  it("loadFromSettings falls back to system for an invalid language", () => {
+    useSettingsStore.getState().loadFromSettings({ language: "fr" as unknown as "system" });
+    expect(useSettingsStore.getState().language).toBe("system");
+  });
+
+  it("loadFromSettings leaves language untouched when absent", () => {
+    useSettingsStore.getState().setLanguage("ko");
+    useSettingsStore.getState().loadFromSettings({ defaultProfile: "WSL" });
+    expect(useSettingsStore.getState().language).toBe("ko");
+  });
+
   it("has default profiles", () => {
     const { profiles } = useSettingsStore.getState();
     expect(profiles).toHaveLength(2);

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -16,6 +16,10 @@ import {
   type TerminalLocation,
 } from "../lib/sync-cwd-config";
 import type { PastePathSeparator } from "../lib/smart-text";
+import type { LanguageSetting } from "../i18n/resolve-language";
+
+/** Re-export so settings consumers can import the language type from one place. */
+export type { LanguageSetting };
 
 export interface FontSettings {
   face: string;
@@ -332,6 +336,8 @@ export const builtinAppThemes: AppTheme[] = [
 ];
 
 interface SettingsState {
+  /** App UI language. "system" follows the OS/browser locale (ko* → Korean, else English). */
+  language: LanguageSetting;
   defaultProfile: string;
   profileDefaults: ProfileDefaults;
   profiles: Profile[];
@@ -352,6 +358,7 @@ interface SettingsState {
   fileExplorer: FileExplorerSettings;
   syncCwdDefaults: SyncCwdDefaults;
 
+  setLanguage: (language: LanguageSetting) => void;
   setDefaultProfile: (profile: string) => void;
   setViewOrder: (order: string[]) => void;
   setAppearance: (data: Partial<AppearanceSettings>) => void;
@@ -392,6 +399,7 @@ interface SettingsState {
     data: Partial<
       Pick<
         SettingsState,
+        | "language"
         | "defaultProfile"
         | "profileDefaults"
         | "profiles"
@@ -461,6 +469,9 @@ export const DEFAULT_FONT: FontSettings = { face: "Cascadia Mono", size: 14, wei
 
 /** Default app font for non-terminal views (Memo, Issue Reporter, etc.). */
 export const DEFAULT_APP_FONT: FontSettings = { face: "Cascadia Mono", size: 13, weight: "normal" };
+
+/** Default UI language. "system" defers to the OS/browser locale on first run. */
+export const DEFAULT_LANGUAGE: LanguageSetting = "system";
 
 export const DEFAULT_APPEARANCE: AppearanceSettings = {
   themeId: "catppuccin-mocha",
@@ -863,6 +874,7 @@ export const builtinColorSchemes: ColorScheme[] = [
 ];
 
 export const useSettingsStore = create<SettingsState>()((set, get) => ({
+  language: DEFAULT_LANGUAGE,
   defaultProfile: "PowerShell",
   profileDefaults: { ...defaultProfileDefaults },
   profiles: [makeProfile("PowerShell", "powershell.exe -NoLogo"), makeProfile("WSL", "wsl.exe")],
@@ -962,6 +974,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     set((state) => ({
       syncCwdDefaults: { ...state.syncCwdDefaults, ...data },
     })),
+
+  setLanguage: (language) => set({ language }),
 
   setDefaultProfile: (defaultProfile) => set({ defaultProfile }),
 
@@ -1178,6 +1192,14 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
           ...(data.syncCwdDefaults as Partial<SyncCwdDefaults>),
         }
       : undefined;
+    // Validate language; unknown values fall back to the default ("system").
+    const validLanguages: LanguageSetting[] = ["system", "ko", "en"];
+    const language =
+      data.language !== undefined
+        ? validLanguages.includes(data.language)
+          ? data.language
+          : DEFAULT_LANGUAGE
+        : undefined;
 
     const {
       appearance: _rawAppearance,
@@ -1187,11 +1209,13 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       dock: _rawDock,
       notifications: _rawNotifications,
       workspaceSelector: _rawWorkspaceSelector,
+      language: _rawLanguage,
       ...rest
     } = data;
     set((state) => ({
       ...state,
       ...rest,
+      ...(language ? { language } : {}),
       ...(profiles ? { profiles } : {}),
       ...(profileDefaults ? { profileDefaults } : {}),
       ...(mergedSchemes ? { colorSchemes: mergedSchemes } : {}),

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -1,4 +1,9 @@
 import "@testing-library/jest-dom/vitest";
+import i18n from "@/i18n";
+
+// Tests assert against English UI strings; pin the test locale to English so
+// the default ("ko") fallback does not flip rendered labels.
+void i18n.changeLanguage("en");
 
 // Polyfill ResizeObserver for jsdom — fires callback immediately with non-zero dimensions
 if (typeof globalThis.ResizeObserver === "undefined") {


### PR DESCRIPTION
## 개요
다국어 지원(한글/영어) **1차 PR** — i18n 인프라 구축 + 시작 시 OS 로케일 자동감지 + 언어 설정 UI + 슬라이스 번역. Fixes #350

## 설계 결정
- **react-i18next 도입** (`i18next` + `react-i18next`)
- **기본 언어 = OS 로케일 자동감지 → 한글 폴백**: `language="system"`이면 `navigator.language`가 `ko*`일 때 한글, 그 외 영어. 첫 실행 기본값은 `"system"`. 사용자는 설정에서 시스템/한국어/English 변경.
- **범위는 슬라이스만**: 시작 화면 `WorkspaceSelectorView` + Language 설정 카드만 번역. 나머지 ~45개 파일 전체 번역은 후속 PR (인프라가 깔려 점진 가능).

## 주요 변경
**i18n 인프라 (신규)**
- `ui/src/i18n/index.ts` — i18next 초기화(ko/en, fallbackLng "ko", escapeValue false), `applyLanguage()`
- `ui/src/i18n/resolve-language.ts` (+테스트) — 로케일 감지 순수 함수
- `ui/src/i18n/locales/{ko,en}.json` — 네임스페이스 common/settings/workspace
- `ui/src/hooks/useLanguageSync.ts` — store language → i18next 동기화

**설정 양 끝단**
- 프론트 `settings-store.ts`: `language` 필드 + `DEFAULT_LANGUAGE("system")` + `setLanguage` + 직렬화
- Rust `settings/models.rs`: `Settings.language` + `#[serde(default)]`(하위호환) + Default

**UI/번역**
- `SettingsView.tsx`: "Startup" 섹션에 Language 토글(즉시 적용 — 라이브 i18n 피드백)
- `WorkspaceSelectorView.tsx`: 하드코딩 문자열 → `t()`

## 테스트 결과 (모두 통과)
- `cd ui && npx vitest run` → 87파일 / **2179 테스트 통과**
- `cd src-tauri && cargo test` → settings 35개 + language 라운드트립 2개 통과
- `tsc --noEmit` / `npm run build` / lint / fmt / clippy 클린(내 파일)

## 주의사항
- Language 토글은 다른 Startup 카드(draft+Save 패턴)와 달리 **즉시 커밋**된다 — 라이브 i18n 효과를 위해 의도된 동작.
- 기존 `settings.json`(language 키 없음)은 프론트·백엔드 모두 `"system"`으로 안전 파싱.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
