### PR TITLE
feat: 터미널 프로파일별 CWD 전파 설정 UI (#382)

### DIFF
--- a/ui/src/components/views/SettingsView.test.tsx
+++ b/ui/src/components/views/SettingsView.test.tsx
@@ -145,6 +145,37 @@ describe("SettingsView", () => {
     expect(useSettingsStore.getState().profileDefaults.font.weight).toBe("bold");
   });
 
+  // -- CWD propagation (syncCwd) in Profile Defaults --
+
+  it("shows CWD propagation select defaulting to inherit in Profile Defaults", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+    await user.click(screen.getByTestId("nav-profile-defaults"));
+
+    const select = screen.getByTestId("sync-cwd-profile-select") as HTMLSelectElement;
+    // defaultProfileDefaults.syncCwd === "default" → token "default"
+    expect(select.value).toBe("default");
+  });
+
+  it("updates profileDefaults.syncCwd to a concrete pair only after Save", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+    await user.click(screen.getByTestId("nav-profile-defaults"));
+
+    const select = screen.getByTestId("sync-cwd-profile-select");
+    await user.selectOptions(select, "send");
+
+    // Not persisted until Save
+    expect(useSettingsStore.getState().profileDefaults.syncCwd).toBe("default");
+
+    await user.click(screen.getByTestId("save-settings-btn"));
+
+    expect(useSettingsStore.getState().profileDefaults.syncCwd).toEqual({
+      send: true,
+      receive: false,
+    });
+  });
+
   // -- App Theme draft --
 
   it("does NOT update appTheme in store until Save is clicked", async () => {

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -19,6 +19,7 @@ import {
   type LanguageSetting,
 } from "@/stores/settings-store";
 import type { FileExplorerSettings, ExtensionViewer } from "@/lib/tauri-api";
+import type { SyncCwdConfig } from "@/lib/sync-cwd-config";
 import { persistSession } from "@/lib/persist-session";
 import {
   DEFAULT_KEYBINDINGS,
@@ -656,6 +657,31 @@ function CursorFields({
   );
 }
 
+/** Map a syncCwd config to a select token. */
+function syncCwdToToken(v: SyncCwdConfig | undefined): string {
+  if (v == null || v === "default") return "default";
+  if (v.send && v.receive) return "both";
+  if (!v.send && v.receive) return "receive";
+  if (v.send && !v.receive) return "send";
+  return "off";
+}
+
+/** Map a select token back to a syncCwd config. */
+function tokenToSyncCwd(tok: string): SyncCwdConfig {
+  switch (tok) {
+    case "both":
+      return { send: true, receive: true };
+    case "receive":
+      return { send: false, receive: true };
+    case "send":
+      return { send: true, receive: false };
+    case "off":
+      return { send: false, receive: false };
+    default:
+      return "default";
+  }
+}
+
 function AdvancedFields({
   data,
   onChange,
@@ -672,6 +698,7 @@ function AdvancedFields({
     | "snapOnInput"
     | "restoreCwd"
     | "restoreOutput"
+    | "syncCwd"
   >;
   onChange: (d: Partial<Profile>) => void;
   defaults?: ProfileDefaults;
@@ -831,6 +858,29 @@ function AdvancedFields({
               </span>
             </label>
             {resetBtn("restoreOutput")}
+          </div>
+        </SettingRow>
+
+        <h4 className="mb-2 mt-4 text-xs font-semibold" style={{ color: "var(--text-primary)" }}>
+          {t("advanced.cwdPropagation")}
+        </h4>
+        <SettingRow label={t("advanced.cwdPropagation")} desc={t("advanced.cwdPropagationDesc")}>
+          <div className="flex items-center">
+            <select
+              data-testid="sync-cwd-profile-select"
+              value={syncCwdToToken(data.syncCwd)}
+              onChange={(e) => onChange({ syncCwd: tokenToSyncCwd(e.target.value) })}
+              className={inputCls}
+              style={inputStyle}
+            >
+              <option value="default">
+                {defaults ? t("advanced.cwdInherit") : t("advanced.cwdInheritLocation")}
+              </option>
+              <option value="both">{t("advanced.cwdBoth")}</option>
+              <option value="receive">{t("advanced.cwdReceiveOnly")}</option>
+              <option value="send">{t("advanced.cwdSendOnly")}</option>
+              <option value="off">{t("advanced.cwdOff")}</option>
+            </select>
           </div>
         </SettingRow>
       </div>

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -143,7 +143,15 @@
       "restoreCwdEnable": "Start terminal in last used directory",
       "restoreOutput": "Restore Terminal Output",
       "restoreOutputDesc": "Restore previous terminal output on restart",
-      "restoreOutputEnable": "Show previous session output above new shell"
+      "restoreOutputEnable": "Show previous session output above new shell",
+      "cwdPropagation": "CWD Propagation",
+      "cwdPropagationDesc": "Whether this profile's terminals send/receive working directory changes within a sync group",
+      "cwdInherit": "Inherit default",
+      "cwdInheritLocation": "Use location default",
+      "cwdBoth": "Send + Receive",
+      "cwdReceiveOnly": "Receive only",
+      "cwdSendOnly": "Send only",
+      "cwdOff": "Off"
     },
     "defaults": {
       "title": "Profile Defaults",

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -143,7 +143,15 @@
       "restoreCwdEnable": "마지막으로 사용한 디렉터리에서 터미널 시작",
       "restoreOutput": "터미널 출력 복원",
       "restoreOutputDesc": "재시작 시 이전 터미널 출력 복원",
-      "restoreOutputEnable": "새 셸 위에 이전 세션 출력 표시"
+      "restoreOutputEnable": "새 셸 위에 이전 세션 출력 표시",
+      "cwdPropagation": "CWD 전파",
+      "cwdPropagationDesc": "이 프로파일의 터미널이 sync 그룹 내에서 작업 디렉터리 변경을 보낼지/받을지 결정",
+      "cwdInherit": "기본값 상속",
+      "cwdInheritLocation": "위치 기본값 사용",
+      "cwdBoth": "보내기 + 받기",
+      "cwdReceiveOnly": "받기만",
+      "cwdSendOnly": "보내기만",
+      "cwdOff": "끔"
     },
     "defaults": {
       "title": "프로필 기본값",


### PR DESCRIPTION
## 배경
이슈 #382 — 터미널 프로파일에서 CWD 전파를 결정해둘 수 있어야 한다.

조사 결과 `profile.syncCwd` 모델(Rust+TS)·상속(`INHERITABLE_KEYS`)·해석(`resolveSyncCwd`: 프로파일 → profileDefaults → 위치)·배선(`ViewRenderer → TerminalView.cwdSend/cwdReceive`)은 **이미 전부 존재**. 빠진 건 GUI 컨트롤 하나뿐 — 지금까지 settings.json 직접 편집으로만 설정 가능했다.

## 변경
- `SettingsView.tsx` `AdvancedFields` 에 CWD 전파 select 추가
  - 3-상태(`"default" | {send,receive}`) 를 select 로 표현: **상속 / 보내기+받기 / 받기만 / 보내기만 / 끔**
  - 프로파일 편집기: "기본값 상속" = profileDefaults 위임 / ProfileDefaults 편집기: "위치 기본값 사용" = workspace·dock 위임
  - `syncCwd` 토큰↔config 변환 헬퍼
- en/ko i18n 키
- 테스트 2개: 기본값 inherit 렌더, Save 후에만 store 반영

배선 로직은 손대지 않음 — UI 가 기존 `profile.syncCwd` 값을 쓸 뿐.

## 검증
- `tsc --noEmit` clean
- vitest 230 passed
- eslint / prettier clean

Fixes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)