### PR TITLE
feat: pane을 워크스페이스로 드래그하면 해당 워크스페이스로 이동 (#380)

### DIFF
--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -43,6 +43,14 @@
 - 네이티브 HTML5 DnD(`draggable` + `dataTransfer`)를 사용 — WorkspaceSelectorView 의 워크스페이스 재정렬과 동일 패턴. 별도 DnD 라이브러리 없음.
 - UI(`PaneGrid`)는 `onSwapPanes(srcPaneId, tgtPaneId)` 콜백만 노출하고, 실제 교환은 기존 `workspace-store.swapPanes(srcIndex, tgtIndex)`(MCP `swap_panes` 와 공유) 한 곳에서 수행한다. `WorkspaceArea` 가 paneId→paneIndex 로 변환해 연결.
 - 핸들은 활성 워크스페이스에서 hover 시에만 나타나며, dock(PaneGrid 재사용)은 `onSwapPanes` 미제공으로 비활성. 같은 Pane 위로 드롭하면 무시.
+- 드래그 페이로드는 `lib/pane-dnd.ts`(MIME `application/x-laymux-pane`, paneId 만 적재)로 공유한다 — 같은 드래그 소스가 swap·move 두 drop 타겟을 모두 먹인다.
+
+### 다른 워크스페이스로 이동 (드래그&드롭, issue #380)
+
+- 같은 드래그 핸들을 **WorkspaceSelectorView 의 워크스페이스 항목** 위로 드롭하면, 그 Pane 이 원래 워크스페이스에서 제거되고 대상 워크스페이스로 이동(추가)된다.
+- 소스 제거는 `removePane` 과 동일한 `removePaneAndRedistribute`(인접 Pane 이 공간 흡수). 대상 추가는 대상의 **가장 큰 Pane 을 반으로 분할**(긴 축 기준)해 그 자리에 옮겨온 Pane 을 둔다 — Pane id 와 view 설정은 보존.
+- 실제 이동은 `workspace-store.movePaneToWorkspace(paneId, targetWorkspaceId)` 한 곳에서 수행한다. 소스가 Pane 1개뿐이면(워크스페이스가 비게 됨) 무시하고, 같은 워크스페이스·미존재 paneId/대상도 무시.
+- 워크스페이스 항목은 재정렬(reorder, `text/plain`)과 이동(move, `application/x-laymux-pane`) drop 을 같은 핸들러에서 MIME(`isPaneDrag`)으로 분기한다. 이동 drop 은 sort 모드와 무관하게 항상 동작하며, 끌어온 워크스페이스는 액센트 링으로 하이라이트된다.
 
 ---
 

--- a/ui/src/components/layout/PaneGrid.tsx
+++ b/ui/src/components/layout/PaneGrid.tsx
@@ -10,9 +10,7 @@ import { useHoverTimer } from "@/hooks/useHoverTimer";
 import { useSettingsStore } from "@/stores/settings-store";
 import { computePaneNumbers } from "@/lib/pane-numbers";
 import { propagateCwdOnceForPane } from "@/lib/propagate-cwd-once";
-
-/** dataTransfer MIME for pane drag-to-swap (issue #377). */
-const PANE_DND_MIME = "application/x-laymux-pane";
+import { PANE_DND_MIME, setPaneDragData } from "@/lib/pane-dnd";
 
 export interface GridPane {
   id: string;
@@ -123,8 +121,7 @@ export function PaneGrid({
 
   const handleDragStart = (e: React.DragEvent, paneId: string) => {
     dragSrcRef.current = paneId;
-    e.dataTransfer.setData(PANE_DND_MIME, paneId);
-    e.dataTransfer.effectAllowed = "move";
+    setPaneDragData(e, paneId);
   };
   const handleDragOver = (e: React.DragEvent, paneId: string) => {
     if (!dndEnabled || !dragSrcRef.current) return;

--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -2119,4 +2119,66 @@ describe("WorkspaceSelectorView", () => {
       });
     });
   });
+
+  // 드래그한 pane 을 워크스페이스 항목으로 드롭하면 그 워크스페이스로 이동한다 (issue #380).
+  describe("pane drop onto workspace (issue #380)", () => {
+    const PANE_DND_MIME = "application/x-laymux-pane";
+
+    // jsdom dataTransfer 스텁: types/getData/dropEffect 지원.
+    const makePaneDataTransfer = (paneId: string) => ({
+      types: [PANE_DND_MIME],
+      data: { [PANE_DND_MIME]: paneId } as Record<string, string>,
+      getData(type: string) {
+        return this.data[type] ?? "";
+      },
+      setData(type: string, val: string) {
+        this.data[type] = val;
+      },
+      effectAllowed: "",
+      dropEffect: "",
+    });
+
+    /** 활성 워크스페이스를 split(2 pane) 하고, 두 번째 워크스페이스를 추가한다. */
+    const setup = () => {
+      const srcId = useWorkspaceStore.getState().workspaces[0].id;
+      useWorkspaceStore.getState().setActiveWorkspace(srcId);
+      useWorkspaceStore.getState().splitPane(0, "vertical");
+      useWorkspaceStore.getState().addWorkspace("Target", "default-layout");
+      const tgtId = useWorkspaceStore.getState().workspaces[1].id;
+      return { srcId, tgtId };
+    };
+
+    it("moves the dragged pane to the workspace it is dropped on", () => {
+      const { srcId, tgtId } = setup();
+      const movedPaneId = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!
+        .panes[1].id;
+
+      render(<WorkspaceSelectorView />);
+      const target = screen.getByTestId(`workspace-item-${tgtId}`);
+      const dataTransfer = makePaneDataTransfer(movedPaneId);
+      fireEvent.dragOver(target, { dataTransfer });
+      fireEvent.drop(target, { dataTransfer });
+
+      const afterSrc = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!;
+      const afterTgt = useWorkspaceStore.getState().workspaces.find((w) => w.id === tgtId)!;
+      expect(afterSrc.panes.some((p) => p.id === movedPaneId)).toBe(false);
+      expect(afterTgt.panes.some((p) => p.id === movedPaneId)).toBe(true);
+      expect(afterTgt.panes).toHaveLength(2);
+    });
+
+    it("does nothing when dropping a pane back onto its own (source) workspace", () => {
+      const { srcId } = setup();
+      const movedPaneId = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!
+        .panes[1].id;
+
+      render(<WorkspaceSelectorView />);
+      const sourceItem = screen.getByTestId(`workspace-item-${srcId}`);
+      const dataTransfer = makePaneDataTransfer(movedPaneId);
+      fireEvent.dragOver(sourceItem, { dataTransfer });
+      fireEvent.drop(sourceItem, { dataTransfer });
+
+      const afterSrc = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!;
+      expect(afterSrc.panes).toHaveLength(2);
+    });
+  });
 });

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -27,6 +27,7 @@ import type { TerminalActivityInfo } from "@/stores/terminal-store";
 import { persistSession } from "@/lib/persist-session";
 import { useUiStore } from "@/stores/ui-store";
 import { useRenameWorkspaceStore } from "@/stores/rename-workspace-store";
+import { getPaneDragData, isPaneDrag } from "@/lib/pane-dnd";
 
 /** Abbreviate profile/view labels to max 3 characters. */
 const LABEL_ABBREV: Record<string, string> = {
@@ -165,6 +166,10 @@ function WorkspaceItem({
   pathEllipsis,
   drag,
   dropIndicator,
+  isPaneDropTarget,
+  onPaneDragOver,
+  onPaneDragLeave,
+  onPaneDrop,
   hideMode,
   isWsHidden,
   hiddenPaneIds,
@@ -184,6 +189,11 @@ function WorkspaceItem({
   pathEllipsis: "start" | "end";
   drag: DragContext;
   dropIndicator: DropIndicator | null;
+  // Pane 을 이 워크스페이스 위로 끌어왔는지(하이라이트용)와 그 drop 핸들러 (issue #380).
+  isPaneDropTarget: boolean;
+  onPaneDragOver: (e: React.DragEvent, wsId: string) => void;
+  onPaneDragLeave: (e: React.DragEvent) => void;
+  onPaneDrop: (e: React.DragEvent, wsId: string) => void;
   hideMode: boolean;
   isWsHidden: boolean;
   hiddenPaneIds: Set<string>;
@@ -229,19 +239,37 @@ function WorkspaceItem({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onDragStart={(e) => drag.onDragStart(e, ws.id)}
-      onDragOver={(e) => drag.onDragOver(e, ws.id)}
-      onDragLeave={(e) => drag.onDragLeave(e)}
-      onDrop={(e) => drag.onDrop(e, ws.id)}
+      onDragOver={(e) => {
+        // Pane 드래그(이동)와 워크스페이스 재정렬 드래그를 같은 항목에서 모두 받는다.
+        // pane MIME 가 실려 있으면 이동 경로, 아니면 기존 재정렬 경로.
+        if (isPaneDrag(e)) onPaneDragOver(e, ws.id);
+        else drag.onDragOver(e, ws.id);
+      }}
+      onDragLeave={(e) => {
+        onPaneDragLeave(e);
+        drag.onDragLeave(e);
+      }}
+      onDrop={(e) => {
+        if (isPaneDrag(e)) onPaneDrop(e, ws.id);
+        else drag.onDrop(e, ws.id);
+      }}
       onDragEnd={drag.onDragEnd}
       className={`workspace-item-animated relative shrink-0 cursor-pointer${
         isCollapsed ? " workspace-item-collapsed" : ""
       }`}
       style={{
-        background: isActive ? "var(--accent-08)" : hovered ? "var(--active-bg)" : "transparent",
+        background: isPaneDropTarget
+          ? "var(--accent-12)"
+          : isActive
+            ? "var(--accent-08)"
+            : hovered
+              ? "var(--active-bg)"
+              : "transparent",
         borderLeft: isActive ? "3px solid var(--accent)" : "3px solid transparent",
         borderBottom: isCollapsed ? "0 solid transparent" : "1px solid var(--border)",
-        boxShadow:
-          dropIndicator?.wsId === ws.id
+        boxShadow: isPaneDropTarget
+          ? "inset 0 0 0 2px var(--accent)"
+          : dropIndicator?.wsId === ws.id
             ? dropIndicator.position === "top"
               ? "inset 0 2px 0 0 var(--accent)"
               : "inset 0 -2px 0 0 var(--accent)"
@@ -1045,6 +1073,8 @@ export function WorkspaceSelectorView() {
   const { t } = useTranslation("workspace");
   const [showNotifPanel, setShowNotifPanel] = useState(false);
   const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(null);
+  // 어떤 워크스페이스 위로 pane 을 끌어왔는지(이동 drop 타겟 하이라이트, issue #380).
+  const [paneDropWsId, setPaneDropWsId] = useState<string | null>(null);
   const selectorRef = useRef<HTMLDivElement>(null);
 
   const workspaces = useWorkspaceStore((s) => s.workspaces);
@@ -1053,6 +1083,7 @@ export function WorkspaceSelectorView() {
   const removeWorkspace = useWorkspaceStore((s) => s.removeWorkspace);
   const duplicateWorkspace = useWorkspaceStore((s) => s.duplicateWorkspace);
   const addWorkspace = useWorkspaceStore((s) => s.addWorkspace);
+  const movePaneToWorkspace = useWorkspaceStore((s) => s.movePaneToWorkspace);
   const reorderWorkspaces = useWorkspaceStore((s) => s.reorderWorkspaces);
   const workspaceDisplayOrder = useWorkspaceStore((s) => s.workspaceDisplayOrder);
   const layouts = useWorkspaceStore((s) => s.layouts);
@@ -1157,6 +1188,36 @@ export function WorkspaceSelectorView() {
     setDropIndicator(null);
     dragIdRef.current = null;
   }, []);
+
+  // -- Pane → workspace 이동 drop (issue #380) --
+  // PaneGrid 컨트롤바의 드래그 핸들에서 시작된 pane 드래그를 워크스페이스 항목 위로
+  // 드롭하면 그 워크스페이스로 pane 을 이동한다. 워크스페이스 재정렬과 달리 sort 모드와
+  // 무관하게 항상 동작한다.
+  const handlePaneDragOver = useCallback((e: React.DragEvent, wsId: string) => {
+    // preventDefault 를 호출해야 drop 이 허용된다(HTML5 DnD 규약).
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setPaneDropWsId((prev) => (prev === wsId ? prev : wsId));
+  }, []);
+
+  const handlePaneDragLeave = useCallback((e: React.DragEvent) => {
+    // 자식 요소로 이동하는 leave 는 무시(하이라이트 깜빡임 방지).
+    if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+    setPaneDropWsId(null);
+  }, []);
+
+  const handlePaneDrop = useCallback(
+    (e: React.DragEvent, wsId: string) => {
+      e.preventDefault();
+      setPaneDropWsId(null);
+      const paneId = getPaneDragData(e);
+      if (paneId) {
+        movePaneToWorkspace(paneId, wsId);
+        persistSession();
+      }
+    },
+    [movePaneToWorkspace],
+  );
 
   const isManualSort = workspaceSortOrder === "manual";
 
@@ -1385,6 +1446,10 @@ export function WorkspaceSelectorView() {
               pathEllipsis={pathEllipsis}
               drag={dragContext}
               dropIndicator={dropIndicator}
+              isPaneDropTarget={paneDropWsId === ws.id}
+              onPaneDragOver={handlePaneDragOver}
+              onPaneDragLeave={handlePaneDragLeave}
+              onPaneDrop={handlePaneDrop}
               hideMode={hideMode}
               isWsHidden={isWsHidden}
               hiddenPaneIds={wsHiddenPaneIds}

--- a/ui/src/lib/pane-dnd.ts
+++ b/ui/src/lib/pane-dnd.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared HTML5 DnD payload for dragging a pane (issue #377 swap, issue #380 move).
+ *
+ * The same drag source (PaneGrid 컨트롤바의 드래그 핸들) feeds two drop targets:
+ *  - 같은 그리드의 다른 pane → 위치 교환(swap, workspace-store.swapPanes)
+ *  - WorkspaceSelectorView 의 워크스페이스 항목 → 그 워크스페이스로 이동(move,
+ *    workspace-store.movePaneToWorkspace)
+ *
+ * dataTransfer 에 paneId 만 실으면 충분하다. 소스 워크스페이스는 paneId 로 조회 가능하고
+ * (workspace-store.movePaneToWorkspace), swap 은 같은 그리드 안이라 워크스페이스가 동일하다.
+ */
+export const PANE_DND_MIME = "application/x-laymux-pane";
+
+/** dataTransfer 에 드래그 중인 paneId 를 기록한다. */
+export function setPaneDragData(e: React.DragEvent, paneId: string): void {
+  e.dataTransfer.setData(PANE_DND_MIME, paneId);
+  e.dataTransfer.effectAllowed = "move";
+}
+
+/** dataTransfer 에서 드래그 중인 paneId 를 읽는다. 없으면 null. */
+export function getPaneDragData(e: React.DragEvent): string | null {
+  return e.dataTransfer.getData(PANE_DND_MIME) || null;
+}
+
+/**
+ * 현재 드래그가 pane 드래그인지 판정한다.
+ * dragover/drop 시점에는 보안상 getData 가 빈 문자열을 돌려줄 수 있으므로 `types` 로 판정한다.
+ * (`types` 는 브라우저에서 항상 제공되지만, 일부 테스트 스텁에는 없을 수 있어 방어한다.)
+ */
+export function isPaneDrag(e: React.DragEvent): boolean {
+  return e.dataTransfer.types?.includes(PANE_DND_MIME) ?? false;
+}

--- a/ui/src/stores/workspace-store.test.ts
+++ b/ui/src/stores/workspace-store.test.ts
@@ -282,6 +282,113 @@ describe("WorkspaceStore", () => {
     });
   });
 
+  // 드래그한 pane 을 다른 워크스페이스로 이동 (issue #380)
+  describe("movePaneToWorkspace", () => {
+    /** 활성 워크스페이스를 split 해 2개 pane 으로 만들고, 두 번째 워크스페이스를 추가한다. */
+    const setupSourceWithTwoPanes = () => {
+      const { addWorkspace, layouts, workspaces } = useWorkspaceStore.getState();
+      const srcId = workspaces[0].id;
+      useWorkspaceStore.getState().setActiveWorkspace(srcId);
+      useWorkspaceStore.getState().splitPane(0, "vertical");
+      addWorkspace("Target", layouts[0].id);
+      const tgtId = useWorkspaceStore.getState().workspaces[1].id;
+      return { srcId, tgtId };
+    };
+
+    it("removes the pane from its source workspace and appends it to the target", () => {
+      const { srcId, tgtId } = setupSourceWithTwoPanes();
+      const src = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!;
+      const movedPane = src.panes[1];
+
+      useWorkspaceStore.getState().movePaneToWorkspace(movedPane.id, tgtId);
+
+      const afterSrc = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!;
+      const afterTgt = useWorkspaceStore.getState().workspaces.find((w) => w.id === tgtId)!;
+      // 소스에서 제거됨
+      expect(afterSrc.panes.some((p) => p.id === movedPane.id)).toBe(false);
+      expect(afterSrc.panes).toHaveLength(1);
+      // 대상에 추가됨 (pane id 보존)
+      expect(afterTgt.panes.some((p) => p.id === movedPane.id)).toBe(true);
+      expect(afterTgt.panes).toHaveLength(2);
+    });
+
+    it("preserves the moved pane's view config", () => {
+      const { srcId, tgtId } = setupSourceWithTwoPanes();
+      const src = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!;
+      const movedPane = src.panes[1];
+      // 식별 가능한 view 로 바꾼다.
+      const movedIndex = 1;
+      useWorkspaceStore.getState().setActiveWorkspace(srcId);
+      useWorkspaceStore
+        .getState()
+        .setPaneView(movedIndex, { type: "TerminalView", profile: "WSL" });
+
+      useWorkspaceStore.getState().movePaneToWorkspace(movedPane.id, tgtId);
+
+      const afterTgt = useWorkspaceStore.getState().workspaces.find((w) => w.id === tgtId)!;
+      const arrived = afterTgt.panes.find((p) => p.id === movedPane.id)!;
+      expect(arrived.view.type).toBe("TerminalView");
+      expect(arrived.view.profile).toBe("WSL");
+    });
+
+    it("keeps target panes non-overlapping (every pane fits in the unit square)", () => {
+      const { srcId, tgtId } = setupSourceWithTwoPanes();
+      const movedPane = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!
+        .panes[1];
+
+      useWorkspaceStore.getState().movePaneToWorkspace(movedPane.id, tgtId);
+
+      const afterTgt = useWorkspaceStore.getState().workspaces.find((w) => w.id === tgtId)!;
+      for (const p of afterTgt.panes) {
+        expect(p.x).toBeGreaterThanOrEqual(-0.001);
+        expect(p.y).toBeGreaterThanOrEqual(-0.001);
+        expect(p.x + p.w).toBeLessThanOrEqual(1.001);
+        expect(p.y + p.h).toBeLessThanOrEqual(1.001);
+      }
+    });
+
+    it("no-ops when the source workspace would be left empty (single pane)", () => {
+      const { addWorkspace, layouts, workspaces } = useWorkspaceStore.getState();
+      const srcId = workspaces[0].id; // single pane
+      addWorkspace("Target", layouts[0].id);
+      const tgtId = useWorkspaceStore.getState().workspaces[1].id;
+      const onlyPane = workspaces[0].panes[0];
+
+      useWorkspaceStore.getState().movePaneToWorkspace(onlyPane.id, tgtId);
+
+      const afterSrc = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!;
+      const afterTgt = useWorkspaceStore.getState().workspaces.find((w) => w.id === tgtId)!;
+      expect(afterSrc.panes).toHaveLength(1);
+      expect(afterTgt.panes).toHaveLength(1);
+    });
+
+    it("no-ops when target equals source workspace", () => {
+      const { srcId } = setupSourceWithTwoPanes();
+      const movedPane = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!
+        .panes[1];
+
+      useWorkspaceStore.getState().movePaneToWorkspace(movedPane.id, srcId);
+
+      const afterSrc = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!;
+      expect(afterSrc.panes).toHaveLength(2);
+    });
+
+    it("no-ops for an unknown pane id or unknown target", () => {
+      const { srcId, tgtId } = setupSourceWithTwoPanes();
+      useWorkspaceStore.getState().movePaneToWorkspace("pane-does-not-exist", tgtId);
+      useWorkspaceStore
+        .getState()
+        .movePaneToWorkspace(
+          useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!.panes[1].id,
+          "ws-does-not-exist",
+        );
+      const afterSrc = useWorkspaceStore.getState().workspaces.find((w) => w.id === srcId)!;
+      const afterTgt = useWorkspaceStore.getState().workspaces.find((w) => w.id === tgtId)!;
+      expect(afterSrc.panes).toHaveLength(2);
+      expect(afterTgt.panes).toHaveLength(1);
+    });
+  });
+
   // Layout actions
   describe("exportAsNewLayout", () => {
     it("creates a new layout from current workspace panes", () => {

--- a/ui/src/stores/workspace-store.ts
+++ b/ui/src/stores/workspace-store.ts
@@ -100,6 +100,13 @@ interface WorkspaceState {
     delta: Partial<Pick<WorkspacePane, "x" | "y" | "w" | "h">>,
   ) => void;
   swapPanes: (srcIndex: number, tgtIndex: number) => void;
+  /**
+   * 드래그한 pane 을 다른 워크스페이스로 이동한다 (issue #380).
+   * 소스 워크스페이스에서 제거(공간은 인접 pane 이 흡수, removePane 과 동일)하고
+   * 대상 워크스페이스의 가장 큰 pane 을 반으로 분할해 그 자리에 옮겨온 pane 을 둔다.
+   * pane id 와 view 설정은 보존된다. 소스가 1개뿐이면(빈 워크스페이스 방지) 무시.
+   */
+  movePaneToWorkspace: (paneId: string, targetWorkspaceId: string) => void;
   setPaneView: (paneIndex: number, view: ViewInstanceConfig) => void;
 
   // Layout actions
@@ -342,6 +349,64 @@ export const useWorkspaceStore = create<WorkspaceState>()((set, get) => ({
 
     set((state) => ({
       workspaces: state.workspaces.map((w) => (w.id === ws.id ? { ...w, panes: newPanes } : w)),
+    }));
+  },
+
+  movePaneToWorkspace: (paneId, targetWorkspaceId) => {
+    const { workspaces } = get();
+    const source = workspaces.find((w) => w.panes.some((p) => p.id === paneId));
+    const target = workspaces.find((w) => w.id === targetWorkspaceId);
+    if (!source || !target) return;
+    // 같은 워크스페이스로의 이동은 무의미하고, 소스를 비우는 이동은 막는다.
+    if (source.id === target.id) return;
+    if (source.panes.length <= 1) return;
+
+    const srcIndex = source.panes.findIndex((p) => p.id === paneId);
+    const moved = source.panes[srcIndex];
+
+    // 1) 소스에서 제거 — removePane 과 동일하게 인접 pane 이 공간을 흡수한다.
+    const newSourcePanes = removePaneAndRedistribute(source.panes, srcIndex);
+    if (!newSourcePanes) return;
+
+    // 2) 대상의 가장 큰 pane 을 반으로 나눠 그 자리에 옮겨온 pane 을 둔다.
+    //    (splitPane 과 같은 기하학: 더 긴 축을 따라 절반으로 가른다.)
+    let hostIdx = 0;
+    let hostArea = -1;
+    target.panes.forEach((p, i) => {
+      const area = p.w * p.h;
+      if (area > hostArea) {
+        hostArea = area;
+        hostIdx = i;
+      }
+    });
+    const host = target.panes[hostIdx];
+    const splitVertical = host.w >= host.h; // 가로가 더 길면 좌우로 분할
+    let hostSlot: Pick<WorkspacePane, "x" | "y" | "w" | "h">;
+    let movedSlot: Pick<WorkspacePane, "x" | "y" | "w" | "h">;
+    if (splitVertical) {
+      const halfW = host.w / 2;
+      hostSlot = { x: host.x, y: host.y, w: halfW, h: host.h };
+      movedSlot = { x: host.x + halfW, y: host.y, w: halfW, h: host.h };
+    } else {
+      const halfH = host.h / 2;
+      hostSlot = { x: host.x, y: host.y, w: host.w, h: halfH };
+      movedSlot = { x: host.x, y: host.y + halfH, w: host.w, h: halfH };
+    }
+
+    const movedPane: WorkspacePane = {
+      id: moved.id,
+      ...movedSlot,
+      view: { ...moved.view },
+    };
+    const newTargetPanes = target.panes.map((p, i) => (i === hostIdx ? { ...p, ...hostSlot } : p));
+    newTargetPanes.splice(hostIdx + 1, 0, movedPane);
+
+    set((state) => ({
+      workspaces: state.workspaces.map((w) => {
+        if (w.id === source.id) return { ...w, panes: newSourcePanes };
+        if (w.id === target.id) return { ...w, panes: newTargetPanes };
+        return w;
+      }),
     }));
   },
 


### PR DESCRIPTION
## 요약
pane 을 끌어서 워크스페이스 항목 위에 드롭하면, 소스 워크스페이스에서 제거되고 대상 워크스페이스로 이동(추가)된다. #377 의 기존 pane 드래그&드롭(swap) 인프라를 재사용/확장했다 — 같은 드래그 핸들이 두 drop 타겟을 먹인다: 다른 pane 위 = swap, 워크스페이스 항목 위 = move.

## 변경
- `workspace-store.movePaneToWorkspace(paneId, targetWorkspaceId)` 신규 액션: 소스에서 인접 pane 이 공간 흡수하며 제거, 대상의 가장 큰 pane 을 긴 축 기준 반분할해 배치. id·view 설정 보존. 가드: 소스 pane 1개뿐/같은 ws/미존재 시 no-op.
- `lib/pane-dnd.ts` 신규: 드래그 페이로드 공유 헬퍼(MIME `application/x-laymux-pane`). PaneGrid 인라인 상수 통합.
- `WorkspaceSelectorView`: 재정렬(`text/plain`) drop 과 이동(pane MIME) drop 을 `isPaneDrag` 로 분기. 이동은 sort 모드 무관 동작, 대상 워크스페이스 액센트 링 하이라이트.
- `docs/architecture/data-flow.md` §5 living doc 갱신.

## 테스트
- workspace-store +6, WorkspaceSelectorView +2 테스트 추가 (TDD)
- 변경 영역 180 passed, `tsc --noEmit` 클린, husky pre-commit(prettier/eslint) 통과
- 전체 vitest 2266 passed / 1 failed — 유일 실패 `FileViewerOverlay.test.tsx` 는 본 변경 무관 기존 실패(격리 실행에서도 동일)

Fixes #380