### PR TITLE
fix(file-viewer): viewer 검은 화면 수정 — 이벤트 이름 안전 id (#342)

### DIFF
--- a/ui/src/components/layout/FileViewerOverlay.tsx
+++ b/ui/src/components/layout/FileViewerOverlay.tsx
@@ -4,7 +4,7 @@ import { useFileViewerStore } from "@/stores/file-viewer-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { FileViewer } from "@/components/ui/FileViewer";
 import { FocusInput } from "@/components/ui/FormControls";
-import { resolveViewer } from "@/lib/file-viewer";
+import { resolveViewer, viewerInstanceId } from "@/lib/file-viewer";
 
 /**
  * The single global floating file viewer (#277 / #279). It is rendered once at
@@ -209,7 +209,7 @@ export function FileViewerOverlay() {
               // The session-spawn effect keys off instanceId, so a fresh id tears
               // down the old PTY and runs the new startup command. Web viewers
               // ignore the id, so this is harmless for them.
-              viewerInstanceId={`global-file-viewer:${path}`}
+              viewerInstanceId={viewerInstanceId(path)}
               isFocused
               bodyStyle={bodyStyle}
             />

--- a/ui/src/lib/file-viewer.test.ts
+++ b/ui/src/lib/file-viewer.test.ts
@@ -5,6 +5,7 @@ import {
   fileExtension,
   resolveViewer,
   resolveViewerProfile,
+  viewerInstanceId,
 } from "./file-viewer";
 import type { ExtensionViewer } from "@/lib/tauri-api";
 
@@ -91,6 +92,38 @@ describe("resolveViewer", () => {
 
   it("returns web for files with no extension", () => {
     expect(resolveViewer("/usr/bin/ls", viewers)).toEqual({ viewerType: "web" });
+  });
+});
+
+describe("viewerInstanceId", () => {
+  // The id is the suffix of the Tauri output channel `terminal-output-<id>`,
+  // and Tauri v2 only allows [a-zA-Z0-9-/:_] in event names. Any other char
+  // (notably the `.` in a file extension) made `listen()` throw, so the viewer
+  // terminal received no PTY output and opened to a black screen.
+  const EVENT_NAME_SAFE = /^[a-zA-Z0-9/:_-]+$/;
+
+  it("strips the dot of a file extension so the event name is valid", () => {
+    const id = viewerInstanceId("/home/me/notes.txt");
+    expect(EVENT_NAME_SAFE.test(`terminal-output-${id}`)).toBe(true);
+    expect(id).toBe("global-file-viewer:/home/me/notes_txt");
+  });
+
+  it("replaces spaces and other disallowed characters", () => {
+    const id = viewerInstanceId("C:\\Users\\me\\my report (final).md");
+    expect(EVENT_NAME_SAFE.test(`terminal-output-${id}`)).toBe(true);
+  });
+
+  it("keeps slashes and colons (allowed by Tauri)", () => {
+    expect(viewerInstanceId("/a/b/c")).toBe("global-file-viewer:/a/b/c");
+  });
+
+  it("produces valid event names for unicode paths", () => {
+    const id = viewerInstanceId("/home/사용자/메모.txt");
+    expect(EVENT_NAME_SAFE.test(`terminal-output-${id}`)).toBe(true);
+  });
+
+  it("stays distinct for paths that differ before sanitization", () => {
+    expect(viewerInstanceId("/a/x.txt")).not.toBe(viewerInstanceId("/a/y.txt"));
   });
 });
 

--- a/ui/src/lib/file-viewer.test.ts
+++ b/ui/src/lib/file-viewer.test.ts
@@ -105,7 +105,7 @@ describe("viewerInstanceId", () => {
   it("strips the dot of a file extension so the event name is valid", () => {
     const id = viewerInstanceId("/home/me/notes.txt");
     expect(EVENT_NAME_SAFE.test(`terminal-output-${id}`)).toBe(true);
-    expect(id).toBe("global-file-viewer:/home/me/notes_txt");
+    expect(id).toMatch(/^global-file-viewer:\/home\/me\/notes_txt:[0-9a-f]+$/);
   });
 
   it("replaces spaces and other disallowed characters", () => {
@@ -114,7 +114,7 @@ describe("viewerInstanceId", () => {
   });
 
   it("keeps slashes and colons (allowed by Tauri)", () => {
-    expect(viewerInstanceId("/a/b/c")).toBe("global-file-viewer:/a/b/c");
+    expect(viewerInstanceId("/a/b/c")).toMatch(/^global-file-viewer:\/a\/b\/c:[0-9a-f]+$/);
   });
 
   it("produces valid event names for unicode paths", () => {
@@ -124,6 +124,17 @@ describe("viewerInstanceId", () => {
 
   it("stays distinct for paths that differ before sanitization", () => {
     expect(viewerInstanceId("/a/x.txt")).not.toBe(viewerInstanceId("/a/y.txt"));
+  });
+
+  it("stays distinct when two paths sanitize to the same string", () => {
+    // `notes.txt` and `notes_txt` both sanitize to `notes_txt`; the appended
+    // hash of the original path must keep their ids distinct so a path change
+    // still tears down the previous viewer PTY.
+    expect(viewerInstanceId("/a/notes.txt")).not.toBe(viewerInstanceId("/a/notes_txt"));
+  });
+
+  it("is deterministic for the same path", () => {
+    expect(viewerInstanceId("/a/notes.txt")).toBe(viewerInstanceId("/a/notes.txt"));
   });
 });
 

--- a/ui/src/lib/file-viewer.ts
+++ b/ui/src/lib/file-viewer.ts
@@ -35,6 +35,23 @@ export function isOpenablePath(path: string): boolean {
   return normalizeViewerPath(path).length > 0;
 }
 
+/**
+ * Build the terminal instance id for the global file viewer.
+ *
+ * The id doubles as the suffix of the backend↔frontend output channel
+ * (`terminal-output-<id>`), and Tauri v2 only permits `[a-zA-Z0-9-/:_]` in
+ * event names. A raw file path almost always contains a `.` (the extension) —
+ * and may contain spaces or unicode — which makes the derived event name
+ * invalid, so `listen()` throws and the viewer terminal never receives any PTY
+ * output (the "opens to a black screen with a blinking cursor" bug: every
+ * extension-mapped viewer like `.txt → vi` was affected). Replacing every
+ * disallowed character keeps the id valid while staying unique-enough per path
+ * to still force a fresh TerminalView/PTY when the open path changes.
+ */
+export function viewerInstanceId(path: string): string {
+  return `global-file-viewer:${path.replace(/[^a-zA-Z0-9/:_-]/g, "_")}`;
+}
+
 /** Extract the lowercased extension (with leading dot) from a path, or "". */
 export function fileExtension(path: string): string {
   // Use the last path segment so directory dots don't count.

--- a/ui/src/lib/file-viewer.ts
+++ b/ui/src/lib/file-viewer.ts
@@ -45,11 +45,22 @@ export function isOpenablePath(path: string): boolean {
  * invalid, so `listen()` throws and the viewer terminal never receives any PTY
  * output (the "opens to a black screen with a blinking cursor" bug: every
  * extension-mapped viewer like `.txt → vi` was affected). Replacing every
- * disallowed character keeps the id valid while staying unique-enough per path
- * to still force a fresh TerminalView/PTY when the open path changes.
+ * disallowed character keeps the id valid, and a short hash of the ORIGINAL
+ * path is appended so two paths that sanitize to the same string (e.g.
+ * `a/notes.txt` vs `a/notes_txt`) still get distinct ids — otherwise a path
+ * change wouldn't tear down the previous viewer's PTY. The hash is hex, so it
+ * stays within the allowed event-name character set.
  */
 export function viewerInstanceId(path: string): string {
-  return `global-file-viewer:${path.replace(/[^a-zA-Z0-9/:_-]/g, "_")}`;
+  const safe = path.replace(/[^a-zA-Z0-9/:_-]/g, "_");
+  // FNV-1a 32-bit — deterministic, dependency-free, collision-resistant enough
+  // to disambiguate the rare sanitization clash above.
+  let h = 0x811c9dc5;
+  for (let i = 0; i < path.length; i++) {
+    h ^= path.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return `global-file-viewer:${safe}:${(h >>> 0).toString(16)}`;
 }
 
 /** Extract the lowercased extension (with leading dot) from a path, or "". */


### PR DESCRIPTION
## 문제
확장자별 viewer(`.txt → vi` 등)로 파일을 열면 **검은 화면에 커서만 깜빡**이고 내용이 안 보임 (#342).

## 원인
viewer 터미널 `instanceId` 에 파일 경로를 그대로 사용 → `global-file-viewer:/home/me/notes.txt`.
이 id 가 출력 이벤트 이름 `terminal-output-<id>` 접미사로 쓰이는데, Tauri v2 이벤트 이름은 `[a-zA-Z0-9-/:_]` 만 허용.
확장자의 `.` 때문에 프론트 `listen()` 이 throw → 출력 구독 미등록 → xterm 이 PTY 출력을 전혀 수신 못 함.

vi 는 정상 실행돼 백엔드 버퍼엔 화면을 다 그렸지만 프론트로 전달이 안 됐을 뿐. 확장자 있는 파일 = 사실상 모든 extension viewer 대상이라 vi/less/mpv 전부 항상 깨져 있었다. (#342 의 hydration 수정은 별개 문제였고 이 버그는 잔존했음.)

## 수정
- `viewerInstanceId(path)` 헬퍼 추가 — 허용 외 문자(`.`·공백·유니코드) `[^a-zA-Z0-9/:_-]` → `_`. 슬래시·콜론은 허용되므로 보존.
- `FileViewerOverlay` 가 헬퍼 사용.
- 회귀 테스트 5개.

## 검증
dev(19281)에서 `.txt→vi` 매핑으로 실제 오픈 → xterm 버퍼·스크린샷에 파일 내용 + vi 상태줄 정상 표시 확인.
테스트 25개 통과, tsc·eslint clean.

Fixes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)