### PR TITLE
feat(terminal): 맨 아래로 이동 버튼 다듬기 + 표시 토글 설정 추가

### DIFF
--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1414,6 +1414,14 @@ function TerminalSection() {
             <option value="separate">{t("terminal.scrollbarSeparate")}</option>
           </FocusSelect>
         </SettingRow>
+
+        <ToggleRow
+          label={t("terminal.scrollToBottomButton")}
+          desc={t("terminal.scrollToBottomButtonDesc")}
+          testid="scroll-to-bottom-button-toggle"
+          checked={terminal.showScrollToBottomButton}
+          onChange={(v) => update({ showScrollToBottomButton: v })}
+        />
       </div>
     </div>
   );

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -4331,6 +4331,27 @@ describe("TerminalView jump-to-bottom button (issue #349)", () => {
     expect(screen.getByTestId("terminal-scroll-to-bottom-t-jump")).toBeInTheDocument();
   });
 
+  it("keeps the button hidden when disabled via settings, even when scrolled up", async () => {
+    useSettingsStore.getState().setTerminal({ showScrollToBottomButton: false });
+    try {
+      render(<TerminalView instanceId="t-jump-off" profile="PowerShell" syncGroup="" />);
+      await vi.waitFor(() => {
+        expect(capturedScrollHandler).not.toBeNull();
+      });
+
+      // Scroll up: normally this would reveal the button.
+      mockBufferActive.baseY = 100;
+      mockBufferActive.viewportY = 30;
+      await act(async () => {
+        capturedScrollHandler?.();
+      });
+
+      expect(screen.queryByTestId("terminal-scroll-to-bottom-t-jump-off")).not.toBeInTheDocument();
+    } finally {
+      useSettingsStore.getState().setTerminal({ showScrollToBottomButton: true });
+    }
+  });
+
   it("scrolls to bottom and hides the button on click", async () => {
     render(<TerminalView instanceId="t-jump2" profile="PowerShell" syncGroup="" />);
     await vi.waitFor(() => {
@@ -4389,21 +4410,22 @@ describe("TerminalView jump-to-bottom button (issue #349)", () => {
     expect(screen.queryByTestId("terminal-scroll-to-bottom-t-jump3")).not.toBeInTheDocument();
   });
 
-  // Issue #361: the button must clear the scrollbar slider. The right offset is
-  // exposed via the --terminal-scroll-btn-right CSS variable on the wrapper so
-  // it can be widened when the scrollbar reserves its own gutter.
-  it("uses a 16px right offset in overlay scrollbar mode", () => {
+  // Issue #361: the button must clear the scrollbar slider. The slider renders at
+  // the same right-edge width in both modes and the button is positioned relative
+  // to the pane edge, so the offset (--terminal-scroll-btn-right) is the same
+  // (26px = 14px slider + 12px clearance) regardless of scrollbar mode.
+  it("uses a 26px right offset in overlay scrollbar mode", () => {
     useSettingsStore.getState().setTerminal({ scrollbarStyle: "overlay" });
     render(<TerminalView instanceId="t-sb-overlay" profile="PowerShell" syncGroup="" />);
     const wrapper = screen.getByTestId("terminal-view-t-sb-overlay");
-    expect(wrapper.style.getPropertyValue("--terminal-scroll-btn-right")).toBe("16px");
+    expect(wrapper.style.getPropertyValue("--terminal-scroll-btn-right")).toBe("26px");
   });
 
-  it("pushes the button left past the reserved gutter in separate scrollbar mode", () => {
+  it("uses the same 26px right offset in separate scrollbar mode", () => {
     useSettingsStore.getState().setTerminal({ scrollbarStyle: "separate" });
     render(<TerminalView instanceId="t-sb-separate" profile="PowerShell" syncGroup="" />);
     const wrapper = screen.getByTestId("terminal-view-t-sb-separate");
-    // 14px reserved scrollbar gutter + 12px clearance.
+    // 14px scrollbar slider + 12px clearance.
     expect(wrapper.style.getPropertyValue("--terminal-scroll-btn-right")).toBe("26px");
   });
 });

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -106,6 +106,14 @@ const LARGE_PASTE_THRESHOLD = 5120;
 /** "separate" 스크롤바 모드에서 xterm overviewRuler가 예약하는 거터 폭(px). */
 const SCROLLBAR_SEPARATE_GUTTER_PX = 14;
 
+/**
+ * jump-to-bottom 버튼의 우측 오프셋(px). 버튼은 pane 우측 끝 기준 절대위치이고,
+ * xterm 스크롤바 슬라이더는 overlay/separate 모드 모두 우측 끝에 동일 폭으로
+ * 렌더되므로(슬라이더 폭 ~14px), 모드와 무관하게 슬라이더를 비켜가는 단일 값을 쓴다.
+ * 14px 슬라이더 + 12px 여유 = 26px (issue #361).
+ */
+const SCROLL_BTN_RIGHT_PX = SCROLLBAR_SEPARATE_GUTTER_PX + 12;
+
 const textEncoder = new TextEncoder();
 
 function markBackendInteractiveTerminal(instanceId: string, activity: TerminalActivityInfo): void {
@@ -2483,12 +2491,16 @@ export function TerminalView({
   const scrollbarStyle = useSettingsStore((s) => s.terminal.scrollbarStyle ?? "overlay");
   const scrollbarClass = scrollbarStyle === "overlay" ? "scrollbar-overlay" : "scrollbar-separate";
 
+  // Issue #361: the jump-to-bottom button is opt-out via settings (default on).
+  const showScrollToBottomButtonSetting = useSettingsStore(
+    (s) => s.terminal.showScrollToBottomButton ?? true,
+  );
+
   // Issue #361: the jump-to-bottom button must clear the scrollbar slider so
-  // they do not overlap. In "separate" mode the scrollbar reserves a
-  // SCROLLBAR_SEPARATE_GUTTER_PX-wide gutter, so push the button further left
-  // (plus a 12px slider clearance); in "overlay" mode the slider is narrower
-  // and renders on top of content.
-  const scrollBtnRight = scrollbarStyle === "separate" ? SCROLLBAR_SEPARATE_GUTTER_PX + 12 : 16;
+  // they do not overlap. The slider renders at the same right-edge width in both
+  // overlay and separate modes, and the button is positioned relative to the
+  // pane edge, so the offset is mode-independent (see SCROLL_BTN_RIGHT_PX).
+  const scrollBtnRight = SCROLL_BTN_RIGHT_PX;
 
   const wrapperStyle: CSSProperties & {
     "--terminal-overlay-caret-color": string;
@@ -2547,7 +2559,7 @@ export function TerminalView({
       >
         <div className="terminal-loading-spinner" />
       </div>
-      {showScrollToBottom && (
+      {showScrollToBottom && showScrollToBottomButtonSetting && (
         <button
           type="button"
           data-testid={`terminal-scroll-to-bottom-${instanceId}`}
@@ -2562,18 +2574,17 @@ export function TerminalView({
           }}
         >
           <svg
-            width="16"
-            height="16"
+            width="24"
+            height="24"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
+            strokeWidth="3"
+            strokeLinecap="butt"
             strokeLinejoin="round"
             aria-hidden
           >
-            <path d="M12 5v14" />
-            <path d="m19 12-7 7-7-7" />
+            <path d="m5 8.5 7 7 7-7" />
           </svg>
         </button>
       )}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -222,7 +222,9 @@
       "scrollbarStyle": "Scrollbar Style",
       "scrollbarStyleDesc": "How the terminal scrollbar is shown. Overlay overlaps the content, Separate takes its own space.",
       "scrollbarOverlay": "Overlay (overlaps content)",
-      "scrollbarSeparate": "Separate (takes own space)"
+      "scrollbarSeparate": "Separate (takes own space)",
+      "scrollToBottomButton": "Jump-to-bottom Button",
+      "scrollToBottomButtonDesc": "Show the floating button that jumps to the bottom when scrolled up into the scrollback."
     },
     "interface": {
       "title": "Interface",

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -222,7 +222,9 @@
       "scrollbarStyle": "스크롤바 방식",
       "scrollbarStyleDesc": "터미널 스크롤바 표시 방식. Overlay는 콘텐츠 위에 겹쳐서, Separate는 별도 공간을 차지합니다.",
       "scrollbarOverlay": "Overlay (콘텐츠 위에 겹침)",
-      "scrollbarSeparate": "Separate (별도 공간 차지)"
+      "scrollbarSeparate": "Separate (별도 공간 차지)",
+      "scrollToBottomButton": "맨 아래로 이동 버튼",
+      "scrollToBottomButtonDesc": "스크롤백을 위로 올렸을 때 맨 아래로 이동하는 떠 있는 버튼을 표시합니다."
     },
     "interface": {
       "title": "인터페이스",

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -389,7 +389,9 @@
   background: var(--accent);
   color: var(--bg-base);
   cursor: pointer;
-  opacity: 0.9;
+  /* Issue #361: keep the resting state subtle so it does not distract from
+     terminal content; it becomes fully opaque on hover. */
+  opacity: 0.4;
   box-shadow: 0 2px 8px var(--backdrop-light);
   transition:
     opacity 120ms ease,

--- a/ui/src/stores/settings-store.test.ts
+++ b/ui/src/stores/settings-store.test.ts
@@ -603,6 +603,24 @@ describe("settings-store", () => {
     expect(terminal.scrollbarStyle).toBe("separate");
   });
 
+  // -- Jump-to-bottom button setting (issue #361) --
+
+  it("has default showScrollToBottomButton as true", () => {
+    expect(useSettingsStore.getState().terminal.showScrollToBottomButton).toBe(true);
+  });
+
+  it("setTerminal toggles showScrollToBottomButton", () => {
+    useSettingsStore.getState().setTerminal({ showScrollToBottomButton: false });
+    expect(useSettingsStore.getState().terminal.showScrollToBottomButton).toBe(false);
+  });
+
+  it("loadFromSettings fills missing showScrollToBottomButton with default true", () => {
+    useSettingsStore.getState().loadFromSettings({
+      terminal: { copyOnSelect: false } as any,
+    });
+    expect(useSettingsStore.getState().terminal.showScrollToBottomButton).toBe(true);
+  });
+
   // -- Workspace display settings --
 
   it("has default workspaceSelector.display with all items enabled", () => {

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -110,6 +110,8 @@ export interface TerminalSettings {
   copyOnSelect: boolean;
   /** Terminal scrollbar style: "overlay" renders on top of content, "separate" reserves space. */
   scrollbarStyle: ScrollbarStyle;
+  /** Show the floating jump-to-bottom button while scrolled up into scrollback (issue #361). */
+  showScrollToBottomButton: boolean;
 }
 
 /** Pane control bar behavior. */
@@ -499,6 +501,7 @@ export const DEFAULT_PASTE: PasteSettings = {
 export const DEFAULT_TERMINAL: TerminalSettings = {
   copyOnSelect: true,
   scrollbarStyle: "overlay",
+  showScrollToBottomButton: true,
 };
 
 export const DEFAULT_CONTROL_BAR: ControlBarSettings = {


### PR DESCRIPTION
## 배경
overlay 스크롤바 모드(기본값)에서 "맨 아래로 이동" 버튼이 스크롤바 슬라이더와 겹치는 문제가 남아 있었습니다(이전 #361 수정은 separate 모드만 보정). 사용자 피드백을 반영해 버튼을 다듬고, 표시 여부를 설정으로 끄고 켤 수 있게 했습니다. **스크롤바 자체는 일절 건드리지 않고 버튼만 조정**했습니다.

## 변경 내용
### 버튼 다듬기 (`TerminalView.tsx`, `index.css`)
- **오프셋 통일**: overlay/separate 모드 공통 `26px`. 슬라이더는 두 모드 모두 우측 끝에 동일 폭으로 렌더되고 버튼은 pane 우측 끝 기준 절대위치이므로 모드 분기가 불필요 → `SCROLL_BTN_RIGHT_PX` 단일 상수로 정리. overlay 겹침 해결.
- **투명도**: 비호버 `0.9 → 0.4` (콘텐츠 가리지 않게), 호버 `1.0`.
- **아이콘**: chevron(v) 모양으로 교체, strokeWidth `3`, `butt` 캡, 크기 `16 → 24` (세로 중앙 유지).

### 표시 토글 설정 (기본 ON)
- `TerminalSettings.showScrollToBottomButton: boolean` 추가, `DEFAULT_TERMINAL`에서 `true`.
- `TerminalView`에서 렌더 조건에 설정 반영(`showScrollToBottom && showScrollToBottomButtonSetting`).
- **Settings UI**: `터미널` 섹션의 **스크롤바 방식 바로 아래**에 토글 배치(둘 다 스크롤 관련이라 인접 배치). ko/en i18n 추가.
- 세션 영속화는 `terminal` 객체 전체를 직렬화하므로 자동 저장.

## 테스트
- `settings-store.test`: 기본값 true / 토글 / load 시 기본값 채움 (3개 추가)
- `TerminalView.test`: 설정 off 시 스크롤 업 해도 버튼 미표시 / 오프셋 26px(양 모드) 검증
- 영향 범위 전체 통과: settings-store + TerminalView(233), SettingsView + persist-session + useSessionPersistence(174). prettier/eslint 0 error.

## 참고
- 프론트 변경이라 dev(19281) vite HMR로 실시간 확인하며 작업했습니다.