### PR TITLE
fix: pane swap 을 controlbar 빈 영역 드래그로 변경 (#386)

### DIFF
--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -37,17 +37,19 @@
 | 경계선 더블클릭                   | 작은 쪽 Pane 제거, 큰 쪽이 흡수 |
 | 편집 모드에서 Pane 선택 후 Delete | 인접 Pane 중 가장 큰 것이 흡수  |
 
-### 위치 교환 (드래그&드롭, issue #377)
+### 위치 교환 (드래그&드롭, issue #377, 재설계 #386)
 
-- 각 Pane 컨트롤바 우측 상단의 **드래그 핸들(grip)** 을 다른 Pane 위로 드래그&드롭하면 두 Pane의 `{ x, y, w, h }` 가 교환된다(view/콘텐츠는 그대로, 슬롯 위치만 swap).
+- **Pane 컨트롤바(PaneControlBar)의 버튼 없는 빈 영역을 드래그**해 다른 Pane 위로 드롭하면 두 Pane의 `{ x, y, w, h }` 가 교환된다(view/콘텐츠는 그대로, 슬롯 위치만 swap). 별도 드래그 핸들 요소는 두지 않는다 — 좌하단/우상단 floating 핸들은 콘텐츠와 겹쳐(issue #386) 폐기했다.
+- 바 컨테이너 자체가 `draggable` 이며, `onDragStart` 에서 `e.target !== e.currentTarget` 이면(= 버튼/select 등 자식 위에서 시작) `preventDefault` 로 드래그를 취소한다 — 빈 영역(바 배경)에서 시작한 드래그만 swap 으로 처리하고, 버튼 클릭/포커스는 정상 동작한다.
+- 컨트롤바는 모드별로 다른 바(hover 오버레이 / pinned / narrow / minimized)와 ViewHeader 기반 바를 렌더하므로, 동일한 draggable 속성을 공통 헬퍼(`barDragProps`)로 만들어 현재 보이는 바 컨테이너에 일관 적용한다. ViewHeader 를 쓰는 View 는 `PaneControlContext.barDragProps` 로 전달받아 자기 바에 펼친다.
 - 네이티브 HTML5 DnD(`draggable` + `dataTransfer`)를 사용 — WorkspaceSelectorView 의 워크스페이스 재정렬과 동일 패턴. 별도 DnD 라이브러리 없음.
 - UI(`PaneGrid`)는 `onSwapPanes(srcPaneId, tgtPaneId)` 콜백만 노출하고, 실제 교환은 기존 `workspace-store.swapPanes(srcIndex, tgtIndex)`(MCP `swap_panes` 와 공유) 한 곳에서 수행한다. `WorkspaceArea` 가 paneId→paneIndex 로 변환해 연결.
-- 핸들은 활성 워크스페이스에서 hover 시에만 나타나며, dock(PaneGrid 재사용)은 `onSwapPanes` 미제공으로 비활성. 같은 Pane 위로 드롭하면 무시.
+- 드래그는 활성 워크스페이스(`dndEnabled = isActive && !!onSwapPanes`)에서 바가 보일 때만 동작하며, dock(PaneGrid 재사용)은 `onSwapPanes` 미제공으로 비활성. 같은 Pane 위로 드롭하면 무시. minimized(버튼 1개)처럼 빈 영역이 거의 없는 모드는 swap 시작점이 사실상 없다.
 - 드래그 페이로드는 `lib/pane-dnd.ts`(MIME `application/x-laymux-pane`, paneId 만 적재)로 공유한다 — 같은 드래그 소스가 swap·move 두 drop 타겟을 모두 먹인다.
 
 ### 다른 워크스페이스로 이동 (드래그&드롭, issue #380)
 
-- 같은 드래그 핸들을 **WorkspaceSelectorView 의 워크스페이스 항목** 위로 드롭하면, 그 Pane 이 원래 워크스페이스에서 제거되고 대상 워크스페이스로 이동(추가)된다.
+- 같은 드래그(컨트롤바 빈 영역에서 시작)를 **WorkspaceSelectorView 의 워크스페이스 항목** 위로 드롭하면, 그 Pane 이 원래 워크스페이스에서 제거되고 대상 워크스페이스로 이동(추가)된다.
 - 소스 제거는 `removePane` 과 동일한 `removePaneAndRedistribute`(인접 Pane 이 공간 흡수). 대상 추가는 대상의 **가장 큰 Pane 을 반으로 분할**(긴 축 기준)해 그 자리에 옮겨온 Pane 을 둔다 — Pane id 와 view 설정은 보존.
 - 실제 이동은 `workspace-store.movePaneToWorkspace(paneId, targetWorkspaceId)` 한 곳에서 수행한다. 소스가 Pane 1개뿐이면(워크스페이스가 비게 됨) 무시하고, 같은 워크스페이스·미존재 paneId/대상도 무시.
 - 워크스페이스 항목은 재정렬(reorder, `text/plain`)과 이동(move, `application/x-laymux-pane`) drop 을 같은 핸들러에서 MIME(`isPaneDrag`)으로 분기한다. 이동 drop 은 sort 모드와 무관하게 항상 동작하며, 끌어온 워크스페이스는 액센트 링으로 하이라이트된다.

--- a/ui/src/components/layout/PaneControlBar.test.tsx
+++ b/ui/src/components/layout/PaneControlBar.test.tsx
@@ -95,6 +95,63 @@ describe("PaneControlBar", () => {
     expect(screen.getByTestId("pane-control-bar")).toBeInTheDocument();
   });
 
+  // -- pane swap drag from the control bar empty area (issue #386) --
+  describe("pane swap drag (issue #386)", () => {
+    it("bar is not draggable when dnd disabled", () => {
+      render(
+        <PaneControlBar currentView={defaultView} actions={defaultActions} hovered={true}>
+          <div>content</div>
+        </PaneControlBar>,
+      );
+      expect(screen.getByTestId("pane-control-bar").getAttribute("draggable")).not.toBe("true");
+    });
+
+    it("bar is draggable and dragging the empty area fires onPaneDragStart", () => {
+      const onPaneDragStart = vi.fn();
+      render(
+        <PaneControlBar
+          currentView={defaultView}
+          actions={defaultActions}
+          hovered={true}
+          dndEnabled
+          onPaneDragStart={onPaneDragStart}
+          onPaneDragEnd={vi.fn()}
+        >
+          <div>content</div>
+        </PaneControlBar>,
+      );
+      const bar = screen.getByTestId("pane-control-bar");
+      expect(bar.getAttribute("draggable")).toBe("true");
+      // dragStart dispatched on the bar itself (target === currentTarget) → empty area.
+      const ev = new Event("dragstart", { bubbles: true, cancelable: true });
+      bar.dispatchEvent(ev);
+      expect(onPaneDragStart).toHaveBeenCalledTimes(1);
+      expect(ev.defaultPrevented).toBe(false);
+    });
+
+    it("dragging from a button (child) is ignored: preventDefault, no onPaneDragStart", () => {
+      const onPaneDragStart = vi.fn();
+      render(
+        <PaneControlBar
+          currentView={defaultView}
+          actions={defaultActions}
+          hovered={true}
+          dndEnabled
+          onPaneDragStart={onPaneDragStart}
+          onPaneDragEnd={vi.fn()}
+        >
+          <div>content</div>
+        </PaneControlBar>,
+      );
+      const btn = screen.getByTestId("pane-control-split-h");
+      // dragStart originating on the button bubbles to the bar with target === button.
+      const ev = new Event("dragstart", { bubbles: true, cancelable: true });
+      btn.dispatchEvent(ev);
+      expect(onPaneDragStart).not.toHaveBeenCalled();
+      expect(ev.defaultPrevented).toBe(true);
+    });
+  });
+
   it("renders the pane number badge in the bar when paneNumber is set", () => {
     render(
       <PaneControlBar

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -58,6 +58,15 @@ interface PaneControlBarProps {
    */
   workspaceId?: string;
   workspaceName?: string;
+  /**
+   * pane 위치 교환 드래그 활성화(issue #377, 재설계 #386). 활성 시 컨트롤 바의
+   * 버튼 없는 빈 영역을 드래그하면 pane swap DnD 가 시작된다(별도 핸들 없음).
+   */
+  dndEnabled?: boolean;
+  /** 빈 영역 드래그 시작 핸들러(paneId 는 PaneGrid 가 클로저로 주입). */
+  onPaneDragStart?: (e: React.DragEvent) => void;
+  /** 드래그 종료 핸들러. */
+  onPaneDragEnd?: () => void;
   children: React.ReactNode;
 }
 
@@ -648,6 +657,34 @@ function BarLabel({ viewType }: { viewType: ViewType }) {
 }
 
 // ─── Main component ─────────────────────────────────────
+/**
+ * 바 컨테이너에 적용할 draggable 속성을 만든다(issue #386).
+ *
+ * 빈 영역(바 배경)에서 시작한 드래그만 pane swap 으로 처리한다. 버튼/select 등
+ * 인터랙티브 요소 위에서 시작한 드래그는 `e.target !== e.currentTarget` 으로 걸러
+ * preventDefault 하여 무시한다 — 그래야 버튼 클릭/포커스가 정상 동작한다.
+ * dndEnabled 가 아니면 빈 객체를 돌려줘 평소 렌더와 동일하다.
+ */
+function barDragProps(
+  dndEnabled: boolean | undefined,
+  onPaneDragStart: ((e: React.DragEvent) => void) | undefined,
+  onPaneDragEnd: (() => void) | undefined,
+): { draggable?: boolean; onDragStart?: (e: React.DragEvent) => void; onDragEnd?: () => void } {
+  if (!dndEnabled || !onPaneDragStart) return {};
+  return {
+    draggable: true,
+    onDragStart: (e) => {
+      if (e.target !== e.currentTarget) {
+        // 버튼/select 등 자식 위에서 시작 → 드래그 개시 취소(클릭 정상 유지).
+        e.preventDefault();
+        return;
+      }
+      onPaneDragStart(e);
+    },
+    onDragEnd: onPaneDragEnd,
+  };
+}
+
 export function PaneControlBar({
   paneId,
   currentView,
@@ -658,6 +695,9 @@ export function PaneControlBar({
   paneNumber,
   workspaceId,
   workspaceName,
+  dndEnabled,
+  onPaneDragStart,
+  onPaneDragEnd,
   children,
 }: PaneControlBarProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -716,6 +756,13 @@ export function PaneControlBar({
   if (!narrowBar && narrowMenuOpen) setNarrowMenuOpen(false);
   // 떠 있는 메뉴의 실제 가시성은 narrow 여부에서 파생한다(상태로 저장하지 않음).
   const narrowMenuVisible = narrowBar && narrowMenuOpen;
+
+  // pane swap 드래그 속성(issue #386). 현재 보이는 바 컨테이너(pinned/hover/ViewHeader)에
+  // 동일하게 적용한다. 빈 영역에서 시작한 드래그만 swap 으로 처리(아래 헬퍼 참조).
+  const dragProps = useMemo(
+    () => barDragProps(dndEnabled, onPaneDragStart, onPaneDragEnd),
+    [dndEnabled, onPaneDragStart, onPaneDragEnd],
+  );
 
   // 모든 모드에서 children을 동일한 DOM 위치에 유지하여
   // pin/unpin 전환 시 React가 children을 리마운트하지 않도록 한다.
@@ -817,6 +864,7 @@ export function PaneControlBar({
       paneNumber,
       workspaceId,
       workspaceName,
+      barDragProps: dragProps,
     }),
     [
       paneControls,
@@ -833,6 +881,7 @@ export function PaneControlBar({
       paneNumber,
       workspaceId,
       workspaceName,
+      dragProps,
     ],
   );
 
@@ -848,6 +897,7 @@ export function PaneControlBar({
               background: barBg,
               borderBottom: `1px solid ${borderClr}`,
             }}
+            {...dragProps}
           >
             {leftIcons}
             {hasBarLabel ? (
@@ -895,6 +945,7 @@ export function PaneControlBar({
                 ...(!hasLeftContent && !narrowBar ? { borderLeft: `1px solid ${sepClr}` } : {}),
                 borderRadius: 0,
               }}
+              {...dragProps}
             >
               {leftIcons}
               {hasBarLabel ? (

--- a/ui/src/components/layout/PaneControlContext.tsx
+++ b/ui/src/components/layout/PaneControlContext.tsx
@@ -45,6 +45,16 @@ export interface PaneControlContextValue {
    */
   workspaceId?: string;
   workspaceName?: string;
+  /**
+   * pane 위치 교환 드래그 속성(issue #386). ViewHeader 를 쓰는 View 가 자신의 바
+   * 컨테이너에 펼쳐(`{...barDragProps}`) 빈 영역 드래그로 swap 을 시작하게 한다.
+   * dnd 비활성이면 빈 객체.
+   */
+  barDragProps?: {
+    draggable?: boolean;
+    onDragStart?: (e: React.DragEvent) => void;
+    onDragEnd?: () => void;
+  };
 }
 
 export const PaneControlContext = createContext<PaneControlContextValue | null>(null);

--- a/ui/src/components/layout/PaneGrid.test.tsx
+++ b/ui/src/components/layout/PaneGrid.test.tsx
@@ -134,12 +134,14 @@ describe("PaneGrid", () => {
     });
   });
 
-  // -- Drag-and-drop pane swap (issue #377) --
+  // -- Drag-and-drop pane swap (issue #377, redesigned #386) --
   //
   // 워크스페이스 그리드 안에서 pane을 드래그해 다른 pane 위로 드롭하면 두 pane의
-  // 위치가 교환된다. PaneGrid는 onSwapPanes(srcPaneId, tgtPaneId) 콜백만 노출하고
-  // 실제 위치 교환은 workspace-store.swapPanes(기존 로직)가 담당한다.
-  describe("drag-to-swap (issue #377)", () => {
+  // 위치가 교환된다. 별도 드래그 핸들 대신(issue #386: 핸들이 콘텐츠와 겹침) 컨트롤바
+  // (PaneControlBar)의 버튼 없는 빈 영역을 드래그하면 swap 이 시작된다. PaneGrid는
+  // onSwapPanes(srcPaneId, tgtPaneId) 콜백만 노출하고 실제 위치 교환은
+  // workspace-store.swapPanes(기존 로직)가 담당한다.
+  describe("drag-to-swap (issue #377 / #386)", () => {
     const dndProps = {
       ...defaultProps,
       panes: makePanes(3),
@@ -159,25 +161,38 @@ describe("PaneGrid", () => {
       dropEffect: "",
     });
 
-    it("renders a drag handle for each pane only when onSwapPanes is provided", () => {
-      const { unmount } = render(<PaneGrid {...dndProps} />);
+    // 빈 영역(바 배경) 드래그를 모사하려면 dragStart 가 바 컨테이너 자신(currentTarget)을
+    // target 으로 발생해야 한다. fireEvent.dragStart(bar) 는 target===bar 로 디스패치된다.
+    const barOf = (i: number) =>
+      within(screen.getByTestId(`test-pane-${i}`)).getByTestId("pane-control-bar");
+
+    it("no longer renders the old floating drag handle (#386)", () => {
+      render(<PaneGrid {...dndProps} onSwapPanes={vi.fn()} />);
       expect(screen.queryByTestId("pane-drag-handle-0")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("pane-drag-handle-2")).not.toBeInTheDocument();
+    });
+
+    it("control bar is draggable only when onSwapPanes is provided", () => {
+      const { unmount } = render(<PaneGrid {...dndProps} />);
+      fireEvent.mouseEnter(screen.getByTestId("test-pane-0"));
+      expect(barOf(0).getAttribute("draggable")).not.toBe("true");
       unmount();
 
       render(<PaneGrid {...dndProps} onSwapPanes={vi.fn()} />);
-      expect(screen.getByTestId("pane-drag-handle-0")).toBeInTheDocument();
-      expect(screen.getByTestId("pane-drag-handle-2")).toBeInTheDocument();
+      fireEvent.mouseEnter(screen.getByTestId("test-pane-0"));
+      expect(barOf(0).getAttribute("draggable")).toBe("true");
     });
 
-    it("calls onSwapPanes with source and target pane ids on drop", () => {
+    it("dragging the control bar empty area swaps source and target panes on drop", () => {
       const onSwapPanes = vi.fn();
       render(<PaneGrid {...dndProps} onSwapPanes={onSwapPanes} />);
 
-      const handle0 = screen.getByTestId("pane-drag-handle-0");
+      fireEvent.mouseEnter(screen.getByTestId("test-pane-0"));
+      const bar0 = barOf(0);
       const target2 = screen.getByTestId("test-pane-2");
       const dataTransfer = makeDataTransfer();
 
-      fireEvent.dragStart(handle0, { dataTransfer });
+      fireEvent.dragStart(bar0, { dataTransfer });
       fireEvent.dragOver(target2, { dataTransfer });
       fireEvent.drop(target2, { dataTransfer });
 
@@ -188,20 +203,44 @@ describe("PaneGrid", () => {
       const onSwapPanes = vi.fn();
       render(<PaneGrid {...dndProps} onSwapPanes={onSwapPanes} />);
 
-      const handle1 = screen.getByTestId("pane-drag-handle-1");
+      fireEvent.mouseEnter(screen.getByTestId("test-pane-1"));
+      const bar1 = barOf(1);
       const target1 = screen.getByTestId("test-pane-1");
       const dataTransfer = makeDataTransfer();
 
-      fireEvent.dragStart(handle1, { dataTransfer });
+      fireEvent.dragStart(bar1, { dataTransfer });
       fireEvent.dragOver(target1, { dataTransfer });
       fireEvent.drop(target1, { dataTransfer });
 
       expect(onSwapPanes).not.toHaveBeenCalled();
     });
 
-    it("does not render drag handles when isActive is false", () => {
+    it("starting the drag on a control button does not begin a pane swap (click still works)", () => {
+      const onSwapPanes = vi.fn();
+      const onSplitPane = vi.fn();
+      render(<PaneGrid {...dndProps} onSwapPanes={onSwapPanes} onSplitPane={onSplitPane} />);
+
+      fireEvent.mouseEnter(screen.getByTestId("test-pane-0"));
+      const btn = screen.getAllByTestId("pane-control-split-h")[0];
+      const target2 = screen.getByTestId("test-pane-2");
+      const dataTransfer = makeDataTransfer();
+
+      // 버튼 위에서 시작한 drag: dragStart 가 currentTarget(바)이 아닌 버튼에서 발생하므로
+      // preventDefault 로 무시되어 dataTransfer 에 paneId 가 실리지 않는다.
+      fireEvent.dragStart(btn, { dataTransfer });
+      fireEvent.dragOver(target2, { dataTransfer });
+      fireEvent.drop(target2, { dataTransfer });
+      expect(onSwapPanes).not.toHaveBeenCalled();
+
+      // 버튼 클릭은 정상 동작한다.
+      fireEvent.click(btn);
+      expect(onSplitPane).toHaveBeenCalledWith("pane-0", "horizontal");
+    });
+
+    it("control bar is not draggable when isActive is false", () => {
       render(<PaneGrid {...dndProps} onSwapPanes={vi.fn()} isActive={false} />);
-      expect(screen.queryByTestId("pane-drag-handle-0")).not.toBeInTheDocument();
+      // 비활성 워크스페이스는 hover 가 동작하지 않아 바 자체가 렌더되지 않는다.
+      expect(screen.queryByTestId("pane-control-bar")).not.toBeInTheDocument();
     });
   });
 

--- a/ui/src/components/layout/PaneGrid.tsx
+++ b/ui/src/components/layout/PaneGrid.tsx
@@ -195,39 +195,6 @@ export function PaneGrid({
             }}
           >
             {focused && <FocusIndicator testId="pane-focus-indicator" />}
-            {dndEnabled && (
-              <div
-                data-testid={`pane-drag-handle-${i}`}
-                draggable
-                onDragStart={(e) => handleDragStart(e, pane.id)}
-                onDragEnd={handleDragEnd}
-                // 핸들 자체에 mousedown 이 pane 의 focus 로 버블링되지 않도록 막는다.
-                onMouseDown={(e) => e.stopPropagation()}
-                onClick={(e) => e.stopPropagation()}
-                title="Drag to swap pane position"
-                aria-label="Drag to swap pane position"
-                className={`absolute right-1 top-1 z-30 flex cursor-grab items-center justify-center rounded transition-opacity ${
-                  isActive && isHovered ? "opacity-90" : "opacity-0"
-                }`}
-                style={{
-                  width: "var(--btn-min-w)",
-                  height: "var(--btn-h)",
-                  background: "var(--bg-surface)",
-                  color: "var(--text-secondary)",
-                  border: "1px solid var(--border)",
-                  borderRadius: "var(--radius-sm)",
-                }}
-              >
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
-                  <circle cx="4" cy="2.5" r="1" />
-                  <circle cx="8" cy="2.5" r="1" />
-                  <circle cx="4" cy="6" r="1" />
-                  <circle cx="8" cy="6" r="1" />
-                  <circle cx="4" cy="9.5" r="1" />
-                  <circle cx="8" cy="9.5" r="1" />
-                </svg>
-              </div>
-            )}
             {dndEnabled && dragOverId === pane.id && (
               <div
                 data-testid={`pane-drop-target-${i}`}
@@ -247,6 +214,9 @@ export function PaneGrid({
               paneNumber={paneNumbers?.get(pane.id)}
               workspaceId={workspaceId}
               workspaceName={workspaceName}
+              dndEnabled={dndEnabled}
+              onPaneDragStart={(e) => handleDragStart(e, pane.id)}
+              onPaneDragEnd={handleDragEnd}
               actions={{
                 onChangeView: onSetPaneView
                   ? (config) => onSetPaneView(pane.id, config)

--- a/ui/src/components/ui/ViewHeader.tsx
+++ b/ui/src/components/ui/ViewHeader.tsx
@@ -49,6 +49,7 @@ export function ViewHeader({
         background: "var(--bg-surface)",
         ...(borderBottom ? { borderBottom: "1px solid var(--border)" } : {}),
       }}
+      {...ctx?.barDragProps}
     >
       <div className="flex min-w-0 flex-1 items-center">
         <PaneNumberBadge


### PR DESCRIPTION
## 문제
좁은 pane 에서 별도 drag-to-swap 핸들(#377)이 우상단 controlbar ⋯ 트리거를 가림. 넓은 pane 에서도 우측 컨트롤을 일부 가림.

## 수정 (설계 변경)
별도 floating 핸들을 **제거**하고, **controlbar 의 버튼 없는 빈 영역을 드래그**하면 pane 위치가 교환되도록 변경.

- 바 컨테이너 자체를 `draggable` 로. `onDragStart` 에서 `e.target !== e.currentTarget` 이면 `preventDefault()` → 버튼/select 위 드래그는 무시(클릭 정상), 빈 영역에서 시작한 것만 swap 개시.
- `dndEnabled = isActive && !!onSwapPanes` 유지 (dock 등 비활성).
- hover/pinned/narrow/ViewHeader 다중 바 모드를 단일 헬퍼 `barDragProps` 로 일관 적용.
- DnD 데이터·swap·dragOver/drop 하이라이트는 기존 PaneGrid 로직 재사용.

## 변경 파일
- `PaneGrid.tsx` — floating 핸들 제거, drag 핸들러를 PaneControlBar 에 props 전달
- `PaneControlBar.tsx` — `barDragProps` 헬퍼(빈영역 가드)를 바 컨테이너에 적용
- `PaneControlContext.tsx` / `ViewHeader.tsx` — ViewHeader 쓰는 View 도 일관 동작
- `PaneGrid.test.tsx` / `PaneControlBar.test.tsx` — 새 설계 테스트
- `docs/architecture/data-flow.md` — §위치교환 서술 갱신

## 테스트
- 대상 2파일 78 통과 (PaneGrid 24 + PaneControlBar 54)
- 빈영역 드래그→swap 트리거 / 버튼 위 드래그→무시(클릭 동작) / 핸들 요소 미렌더 검증
- tsc --noEmit, vite build, eslint 통과
- (참고) layout/ui 전역에서 FileViewerOverlay path 정규화 테스트 1건 실패하나 origin/main 에서도 동일한 기존 문제, 본 변경과 무관

Fixes #386