### PR TITLE
test(file-viewer): viewer instance id 테스트를 sanitize 동작에 맞게 갱신

### DIFF
--- a/ui/src/components/layout/FileViewerOverlay.test.tsx
+++ b/ui/src/components/layout/FileViewerOverlay.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { FileViewerOverlay } from "./FileViewerOverlay";
 import { useFileViewerStore } from "@/stores/file-viewer-store";
 import { useSettingsStore } from "@/stores/settings-store";
+import { viewerInstanceId } from "@/lib/file-viewer";
 
 // Mock FileViewer so the overlay tests stay focused on overlay behaviour
 // (dismiss handling + the id it forwards), not on file reading / TerminalView.
@@ -261,7 +262,9 @@ describe("FileViewerOverlay", () => {
     });
     const { rerender } = render(<FileViewerOverlay />);
     const idA = screen.getByTestId("mock-file-viewer").getAttribute("data-instance-id");
-    expect(idA).toContain("/home/user/a.txt");
+    // The id is the sanitized viewer instance id (path with event-name-illegal
+    // chars replaced + hash suffix), not the raw path — see viewerInstanceId.
+    expect(idA).toBe(viewerInstanceId("/home/user/a.txt"));
 
     act(() => {
       // Re-open a different file WITHOUT closing first (MCP/REST/Explorer can do
@@ -271,7 +274,7 @@ describe("FileViewerOverlay", () => {
     });
     rerender(<FileViewerOverlay />);
     const idB = screen.getByTestId("mock-file-viewer").getAttribute("data-instance-id");
-    expect(idB).toContain("/home/user/b.txt");
+    expect(idB).toBe(viewerInstanceId("/home/user/b.txt"));
     expect(idB).not.toBe(idA);
   });
 });


### PR DESCRIPTION
## 문제
`FileViewerOverlay.test.tsx` 의 "forwards a per-path viewer instance id..." 테스트가 origin/main 에서 실패 중이었음 (PR #387 작업 중 발견).

`viewerInstanceId` 가 Tauri v2 event-name 허용 문자(`[a-zA-Z0-9-/:_]`)만 남기도록 비허용 문자를 `_` 로 치환하고 원본 path 의 hash 접미사를 붙이도록 바뀌었는데(1cf5859, 2cce721 — `.txt → vi` 뷰어 black-screen 버그 수정), 테스트는 여전히 raw path(`/home/user/a.txt`) 포함을 기대해 실패.

```
expected 'global-file-viewer:/home/user/a_txt:5d526533' to contain '/home/user/a.txt'
```

## 수정
테스트를 sanitize 된 id 와 정확히 비교하도록 갱신 (`expect(idA).toBe(viewerInstanceId("/home/user/a.txt"))`). path 별 파생·경로 변경 시 remount(id 변경) 불변식은 그대로 검증.

코드 변경 없음 — stale 테스트만 수정.

## 테스트
- `npx vitest run FileViewerOverlay.test.tsx` → 19 passed