### PR TITLE
fix(ui): kill startup white flash

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,8 @@
         "resizable": true,
         "fullscreen": false,
         "decorations": false,
-        "dragDropEnabled": false
+        "dragDropEnabled": false,
+        "backgroundColor": "#1e1e2e"
       }
     ],
     "security": {

--- a/ui/index.html
+++ b/ui/index.html
@@ -5,6 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <title>Laymux</title>
+    <style>
+      /* Applied before the JS/CSS bundle loads to avoid a white flash on
+         startup while vendor chunks are fetched. Matches --bg-base. */
+      html,
+      body {
+        margin: 0;
+        background: #1e1e2e;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## 문제

벤더 청크 분할(#390) 이후 앱 기동 시 잠깐 흰 화면 노출. 엔트리가 React 마운트 전 여러 JS 청크를 fetch하는 동안, body 배경은 JS로 로드되는 `index.css` 안에 있어 적용이 늦음 → 기본 흰 body가 한 프레임 보임.

## 수정

- `index.html <head>`에 base 배경(`#1e1e2e`, `--bg-base` 일치) 인라인 → 첫 페인트부터 앱 색상
- Tauri 윈도우 `backgroundColor` 설정 → webview 페인트 전 네이티브 윈도우 흰색도 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)