### PR TITLE
feat(cwd-sync): CWD 전파 기본값 받기(receive)를 true로

### DIFF
--- a/ui/src/components/layout/Dock.test.tsx
+++ b/ui/src/components/layout/Dock.test.tsx
@@ -369,7 +369,7 @@ describe("Dock", () => {
   // 기본 syncCwdDefaults는 workspace/dock 모두 { send: false, receive: false } 이다.
   // 신규 dock 페인이 cwdSend/cwdReceive override 없이 표시될 때 OFF 아이콘이 나와야 한다.
 
-  it("single-pane dock shows CWD send/receive OFF by default (syncCwdDefaults.dock=off)", () => {
+  it("single-pane dock shows CWD send OFF, receive ON by default (syncCwdDefaults.dock)", () => {
     render(
       <Dock
         position="bottom"
@@ -393,7 +393,7 @@ describe("Dock", () => {
       "CWD Send (off)",
     );
     expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
-      "CWD Receive (off)",
+      "CWD Receive (on)",
     );
   });
 
@@ -498,7 +498,7 @@ describe("Dock", () => {
     );
   });
 
-  it("split-pane dock shows CWD send/receive OFF by default", () => {
+  it("split-pane dock shows CWD send OFF, receive ON by default", () => {
     render(
       <Dock
         position="left"
@@ -530,7 +530,7 @@ describe("Dock", () => {
       "CWD Send (off)",
     );
     expect(screen.getByTestId("pane-control-cwd-receive").getAttribute("title")).toBe(
-      "CWD Receive (off)",
+      "CWD Receive (on)",
     );
   });
 

--- a/ui/src/components/views/SettingsView.test.tsx
+++ b/ui/src/components/views/SettingsView.test.tsx
@@ -1668,12 +1668,12 @@ describe("SettingsView", () => {
       ).toBe(false);
       expect(
         (screen.getByTestId("sync-cwd-workspace-receive-toggle") as HTMLInputElement).checked,
-      ).toBe(false);
+      ).toBe(true);
       expect((screen.getByTestId("sync-cwd-dock-send-toggle") as HTMLInputElement).checked).toBe(
         false,
       );
       expect((screen.getByTestId("sync-cwd-dock-receive-toggle") as HTMLInputElement).checked).toBe(
-        false,
+        true,
       );
     });
 
@@ -1686,7 +1686,7 @@ describe("SettingsView", () => {
       await user.click(screen.getByTestId("sync-cwd-dock-receive-toggle"));
 
       expect(useSettingsStore.getState().syncCwdDefaults.workspace.send).toBe(false);
-      expect(useSettingsStore.getState().syncCwdDefaults.dock.receive).toBe(false);
+      expect(useSettingsStore.getState().syncCwdDefaults.dock.receive).toBe(true);
     });
 
     it("saving default CWD propagation toggles updates store", async () => {
@@ -1700,11 +1700,11 @@ describe("SettingsView", () => {
 
       expect(useSettingsStore.getState().syncCwdDefaults.workspace).toEqual({
         send: true,
-        receive: false,
+        receive: true,
       });
       expect(useSettingsStore.getState().syncCwdDefaults.dock).toEqual({
         send: false,
-        receive: true,
+        receive: false,
       });
     });
   });

--- a/ui/src/components/views/ViewRenderer.test.tsx
+++ b/ui/src/components/views/ViewRenderer.test.tsx
@@ -169,8 +169,8 @@ describe("ViewRenderer", () => {
     expect(onSelectView).not.toHaveBeenCalled();
   });
 
-  it("FileExplorerView defaults cwdSend/cwdReceive from syncCwdDefaults (dock=off by default)", () => {
-    // 기본 syncCwdDefaults.dock = { send: false, receive: false } → 표시·적용 모두 off
+  it("FileExplorerView defaults cwdSend off / cwdReceive on from syncCwdDefaults", () => {
+    // 기본 syncCwdDefaults.dock = { send: false, receive: true } → send off, receive on
     render(
       <ViewRenderer
         viewType="FileExplorerView"
@@ -182,7 +182,7 @@ describe("ViewRenderer", () => {
     );
     const last = fileExplorerProps.at(-1);
     expect(last?.cwdSend).toBe(false);
-    expect(last?.cwdReceive).toBe(false);
+    expect(last?.cwdReceive).toBe(true);
   });
 
   it("FileExplorerView honors custom syncCwdDefaults.dock", () => {

--- a/ui/src/lib/sync-cwd-config.test.ts
+++ b/ui/src/lib/sync-cwd-config.test.ts
@@ -9,7 +9,7 @@ describe("resolveSyncCwd", () => {
       profileName: "WSL",
       location: "workspace",
     });
-    expect(result).toEqual({ send: false, receive: false });
+    expect(result).toEqual({ send: false, receive: true });
   });
 
   it("returns dock defaults when no profile override", () => {
@@ -17,7 +17,7 @@ describe("resolveSyncCwd", () => {
       profileName: "WSL",
       location: "dock",
     });
-    expect(result).toEqual({ send: false, receive: false });
+    expect(result).toEqual({ send: false, receive: true });
   });
 
   // --- Profile override ---
@@ -37,7 +37,7 @@ describe("resolveSyncCwd", () => {
       location: "dock",
       profileSyncCwd: "default",
     });
-    expect(result).toEqual({ send: false, receive: false });
+    expect(result).toEqual({ send: false, receive: true });
   });
 
   // --- profileDefaults override ---
@@ -57,7 +57,7 @@ describe("resolveSyncCwd", () => {
       location: "dock",
       profileDefaultsSyncCwd: "default",
     });
-    expect(result).toEqual({ send: false, receive: false });
+    expect(result).toEqual({ send: false, receive: true });
   });
 
   // --- Priority chain: profile > profileDefaults > syncCwdDefaults ---
@@ -118,7 +118,7 @@ describe("resolveSyncCwd", () => {
       profileName: "NonExistent",
       location: "workspace",
     });
-    expect(result).toEqual({ send: false, receive: false });
+    expect(result).toEqual({ send: false, receive: true });
   });
 
   it("returns location defaults when all overrides are undefined", () => {
@@ -126,7 +126,7 @@ describe("resolveSyncCwd", () => {
       profileName: "WSL",
       location: "dock",
     });
-    expect(result).toEqual({ send: false, receive: false });
+    expect(result).toEqual({ send: false, receive: true });
   });
 
   it("handles undefined profileSyncCwd (same as no override)", () => {
@@ -135,16 +135,16 @@ describe("resolveSyncCwd", () => {
       location: "workspace",
       profileSyncCwd: undefined,
     });
-    expect(result).toEqual({ send: false, receive: false });
+    expect(result).toEqual({ send: false, receive: true });
   });
 });
 
 describe("DEFAULT_SYNC_CWD_DEFAULTS", () => {
   it("has correct workspace defaults", () => {
-    expect(DEFAULT_SYNC_CWD_DEFAULTS.workspace).toEqual({ send: false, receive: false });
+    expect(DEFAULT_SYNC_CWD_DEFAULTS.workspace).toEqual({ send: false, receive: true });
   });
 
   it("has correct dock defaults", () => {
-    expect(DEFAULT_SYNC_CWD_DEFAULTS.dock).toEqual({ send: false, receive: false });
+    expect(DEFAULT_SYNC_CWD_DEFAULTS.dock).toEqual({ send: false, receive: true });
   });
 });

--- a/ui/src/lib/sync-cwd-config.ts
+++ b/ui/src/lib/sync-cwd-config.ts
@@ -28,8 +28,8 @@ export interface SyncCwdDefaults {
 export type TerminalLocation = "workspace" | "dock";
 
 export const DEFAULT_SYNC_CWD_DEFAULTS: SyncCwdDefaults = {
-  workspace: { send: false, receive: false },
-  dock: { send: false, receive: false },
+  workspace: { send: false, receive: true },
+  dock: { send: false, receive: true },
 };
 
 export interface ResolveSyncCwdParams {

--- a/ui/src/stores/settings-store.test.ts
+++ b/ui/src/stores/settings-store.test.ts
@@ -691,8 +691,8 @@ describe("settings-store", () => {
 
   it("has default syncCwdDefaults", () => {
     const { syncCwdDefaults } = useSettingsStore.getState();
-    expect(syncCwdDefaults.workspace).toEqual({ send: false, receive: false });
-    expect(syncCwdDefaults.dock).toEqual({ send: false, receive: false });
+    expect(syncCwdDefaults.workspace).toEqual({ send: false, receive: true });
+    expect(syncCwdDefaults.dock).toEqual({ send: false, receive: true });
   });
 
   it("loads syncCwdDefaults from settings", () => {
@@ -712,8 +712,8 @@ describe("settings-store", () => {
       defaultProfile: "WSL",
     });
     const { syncCwdDefaults } = useSettingsStore.getState();
-    expect(syncCwdDefaults.workspace).toEqual({ send: false, receive: false });
-    expect(syncCwdDefaults.dock).toEqual({ send: false, receive: false });
+    expect(syncCwdDefaults.workspace).toEqual({ send: false, receive: true });
+    expect(syncCwdDefaults.dock).toEqual({ send: false, receive: true });
   });
 
   it("setSyncCwdDefaults updates partial values", () => {
@@ -721,7 +721,7 @@ describe("settings-store", () => {
       dock: { send: true, receive: true },
     });
     const { syncCwdDefaults } = useSettingsStore.getState();
-    expect(syncCwdDefaults.workspace).toEqual({ send: false, receive: false }); // unchanged
+    expect(syncCwdDefaults.workspace).toEqual({ send: false, receive: true }); // unchanged
     expect(syncCwdDefaults.dock).toEqual({ send: true, receive: true }); // updated
   });
 
@@ -729,12 +729,12 @@ describe("settings-store", () => {
 
   it("resolveSyncCwdForProfile returns workspace defaults for unset profile", () => {
     const result = useSettingsStore.getState().resolveSyncCwdForProfile("WSL", "workspace");
-    expect(result).toEqual({ send: false, receive: false });
+    expect(result).toEqual({ send: false, receive: true });
   });
 
   it("resolveSyncCwdForProfile returns dock defaults for unset profile", () => {
     const result = useSettingsStore.getState().resolveSyncCwdForProfile("WSL", "dock");
-    expect(result).toEqual({ send: false, receive: false });
+    expect(result).toEqual({ send: false, receive: true });
   });
 
   it("resolveSyncCwdForProfile uses profile syncCwd override", () => {
@@ -758,7 +758,7 @@ describe("settings-store", () => {
       syncCwd: "default",
     });
     const result = useSettingsStore.getState().resolveSyncCwdForProfile("WSL", "dock");
-    expect(result).toEqual({ send: false, receive: false });
+    expect(result).toEqual({ send: false, receive: true });
   });
 
   it("loads profile syncCwd from settings", () => {


### PR DESCRIPTION
## 변경
`DEFAULT_SYNC_CWD_DEFAULTS`의 `receive`를 workspace/dock 모두 `false`→`true`로 변경.

별도 설정 없이도 새 페인이 그룹 CWD를 따라가도록(받기 활성) 한다. `send`는 기존대로 `false` 유지.

## 영향
- `ui/src/lib/sync-cwd-config.ts` — 기본값 1곳 수정
- 기본값 가정에 의존하던 테스트 5개 파일 기대값 갱신

## 테스트
전체 vitest 2245개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)