### PR TITLE
워크스페이스 내 pane 드래그앤드롭 위치 교환

### DIFF
--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -37,6 +37,13 @@
 | 경계선 더블클릭                   | 작은 쪽 Pane 제거, 큰 쪽이 흡수 |
 | 편집 모드에서 Pane 선택 후 Delete | 인접 Pane 중 가장 큰 것이 흡수  |
 
+### 위치 교환 (드래그&드롭, issue #377)
+
+- 각 Pane 컨트롤바 우측 상단의 **드래그 핸들(grip)** 을 다른 Pane 위로 드래그&드롭하면 두 Pane의 `{ x, y, w, h }` 가 교환된다(view/콘텐츠는 그대로, 슬롯 위치만 swap).
+- 네이티브 HTML5 DnD(`draggable` + `dataTransfer`)를 사용 — WorkspaceSelectorView 의 워크스페이스 재정렬과 동일 패턴. 별도 DnD 라이브러리 없음.
+- UI(`PaneGrid`)는 `onSwapPanes(srcPaneId, tgtPaneId)` 콜백만 노출하고, 실제 교환은 기존 `workspace-store.swapPanes(srcIndex, tgtIndex)`(MCP `swap_panes` 와 공유) 한 곳에서 수행한다. `WorkspaceArea` 가 paneId→paneIndex 로 변환해 연결.
+- 핸들은 활성 워크스페이스에서 hover 시에만 나타나며, dock(PaneGrid 재사용)은 `onSwapPanes` 미제공으로 비활성. 같은 Pane 위로 드롭하면 무시.
+
 ---
 
 ## 8. TerminalView

--- a/ui/src/components/layout/PaneGrid.test.tsx
+++ b/ui/src/components/layout/PaneGrid.test.tsx
@@ -134,6 +134,77 @@ describe("PaneGrid", () => {
     });
   });
 
+  // -- Drag-and-drop pane swap (issue #377) --
+  //
+  // 워크스페이스 그리드 안에서 pane을 드래그해 다른 pane 위로 드롭하면 두 pane의
+  // 위치가 교환된다. PaneGrid는 onSwapPanes(srcPaneId, tgtPaneId) 콜백만 노출하고
+  // 실제 위치 교환은 workspace-store.swapPanes(기존 로직)가 담당한다.
+  describe("drag-to-swap (issue #377)", () => {
+    const dndProps = {
+      ...defaultProps,
+      panes: makePanes(3),
+      testIdFn: (_p: GridPane, i: number) => `test-pane-${i}`,
+    };
+
+    // dataTransfer is not implemented in jsdom; provide a minimal stub factory.
+    const makeDataTransfer = () => ({
+      data: {} as Record<string, string>,
+      setData(type: string, val: string) {
+        this.data[type] = val;
+      },
+      getData(type: string) {
+        return this.data[type] ?? "";
+      },
+      effectAllowed: "",
+      dropEffect: "",
+    });
+
+    it("renders a drag handle for each pane only when onSwapPanes is provided", () => {
+      const { unmount } = render(<PaneGrid {...dndProps} />);
+      expect(screen.queryByTestId("pane-drag-handle-0")).not.toBeInTheDocument();
+      unmount();
+
+      render(<PaneGrid {...dndProps} onSwapPanes={vi.fn()} />);
+      expect(screen.getByTestId("pane-drag-handle-0")).toBeInTheDocument();
+      expect(screen.getByTestId("pane-drag-handle-2")).toBeInTheDocument();
+    });
+
+    it("calls onSwapPanes with source and target pane ids on drop", () => {
+      const onSwapPanes = vi.fn();
+      render(<PaneGrid {...dndProps} onSwapPanes={onSwapPanes} />);
+
+      const handle0 = screen.getByTestId("pane-drag-handle-0");
+      const target2 = screen.getByTestId("test-pane-2");
+      const dataTransfer = makeDataTransfer();
+
+      fireEvent.dragStart(handle0, { dataTransfer });
+      fireEvent.dragOver(target2, { dataTransfer });
+      fireEvent.drop(target2, { dataTransfer });
+
+      expect(onSwapPanes).toHaveBeenCalledWith("pane-0", "pane-2");
+    });
+
+    it("does not call onSwapPanes when dropping a pane onto itself", () => {
+      const onSwapPanes = vi.fn();
+      render(<PaneGrid {...dndProps} onSwapPanes={onSwapPanes} />);
+
+      const handle1 = screen.getByTestId("pane-drag-handle-1");
+      const target1 = screen.getByTestId("test-pane-1");
+      const dataTransfer = makeDataTransfer();
+
+      fireEvent.dragStart(handle1, { dataTransfer });
+      fireEvent.dragOver(target1, { dataTransfer });
+      fireEvent.drop(target1, { dataTransfer });
+
+      expect(onSwapPanes).not.toHaveBeenCalled();
+    });
+
+    it("does not render drag handles when isActive is false", () => {
+      render(<PaneGrid {...dndProps} onSwapPanes={vi.fn()} isActive={false} />);
+      expect(screen.queryByTestId("pane-drag-handle-0")).not.toBeInTheDocument();
+    });
+  });
+
   it("calls onSplitPane via PaneControlBar split button", () => {
     const onSplitPane = vi.fn();
     render(<PaneGrid {...defaultProps} onSplitPane={onSplitPane} />);

--- a/ui/src/components/layout/PaneGrid.tsx
+++ b/ui/src/components/layout/PaneGrid.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import type { ViewInstanceConfig } from "@/stores/types";
 import type { TerminalLocation } from "@/stores/settings-store";
 import { ViewRenderer } from "@/components/views/ViewRenderer";
@@ -10,6 +10,9 @@ import { useHoverTimer } from "@/hooks/useHoverTimer";
 import { useSettingsStore } from "@/stores/settings-store";
 import { computePaneNumbers } from "@/lib/pane-numbers";
 import { propagateCwdOnceForPane } from "@/lib/propagate-cwd-once";
+
+/** dataTransfer MIME for pane drag-to-swap (issue #377). */
+const PANE_DND_MIME = "application/x-laymux-pane";
 
 export interface GridPane {
   id: string;
@@ -38,6 +41,13 @@ export interface PaneGridProps {
   onSetPaneView?: (paneId: string, config: ViewInstanceConfig) => void;
   onSplitPane?: (paneId: string, dir: "horizontal" | "vertical") => void;
   onRemovePane?: (paneId: string) => void;
+  /**
+   * 그리드 안에서 pane 위치를 드래그&드롭으로 교환한다 (issue #377).
+   * 제공되면 각 pane 컨트롤바에 드래그 핸들이 나타나고, 다른 pane 위로 드롭하면
+   * srcPaneId·tgtPaneId 로 호출된다. 실제 위치 교환은 workspace-store.swapPanes 가 담당.
+   * 미제공이면(예: dock) 드래그 핸들/드롭 타겟이 비활성화된다.
+   */
+  onSwapPanes?: (srcPaneId: string, tgtPaneId: string) => void;
 
   // CWD toggle defaults
   getCwdDefaults?: (view: ViewInstanceConfig) => CwdDefaults;
@@ -83,6 +93,7 @@ export function PaneGrid({
   onSetPaneView,
   onSplitPane,
   onRemovePane,
+  onSwapPanes,
   getCwdDefaults,
   workspaceId,
   workspaceName,
@@ -102,6 +113,38 @@ export function PaneGrid({
   const hover = useHoverTimer(hoverIdleSeconds);
   // Spatial reading-order pane numbers (issue #256). Derived from geometry, never cached.
   const paneNumbers = showPaneNumbers ? computePaneNumbers(panes) : null;
+
+  // Drag-to-swap (issue #377). Native HTML5 DnD, same pattern as workspace reorder
+  // in WorkspaceSelectorView. dragSrcId 는 현재 드래그 중인 pane, dragOverId 는
+  // 드롭 타겟 하이라이트용. dataTransfer 에도 id 를 실어 jsdom/실제 양쪽에서 동작.
+  const dndEnabled = isActive && !!onSwapPanes;
+  const dragSrcRef = useRef<string | null>(null);
+  const [dragOverId, setDragOverId] = useState<string | null>(null);
+
+  const handleDragStart = (e: React.DragEvent, paneId: string) => {
+    dragSrcRef.current = paneId;
+    e.dataTransfer.setData(PANE_DND_MIME, paneId);
+    e.dataTransfer.effectAllowed = "move";
+  };
+  const handleDragOver = (e: React.DragEvent, paneId: string) => {
+    if (!dndEnabled || !dragSrcRef.current) return;
+    // preventDefault 를 호출해야 drop 이 허용된다(HTML5 DnD 규약).
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    if (dragSrcRef.current !== paneId) setDragOverId(paneId);
+  };
+  const handleDrop = (e: React.DragEvent, paneId: string) => {
+    if (!dndEnabled) return;
+    e.preventDefault();
+    const srcId = dragSrcRef.current ?? (e.dataTransfer.getData(PANE_DND_MIME) || null);
+    dragSrcRef.current = null;
+    setDragOverId(null);
+    if (srcId && srcId !== paneId) onSwapPanes?.(srcId, paneId);
+  };
+  const handleDragEnd = () => {
+    dragSrcRef.current = null;
+    setDragOverId(null);
+  };
 
   return (
     <div
@@ -142,6 +185,8 @@ export function PaneGrid({
             onMouseEnter={() => isActive && hover.activate(pane.id)}
             onMouseMove={() => isActive && hover.activate(pane.id)}
             onMouseLeave={hover.clear}
+            onDragOver={dndEnabled ? (e) => handleDragOver(e, pane.id) : undefined}
+            onDrop={dndEnabled ? (e) => handleDrop(e, pane.id) : undefined}
             style={{
               left: `${pane.x * 100}%`,
               top: `${pane.y * 100}%`,
@@ -153,6 +198,49 @@ export function PaneGrid({
             }}
           >
             {focused && <FocusIndicator testId="pane-focus-indicator" />}
+            {dndEnabled && (
+              <div
+                data-testid={`pane-drag-handle-${i}`}
+                draggable
+                onDragStart={(e) => handleDragStart(e, pane.id)}
+                onDragEnd={handleDragEnd}
+                // 핸들 자체에 mousedown 이 pane 의 focus 로 버블링되지 않도록 막는다.
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+                title="Drag to swap pane position"
+                aria-label="Drag to swap pane position"
+                className={`absolute right-1 top-1 z-30 flex cursor-grab items-center justify-center rounded transition-opacity ${
+                  isActive && isHovered ? "opacity-90" : "opacity-0"
+                }`}
+                style={{
+                  width: "var(--btn-min-w)",
+                  height: "var(--btn-h)",
+                  background: "var(--bg-surface)",
+                  color: "var(--text-secondary)",
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--radius-sm)",
+                }}
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
+                  <circle cx="4" cy="2.5" r="1" />
+                  <circle cx="8" cy="2.5" r="1" />
+                  <circle cx="4" cy="6" r="1" />
+                  <circle cx="8" cy="6" r="1" />
+                  <circle cx="4" cy="9.5" r="1" />
+                  <circle cx="8" cy="9.5" r="1" />
+                </svg>
+              </div>
+            )}
+            {dndEnabled && dragOverId === pane.id && (
+              <div
+                data-testid={`pane-drop-target-${i}`}
+                className="pointer-events-none absolute inset-0 z-20"
+                style={{
+                  border: "2px solid var(--accent)",
+                  background: "var(--accent-20)",
+                }}
+              />
+            )}
             <PaneControlBar
               paneId={pane.id}
               currentView={pane.view}

--- a/ui/src/components/layout/WorkspaceArea.tsx
+++ b/ui/src/components/layout/WorkspaceArea.tsx
@@ -21,6 +21,7 @@ export function WorkspaceArea() {
   const setPaneView = useWorkspaceStore((s) => s.setPaneView);
   const splitPane = useWorkspaceStore((s) => s.splitPane);
   const removePane = useWorkspaceStore((s) => s.removePane);
+  const swapPanes = useWorkspaceStore((s) => s.swapPanes);
   const location: TerminalLocation = "workspace";
   const resolveCwdDefaults = useCwdDefaultsResolver(location);
 
@@ -68,6 +69,11 @@ export function WorkspaceArea() {
             }
             onSplitPane={isActive ? (paneId, dir) => splitPane(idxOf(paneId), dir) : undefined}
             onRemovePane={isActive ? (paneId) => removePane(idxOf(paneId)) : undefined}
+            onSwapPanes={
+              isActive
+                ? (srcPaneId, tgtPaneId) => swapPanes(idxOf(srcPaneId), idxOf(tgtPaneId))
+                : undefined
+            }
             getCwdDefaults={resolveCwdDefaults}
             isHoveredOverride={
               isActive && automationHoverIndex !== null


### PR DESCRIPTION
Fixes #377

## 기능
워크스페이스 그리드 안에서 pane 을 드래그해 다른 pane 위치로 드롭하면 두 pane 위치가 교환된다.

## 구현
- **재사용**: `workspace-store.swapPanes(srcIndex, tgtIndex)` — 기존 위치 교환 액션(MCP `swap_panes` 툴과 공유). 새 swap 로직 추가 없이 연결만.
- **재사용 패턴**: WorkspaceSelectorView 재정렬에 쓰인 네이티브 HTML5 DnD(`draggable` + `dataTransfer`). 별도 DnD 라이브러리 도입 없음.
- **신규**: `PaneGrid` 에 `onSwapPanes(srcPaneId, tgtPaneId)` prop, hover 시 드래그 핸들(우상단 grip), 드롭 타겟 하이라이트. `WorkspaceArea` 가 paneId→index 변환 후 `swapPanes` 호출.

## 변경 파일
- `ui/src/components/layout/PaneGrid.tsx` (드래그/드롭)
- `ui/src/components/layout/PaneGrid.test.tsx` (TDD 4개)
- `ui/src/components/layout/WorkspaceArea.tsx` (콜백 연결)
- `docs/architecture/data-flow.md` §5 (living doc)

## 테스트
- PaneGrid: 22개 통과 (신규 4 포함)
- layout 전체: 190 중 189 통과 (유일 실패 `FileViewerOverlay.test.tsx` 는 사전 존재, 본 변경 무관 — stash 재실행 확인)
- tsc/eslint/prettier clean, husky 통과

## 한계 (후속 과제)
- **터치 미지원**: 네이티브 HTML5 DnD = 데스크톱 마우스 기반. laymux 데스크톱 IDE라 무방하나 터치/펜 동작 안 함.
- **키보드 swap 없음**: 드래그 전용. 핸들에 aria-label 있으나 키보드 경로는 미구현 — 필요 시 키바인딩 레지스트리에 액션 추가.
- **dock 미적용**: dock 의 PaneGrid 에는 `onSwapPanes` 미전달 (워크스페이스 그리드 한정, 이슈 의도 일치).

🤖 Generated with [Claude Code](https://claude.com/claude-code)