### PR TITLE
fix(ui): drop INEFFECTIVE_DYNAMIC_IMPORT warnings

### DIFF
--- a/ui/src/components/views/IssueReporterView.tsx
+++ b/ui/src/components/views/IssueReporterView.tsx
@@ -6,6 +6,7 @@ import { ViewShell } from "@/components/ui/ViewShell";
 import { ViewHeader } from "@/components/ui/ViewHeader";
 import { ViewBody } from "@/components/ui/ViewBody";
 import { openExternal } from "@/lib/tauri-api";
+import { invoke } from "@tauri-apps/api/core";
 
 type SubmitState = "idle" | "capturing" | "submitting" | "success" | "error";
 
@@ -72,7 +73,6 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
   const captureScreenshot = async () => {
     setState("capturing");
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
       const info = await invoke<{ port: number }>("get_automation_info");
       const res = await fetch(`http://127.0.0.1:${info.port}/api/v1/screenshot`, {
         method: "POST",
@@ -92,7 +92,6 @@ export function IssueReporterView({ isFocused }: IssueReporterViewProps) {
     setState("submitting");
     setResultMsg("");
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
       const url = await invoke<string>("submit_github_issue", {
         title: title.trim(),
         body,

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, createContext, useContext, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { invoke } from "@tauri-apps/api/core";
 import { useUiStore } from "@/stores/ui-store";
 import {
   useSettingsStore,
@@ -3204,7 +3205,6 @@ export function SettingsView() {
 
   const handleOpenSettingsJson = async () => {
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
       await invoke("open_settings_file");
     } catch {
       /* ignore — not available outside Tauri */

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -28,6 +28,7 @@ import { persistSession } from "@/lib/persist-session";
 import { useUiStore } from "@/stores/ui-store";
 import { useRenameWorkspaceStore } from "@/stores/rename-workspace-store";
 import { getPaneDragData, isPaneDrag } from "@/lib/pane-dnd";
+import { markNotificationsRead } from "@/lib/tauri-api";
 
 /** Abbreviate profile/view labels to max 3 characters. */
 const LABEL_ABBREV: Record<string, string> = {
@@ -1248,9 +1249,7 @@ export function WorkspaceSelectorView() {
         ?.panes.filter((p) => p.view.type === "TerminalView")
         .map((p) => `terminal-${p.id}`) ?? [];
     if (wsTerminalIds.length > 0) {
-      import("@/lib/tauri-api").then(({ markNotificationsRead }) =>
-        markNotificationsRead(wsTerminalIds).catch(() => {}),
-      );
+      markNotificationsRead(wsTerminalIds).catch(() => {});
     }
     setActiveWorkspace(wsId);
   };


### PR DESCRIPTION
## 변경

빌드 시 발생하던 `INEFFECTIVE_DYNAMIC_IMPORT` 경고 제거.

`markNotificationsRead`, `invoke`(@tauri-apps/api/core)를 동적 import 하던 뷰들이 이미 같은 모듈을 다른 곳에서 정적 import 하고 있어 코드 분할 효과가 없었음. 정적 import로 통일.

- `WorkspaceSelectorView.tsx` — `markNotificationsRead`
- `IssueReporterView.tsx` — `invoke` (2곳)
- `SettingsView.tsx` — `invoke`

빌드 확인: 두 경고 모두 사라짐. (chunk >500kB 경고는 별개 — 실제 코드 분할 필요, 범위 외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)