### PR TITLE
chore(build): split vendor chunks to clear 500kB warning

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -16,5 +16,16 @@ export default defineConfig({
   },
   build: {
     outDir: "dist",
+    rolldownOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes("node_modules")) return;
+          if (id.includes("@xterm")) return "xterm";
+          if (id.includes("html2canvas")) return "html2canvas";
+          if (id.includes("i18next")) return "i18n";
+          if (/[\\/]react(-dom)?[\\/]/.test(id)) return "react";
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
## 변경

단일 `index` 청크가 1.28MB라 빌드 시 `>500kB` 경고 발생. `manualChunks`로 벤더 분리.

| chunk | size |
|---|---|
| index (app) | 1.28MB → 360kB |
| xterm | 481kB |
| html2canvas | 200kB |
| react | 182kB |
| i18n | 55kB |

모든 청크 500kB 미만 → 경고 제거. 빌드 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)