### PR TITLE
fix: 아래로 이동 버튼이 스크롤바 슬라이더와 겹치는 문제 (#361)

### DIFF
--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -4388,6 +4388,24 @@ describe("TerminalView jump-to-bottom button (issue #349)", () => {
     });
     expect(screen.queryByTestId("terminal-scroll-to-bottom-t-jump3")).not.toBeInTheDocument();
   });
+
+  // Issue #361: the button must clear the scrollbar slider. The right offset is
+  // exposed via the --terminal-scroll-btn-right CSS variable on the wrapper so
+  // it can be widened when the scrollbar reserves its own gutter.
+  it("uses a 16px right offset in overlay scrollbar mode", () => {
+    useSettingsStore.getState().setTerminal({ scrollbarStyle: "overlay" });
+    render(<TerminalView instanceId="t-sb-overlay" profile="PowerShell" syncGroup="" />);
+    const wrapper = screen.getByTestId("terminal-view-t-sb-overlay");
+    expect(wrapper.style.getPropertyValue("--terminal-scroll-btn-right")).toBe("16px");
+  });
+
+  it("pushes the button left past the reserved gutter in separate scrollbar mode", () => {
+    useSettingsStore.getState().setTerminal({ scrollbarStyle: "separate" });
+    render(<TerminalView instanceId="t-sb-separate" profile="PowerShell" syncGroup="" />);
+    const wrapper = screen.getByTestId("terminal-view-t-sb-separate");
+    // 14px reserved scrollbar gutter + 12px clearance.
+    expect(wrapper.style.getPropertyValue("--terminal-scroll-btn-right")).toBe("26px");
+  });
 });
 
 describe("shouldEnableTerminalWebgl", () => {

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -2480,14 +2480,22 @@ export function TerminalView({
   const scrollbarStyle = useSettingsStore((s) => s.terminal.scrollbarStyle ?? "overlay");
   const scrollbarClass = scrollbarStyle === "overlay" ? "scrollbar-overlay" : "scrollbar-separate";
 
+  // Issue #361: the jump-to-bottom button must clear the scrollbar slider so
+  // they do not overlap. In "separate" mode the scrollbar reserves a 14px
+  // gutter, so push the button further left; in "overlay" mode the slider is
+  // narrower and renders on top of content.
+  const scrollBtnRight = scrollbarStyle === "separate" ? 14 + 12 : 16;
+
   const wrapperStyle: CSSProperties & {
     "--terminal-overlay-caret-color": string;
     "--terminal-foreground-color": string;
     "--terminal-background-color": string;
+    "--terminal-scroll-btn-right": string;
   } = {
     "--terminal-overlay-caret-color": overlayCaretColor,
     "--terminal-foreground-color": termFg,
     "--terminal-background-color": termBg,
+    "--terminal-scroll-btn-right": `${scrollBtnRight}px`,
     background: termBg,
     padding: `${pt}px ${pr}px ${pb}px ${pl}px`,
   };

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -103,6 +103,9 @@ const RESIZE_FIT_DEBOUNCE_MS = 80;
 /** Byte-size threshold for the large paste warning dialog. */
 const LARGE_PASTE_THRESHOLD = 5120;
 
+/** "separate" 스크롤바 모드에서 xterm overviewRuler가 예약하는 거터 폭(px). */
+const SCROLLBAR_SEPARATE_GUTTER_PX = 14;
+
 const textEncoder = new TextEncoder();
 
 function markBackendInteractiveTerminal(instanceId: string, activity: TerminalActivityInfo): void {
@@ -550,7 +553,7 @@ export function TerminalView({
     // Scrollbar overlay mode: set overviewRuler width to 0 so FitAddon
     // does not reserve space for the scrollbar — it renders on top of content.
     const sbStyle = settingsState.terminal.scrollbarStyle ?? "overlay";
-    const overviewRulerWidth = sbStyle === "overlay" ? 0 : 14;
+    const overviewRulerWidth = sbStyle === "overlay" ? 0 : SCROLLBAR_SEPARATE_GUTTER_PX;
 
     const resolvedFont = settingsState.resolveFont(
       profile,
@@ -2447,7 +2450,7 @@ export function TerminalView({
     const term = terminalRef.current;
     if (!term?.options) return;
     try {
-      const newWidth = scrollbarStyleForEffect === "overlay" ? 0 : 14;
+      const newWidth = scrollbarStyleForEffect === "overlay" ? 0 : SCROLLBAR_SEPARATE_GUTTER_PX;
       term.options.overviewRuler = { width: newWidth };
       // The overviewRuler option update is harmless while hidden, but
       // fit() on a 0×0 container would PTY-resize to cols=0. Defer.
@@ -2481,10 +2484,11 @@ export function TerminalView({
   const scrollbarClass = scrollbarStyle === "overlay" ? "scrollbar-overlay" : "scrollbar-separate";
 
   // Issue #361: the jump-to-bottom button must clear the scrollbar slider so
-  // they do not overlap. In "separate" mode the scrollbar reserves a 14px
-  // gutter, so push the button further left; in "overlay" mode the slider is
-  // narrower and renders on top of content.
-  const scrollBtnRight = scrollbarStyle === "separate" ? 14 + 12 : 16;
+  // they do not overlap. In "separate" mode the scrollbar reserves a
+  // SCROLLBAR_SEPARATE_GUTTER_PX-wide gutter, so push the button further left
+  // (plus a 12px slider clearance); in "overlay" mode the slider is narrower
+  // and renders on top of content.
+  const scrollBtnRight = scrollbarStyle === "separate" ? SCROLLBAR_SEPARATE_GUTTER_PX + 12 : 16;
 
   const wrapperStyle: CSSProperties & {
     "--terminal-overlay-caret-color": string;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -371,10 +371,13 @@
 
 /* Issue #349: floating jump-to-bottom button, shown while scrolled up into
    scrollback. Sits above the overlay caret / loading layers so it stays
-   clickable, and clears the overlay scrollbar gutter on the right. */
+   clickable, and clears the overlay scrollbar gutter on the right.
+   Issue #361: the right offset is driven by --terminal-scroll-btn-right so the
+   button clears the scrollbar slider (wider gutter in "separate" mode) instead
+   of overlapping it. */
 .terminal-scroll-to-bottom {
   position: absolute;
-  right: 16px;
+  right: var(--terminal-scroll-btn-right, 16px);
   bottom: 16px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 요약
"아래로 이동" 원형 버튼이 스크롤바 슬라이더와 겹치는 문제를 CSS 오프셋 조정으로 해결.

- `scrollbar-separate` 모드는 14px 폭의 스크롤바 거터를 예약하는데, 버튼이 `right: 16px`(폭 34px)에 위치해 슬라이더와 겹쳤음.
- 모드별로 `--terminal-scroll-btn-right` 오프셋을 분기: separate 모드 `26px`, overlay 모드 기존 `16px`.

## 변경 파일
- `ui/src/components/views/TerminalView.tsx` — 스크롤바 모드에 따라 CSS 변수 주입
- `ui/src/index.css` — `.terminal-scroll-to-bottom`의 `right`를 변수화
- `ui/src/components/views/TerminalView.test.tsx` — 모드별 오프셋 검증 테스트 2개 추가

## 테스트
`npx vitest run TerminalView` → 135개 전부 통과(신규 2개 포함). prettier/eslint 통과.

기능 변경 없이 위치/스타일만 조정.

Fixes #361