### PR TITLE
fix(file-link): WSL 심볼릭 링크 stat/열기 처리 (#363)

### DIFF
--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -64,8 +64,9 @@ pub fn read_file_for_viewer(
     path: String,
     max_bytes: Option<usize>,
 ) -> Result<FileViewerContent, String> {
-    // Resolve WSL/Windows paths with the shared inference rule (#282).
-    let resolved = path_utils::resolve_address_path(&path, None);
+    // Resolve WSL/Windows paths with the shared inference rule (#282), following
+    // WSL symlinks so a linked file actually opens (#363).
+    let resolved = path_utils::resolve_address_path_following_symlinks(&path, None);
     let file_path = std::path::Path::new(&resolved);
     let ext = file_path
         .extension()
@@ -148,7 +149,8 @@ pub struct PathInfo {
 /// without treating "not found" as a hard error.
 #[tauri::command]
 pub fn stat_path(path: String, wsl_distro: Option<String>) -> PathInfo {
-    let resolved = path_utils::resolve_address_path(&path, wsl_distro.as_deref());
+    let resolved =
+        path_utils::resolve_address_path_following_symlinks(&path, wsl_distro.as_deref());
     match std::fs::metadata(&resolved) {
         Ok(meta) => PathInfo {
             exists: true,
@@ -193,8 +195,10 @@ pub struct DirEntry {
 /// List directory contents and return structured metadata for each entry.
 #[tauri::command]
 pub fn list_directory(path: String, wsl_distro: Option<String>) -> Result<Vec<DirEntry>, String> {
-    // Resolve WSL/Windows paths with the shared inference rule (#282).
-    let resolved = path_utils::resolve_address_path(&path, wsl_distro.as_deref());
+    // Resolve WSL/Windows paths with the shared inference rule (#282), following
+    // WSL symlinks so a linked directory is browsable (#363).
+    let resolved =
+        path_utils::resolve_address_path_following_symlinks(&path, wsl_distro.as_deref());
     let dir_path = std::path::Path::new(&resolved);
     let entries = std::fs::read_dir(dir_path).map_err(|e| format!("Cannot read directory: {e}"))?;
 

--- a/src-tauri/src/path_utils.rs
+++ b/src-tauri/src/path_utils.rs
@@ -207,6 +207,79 @@ pub fn resolve_address_path(path: &str, wsl_distro: Option<&str>) -> String {
     resolve_path_for_windows(path, distro.as_deref())
 }
 
+/// Like [`resolve_address_path`], but transparently follows WSL (Linux) symlinks.
+///
+/// Windows cannot follow a WSL symlink over `\\wsl.localhost`: both
+/// `std::fs::metadata` and opening the link fail with "cannot find path" even
+/// though the link is valid (the reparse tag is `IO_REPARSE_TAG_LX_SYMLINK`,
+/// which Windows does not resolve). That breaks the terminal path-link feature
+/// (#363) for symlinks — `stat_path` reports the file as missing so the link
+/// never lights up, and `read_file_for_viewer` could not open it either.
+///
+/// Fix: after the usual resolution, if the result is a reparse point, ask WSL to
+/// canonicalize the original Linux path (`readlink -f`) and rebuild the path from
+/// the real target — a regular file Windows can stat and open. The reparse check
+/// is a cheap, spawn-free guard so normal files never pay for a `wsl.exe` call;
+/// non-WSL paths (Windows symlinks/junctions, which Windows follows natively)
+/// fall through unchanged.
+pub fn resolve_address_path_following_symlinks(path: &str, wsl_distro: Option<&str>) -> String {
+    let resolved = resolve_address_path(path, wsl_distro);
+    #[cfg(windows)]
+    {
+        if is_reparse_point(&resolved) {
+            if let Some(real) = wsl_follow_symlink(path, wsl_distro) {
+                return real;
+            }
+        }
+    }
+    resolved
+}
+
+/// True if `path` is a reparse point (symlink/junction). Uses `symlink_metadata`
+/// so it inspects the link itself rather than its (unfollowable) target.
+#[cfg(windows)]
+fn is_reparse_point(path: &str) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    std::fs::symlink_metadata(path)
+        .map(|m| m.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0)
+        .unwrap_or(false)
+}
+
+/// Resolve a WSL symlink to its real Windows-accessible path via `wsl.exe
+/// readlink -f`. Returns `None` for non-WSL paths (so Windows-native reparse
+/// points are left untouched) or when `wsl.exe` is unavailable.
+#[cfg(windows)]
+fn wsl_follow_symlink(path: &str, wsl_distro: Option<&str>) -> Option<String> {
+    let fwd = path.replace('\\', "/");
+    // `/mnt/...` is Windows-backed — let Windows handle it natively.
+    if fwd.starts_with("/mnt/") {
+        return None;
+    }
+    let (linux, distro) = if fwd.starts_with("//wsl.localhost/") || fwd.starts_with("//wsl$/") {
+        let d = extract_wsl_distro_from_path(&fwd).or_else(|| wsl_distro.map(str::to_string));
+        (normalize_wsl_path(&fwd), d)
+    } else if fwd.starts_with('/') {
+        let d = wsl_distro
+            .map(str::to_string)
+            .or_else(get_default_wsl_distro);
+        (fwd, d)
+    } else {
+        return None;
+    };
+
+    let mut cmd = crate::process::headless_command("wsl.exe");
+    if let Some(ref d) = distro {
+        cmd.args(["-d", d]);
+    }
+    let output = cmd.args(["--", "readlink", "-f", &linux]).output().ok()?;
+    let real = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if real.is_empty() {
+        return None;
+    }
+    Some(resolve_path_for_windows(&real, distro.as_deref()))
+}
+
 /// Extract WSL distro name from a raw path (before normalization).
 /// Handles `//wsl.localhost/<distro>/path` and `//wsl$/<distro>/path` formats.
 pub fn extract_wsl_distro_from_path(path: &str) -> Option<String> {


### PR DESCRIPTION
## 문제
터미널 경로 링크 기능(#363)에서 WSL 심볼릭 링크는 열리지 않음.

`\wsl.localhost` 경유 WSL 심볼릭 링크는 reparse 태그가 `IO_REPARSE_TAG_LX_SYMLINK` 이고 Windows가 이를 따라가지 못함. 실측(Ubuntu-22.04):
- `std::fs::metadata`(stat)·파일 open/read 모두 `"Could not find a part of the path"` 로 실패.
- → `stat_path` 가 `exists=false` 반환 → 링크 안 켜짐. `read_file_for_viewer` 도 열기 실패. **validity 게이트만으론 부족, 둘 다 깨짐.**

## 수정
`path_utils::resolve_address_path_following_symlinks` 추가:
1. 기존대로 경로 해석.
2. 결과가 reparse point 인지 값싼 검사(`symlink_metadata` 속성, 스폰 없음) — 일반 파일은 통과.
3. reparse + WSL 경로면 `wsl.exe -d <distro> readlink -f <linux_path>` 로 실제 대상 → UNC 재구성.
4. WSL 외 reparse(Windows 심볼릭/정션)는 그대로(Windows가 직접 따라감).

`stat_path` / `read_file_for_viewer` / `list_directory` 에 적용 — 파일·디렉토리 심볼릭 모두 처리.

## 검증 (실측, Ubuntu-22.04)
- 파일 심볼릭 → 실제 대상 읽힘.
- 디렉토리 심볼릭 → realdir 로 해석/리스팅.
- 깨진/없는 심볼릭 → `readlink -f` 가 없는 대상 반환 → Windows stat 실패 → `exists=false`(정상).
- `cargo check` 통과, `fmt`/`clippy` 신규 경고 없음, `path_utils`+`file_ops` lib 테스트 통과(19+7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)