### PR TITLE
[codex] Stabilize workspace selector layout

### DIFF
--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -127,6 +127,19 @@ describe("WorkspaceSelectorView", () => {
     expect(screen.getByTestId("workspace-item-ws-default")).toBeInTheDocument();
   });
 
+  it("keeps long workspace lists scrollable without flex-shrinking items (#374)", () => {
+    for (let i = 0; i < 20; i += 1) {
+      useWorkspaceStore.getState().addWorkspace(`Workspace ${i + 2}`, "default-layout");
+    }
+
+    render(<WorkspaceSelectorView />);
+
+    expect(screen.getByTestId("workspace-list")).toHaveClass("min-h-0", "overflow-y-auto");
+    for (const item of screen.getAllByTestId(/^workspace-item-/)) {
+      expect(item).toHaveClass("shrink-0");
+    }
+  });
+
   it("shows new workspace panel with layout cards", () => {
     render(<WorkspaceSelectorView />);
     expect(screen.getByTestId("new-workspace-panel")).toBeInTheDocument();
@@ -195,6 +208,55 @@ describe("WorkspaceSelectorView", () => {
     await waitFor(() => {
       expect(screen.getByTestId("unread-badge-ws-default")).toBeInTheDocument();
       expect(screen.getByTestId("unread-badge-ws-default")).toHaveTextContent("1");
+    });
+  });
+
+  it("keeps unread badge height independent from UI font metrics (#373)", async () => {
+    useWorkspaceStore.setState({
+      workspaces: [
+        {
+          id: "ws-default",
+          name: "Default",
+          panes: [
+            {
+              id: "p1",
+              x: 0,
+              y: 0,
+              w: 1,
+              h: 1,
+              view: { type: "TerminalView", profile: "PowerShell" },
+            },
+          ],
+        },
+      ],
+      activeWorkspaceId: "ws-default",
+    });
+    useTerminalStore.getState().registerInstance({
+      id: "terminal-p1",
+      profile: "PowerShell",
+      syncGroup: "Default",
+      workspaceId: "ws-default",
+    });
+    useNotificationStore.setState({
+      notifications: Array.from({ length: 128 }, (_, i) => ({
+        id: `n-${i}`,
+        terminalId: "terminal-p1",
+        workspaceId: "ws-default",
+        message: `msg ${i}`,
+        level: "info" as const,
+        createdAt: i,
+        readAt: null,
+      })),
+    });
+
+    render(<WorkspaceSelectorView />);
+
+    await waitFor(() => {
+      const badge = screen.getByTestId("unread-badge-ws-default");
+      expect(badge).toHaveClass("workspace-count-badge");
+      expect(badge).toHaveTextContent("128");
+      expect(badge.style.fontSize).toBe("8.5px");
+      expect(badge.closest(".workspace-count-badge-frame")).not.toBeNull();
     });
   });
 

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -85,9 +85,10 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
-// 배지 폭은 고정(14px)이므로 자릿수가 늘수록 폰트를 줄여 한 줄에 맞춘다.
-// 인덱스 = 표시 문자열 길이(1~4+), 값 = 해당 길이에서 14px 폭에 들어가는 최대 폰트.
-// 폭 고정 계약의 일부라 값 변경 시 회귀 테스트도 함께 갱신해야 한다.
+// 배지는 최소 폭 14px(1~2자리는 정사각형 유지)이고, 세 자리 이상이면 콘텐츠 폭만큼 가로로 늘어난다.
+// 폭이 과도하게 커지지 않도록 표시 문자열이 길수록 폰트를 줄인다(높이는 14px 고정 유지).
+// 인덱스 = 표시 문자열 길이(1~4+), 값 = 해당 길이용 폰트 크기.
+// fontSize 값은 회귀 테스트(WorkspaceSelectorView.test.tsx)가 검증하므로 값 변경 시 함께 갱신한다.
 const COUNT_BADGE_FONT_SIZE_BY_LENGTH = ["10px", "10px", "9.5px", "8.5px", "7.5px"] as const;
 
 function getCountBadgeFontSize(countText: string): string {

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -85,11 +85,14 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
+// 배지 폭은 고정(14px)이므로 자릿수가 늘수록 폰트를 줄여 한 줄에 맞춘다.
+// 인덱스 = 표시 문자열 길이(1~4+), 값 = 해당 길이에서 14px 폭에 들어가는 최대 폰트.
+// 폭 고정 계약의 일부라 값 변경 시 회귀 테스트도 함께 갱신해야 한다.
+const COUNT_BADGE_FONT_SIZE_BY_LENGTH = ["10px", "10px", "9.5px", "8.5px", "7.5px"] as const;
+
 function getCountBadgeFontSize(countText: string): string {
-  if (countText.length >= 4) return "7.5px";
-  if (countText.length === 3) return "8.5px";
-  if (countText.length === 2) return "9.5px";
-  return "10px";
+  const idx = Math.min(countText.length, COUNT_BADGE_FONT_SIZE_BY_LENGTH.length - 1);
+  return COUNT_BADGE_FONT_SIZE_BY_LENGTH[idx];
 }
 
 function CountBadge({ count, testId }: { count: number; testId?: string }) {

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -85,20 +85,24 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
+function getCountBadgeFontSize(countText: string): string {
+  if (countText.length >= 4) return "7.5px";
+  if (countText.length === 3) return "8.5px";
+  if (countText.length === 2) return "9.5px";
+  return "10px";
+}
+
 function CountBadge({ count, testId }: { count: number; testId?: string }) {
+  const countText = count > 999 ? "999+" : String(count);
   return (
     <span
       data-testid={testId}
-      className="inline-flex shrink-0 items-center justify-center rounded text-[12px] font-semibold"
+      className="workspace-count-badge"
       style={{
-        background: "var(--accent)",
-        color: "var(--bg-base)",
-        width: 14,
-        height: 14,
-        lineHeight: 1,
+        fontSize: getCountBadgeFontSize(countText),
       }}
     >
-      {count}
+      {countText}
     </span>
   );
 }
@@ -225,7 +229,7 @@ function WorkspaceItem({
       onDragLeave={(e) => drag.onDragLeave(e)}
       onDrop={(e) => drag.onDrop(e, ws.id)}
       onDragEnd={drag.onDragEnd}
-      className={`workspace-item-animated relative cursor-pointer${
+      className={`workspace-item-animated relative shrink-0 cursor-pointer${
         isCollapsed ? " workspace-item-collapsed" : ""
       }`}
       style={{
@@ -316,7 +320,7 @@ function WorkspaceItem({
             className="flex items-center gap-1"
             style={{ opacity: hideMode && isWsHidden ? 0.35 : undefined }}
           >
-            <ExitFade show={summary.unreadCount > 0}>
+            <ExitFade show={summary.unreadCount > 0} className="workspace-count-badge-frame">
               <CountBadge count={summary.unreadCount} testId={`unread-badge-${ws.id}`} />
             </ExitFade>
             {hovered && (
@@ -1319,7 +1323,7 @@ export function WorkspaceSelectorView() {
       </div>
 
       {/* Workspace list */}
-      <div className="flex flex-1 flex-col overflow-y-auto">
+      <div data-testid="workspace-list" className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         {sortedWorkspaces.map((ws, idx) => {
           const isWsHidden = hiddenWorkspaceIds.has(ws.id);
           const isActive = ws.id === activeWorkspaceId;
@@ -1446,7 +1450,7 @@ export function WorkspaceSelectorView() {
         style={{ borderTop: "1px solid var(--border)", borderBottom: "1px solid var(--border)" }}
       >
         <SectionLabel>{showNotifPanel ? t("hideNotifications") : t("notifications")}</SectionLabel>
-        <ExitFade show={totalUnread > 0}>
+        <ExitFade show={totalUnread > 0} className="workspace-count-badge-frame">
           <CountBadge count={totalUnread} />
         </ExitFade>
       </div>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -60,6 +60,8 @@
   --transition-fast: 0.1s;
   --transition-list-collapse: 0.18s;
   --pane-row-max-h: 28px;
+  --workspace-count-badge-size: 14px;
+  --workspace-count-badge-px: 3px;
   --terminal-composition-underline-color: currentColor;
 }
 
@@ -165,6 +167,7 @@
 
   .workspace-item-animated {
     display: grid;
+    flex: 0 0 auto;
     grid-template-rows: 1fr;
     overflow: hidden;
     opacity: 1;
@@ -184,6 +187,34 @@
     opacity: 0;
     pointer-events: none;
     transform: translateY(-4px);
+  }
+
+  .workspace-count-badge-frame {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--workspace-count-badge-size);
+    height: var(--workspace-count-badge-size);
+    line-height: 0;
+  }
+
+  .workspace-count-badge {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    min-width: var(--workspace-count-badge-size);
+    height: var(--workspace-count-badge-size);
+    padding: 0 var(--workspace-count-badge-px);
+    border-radius: var(--radius-sm);
+    background: var(--accent);
+    color: var(--bg-base);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+    white-space: nowrap;
   }
 
   .workspace-pane-row {


### PR DESCRIPTION
﻿## Summary

Fixes workspace selector layout instability for long workspace lists and unread count badges.

Closes #373.
Closes #374.

## Changes

- Prevent workspace list items from flex-shrinking when the list exceeds the dock height, so the list scrolls vertically instead of compressing item height.
- Move unread count badge sizing into CSS classes with fixed frame dimensions and tabular numeric text.
- Clamp large badge counts to `999+` and reduce font size by digit count so UI font changes do not alter the badge height.
- Add regression coverage for long-list scrolling and unread badge sizing contracts.

## Validation

- `npm test -- WorkspaceSelectorView.test.tsx` passed: 99 tests.
- `npm run build` passed.
- Full `npm test` currently has an unrelated existing failure in `FileViewerOverlay.test.tsx`: expected `/home/user/a.txt`, received sanitized `global-file-viewer:/home/user/a_txt:...`.
- Verified visually through laymux dev on port 19281 using `/api/v1/screenshot` with 24 workspaces and a `128` unread badge. Dev was stopped via `scripts/kill-dev.sh` only.
