### PR TITLE
feat: viewer를 여는 아이콘을 상단 바메뉴에 추가 (#362)

### DIFF
--- a/ui/src/components/layout/GridEditToolbar.test.tsx
+++ b/ui/src/components/layout/GridEditToolbar.test.tsx
@@ -69,6 +69,12 @@ describe("GridEditToolbar", () => {
     expect(screen.getByTestId("file-viewer-btn")).toBeInTheDocument();
   });
 
+  it("renders the file viewer button with the Document glyph", () => {
+    render(<GridEditToolbar />);
+    // Regression for #366: the glyph escape was a literal "E8A5" string.
+    expect(screen.getByTestId("file-viewer-btn").textContent).toBe("");
+  });
+
   it("opens the empty file viewer on click", async () => {
     const user = userEvent.setup();
     render(<GridEditToolbar />);

--- a/ui/src/components/layout/GridEditToolbar.test.tsx
+++ b/ui/src/components/layout/GridEditToolbar.test.tsx
@@ -9,11 +9,13 @@ vi.mock("@/lib/persist-session", () => ({
 import { GridEditToolbar } from "./GridEditToolbar";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useDockStore } from "@/stores/dock-store";
+import { useFileViewerStore } from "@/stores/file-viewer-store";
 
 describe("GridEditToolbar", () => {
   beforeEach(() => {
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
     useDockStore.setState(useDockStore.getInitialState());
+    useFileViewerStore.setState(useFileViewerStore.getInitialState());
   });
 
   it("always shows export action buttons", () => {
@@ -60,6 +62,21 @@ describe("GridEditToolbar", () => {
     expect(useDockStore.getState().getDock("top")!.visible).toBe(true);
     await user.click(screen.getByTestId("dock-toggle-top"));
     expect(useDockStore.getState().getDock("top")!.visible).toBe(false);
+  });
+
+  it("renders the file viewer button", () => {
+    render(<GridEditToolbar />);
+    expect(screen.getByTestId("file-viewer-btn")).toBeInTheDocument();
+  });
+
+  it("opens the empty file viewer on click", async () => {
+    const user = userEvent.setup();
+    render(<GridEditToolbar />);
+
+    expect(useFileViewerStore.getState().open).toBe(false);
+    await user.click(screen.getByTestId("file-viewer-btn"));
+    expect(useFileViewerStore.getState().open).toBe(true);
+    expect(useFileViewerStore.getState().path).toBe("");
   });
 
   it("shows Saved! after export-new", async () => {

--- a/ui/src/components/layout/GridEditToolbar.tsx
+++ b/ui/src/components/layout/GridEditToolbar.tsx
@@ -209,7 +209,7 @@ export function GridEditToolbar() {
           }}
           title="Open File Viewer (Ctrl+Shift+O)"
         >
-          {"E8A5"}
+          {"\uE8A5"}
         </button>
 
         <button

--- a/ui/src/components/layout/GridEditToolbar.tsx
+++ b/ui/src/components/layout/GridEditToolbar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useDockStore } from "@/stores/dock-store";
 import { useUiStore } from "@/stores/ui-store";
+import { useFileViewerStore } from "@/stores/file-viewer-store";
 import type { DockPosition } from "@/stores/types";
 import logoSvg from "@/assets/logo.svg";
 
@@ -15,6 +16,7 @@ export function GridEditToolbar() {
   const exportAsNewLayout = useWorkspaceStore((s) => s.exportAsNewLayout);
   const toggleSettingsModal = useUiStore((s) => s.toggleSettingsModal);
   const toggleConnectionInfoModal = useUiStore((s) => s.toggleConnectionInfoModal);
+  const openEmptyFileViewer = useFileViewerStore((s) => s.openEmptyFileViewer);
   const docks = useDockStore((s) => s.docks);
   const toggleDockVisible = useDockStore((s) => s.toggleDockVisible);
   const layoutMode = useDockStore((s) => s.layoutMode);
@@ -193,6 +195,22 @@ export function GridEditToolbar() {
         </button>
 
         <div className="ui-sep" />
+
+        <button
+          data-testid="file-viewer-btn"
+          onClick={() => openEmptyFileViewer()}
+          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded"
+          style={{
+            color: "var(--text-secondary)",
+            background: "transparent",
+            border: "none",
+            fontFamily: "'Segoe Fluent Icons', 'Segoe MDL2 Assets'",
+            fontSize: "var(--fs-xs)",
+          }}
+          title="Open File Viewer (Ctrl+Shift+O)"
+        >
+          {"E8A5"}
+        </button>
 
         <button
           data-testid="connection-info-btn"


### PR DESCRIPTION
## 요약
상단 바메뉴(GridEditToolbar) 오른쪽 영역에 파일 뷰어를 여는 아이콘 버튼 추가.

- connection-info 버튼 바로 앞에 `data-testid="file-viewer-btn"` 버튼 추가
- connection-info/settings와 동일한 톤(Segoe Fluent Icons, 6x6, transparent), Document 글리프(``) 사용
- 클릭 시 `useFileViewerStore`의 `openEmptyFileViewer()` 호출 — 전역 단축키(Ctrl+Shift+O)와 동일한 액션으로 인라인 경로 입력 오버레이를 띄움

## 변경 파일
- `ui/src/components/layout/GridEditToolbar.tsx`
- `ui/src/components/layout/GridEditToolbar.test.tsx` — 버튼 렌더링 + 클릭 시 빈 뷰어 오픈 검증 테스트 2개 추가

## 테스트
`npx vitest run GridEditToolbar` → 8/8 통과(기존 6 + 신규 2). prettier/eslint 통과.

Fixes #362