### PR TITLE
[codex] Implement direct remote mode foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -118,8 +119,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -650,6 +653,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
@@ -3008,6 +3017,16 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
@@ -3038,6 +3057,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3053,6 +3082,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3691,6 +3729,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -4486,6 +4535,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4738,6 +4799,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -29,6 +29,25 @@ UI 다국어는 **react-i18next** 로 구현한다(이슈 #350).
 - SettingsView를 Dock에 배치하여 열기 (선택, Dock only)
 - `settings.json` 직접 텍스트 편집
 
+### Direct Remote Mode 설정
+
+브라우저 원격 접속은 명시적 opt-in 설정이다. 기본값은 꺼짐이며, remote API는 Automation API/MCP의 IP allowlist와 별도 인증/Origin/IP 정책을 사용한다([ADR-0013](../adr/0013-direct-remote-mode.md)).
+
+```jsonc
+{
+  "remote": {
+    "enabled": false,                  // 기본값: 비활성화
+    "bindAddress": "0.0.0.0",          // 현재 구현은 Automation 서버 listener를 공유
+    "allowedOrigins": [],              // 비어 있으면 Origin 필터 없음
+    "allowedIps": ["127.0.0.1/32", "::1/128"],
+    "authToken": "",                   // enabled=true일 때 필수
+    "heartbeatTimeoutSeconds": 15       // 최소 5초로 clamp
+  }
+}
+```
+
+Tailscale 직접 접속을 허용하려면 `allowedIps`에 Tailnet 범위(예: `100.64.0.0/10`) 또는 구체적인 peer IP/CIDR를 추가하고 `authToken`을 설정한다. Tailscale은 transport 격리일 뿐 인증을 대체하지 않는다.
+
 ### Windows Terminal 호환 항목
 
 | 항목 | 설명 |
@@ -481,6 +500,41 @@ claude mcp add-json -s user laymux '{"type":"http","url":"http://<IP>:19280/mcp"
 - URL 형식: `http://<IP>:<PORT>/mcp` (trailing slash 없음)
 - 인증 헤더 불필요 — `headers` 필드가 있으면 오히려 문제 가능
 - Claude Code 재시작 필요 (MCP 설정 변경 후)
+
+## 13. Remote UI API
+
+Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Direct Remote Mode 계약이다. 같은 axum 서버에 붙지만 Automation API/MCP와 route namespace, 인증, Origin/CORS, 세션 모델을 분리한다([ADR-0013](../adr/0013-direct-remote-mode.md)). Automation API의 `REGISTERED_ROUTES`/docs 검증 대상이 아니며 `/remote/v1/*` 네임스페이스만 사용한다.
+
+### 13.1 인증과 접근 제어
+
+- `settings.remote.enabled`가 `true`일 때만 응답한다.
+- `settings.remote.authToken`은 필수다. HTTP 요청은 `Authorization: Bearer <token>` 또는 `X-Laymux-Remote-Token`을 사용할 수 있고, WebSocket은 브라우저 제약 때문에 `?token=<token>`도 허용한다.
+- `settings.remote.allowedIps`는 IP/CIDR allowlist다. 기본값은 loopback only이며 Tailscale 직접 접속은 예를 들어 `100.64.0.0/10`을 명시해야 한다.
+- `settings.remote.allowedOrigins`가 비어 있지 않으면 `Origin` 헤더가 정확히 일치해야 한다. 비어 있으면 token 기반 요청을 허용한다.
+
+### 13.2 Controller Lease
+
+원격 제어는 다중 클라이언트 동기화가 아니라 exclusive controller lease다.
+
+| Endpoint | Method | 용도 |
+|---|---|---|
+| `/remote/v1/session/status` | GET | 현재 lease 상태 조회 |
+| `/remote/v1/session/claim` | POST | remote controller lease 획득. 이미 active면 `409` |
+| `/remote/v1/session/heartbeat` | POST | lease heartbeat 갱신 |
+| `/remote/v1/session/release` | POST | remote가 lease 반납 |
+
+`claim` 응답의 `leaseId`가 이후 제어 요청의 권한이다. PC WebView는 `remote-control-changed` Tauri event를 받아 local input overlay를 표시하고, `reclaim_remote_control` Tauri command로 언제든 lease를 해제할 수 있다. Heartbeat timeout이 지나면 다음 status/control 검사에서 lease는 만료된다.
+
+### 13.3 Terminal Control
+
+| Endpoint | Method | 용도 |
+|---|---|---|
+| `/remote/v1/terminals` | GET | 현재 backend terminal session 목록 |
+| `/remote/v1/terminals/{id}/write` | POST | active `leaseId`로 PTY 입력 전송 |
+| `/remote/v1/terminals/{id}/resize` | POST | active `leaseId`로 PTY 크기 변경 |
+| `/remote/v1/terminals/{id}/output?leaseId=...&token=...` | WS | ring buffer tail + 이후 PTY output byte stream |
+
+`write`/`resize`는 JSON body의 `leaseId` 또는 `X-Laymux-Remote-Lease` 헤더가 현재 active lease와 일치해야 한다. 출력 WebSocket도 `leaseId` 쿼리를 요구한다. 이는 인증된 다른 remote peer가 active controller를 우회해 입력을 주입하지 못하게 하는 서버 측 게이트다.
 
 ---
 

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -38,7 +38,7 @@ UI 다국어는 **react-i18next** 로 구현한다(이슈 #350).
   "remote": {
     "enabled": false,                  // 기본값: 비활성화
     "bindAddress": "0.0.0.0",          // 현재 구현은 Automation 서버 listener를 공유
-    "allowedOrigins": [],              // 비어 있으면 Origin 필터 없음
+    "allowedOrigins": [],              // 비어 있으면 Origin 필터 없음, 값이 있으면 Origin 헤더 필수
     "allowedIps": ["127.0.0.1/32", "::1/128"],
     "authToken": "",                   // enabled=true일 때 필수
     "heartbeatTimeoutSeconds": 15       // 최소 5초로 clamp
@@ -510,7 +510,7 @@ Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Dire
 - `settings.remote.enabled`가 `true`일 때만 응답한다.
 - `settings.remote.authToken`은 필수다. HTTP 요청은 `Authorization: Bearer <token>` 또는 `X-Laymux-Remote-Token`을 사용할 수 있고, WebSocket은 브라우저 제약 때문에 `?token=<token>`도 허용한다.
 - `settings.remote.allowedIps`는 IP/CIDR allowlist다. 기본값은 loopback only이며 Tailscale 직접 접속은 예를 들어 `100.64.0.0/10`을 명시해야 한다.
-- `settings.remote.allowedOrigins`가 비어 있지 않으면 `Origin` 헤더가 정확히 일치해야 한다. 비어 있으면 token 기반 요청을 허용한다.
+- `settings.remote.allowedOrigins`가 비어 있지 않으면 `Origin` 헤더가 존재하고 정확히 일치해야 한다. 비어 있으면 token 기반 요청을 허용한다.
 
 ### 13.2 Controller Lease
 
@@ -523,7 +523,7 @@ Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Dire
 | `/remote/v1/session/heartbeat` | POST | lease heartbeat 갱신 |
 | `/remote/v1/session/release` | POST | remote가 lease 반납 |
 
-`claim` 응답의 `leaseId`가 이후 제어 요청의 권한이다. PC WebView는 `remote-control-changed` Tauri event를 받아 local input overlay를 표시하고, `reclaim_remote_control` Tauri command로 언제든 lease를 해제할 수 있다. Heartbeat timeout이 지나면 다음 status/control 검사에서 lease는 만료된다.
+`claim` 응답의 `leaseId`가 이후 제어 요청의 권한이다. PC WebView는 `remote-control-changed` Tauri event를 받아 local input overlay를 표시하고, `reclaim_remote_control` Tauri command로 언제든 lease를 해제할 수 있다. PC reclaim은 현재 lease를 해제하고 `heartbeatTimeoutSeconds` 동안 새 remote claim을 `409`로 거절한다. Heartbeat timeout이 지나면 다음 status/control 검사에서 lease는 만료된다.
 
 ### 13.3 Terminal Control
 

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -508,7 +508,7 @@ Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Dire
 ### 13.1 인증과 접근 제어
 
 - `settings.remote.enabled`가 `true`일 때만 응답한다.
-- `settings.remote.authToken`은 필수다. HTTP 요청은 `Authorization: Bearer <token>` 또는 `X-Laymux-Remote-Token`을 사용할 수 있고, WebSocket은 브라우저 제약 때문에 `?token=<token>`도 허용한다.
+- `settings.remote.authToken`은 필수다. HTTP 요청은 `Authorization: Bearer <token>` 또는 `X-Laymux-Remote-Token`을 사용할 수 있고, WebSocket은 브라우저 제약 때문에 URL-encoded `?token=<token>`도 허용한다.
 - `settings.remote.allowedIps`는 IP/CIDR allowlist다. 기본값은 loopback only이며 Tailscale 직접 접속은 예를 들어 `100.64.0.0/10`을 명시해야 한다.
 - `settings.remote.allowedOrigins`가 비어 있지 않으면 `Origin` 헤더가 존재하고 정확히 일치해야 한다. 비어 있으면 token 기반 요청을 허용한다.
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 portable-pty = "0.8"
 tokio = { version = "1", features = ["full"] }
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 tower-http = { version = "0.6", features = ["cors"] }
 thiserror = "2"
 tracing = "0.1"

--- a/src-tauri/src/automation_server/mod.rs
+++ b/src-tauri/src/automation_server/mod.rs
@@ -176,7 +176,7 @@ async fn ip_allowlist_middleware(
 }
 
 pub fn build_router(state: ServerState, subscriptions: SharedSubscriptionRegistry) -> Router {
-    Router::new()
+    let automation_routes = Router::new()
         .route("/api/v1/docs", get(api_docs))
         .route("/api/v1/health", get(health))
         .route("/api/v1/workspaces", get(workspaces_list))
@@ -270,16 +270,17 @@ pub fn build_router(state: ServerState, subscriptions: SharedSubscriptionRegistr
             post(ui_toggle_pane_hidden),
         )
         .layer(middleware::from_fn(ip_allowlist_middleware))
-        .layer(CorsLayer::permissive())
+        .layer(CorsLayer::permissive());
+
+    automation_routes
+        .merge(crate::remote_server::build_router())
         .with_state(state)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::routing::get;
     use serial_test::serial;
-    use tower::ServiceExt;
 
     #[test]
     fn automation_port_returns_dev_in_debug() {

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use tauri::State;
+use tauri::{AppHandle, State};
 
 use crate::activity;
 use crate::automation_server::AutomationResponse;
@@ -20,6 +20,21 @@ pub fn get_automation_info(state: State<Arc<AppState>>) -> Result<serde_json::Va
     Ok(serde_json::json!({
         "port": port,
     }))
+}
+
+#[tauri::command]
+pub fn get_remote_control_status(
+    state: State<Arc<AppState>>,
+) -> Result<crate::remote_server::RemoteControlStatus, String> {
+    crate::remote_server::get_remote_control_status(&state)
+}
+
+#[tauri::command]
+pub fn reclaim_remote_control(
+    state: State<Arc<AppState>>,
+    app: AppHandle,
+) -> Result<crate::remote_server::RemoteControlStatus, String> {
+    crate::remote_server::reclaim_remote_control(&state, &app)
 }
 
 #[tauri::command]

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -15,6 +15,7 @@ pub const EVENT_TERMINAL_CWD_CHANGED: &str = "terminal-cwd-changed";
 pub const EVENT_TERMINAL_TITLE_CHANGED: &str = "terminal-title-changed";
 pub const EVENT_CLAUDE_MESSAGE_CHANGED: &str = "claude-message-changed";
 pub const EVENT_TERMINAL_OUTPUT_ACTIVITY: &str = "terminal-output-activity";
+pub const EVENT_REMOTE_CONTROL_CHANGED: &str = "remote-control-changed";
 
 // ── Environment variable names ─────────────────────────────────────
 
@@ -151,6 +152,7 @@ mod tests {
             EVENT_TERMINAL_TITLE_CHANGED,
             EVENT_CLAUDE_MESSAGE_CHANGED,
             EVENT_TERMINAL_OUTPUT_ACTIVITY,
+            EVENT_REMOTE_CONTROL_CHANGED,
             EVENT_WORKSPACE_STATE_CHANGED,
             EVENT_TERMINALS_LIST_CHANGED,
         ];

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ pub mod process;
 pub mod process_tree;
 pub mod pty;
 pub mod pty_trace;
+pub mod remote_server;
 pub mod settings;
 pub mod state;
 pub mod terminal;
@@ -167,6 +168,8 @@ pub fn run() {
             commands::load_settings_validated,
             commands::reset_settings,
             commands::get_settings_path,
+            commands::get_remote_control_status,
+            commands::reclaim_remote_control,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/remote_server/auth.rs
+++ b/src-tauri/src/remote_server/auth.rs
@@ -77,7 +77,7 @@ fn origin_allowed(headers: &HeaderMap, settings: &RemoteSettings) -> bool {
         .get(header::ORIGIN)
         .and_then(|value| value.to_str().ok())
     else {
-        return true;
+        return false;
     };
     settings
         .allowed_origins
@@ -239,6 +239,17 @@ mod tests {
             header::ORIGIN,
             HeaderValue::from_static("http://example.com"),
         );
+        assert!(!origin_allowed(&headers, &settings));
+    }
+
+    #[test]
+    fn origin_allowlist_rejects_missing_origin_when_configured() {
+        let settings = RemoteSettings {
+            allowed_origins: vec!["http://100.64.0.2:19281".into()],
+            ..RemoteSettings::default()
+        };
+        let headers = HeaderMap::new();
+
         assert!(!origin_allowed(&headers, &settings));
     }
 }

--- a/src-tauri/src/remote_server/auth.rs
+++ b/src-tauri/src/remote_server/auth.rs
@@ -1,0 +1,244 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use axum::extract::{ConnectInfo, Request};
+use axum::http::{header, HeaderMap, StatusCode, Uri};
+use axum::middleware::Next;
+use axum::response::Response;
+
+use crate::settings::models::RemoteSettings;
+
+use super::json_error;
+
+const REMOTE_TOKEN_HEADER: &str = "x-laymux-remote-token";
+
+pub(crate) async fn remote_guard(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let settings = crate::settings::load_settings().remote;
+
+    if !settings.enabled {
+        return json_error(StatusCode::FORBIDDEN, "direct remote mode is disabled");
+    }
+    if settings.auth_token.is_empty() {
+        return json_error(
+            StatusCode::UNAUTHORIZED,
+            "direct remote mode requires remote.authToken",
+        );
+    }
+    if !is_remote_ip_allowed(&normalize_ip(addr.ip()), &settings.allowed_ips) {
+        return json_error(StatusCode::FORBIDDEN, "remote client IP is not allowed");
+    }
+    if !origin_allowed(req.headers(), &settings) {
+        return json_error(StatusCode::FORBIDDEN, "remote Origin is not allowed");
+    }
+    if !remote_token_matches(req.headers(), req.uri(), &settings) {
+        return json_error(StatusCode::UNAUTHORIZED, "remote token is invalid");
+    }
+
+    next.run(req).await
+}
+
+fn remote_token_matches(headers: &HeaderMap, uri: &Uri, settings: &RemoteSettings) -> bool {
+    token_from_authorization(headers)
+        .or_else(|| header_value(headers, REMOTE_TOKEN_HEADER))
+        .or_else(|| query_param(uri, "token"))
+        .is_some_and(|token| token == settings.auth_token)
+}
+
+fn token_from_authorization(headers: &HeaderMap) -> Option<&str> {
+    let value = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    value
+        .strip_prefix("Bearer ")
+        .or_else(|| value.strip_prefix("bearer "))
+        .filter(|token| !token.is_empty())
+}
+
+fn header_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+}
+
+fn query_param<'a>(uri: &'a Uri, key: &str) -> Option<&'a str> {
+    uri.query()?.split('&').find_map(|pair| {
+        let (name, value) = pair.split_once('=')?;
+        (name == key && !value.is_empty()).then_some(value)
+    })
+}
+
+fn origin_allowed(headers: &HeaderMap, settings: &RemoteSettings) -> bool {
+    if settings.allowed_origins.is_empty() {
+        return true;
+    }
+    let Some(origin) = headers
+        .get(header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return true;
+    };
+    settings
+        .allowed_origins
+        .iter()
+        .any(|allowed| allowed == "*" || allowed == origin)
+}
+
+fn normalize_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(v6) => v6
+            .to_ipv4_mapped()
+            .map(IpAddr::V4)
+            .unwrap_or(IpAddr::V6(v6)),
+        other => other,
+    }
+}
+
+fn is_remote_ip_allowed(ip: &IpAddr, allowed_ips: &[String]) -> bool {
+    if allowed_ips.is_empty() {
+        return ip.is_loopback();
+    }
+
+    allowed_ips
+        .iter()
+        .any(|entry| ip_matches_allowlist_entry(ip, entry.trim()))
+}
+
+fn ip_matches_allowlist_entry(ip: &IpAddr, entry: &str) -> bool {
+    if entry.is_empty() {
+        return false;
+    }
+    if entry == "*" {
+        return true;
+    }
+    if let Ok(exact) = entry.parse::<IpAddr>() {
+        return normalize_ip(exact) == *ip;
+    }
+    let Some((network, prefix)) = entry.split_once('/') else {
+        return false;
+    };
+    let Ok(prefix) = prefix.parse::<u8>() else {
+        return false;
+    };
+    match (ip, network.parse::<IpAddr>().map(normalize_ip)) {
+        (IpAddr::V4(addr), Ok(IpAddr::V4(network))) => ipv4_in_cidr(*addr, network, prefix),
+        (IpAddr::V6(addr), Ok(IpAddr::V6(network))) => ipv6_in_cidr(*addr, network, prefix),
+        _ => false,
+    }
+}
+
+fn ipv4_in_cidr(addr: Ipv4Addr, network: Ipv4Addr, prefix: u8) -> bool {
+    if prefix > 32 {
+        return false;
+    }
+    let mask = if prefix == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix)
+    };
+    (u32::from(addr) & mask) == (u32::from(network) & mask)
+}
+
+fn ipv6_in_cidr(addr: Ipv6Addr, network: Ipv6Addr, prefix: u8) -> bool {
+    if prefix > 128 {
+        return false;
+    }
+    let mask = if prefix == 0 {
+        0
+    } else {
+        u128::MAX << (128 - prefix)
+    };
+    let addr = u128::from_be_bytes(addr.octets());
+    let network = u128::from_be_bytes(network.octets());
+    (addr & mask) == (network & mask)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn remote_allowlist_matches_tailscale_cidr() {
+        let allowed = vec!["100.64.0.0/10".to_string()];
+        assert!(is_remote_ip_allowed(
+            &"100.100.10.20".parse::<IpAddr>().unwrap(),
+            &allowed
+        ));
+        assert!(is_remote_ip_allowed(
+            &"100.127.255.255".parse::<IpAddr>().unwrap(),
+            &allowed
+        ));
+        assert!(!is_remote_ip_allowed(
+            &"100.128.0.1".parse::<IpAddr>().unwrap(),
+            &allowed
+        ));
+    }
+
+    #[test]
+    fn remote_allowlist_defaults_to_loopback_when_empty() {
+        assert!(is_remote_ip_allowed(
+            &"127.0.0.1".parse::<IpAddr>().unwrap(),
+            &[]
+        ));
+        assert!(!is_remote_ip_allowed(
+            &"192.168.1.10".parse::<IpAddr>().unwrap(),
+            &[]
+        ));
+    }
+
+    #[test]
+    fn remote_token_accepts_bearer_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer secret"),
+        );
+        let settings = RemoteSettings {
+            auth_token: "secret".into(),
+            ..RemoteSettings::default()
+        };
+        assert!(remote_token_matches(
+            &headers,
+            &"/remote/v1/health".parse::<Uri>().unwrap(),
+            &settings
+        ));
+    }
+
+    #[test]
+    fn remote_token_accepts_query_for_websocket() {
+        let headers = HeaderMap::new();
+        let settings = RemoteSettings {
+            auth_token: "secret".into(),
+            ..RemoteSettings::default()
+        };
+        assert!(remote_token_matches(
+            &headers,
+            &"/remote/v1/terminals/t1/output?token=secret"
+                .parse::<Uri>()
+                .unwrap(),
+            &settings
+        ));
+    }
+
+    #[test]
+    fn origin_allowlist_is_enforced_when_configured() {
+        let settings = RemoteSettings {
+            allowed_origins: vec!["http://100.64.0.2:19281".into()],
+            ..RemoteSettings::default()
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::ORIGIN,
+            HeaderValue::from_static("http://100.64.0.2:19281"),
+        );
+        assert!(origin_allowed(&headers, &settings));
+
+        headers.insert(
+            header::ORIGIN,
+            HeaderValue::from_static("http://example.com"),
+        );
+        assert!(!origin_allowed(&headers, &settings));
+    }
+}

--- a/src-tauri/src/remote_server/auth.rs
+++ b/src-tauri/src/remote_server/auth.rs
@@ -41,10 +41,32 @@ pub(crate) async fn remote_guard(
 }
 
 fn remote_token_matches(headers: &HeaderMap, uri: &Uri, settings: &RemoteSettings) -> bool {
-    token_from_authorization(headers)
-        .or_else(|| header_value(headers, REMOTE_TOKEN_HEADER))
-        .or_else(|| query_param(uri, "token"))
-        .is_some_and(|token| token == settings.auth_token)
+    if let Some(token) =
+        token_from_authorization(headers).or_else(|| header_value(headers, REMOTE_TOKEN_HEADER))
+    {
+        return token_matches(token, &settings.auth_token);
+    }
+
+    query_param(uri, "token")
+        .as_deref()
+        .is_some_and(|token| token_matches(token, &settings.auth_token))
+}
+
+fn token_matches(token: &str, expected: &str) -> bool {
+    constant_time_eq(token.as_bytes(), expected.as_bytes())
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    let max_len = left.len().max(right.len());
+    let mut diff = left.len() ^ right.len();
+
+    for index in 0..max_len {
+        let left_byte = left.get(index).copied().unwrap_or(0);
+        let right_byte = right.get(index).copied().unwrap_or(0);
+        diff |= usize::from(left_byte ^ right_byte);
+    }
+
+    diff == 0
 }
 
 fn token_from_authorization(headers: &HeaderMap) -> Option<&str> {
@@ -62,11 +84,50 @@ fn header_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
         .filter(|value| !value.is_empty())
 }
 
-fn query_param<'a>(uri: &'a Uri, key: &str) -> Option<&'a str> {
+fn query_param(uri: &Uri, key: &str) -> Option<String> {
     uri.query()?.split('&').find_map(|pair| {
         let (name, value) = pair.split_once('=')?;
-        (name == key && !value.is_empty()).then_some(value)
+        if name != key || value.is_empty() {
+            return None;
+        }
+        decode_query_component(value)
     })
+}
+
+fn decode_query_component(value: &str) -> Option<String> {
+    let input = value.as_bytes();
+    let mut decoded = Vec::with_capacity(input.len());
+    let mut index = 0;
+
+    while index < input.len() {
+        match input[index] {
+            b'%' => {
+                let high = hex_value(*input.get(index + 1)?)?;
+                let low = hex_value(*input.get(index + 2)?)?;
+                decoded.push((high << 4) | low);
+                index += 3;
+            }
+            b'+' => {
+                decoded.push(b' ');
+                index += 1;
+            }
+            byte => {
+                decoded.push(byte);
+                index += 1;
+            }
+        }
+    }
+
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
 }
 
 fn origin_allowed(headers: &HeaderMap, settings: &RemoteSettings) -> bool {
@@ -220,6 +281,29 @@ mod tests {
                 .unwrap(),
             &settings
         ));
+    }
+
+    #[test]
+    fn remote_token_decodes_query_for_websocket() {
+        let headers = HeaderMap::new();
+        let settings = RemoteSettings {
+            auth_token: "sec/ret+?".into(),
+            ..RemoteSettings::default()
+        };
+        assert!(remote_token_matches(
+            &headers,
+            &"/remote/v1/terminals/t1/output?token=sec%2Fret%2B%3F"
+                .parse::<Uri>()
+                .unwrap(),
+            &settings
+        ));
+    }
+
+    #[test]
+    fn token_match_rejects_mismatch() {
+        assert!(token_matches("secret", "secret"));
+        assert!(!token_matches("secret", "secrets"));
+        assert!(!token_matches("secret", "nope"));
     }
 
     #[test]

--- a/src-tauri/src/remote_server/lease.rs
+++ b/src-tauri/src/remote_server/lease.rs
@@ -1,0 +1,148 @@
+use std::time::{Duration, Instant};
+
+use axum::http::StatusCode;
+use axum::response::Response;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+use crate::constants::EVENT_REMOTE_CONTROL_CHANGED;
+use crate::lock_ext::MutexExt;
+use crate::settings::models::RemoteSettings;
+use crate::state::AppState;
+
+use super::{internal_error, json_error};
+
+const MIN_HEARTBEAT_TIMEOUT_SECONDS: u64 = 5;
+
+/// Internal controller lease for Direct Remote Mode.
+#[derive(Debug, Clone)]
+pub struct RemoteControlLease {
+    pub lease_id: String,
+    pub remote_addr: String,
+    pub client_name: Option<String>,
+    pub last_heartbeat: Instant,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteControlStatus {
+    pub active: bool,
+    pub lease_id: Option<String>,
+    pub remote_addr: Option<String>,
+    pub client_name: Option<String>,
+    pub heartbeat_timeout_seconds: u64,
+}
+
+pub fn get_remote_control_status(app_state: &AppState) -> Result<RemoteControlStatus, String> {
+    let settings = crate::settings::load_settings().remote;
+    let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
+    let mut current = app_state.remote_control.lock_or_err()?;
+    prune_expired_lease(&mut current, Duration::from_secs(timeout_seconds));
+    Ok(status_from_lease(&current, timeout_seconds))
+}
+
+pub fn reclaim_remote_control(
+    app_state: &AppState,
+    app_handle: &AppHandle,
+) -> Result<RemoteControlStatus, String> {
+    let settings = crate::settings::load_settings().remote;
+    let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
+    let status = {
+        let mut current = app_state.remote_control.lock_or_err()?;
+        *current = None;
+        status_from_lease(&current, timeout_seconds)
+    };
+    emit_remote_control_status(app_handle, &status);
+    Ok(status)
+}
+
+pub(crate) fn effective_heartbeat_timeout_seconds(settings: &RemoteSettings) -> u64 {
+    settings
+        .heartbeat_timeout_seconds
+        .max(MIN_HEARTBEAT_TIMEOUT_SECONDS)
+}
+
+pub(crate) fn status_from_lease(
+    lease: &Option<RemoteControlLease>,
+    heartbeat_timeout_seconds: u64,
+) -> RemoteControlStatus {
+    match lease {
+        Some(lease) => RemoteControlStatus {
+            active: true,
+            lease_id: Some(lease.lease_id.clone()),
+            remote_addr: Some(lease.remote_addr.clone()),
+            client_name: lease.client_name.clone(),
+            heartbeat_timeout_seconds,
+        },
+        None => RemoteControlStatus {
+            active: false,
+            lease_id: None,
+            remote_addr: None,
+            client_name: None,
+            heartbeat_timeout_seconds,
+        },
+    }
+}
+
+pub(crate) fn prune_expired_lease(lease: &mut Option<RemoteControlLease>, timeout: Duration) {
+    if lease
+        .as_ref()
+        .is_some_and(|current| current.last_heartbeat.elapsed() > timeout)
+    {
+        *lease = None;
+    }
+}
+
+pub(crate) fn emit_remote_control_status(app_handle: &AppHandle, status: &RemoteControlStatus) {
+    if let Err(err) = app_handle.emit(EVENT_REMOTE_CONTROL_CHANGED, status) {
+        tracing::warn!(error = %err, "failed to emit remote-control-changed");
+    }
+}
+
+pub(crate) fn require_active_lease(
+    app_state: &AppState,
+    lease_id: Option<&str>,
+) -> Result<(), Response> {
+    let Some(lease_id) = lease_id.filter(|value| !value.is_empty()) else {
+        return Err(json_error(
+            StatusCode::CONFLICT,
+            "remote controller lease is required",
+        ));
+    };
+
+    match active_lease_matches(app_state, lease_id) {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(json_error(
+            StatusCode::CONFLICT,
+            "remote controller lease is not active",
+        )),
+        Err(err) => Err(internal_error(err)),
+    }
+}
+
+pub(crate) fn active_lease_matches(app_state: &AppState, lease_id: &str) -> Result<bool, String> {
+    let settings = crate::settings::load_settings().remote;
+    let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
+    let mut current = app_state.remote_control.lock_or_err()?;
+    prune_expired_lease(&mut current, Duration::from_secs(timeout_seconds));
+    Ok(current
+        .as_ref()
+        .is_some_and(|current| current.lease_id == lease_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expired_lease_is_pruned() {
+        let mut lease = Some(RemoteControlLease {
+            lease_id: "lease".into(),
+            remote_addr: "127.0.0.1:1".into(),
+            client_name: None,
+            last_heartbeat: Instant::now() - Duration::from_secs(20),
+        });
+        prune_expired_lease(&mut lease, Duration::from_secs(5));
+        assert!(lease.is_none());
+    }
+}

--- a/src-tauri/src/remote_server/lease.rs
+++ b/src-tauri/src/remote_server/lease.rs
@@ -23,6 +23,12 @@ pub struct RemoteControlLease {
     pub last_heartbeat: Instant,
 }
 
+#[derive(Debug, Default)]
+pub struct RemoteControlState {
+    pub lease: Option<RemoteControlLease>,
+    pub reclaim_lockout_until: Option<Instant>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoteControlStatus {
@@ -37,8 +43,9 @@ pub fn get_remote_control_status(app_state: &AppState) -> Result<RemoteControlSt
     let settings = crate::settings::load_settings().remote;
     let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
     let mut current = app_state.remote_control.lock_or_err()?;
-    prune_expired_lease(&mut current, Duration::from_secs(timeout_seconds));
-    Ok(status_from_lease(&current, timeout_seconds))
+    prune_expired_lease(&mut current.lease, Duration::from_secs(timeout_seconds));
+    prune_expired_reclaim_lockout(&mut current, Instant::now());
+    Ok(status_from_state(&current, timeout_seconds))
 }
 
 pub fn reclaim_remote_control(
@@ -49,8 +56,13 @@ pub fn reclaim_remote_control(
     let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
     let status = {
         let mut current = app_state.remote_control.lock_or_err()?;
-        *current = None;
-        status_from_lease(&current, timeout_seconds)
+        current.lease = None;
+        start_reclaim_lockout(
+            &mut current,
+            Duration::from_secs(timeout_seconds),
+            Instant::now(),
+        );
+        status_from_state(&current, timeout_seconds)
     };
     emit_remote_control_status(app_handle, &status);
     Ok(status)
@@ -84,12 +96,47 @@ pub(crate) fn status_from_lease(
     }
 }
 
+pub(crate) fn status_from_state(
+    state: &RemoteControlState,
+    heartbeat_timeout_seconds: u64,
+) -> RemoteControlStatus {
+    status_from_lease(&state.lease, heartbeat_timeout_seconds)
+}
+
 pub(crate) fn prune_expired_lease(lease: &mut Option<RemoteControlLease>, timeout: Duration) {
     if lease
         .as_ref()
         .is_some_and(|current| current.last_heartbeat.elapsed() > timeout)
     {
         *lease = None;
+    }
+}
+
+pub(crate) fn start_reclaim_lockout(
+    state: &mut RemoteControlState,
+    duration: Duration,
+    now: Instant,
+) {
+    state.reclaim_lockout_until = Some(now + duration);
+}
+
+pub(crate) fn reclaim_lockout_active(state: &mut RemoteControlState, now: Instant) -> bool {
+    match state.reclaim_lockout_until {
+        Some(until) if until > now => true,
+        Some(_) => {
+            state.reclaim_lockout_until = None;
+            false
+        }
+        None => false,
+    }
+}
+
+pub(crate) fn prune_expired_reclaim_lockout(state: &mut RemoteControlState, now: Instant) {
+    if state
+        .reclaim_lockout_until
+        .is_some_and(|until| until <= now)
+    {
+        state.reclaim_lockout_until = None;
     }
 }
 
@@ -123,9 +170,18 @@ pub(crate) fn require_active_lease(
 pub(crate) fn active_lease_matches(app_state: &AppState, lease_id: &str) -> Result<bool, String> {
     let settings = crate::settings::load_settings().remote;
     let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
+    active_lease_matches_with_timeout(app_state, lease_id, Duration::from_secs(timeout_seconds))
+}
+
+pub(crate) fn active_lease_matches_with_timeout(
+    app_state: &AppState,
+    lease_id: &str,
+    timeout: Duration,
+) -> Result<bool, String> {
     let mut current = app_state.remote_control.lock_or_err()?;
-    prune_expired_lease(&mut current, Duration::from_secs(timeout_seconds));
+    prune_expired_lease(&mut current.lease, timeout);
     Ok(current
+        .lease
         .as_ref()
         .is_some_and(|current| current.lease_id == lease_id))
 }
@@ -144,5 +200,22 @@ mod tests {
         });
         prune_expired_lease(&mut lease, Duration::from_secs(5));
         assert!(lease.is_none());
+    }
+
+    #[test]
+    fn reclaim_lockout_expires_after_duration() {
+        let now = Instant::now();
+        let mut state = RemoteControlState::default();
+        start_reclaim_lockout(&mut state, Duration::from_secs(5), now);
+
+        assert!(reclaim_lockout_active(
+            &mut state,
+            now + Duration::from_secs(4)
+        ));
+        assert!(!reclaim_lockout_active(
+            &mut state,
+            now + Duration::from_secs(5)
+        ));
+        assert!(state.reclaim_lockout_until.is_none());
     }
 }

--- a/src-tauri/src/remote_server/mod.rs
+++ b/src-tauri/src/remote_server/mod.rs
@@ -1,0 +1,20 @@
+mod auth;
+mod lease;
+mod routes;
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+
+pub use lease::{
+    get_remote_control_status, reclaim_remote_control, RemoteControlLease, RemoteControlStatus,
+};
+pub use routes::build_router;
+
+pub(crate) fn json_error(status: StatusCode, message: &str) -> Response {
+    (status, Json(serde_json::json!({ "error": message }))).into_response()
+}
+
+pub(crate) fn internal_error(err: impl std::fmt::Display) -> Response {
+    json_error(StatusCode::INTERNAL_SERVER_ERROR, &err.to_string())
+}

--- a/src-tauri/src/remote_server/mod.rs
+++ b/src-tauri/src/remote_server/mod.rs
@@ -7,7 +7,8 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 
 pub use lease::{
-    get_remote_control_status, reclaim_remote_control, RemoteControlLease, RemoteControlStatus,
+    get_remote_control_status, reclaim_remote_control, RemoteControlLease, RemoteControlState,
+    RemoteControlStatus,
 };
 pub use routes::build_router;
 

--- a/src-tauri/src/remote_server/routes.rs
+++ b/src-tauri/src/remote_server/routes.rs
@@ -17,9 +17,9 @@ use crate::lock_ext::MutexExt;
 
 use super::auth::remote_guard;
 use super::lease::{
-    active_lease_matches, effective_heartbeat_timeout_seconds, emit_remote_control_status,
-    get_remote_control_status, prune_expired_lease, require_active_lease, status_from_lease,
-    RemoteControlLease,
+    active_lease_matches_with_timeout, effective_heartbeat_timeout_seconds,
+    emit_remote_control_status, get_remote_control_status, prune_expired_lease,
+    reclaim_lockout_active, require_active_lease, status_from_state, RemoteControlLease,
 };
 use super::{internal_error, json_error};
 
@@ -129,23 +129,28 @@ async fn remote_session_claim(
             Ok(current) => current,
             Err(err) => return internal_error(err),
         };
-        prune_expired_lease(&mut current, Duration::from_secs(timeout_seconds));
+        let now = Instant::now();
+        prune_expired_lease(&mut current.lease, Duration::from_secs(timeout_seconds));
 
-        if current.is_some() {
+        if reclaim_lockout_active(&mut current, now) {
+            return json_error(StatusCode::CONFLICT, "remote control was reclaimed locally");
+        }
+
+        if current.lease.is_some() {
             return (
                 StatusCode::CONFLICT,
-                Json(status_from_lease(&current, timeout_seconds)),
+                Json(status_from_state(&current, timeout_seconds)),
             )
                 .into_response();
         }
 
-        *current = Some(RemoteControlLease {
+        current.lease = Some(RemoteControlLease {
             lease_id: Uuid::new_v4().to_string(),
             remote_addr: addr.to_string(),
             client_name: body.client_name,
-            last_heartbeat: Instant::now(),
+            last_heartbeat: now,
         });
-        status_from_lease(&current, timeout_seconds)
+        status_from_state(&current, timeout_seconds)
     };
 
     emit_remote_control_status(&server.app_handle, &status);
@@ -163,12 +168,12 @@ async fn remote_session_heartbeat(
             Ok(current) => current,
             Err(err) => return internal_error(err),
         };
-        prune_expired_lease(&mut current, Duration::from_secs(timeout_seconds));
+        prune_expired_lease(&mut current.lease, Duration::from_secs(timeout_seconds));
 
-        match current.as_mut() {
+        match current.lease.as_mut() {
             Some(lease) if lease.lease_id == body.lease_id => {
                 lease.last_heartbeat = Instant::now();
-                status_from_lease(&current, timeout_seconds)
+                status_from_state(&current, timeout_seconds)
             }
             _ => {
                 return json_error(
@@ -193,11 +198,11 @@ async fn remote_session_release(
             Ok(current) => current,
             Err(err) => return internal_error(err),
         };
-        prune_expired_lease(&mut current, Duration::from_secs(timeout_seconds));
+        prune_expired_lease(&mut current.lease, Duration::from_secs(timeout_seconds));
 
-        match current.as_ref() {
+        match current.lease.as_ref() {
             Some(lease) if lease.lease_id == body.lease_id => {
-                *current = None;
+                current.lease = None;
             }
             Some(_) => {
                 return json_error(
@@ -207,7 +212,7 @@ async fn remote_session_release(
             }
             None => {}
         }
-        status_from_lease(&current, timeout_seconds)
+        status_from_state(&current, timeout_seconds)
     };
 
     emit_remote_control_status(&server.app_handle, &status);
@@ -317,8 +322,12 @@ async fn remote_terminal_output_ws(
     if let Err(response) = require_active_lease(&server.app_state, Some(&lease_id)) {
         return response;
     }
+    let settings = crate::settings::load_settings().remote;
+    let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
 
-    ws.on_upgrade(move |socket| stream_terminal_output(socket, server.app_state, id, lease_id))
+    ws.on_upgrade(move |socket| {
+        stream_terminal_output(socket, server.app_state, id, lease_id, timeout_seconds)
+    })
 }
 
 async fn stream_terminal_output(
@@ -326,6 +335,7 @@ async fn stream_terminal_output(
     app_state: std::sync::Arc<crate::state::AppState>,
     id: String,
     lease_id: String,
+    timeout_seconds: u64,
 ) {
     let initial_snapshot = {
         let buffers = match app_state.output_buffers.lock_or_err() {
@@ -388,7 +398,11 @@ async fn stream_terminal_output(
                 }
             }
             _ = lease_check.tick() => {
-                match active_lease_matches(&app_state, &lease_id) {
+                match active_lease_matches_with_timeout(
+                    &app_state,
+                    &lease_id,
+                    Duration::from_secs(timeout_seconds),
+                ) {
                     Ok(true) => {}
                     Ok(false) => {
                         let _ = socket.send(Message::Close(None)).await;

--- a/src-tauri/src/remote_server/routes.rs
+++ b/src-tauri/src/remote_server/routes.rs
@@ -1,0 +1,412 @@
+use std::time::{Duration, Instant};
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{ConnectInfo, Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::middleware;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use tokio::time;
+use tower_http::cors::CorsLayer;
+use uuid::Uuid;
+
+use crate::automation_server::ServerState;
+use crate::lock_ext::MutexExt;
+
+use super::auth::remote_guard;
+use super::lease::{
+    active_lease_matches, effective_heartbeat_timeout_seconds, emit_remote_control_status,
+    get_remote_control_status, prune_expired_lease, require_active_lease, status_from_lease,
+    RemoteControlLease,
+};
+use super::{internal_error, json_error};
+
+const REMOTE_LEASE_HEADER: &str = "x-laymux-remote-lease";
+const OUTPUT_INITIAL_BYTES: usize = 64 * 1024;
+const OUTPUT_POLL_MS: u64 = 50;
+const LEASE_CHECK_MS: u64 = 500;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RemoteTerminalInfo {
+    id: String,
+    title: String,
+    profile: String,
+    cwd: Option<String>,
+    branch: Option<String>,
+    cols: u16,
+    rows: u16,
+    sync_group: String,
+    command_running: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ClaimRequest {
+    client_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LeaseRequest {
+    lease_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TerminalWriteRequest {
+    data: String,
+    lease_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TerminalResizeRequest {
+    cols: u16,
+    rows: u16,
+    lease_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RemoteQuery {
+    lease_id: Option<String>,
+}
+
+pub fn build_router() -> Router<ServerState> {
+    Router::new()
+        .route("/remote/v1/health", get(remote_health))
+        .route("/remote/v1/session/status", get(remote_session_status))
+        .route("/remote/v1/session/claim", post(remote_session_claim))
+        .route(
+            "/remote/v1/session/heartbeat",
+            post(remote_session_heartbeat),
+        )
+        .route("/remote/v1/session/release", post(remote_session_release))
+        .route("/remote/v1/terminals", get(remote_terminals_list))
+        .route(
+            "/remote/v1/terminals/{id}/write",
+            post(remote_terminal_write),
+        )
+        .route(
+            "/remote/v1/terminals/{id}/resize",
+            post(remote_terminal_resize),
+        )
+        .route(
+            "/remote/v1/terminals/{id}/output",
+            get(remote_terminal_output_ws),
+        )
+        .layer(middleware::from_fn(remote_guard))
+        .layer(CorsLayer::permissive())
+}
+
+async fn remote_health() -> Response {
+    Json(serde_json::json!({
+        "ok": true,
+        "mode": "directRemote"
+    }))
+    .into_response()
+}
+
+async fn remote_session_status(State(server): State<ServerState>) -> Response {
+    match get_remote_control_status(&server.app_state) {
+        Ok(status) => Json(status).into_response(),
+        Err(err) => json_error(StatusCode::INTERNAL_SERVER_ERROR, &err),
+    }
+}
+
+async fn remote_session_claim(
+    State(server): State<ServerState>,
+    ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
+    Json(body): Json<ClaimRequest>,
+) -> Response {
+    let settings = crate::settings::load_settings().remote;
+    let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
+    let status = {
+        let mut current = match server.app_state.remote_control.lock_or_err() {
+            Ok(current) => current,
+            Err(err) => return internal_error(err),
+        };
+        prune_expired_lease(&mut current, Duration::from_secs(timeout_seconds));
+
+        if current.is_some() {
+            return (
+                StatusCode::CONFLICT,
+                Json(status_from_lease(&current, timeout_seconds)),
+            )
+                .into_response();
+        }
+
+        *current = Some(RemoteControlLease {
+            lease_id: Uuid::new_v4().to_string(),
+            remote_addr: addr.to_string(),
+            client_name: body.client_name,
+            last_heartbeat: Instant::now(),
+        });
+        status_from_lease(&current, timeout_seconds)
+    };
+
+    emit_remote_control_status(&server.app_handle, &status);
+    Json(status).into_response()
+}
+
+async fn remote_session_heartbeat(
+    State(server): State<ServerState>,
+    Json(body): Json<LeaseRequest>,
+) -> Response {
+    let settings = crate::settings::load_settings().remote;
+    let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
+    let status = {
+        let mut current = match server.app_state.remote_control.lock_or_err() {
+            Ok(current) => current,
+            Err(err) => return internal_error(err),
+        };
+        prune_expired_lease(&mut current, Duration::from_secs(timeout_seconds));
+
+        match current.as_mut() {
+            Some(lease) if lease.lease_id == body.lease_id => {
+                lease.last_heartbeat = Instant::now();
+                status_from_lease(&current, timeout_seconds)
+            }
+            _ => {
+                return json_error(
+                    StatusCode::CONFLICT,
+                    "remote controller lease is not active",
+                );
+            }
+        }
+    };
+
+    Json(status).into_response()
+}
+
+async fn remote_session_release(
+    State(server): State<ServerState>,
+    Json(body): Json<LeaseRequest>,
+) -> Response {
+    let settings = crate::settings::load_settings().remote;
+    let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
+    let status = {
+        let mut current = match server.app_state.remote_control.lock_or_err() {
+            Ok(current) => current,
+            Err(err) => return internal_error(err),
+        };
+        prune_expired_lease(&mut current, Duration::from_secs(timeout_seconds));
+
+        match current.as_ref() {
+            Some(lease) if lease.lease_id == body.lease_id => {
+                *current = None;
+            }
+            Some(_) => {
+                return json_error(
+                    StatusCode::CONFLICT,
+                    "remote controller lease is not active",
+                );
+            }
+            None => {}
+        }
+        status_from_lease(&current, timeout_seconds)
+    };
+
+    emit_remote_control_status(&server.app_handle, &status);
+    Json(status).into_response()
+}
+
+async fn remote_terminals_list(State(server): State<ServerState>) -> Response {
+    let terminals = match server.app_state.terminals.lock_or_err() {
+        Ok(terminals) => terminals,
+        Err(err) => return internal_error(err),
+    };
+
+    let result: Vec<RemoteTerminalInfo> = terminals
+        .values()
+        .map(|session| RemoteTerminalInfo {
+            id: session.id.clone(),
+            title: session.title.clone(),
+            profile: session.config.profile.clone(),
+            cwd: session.cwd.clone(),
+            branch: session.branch.clone(),
+            cols: session.config.cols,
+            rows: session.config.rows,
+            sync_group: session.config.sync_group.clone(),
+            command_running: session.command_running,
+        })
+        .collect();
+
+    Json(serde_json::json!({ "terminals": result })).into_response()
+}
+
+async fn remote_terminal_write(
+    State(server): State<ServerState>,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<TerminalWriteRequest>,
+) -> Response {
+    let lease_id = body
+        .lease_id
+        .as_deref()
+        .or_else(|| lease_id_from_headers(&headers));
+    if let Err(response) = require_active_lease(&server.app_state, lease_id) {
+        return response;
+    }
+
+    let ptys = match server.app_state.pty_handles.lock_or_err() {
+        Ok(ptys) => ptys,
+        Err(err) => return internal_error(err),
+    };
+    let Some(handle) = ptys.get(&id) else {
+        return json_error(StatusCode::NOT_FOUND, "terminal session not found");
+    };
+
+    match handle.write(body.data.as_bytes()) {
+        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
+        Err(err) => json_error(StatusCode::INTERNAL_SERVER_ERROR, &err),
+    }
+}
+
+async fn remote_terminal_resize(
+    State(server): State<ServerState>,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<TerminalResizeRequest>,
+) -> Response {
+    let lease_id = body
+        .lease_id
+        .as_deref()
+        .or_else(|| lease_id_from_headers(&headers));
+    if let Err(response) = require_active_lease(&server.app_state, lease_id) {
+        return response;
+    }
+
+    {
+        let mut terminals = match server.app_state.terminals.lock_or_err() {
+            Ok(terminals) => terminals,
+            Err(err) => return internal_error(err),
+        };
+        let Some(session) = terminals.get_mut(&id) else {
+            return json_error(StatusCode::NOT_FOUND, "terminal session not found");
+        };
+        session.config.cols = body.cols;
+        session.config.rows = body.rows;
+    }
+
+    let ptys = match server.app_state.pty_handles.lock_or_err() {
+        Ok(ptys) => ptys,
+        Err(err) => return internal_error(err),
+    };
+    if let Some(handle) = ptys.get(&id) {
+        if let Err(err) = handle.resize(body.cols, body.rows) {
+            return json_error(StatusCode::INTERNAL_SERVER_ERROR, &err);
+        }
+    }
+
+    Json(serde_json::json!({ "ok": true })).into_response()
+}
+
+async fn remote_terminal_output_ws(
+    State(server): State<ServerState>,
+    Path(id): Path<String>,
+    Query(query): Query<RemoteQuery>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let Some(lease_id) = query.lease_id.filter(|value| !value.is_empty()) else {
+        return json_error(StatusCode::CONFLICT, "remote controller lease is required");
+    };
+    if let Err(response) = require_active_lease(&server.app_state, Some(&lease_id)) {
+        return response;
+    }
+
+    ws.on_upgrade(move |socket| stream_terminal_output(socket, server.app_state, id, lease_id))
+}
+
+async fn stream_terminal_output(
+    mut socket: WebSocket,
+    app_state: std::sync::Arc<crate::state::AppState>,
+    id: String,
+    lease_id: String,
+) {
+    let initial_snapshot = {
+        let buffers = match app_state.output_buffers.lock_or_err() {
+            Ok(buffers) => buffers,
+            Err(err) => {
+                tracing::warn!(terminal_id = %id, error = %err, "remote output stream failed to lock buffers");
+                return;
+            }
+        };
+        buffers.get(&id).map(|buffer| {
+            (
+                buffer.recent_bytes(OUTPUT_INITIAL_BYTES),
+                buffer.write_seq(),
+            )
+        })
+    };
+    let Some((initial, mut seq)) = initial_snapshot else {
+        let _ = socket
+            .send(Message::Text("terminal session not found".into()))
+            .await;
+        return;
+    };
+    if !initial.is_empty() && socket.send(Message::Binary(initial.into())).await.is_err() {
+        return;
+    }
+
+    let mut interval = time::interval(Duration::from_millis(OUTPUT_POLL_MS));
+    let mut lease_check = time::interval(Duration::from_millis(LEASE_CHECK_MS));
+    loop {
+        tokio::select! {
+            maybe_msg = socket.recv() => {
+                match maybe_msg {
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(_)) => {}
+                    Some(Err(err)) => {
+                        tracing::debug!(terminal_id = %id, error = %err, "remote output websocket closed");
+                        break;
+                    }
+                }
+            }
+            _ = interval.tick() => {
+                let bytes = {
+                    let buffers = match app_state.output_buffers.lock_or_err() {
+                        Ok(buffers) => buffers,
+                        Err(err) => {
+                            tracing::warn!(terminal_id = %id, error = %err, "remote output stream failed to lock buffers");
+                            break;
+                        }
+                    };
+                    let Some(buffer) = buffers.get(&id) else {
+                        break;
+                    };
+                    let bytes = buffer.bytes_since(seq);
+                    seq = buffer.write_seq();
+                    bytes
+                };
+
+                if !bytes.is_empty() && socket.send(Message::Binary(bytes.into())).await.is_err() {
+                    break;
+                }
+            }
+            _ = lease_check.tick() => {
+                match active_lease_matches(&app_state, &lease_id) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        let _ = socket.send(Message::Close(None)).await;
+                        break;
+                    }
+                    Err(err) => {
+                        tracing::warn!(terminal_id = %id, error = %err, "remote output stream failed to check lease");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn lease_id_from_headers(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(REMOTE_LEASE_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+}

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -247,6 +247,33 @@ mod tests {
     }
 
     #[test]
+    fn remote_settings_default_off_and_round_trip() {
+        let legacy: Settings = serde_json::from_str("{}").unwrap();
+        assert!(!legacy.remote.enabled);
+        assert_eq!(legacy.remote.allowed_ips, vec!["127.0.0.1/32", "::1/128"]);
+        assert_eq!(legacy.remote.heartbeat_timeout_seconds, 15);
+
+        let json = r#"{
+          "remote": {
+            "enabled": true,
+            "allowedIps": ["100.64.0.0/10"],
+            "authToken": "secret",
+            "heartbeatTimeoutSeconds": 30
+          }
+        }"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert!(settings.remote.enabled);
+        assert_eq!(settings.remote.allowed_ips, vec!["100.64.0.0/10"]);
+        assert_eq!(settings.remote.auth_token, "secret");
+        assert_eq!(settings.remote.heartbeat_timeout_seconds, 30);
+
+        let serialized = serde_json::to_string(&settings).unwrap();
+        assert!(serialized.contains("\"remote\""));
+        assert!(serialized.contains("\"allowedIps\":[\"100.64.0.0/10\"]"));
+        assert!(serialized.contains("\"authToken\":\"secret\""));
+    }
+
+    #[test]
     fn language_round_trip_and_backcompat() {
         // Explicit value survives a round trip.
         let mut settings = Settings::default();

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -963,6 +963,56 @@ impl Default for FileExplorerSettings {
     }
 }
 
+/// Direct Remote Mode server settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteSettings {
+    /// User-facing browser remote API/UI switch. Defaults off.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Reserved for the standalone remote listener; the current server shares
+    /// the Automation API listener.
+    #[serde(default = "default_remote_bind_address")]
+    pub bind_address: String,
+    /// Exact Origin values allowed for browser requests. Empty = no Origin filter.
+    #[serde(default)]
+    pub allowed_origins: Vec<String>,
+    /// IP/CIDR allowlist for remote clients. Add 100.64.0.0/10 for Tailscale.
+    #[serde(default = "default_remote_allowed_ips")]
+    pub allowed_ips: Vec<String>,
+    /// Bearer token for remote browser clients. Required when remote is enabled.
+    #[serde(default)]
+    pub auth_token: String,
+    /// Seconds before an inactive remote controller lease expires.
+    #[serde(default = "default_remote_heartbeat_timeout_seconds")]
+    pub heartbeat_timeout_seconds: u64,
+}
+
+fn default_remote_bind_address() -> String {
+    "0.0.0.0".into()
+}
+
+fn default_remote_allowed_ips() -> Vec<String> {
+    vec!["127.0.0.1/32".into(), "::1/128".into()]
+}
+
+fn default_remote_heartbeat_timeout_seconds() -> u64 {
+    15
+}
+
+impl Default for RemoteSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind_address: default_remote_bind_address(),
+            allowed_origins: Vec::new(),
+            allowed_ips: default_remote_allowed_ips(),
+            auth_token: String::new(),
+            heartbeat_timeout_seconds: default_remote_heartbeat_timeout_seconds(),
+        }
+    }
+}
+
 /// Dock pane definition (persisted view config with position).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -1063,6 +1113,8 @@ pub struct Settings {
     pub issue_reporter: IssueReporterSettings,
     #[serde(default)]
     pub file_explorer: FileExplorerSettings,
+    #[serde(default)]
+    pub remote: RemoteSettings,
     /// Location-based CWD sync defaults. Opaque to backend — passed through to frontend.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sync_cwd_defaults: Option<serde_json::Value>,
@@ -1152,6 +1204,7 @@ impl Default for Settings {
             memo: MemoSettings::default(),
             issue_reporter: IssueReporterSettings::default(),
             file_explorer: FileExplorerSettings::default(),
+            remote: RemoteSettings::default(),
             sync_cwd_defaults: None,
             workspace_display_order: Vec::new(),
         }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -72,8 +72,8 @@ pub struct AppState {
     pub notifications: Arc<Mutex<Vec<TerminalNotification>>>,
     /// Auto-incrementing counter for notification IDs.
     pub notification_counter: AtomicU64,
-    /// Current Direct Remote Mode controller lease, if a remote browser holds control.
-    pub remote_control: Mutex<Option<crate::remote_server::RemoteControlLease>>,
+    /// Current Direct Remote Mode controller lease plus local reclaim lockout state.
+    pub remote_control: Mutex<crate::remote_server::RemoteControlState>,
 }
 
 impl AppState {
@@ -93,7 +93,7 @@ impl AppState {
             recently_exited_interactive_app: Arc::new(Mutex::new(HashMap::new())),
             notifications: Arc::new(Mutex::new(Vec::new())),
             notification_counter: AtomicU64::new(1),
-            remote_control: Mutex::new(None),
+            remote_control: Mutex::new(crate::remote_server::RemoteControlState::default()),
         }
     }
 }
@@ -170,6 +170,7 @@ mod tests {
     fn remote_control_starts_empty() {
         let state = AppState::new();
         let remote = state.remote_control.lock().unwrap();
-        assert!(remote.is_none());
+        assert!(remote.lease.is_none());
+        assert!(remote.reclaim_lockout_until.is_none());
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -23,6 +23,7 @@ use crate::terminal::{SyncGroup, TerminalNotification, TerminalSession};
 /// 8. `sync_groups`
 /// 9. `propagated_terminals`
 /// 10. `pty_handles` / `automation_channels` / `automation_port` / `ipc_socket_path`
+/// 11. `remote_control`
 ///
 /// Never acquire a higher-numbered lock while holding a lower-numbered one.
 pub struct AppState {
@@ -71,6 +72,8 @@ pub struct AppState {
     pub notifications: Arc<Mutex<Vec<TerminalNotification>>>,
     /// Auto-incrementing counter for notification IDs.
     pub notification_counter: AtomicU64,
+    /// Current Direct Remote Mode controller lease, if a remote browser holds control.
+    pub remote_control: Mutex<Option<crate::remote_server::RemoteControlLease>>,
 }
 
 impl AppState {
@@ -90,6 +93,7 @@ impl AppState {
             recently_exited_interactive_app: Arc::new(Mutex::new(HashMap::new())),
             notifications: Arc::new(Mutex::new(Vec::new())),
             notification_counter: AtomicU64::new(1),
+            remote_control: Mutex::new(None),
         }
     }
 }
@@ -160,5 +164,12 @@ mod tests {
         let state = AppState::new();
         let notifs = state.notifications.lock().unwrap();
         assert!(notifs.is_empty());
+    }
+
+    #[test]
+    fn remote_control_starts_empty() {
+        let state = AppState::new();
+        let remote = state.remote_control.lock().unwrap();
+        assert!(remote.is_none());
     }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -12,6 +12,7 @@ import { useLanguageSync } from "@/hooks/useLanguageSync";
 import { SettingsRecoveryModal } from "@/components/views/SettingsRecoveryModal";
 import { closeTerminalSession } from "@/lib/tauri-api";
 import { useTerminalStore } from "@/stores/terminal-store";
+import { RemoteControlOverlay } from "@/components/layout/RemoteControlOverlay";
 
 export function App() {
   useKeyboardShortcuts();
@@ -110,6 +111,7 @@ export function App() {
           }}
         />
       )}
+      <RemoteControlOverlay />
     </div>
   );
 }

--- a/ui/src/components/layout/RemoteControlOverlay.test.tsx
+++ b/ui/src/components/layout/RemoteControlOverlay.test.tsx
@@ -14,12 +14,24 @@ vi.mock("@/lib/tauri-api", () => ({
   reclaimRemoteControl: api.reclaimRemoteControl,
 }));
 
+import { useSettingsStore } from "@/stores/settings-store";
 import { RemoteControlOverlay } from "./RemoteControlOverlay";
 
 describe("RemoteControlOverlay", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useSettingsStore.getState().setRemote({ enabled: true });
     api.onRemoteControlChanged.mockResolvedValue(() => {});
+  });
+
+  it("does not poll while direct remote mode is disabled", async () => {
+    useSettingsStore.getState().setRemote({ enabled: false });
+
+    render(<RemoteControlOverlay />);
+    await Promise.resolve();
+
+    expect(api.getRemoteControlStatus).not.toHaveBeenCalled();
+    expect(api.onRemoteControlChanged).not.toHaveBeenCalled();
   });
 
   it("renders while a remote controller is active", async () => {

--- a/ui/src/components/layout/RemoteControlOverlay.test.tsx
+++ b/ui/src/components/layout/RemoteControlOverlay.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const api = vi.hoisted(() => ({
+  getRemoteControlStatus: vi.fn(),
+  onRemoteControlChanged: vi.fn(),
+  reclaimRemoteControl: vi.fn(),
+}));
+
+vi.mock("@/lib/tauri-api", () => ({
+  getRemoteControlStatus: api.getRemoteControlStatus,
+  onRemoteControlChanged: api.onRemoteControlChanged,
+  reclaimRemoteControl: api.reclaimRemoteControl,
+}));
+
+import { RemoteControlOverlay } from "./RemoteControlOverlay";
+
+describe("RemoteControlOverlay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.onRemoteControlChanged.mockResolvedValue(() => {});
+  });
+
+  it("renders while a remote controller is active", async () => {
+    api.getRemoteControlStatus.mockResolvedValue({
+      active: true,
+      leaseId: "lease-1",
+      remoteAddr: "100.64.0.2:51234",
+      clientName: "phone",
+      heartbeatTimeoutSeconds: 15,
+    });
+
+    render(<RemoteControlOverlay />);
+
+    expect(await screen.findByTestId("remote-control-overlay")).toBeInTheDocument();
+    expect(screen.getByText(/phone is controlling this PC/i)).toBeInTheDocument();
+  });
+
+  it("reclaims control from the PC", async () => {
+    api.getRemoteControlStatus.mockResolvedValue({
+      active: true,
+      leaseId: "lease-1",
+      remoteAddr: "100.64.0.2:51234",
+      clientName: "phone",
+      heartbeatTimeoutSeconds: 15,
+    });
+    api.reclaimRemoteControl.mockResolvedValue({
+      active: false,
+      leaseId: null,
+      remoteAddr: null,
+      clientName: null,
+      heartbeatTimeoutSeconds: 15,
+    });
+
+    render(<RemoteControlOverlay />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /take back control/i }));
+
+    expect(api.reclaimRemoteControl).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByTestId("remote-control-overlay")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/layout/RemoteControlOverlay.tsx
+++ b/ui/src/components/layout/RemoteControlOverlay.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from "react";
+import {
+  getRemoteControlStatus,
+  onRemoteControlChanged,
+  reclaimRemoteControl,
+  type RemoteControlStatus,
+} from "@/lib/tauri-api";
+import { useTranslation } from "react-i18next";
+
+const STATUS_POLL_MS = 3000;
+
+export function RemoteControlOverlay() {
+  const { t } = useTranslation("common");
+  const [status, setStatus] = useState<RemoteControlStatus | null>(null);
+  const [reclaiming, setReclaiming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
+    const refresh = () => {
+      getRemoteControlStatus()
+        .then((next) => {
+          if (!cancelled) setStatus(next);
+        })
+        .catch(() => {
+          if (!cancelled) setStatus(null);
+        });
+    };
+
+    refresh();
+    onRemoteControlChanged((next) => {
+      setStatus(next);
+      setError(null);
+    }).then((cleanup) => {
+      if (cancelled) cleanup();
+      else unlisten = cleanup;
+    });
+
+    const timer = window.setInterval(refresh, STATUS_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+      unlisten?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!status?.active) return;
+
+    const blockKeyboard = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target?.closest("[data-remote-control-reclaim]")) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    };
+
+    window.addEventListener("keydown", blockKeyboard, true);
+    window.addEventListener("keyup", blockKeyboard, true);
+    window.addEventListener("keypress", blockKeyboard, true);
+    return () => {
+      window.removeEventListener("keydown", blockKeyboard, true);
+      window.removeEventListener("keyup", blockKeyboard, true);
+      window.removeEventListener("keypress", blockKeyboard, true);
+    };
+  }, [status?.active]);
+
+  if (!status?.active) return null;
+
+  const handleReclaim = async () => {
+    setReclaiming(true);
+    setError(null);
+    try {
+      setStatus(await reclaimRemoteControl());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setReclaiming(false);
+    }
+  };
+
+  const controller =
+    status.clientName || status.remoteAddr || t("remoteControl.fallbackController");
+
+  return (
+    <div
+      className="remote-control-overlay"
+      data-testid="remote-control-overlay"
+      onPointerDownCapture={(event) => event.stopPropagation()}
+      onPointerMoveCapture={(event) => event.stopPropagation()}
+      onWheelCapture={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+    >
+      <div className="remote-control-panel" role="dialog" aria-modal="true">
+        <div className="remote-control-title">{t("remoteControl.title")}</div>
+        <div className="remote-control-body">{t("remoteControl.body", { controller })}</div>
+        <button
+          type="button"
+          className="remote-control-reclaim-button"
+          data-remote-control-reclaim
+          onClick={handleReclaim}
+          disabled={reclaiming}
+        >
+          {reclaiming ? t("remoteControl.reclaiming") : t("remoteControl.reclaim")}
+        </button>
+        {error && <div className="remote-control-error">{error}</div>}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/layout/RemoteControlOverlay.tsx
+++ b/ui/src/components/layout/RemoteControlOverlay.tsx
@@ -5,17 +5,24 @@ import {
   reclaimRemoteControl,
   type RemoteControlStatus,
 } from "@/lib/tauri-api";
+import { useSettingsStore } from "@/stores/settings-store";
 import { useTranslation } from "react-i18next";
 
 const STATUS_POLL_MS = 3000;
 
 export function RemoteControlOverlay() {
   const { t } = useTranslation("common");
+  const remoteEnabled = useSettingsStore((state) => state.remote.enabled);
   const [status, setStatus] = useState<RemoteControlStatus | null>(null);
   const [reclaiming, setReclaiming] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!remoteEnabled) {
+      setStatus(null);
+      return;
+    }
+
     let cancelled = false;
     let unlisten: (() => void) | undefined;
 
@@ -38,13 +45,32 @@ export function RemoteControlOverlay() {
       else unlisten = cleanup;
     });
 
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [remoteEnabled]);
+
+  useEffect(() => {
+    if (!remoteEnabled || !status?.active) return;
+
+    let cancelled = false;
+    const refresh = () => {
+      getRemoteControlStatus()
+        .then((next) => {
+          if (!cancelled) setStatus(next);
+        })
+        .catch(() => {
+          if (!cancelled) setStatus(null);
+        });
+    };
+
     const timer = window.setInterval(refresh, STATUS_POLL_MS);
     return () => {
       cancelled = true;
       window.clearInterval(timer);
-      unlisten?.();
     };
-  }, []);
+  }, [remoteEnabled, status?.active]);
 
   useEffect(() => {
     if (!status?.active) return;

--- a/ui/src/hooks/useAutomationBridge.test.ts
+++ b/ui/src/hooks/useAutomationBridge.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import {
   useAutomationBridge,
+  captureScreenshot,
   handleAutomationRequest,
   handleAsyncAutomationRequest,
 } from "./useAutomationBridge";
+import html2canvas from "html2canvas";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useGridStore } from "@/stores/grid-store";
 import { useDockStore } from "@/stores/dock-store";
@@ -16,6 +18,40 @@ vi.mock("@/lib/tauri-api", () => ({
   onAutomationRequest: vi.fn().mockResolvedValue(vi.fn()),
   automationResponse: vi.fn().mockResolvedValue(undefined),
 }));
+
+vi.mock("html2canvas", () => ({
+  default: vi.fn(),
+}));
+
+function mockScreenshotCanvas() {
+  const drawImage = vi.fn();
+  const resultCanvas = {
+    getContext: vi.fn(() => ({ drawImage })),
+    toDataURL: vi.fn(() => "data:image/png;base64,test"),
+  } as unknown as HTMLCanvasElement;
+
+  vi.mocked(html2canvas).mockResolvedValueOnce(resultCanvas);
+  return { drawImage };
+}
+
+function addCanvasElement() {
+  const canvas = document.createElement("canvas");
+  canvas.width = 16;
+  canvas.height = 16;
+  canvas.getBoundingClientRect = () =>
+    ({
+      x: 4,
+      y: 8,
+      left: 4,
+      top: 8,
+      right: 20,
+      bottom: 24,
+      width: 16,
+      height: 16,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  document.documentElement.appendChild(canvas);
+}
 
 describe("handleAutomationRequest", () => {
   beforeEach(() => {
@@ -393,6 +429,48 @@ describe("handleAutomationRequest", () => {
 });
 
 describe("handleAsyncAutomationRequest", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    document.documentElement.querySelectorAll("canvas").forEach((node) => node.remove());
+    vi.mocked(html2canvas).mockReset();
+  });
+
+  it("composites terminal canvases when no blocking overlay is visible", async () => {
+    const { drawImage } = mockScreenshotCanvas();
+    addCanvasElement();
+
+    const dataUrl = await captureScreenshot();
+
+    expect(dataUrl).toBe("data:image/png;base64,test");
+    expect(drawImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not composite terminal canvases over visible modal overlays", async () => {
+    const { drawImage } = mockScreenshotCanvas();
+    addCanvasElement();
+    const overlay = document.createElement("div");
+    overlay.setAttribute("role", "dialog");
+    overlay.setAttribute("aria-modal", "true");
+    overlay.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        left: 0,
+        top: 0,
+        right: 320,
+        bottom: 180,
+        width: 320,
+        height: 180,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    document.body.appendChild(overlay);
+
+    const dataUrl = await captureScreenshot();
+
+    expect(dataUrl).toBe("data:image/png;base64,test");
+    expect(drawImage).not.toHaveBeenCalled();
+  });
+
   it("falls through to sync handler for non-screenshot targets", async () => {
     const result = await handleAsyncAutomationRequest({
       requestId: "async-1",

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -750,6 +750,25 @@ const handlers: HandlerMap = {
   },
 };
 
+function hasVisibleBlockingOverlay(target: HTMLElement): boolean {
+  if (target !== document.documentElement) return false;
+
+  const overlays = document.querySelectorAll<HTMLElement>(
+    "[data-testid='remote-control-overlay'], [role='dialog'][aria-modal='true']",
+  );
+  return Array.from(overlays).some((overlay) => {
+    const style = window.getComputedStyle(overlay);
+    const rect = overlay.getBoundingClientRect();
+    return (
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      style.opacity !== "0" &&
+      rect.width > 0 &&
+      rect.height > 0
+    );
+  });
+}
+
 /** Capture a screenshot of the current UI (or a specific pane) as a base64 PNG data URL.
  *  html2canvas cannot read WebGL canvases, so after the initial capture we
  *  composite each WebGL canvas (xterm.js terminals) onto the result manually. */
@@ -775,9 +794,11 @@ export async function captureScreenshot(paneIndex?: number): Promise<string> {
     logging: false,
   });
 
-  // Composite WebGL canvases that html2canvas missed
+  // Composite WebGL canvases that html2canvas missed. When a blocking overlay
+  // or modal is visible, keep html2canvas' DOM result intact so terminal
+  // canvases are not redrawn over the dialog.
   const ctx = result.getContext("2d");
-  if (ctx) {
+  if (ctx && !hasVisibleBlockingOverlay(target)) {
     const targetRect = target.getBoundingClientRect();
     target.querySelectorAll("canvas").forEach((c) => {
       if (c.width === 0 || c.height === 0) return;

--- a/ui/src/hooks/useSessionPersistence.ts
+++ b/ui/src/hooks/useSessionPersistence.ts
@@ -150,6 +150,9 @@ export function useSessionPersistence() {
                   rawSettings.fileExplorer as import("@/lib/tauri-api").FileExplorerSettings,
               }
             : {}),
+          ...(rawSettings.remote
+            ? { remote: rawSettings.remote as import("@/lib/tauri-api").RemoteSettings }
+            : {}),
           ...(rawSettings.memo
             ? { memo: rawSettings.memo as import("@/lib/tauri-api").MemoSettings }
             : {}),

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -8,6 +8,13 @@
     "terminal": {
       "pasteConfirm": "The text to paste is {{bytes}} bytes. Do you want to continue?",
       "scrollToBottom": "Scroll to bottom"
+    },
+    "remoteControl": {
+      "title": "Remote control active",
+      "body": "{{controller}} is controlling this PC.",
+      "fallbackController": "Remote browser",
+      "reclaim": "Take back control",
+      "reclaiming": "Taking back..."
     }
   },
   "settings": {

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -8,6 +8,13 @@
     "terminal": {
       "pasteConfirm": "붙여넣을 텍스트가 {{bytes}}바이트입니다. 계속하시겠습니까?",
       "scrollToBottom": "맨 아래로 이동"
+    },
+    "remoteControl": {
+      "title": "원격 제어 중",
+      "body": "{{controller}}에서 이 PC를 제어하고 있습니다.",
+      "fallbackController": "원격 브라우저",
+      "reclaim": "제어권 가져오기",
+      "reclaiming": "가져오는 중..."
     }
   },
   "settings": {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -217,6 +217,77 @@
     white-space: nowrap;
   }
 
+  .remote-control-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    display: grid;
+    place-items: center;
+    padding: 16px;
+    background: var(--backdrop-heavy);
+    color: var(--text-primary);
+    pointer-events: auto;
+  }
+
+  .remote-control-panel {
+    width: min(420px, 100%);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--bg-surface);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+    padding: 18px;
+  }
+
+  .remote-control-title {
+    font-size: var(--fs-lg);
+    font-weight: 650;
+    line-height: 1.3;
+    margin-bottom: 8px;
+  }
+
+  .remote-control-body {
+    color: var(--text-secondary);
+    font-size: var(--fs-md);
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+    margin-bottom: 14px;
+  }
+
+  .remote-control-reclaim-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 30px;
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-md);
+    background: var(--accent);
+    color: var(--bg-base);
+    cursor: pointer;
+    font-size: var(--fs-md);
+    font-weight: 650;
+    padding: 0 12px;
+    transition:
+      background var(--transition-fast) ease,
+      opacity var(--transition-fast) ease;
+  }
+
+  .remote-control-reclaim-button:hover {
+    background: var(--accent-50);
+  }
+
+  .remote-control-reclaim-button:disabled {
+    cursor: default;
+    opacity: 0.65;
+  }
+
+  .remote-control-error {
+    margin-top: 10px;
+    color: var(--red);
+    font-size: var(--fs-sm);
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+  }
+
   .workspace-pane-row {
     max-height: var(--pane-row-max-h);
     opacity: 1;

--- a/ui/src/lib/persist-session.test.ts
+++ b/ui/src/lib/persist-session.test.ts
@@ -105,6 +105,25 @@ describe("persistSession", () => {
     expect(savedArg.profileDefaults.font.size).toBe(18);
   });
 
+  it("includes remote settings in saved settings", async () => {
+    useSettingsStore.getState().setRemote({
+      enabled: true,
+      allowedIps: ["100.64.0.0/10"],
+      authToken: "secret",
+      heartbeatTimeoutSeconds: 30,
+    });
+
+    await persistSession();
+
+    const savedArg = (saveSettings as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(savedArg.remote).toMatchObject({
+      enabled: true,
+      allowedIps: ["100.64.0.0/10"],
+      authToken: "secret",
+      heartbeatTimeoutSeconds: 30,
+    });
+  });
+
   it("includes per-profile font override in saved settings", async () => {
     useSettingsStore
       .getState()

--- a/ui/src/lib/persist-session.ts
+++ b/ui/src/lib/persist-session.ts
@@ -184,6 +184,7 @@ async function persistSessionCore(): Promise<void> {
     memo: { ...settingsState.memo },
     issueReporter: { ...settingsState.issueReporter },
     fileExplorer: { ...settingsState.fileExplorer },
+    remote: { ...settingsState.remote },
     syncCwdDefaults: { ...settingsState.syncCwdDefaults },
     docks: dockState.docks.map((d) => ({
       position: d.position,

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -58,6 +58,22 @@ export async function getSyncGroupTerminals(groupName: string): Promise<string[]
   return invoke("get_sync_group_terminals", { groupName });
 }
 
+export interface RemoteControlStatus {
+  active: boolean;
+  leaseId?: string | null;
+  remoteAddr?: string | null;
+  clientName?: string | null;
+  heartbeatTimeoutSeconds: number;
+}
+
+export async function getRemoteControlStatus(): Promise<RemoteControlStatus> {
+  return invoke("get_remote_control_status");
+}
+
+export async function reclaimRemoteControl(): Promise<RemoteControlStatus> {
+  return invoke("reclaim_remote_control");
+}
+
 export interface TerminalStateInfo {
   activity: TerminalActivityInfo;
 }
@@ -267,6 +283,15 @@ export interface ProfileDefaults {
   syncCwd?: SyncCwdConfig;
 }
 
+export interface RemoteSettings {
+  enabled: boolean;
+  bindAddress: string;
+  allowedOrigins: string[];
+  allowedIps: string[];
+  authToken: string;
+  heartbeatTimeoutSeconds: number;
+}
+
 export interface Settings {
   /** App UI language: "system" (OS locale), "ko", or "en". */
   language?: import("@/stores/settings-store").LanguageSetting;
@@ -293,6 +318,7 @@ export interface Settings {
   memo: MemoSettings;
   issueReporter: IssueReporterSettings;
   fileExplorer: FileExplorerSettings;
+  remote?: RemoteSettings;
 }
 
 export interface ColorScheme {
@@ -632,6 +658,15 @@ export function onAutomationRequest(
   callback: (data: AutomationRequest) => void,
 ): Promise<UnlistenFn> {
   return listen<AutomationRequest>("automation-request", (event) => {
+    callback(event.payload);
+  });
+}
+
+/** Listen for Direct Remote Mode controller lease changes. */
+export function onRemoteControlChanged(
+  callback: (data: RemoteControlStatus) => void,
+): Promise<UnlistenFn> {
+  return listen<RemoteControlStatus>("remote-control-changed", (event) => {
     callback(event.payload);
   });
 }

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -6,6 +6,7 @@ import type {
   FileExplorerSettings,
   IssueReporterSettings,
   MemoSettings,
+  RemoteSettings,
 } from "../lib/tauri-api";
 import {
   resolveSyncCwd,
@@ -368,6 +369,7 @@ interface SettingsState {
   memo: MemoSettings;
   issueReporter: IssueReporterSettings;
   fileExplorer: FileExplorerSettings;
+  remote: RemoteSettings;
   syncCwdDefaults: SyncCwdDefaults;
 
   setLanguage: (language: LanguageSetting) => void;
@@ -385,6 +387,7 @@ interface SettingsState {
   setMemo: (data: Partial<MemoSettings>) => void;
   setIssueReporter: (data: Partial<IssueReporterSettings>) => void;
   setFileExplorer: (data: Partial<FileExplorerSettings>) => void;
+  setRemote: (data: Partial<RemoteSettings>) => void;
   setProfileDefaults: (data: Partial<ProfileDefaults>) => void;
   setSyncCwdDefaults: (data: Partial<SyncCwdDefaults>) => void;
   addProfile: (profile: Profile) => void;
@@ -430,6 +433,7 @@ interface SettingsState {
         | "memo"
         | "issueReporter"
         | "fileExplorer"
+        | "remote"
         | "syncCwdDefaults"
       >
     >,
@@ -475,6 +479,15 @@ const DEFAULT_FILE_EXPLORER: FileExplorerSettings = {
   fontSize: 13,
   copyOnSelect: false,
   extensionViewers: [],
+};
+
+const DEFAULT_REMOTE: RemoteSettings = {
+  enabled: false,
+  bindAddress: "0.0.0.0",
+  allowedOrigins: [],
+  allowedIps: ["127.0.0.1/32", "::1/128"],
+  authToken: "",
+  heartbeatTimeoutSeconds: 15,
 };
 
 export const DEFAULT_FONT: FontSettings = { face: "Cascadia Mono", size: 14, weight: "normal" };
@@ -924,6 +937,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   memo: { ...DEFAULT_MEMO },
   issueReporter: { ...DEFAULT_ISSUE_REPORTER },
   fileExplorer: { ...DEFAULT_FILE_EXPLORER },
+  remote: { ...DEFAULT_REMOTE },
   syncCwdDefaults: { ...DEFAULT_SYNC_CWD_DEFAULTS },
 
   setAppearance: (data) =>
@@ -984,6 +998,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setFileExplorer: (data) =>
     set((state) => ({
       fileExplorer: { ...state.fileExplorer, ...data },
+    })),
+
+  setRemote: (data) =>
+    set((state) => ({
+      remote: { ...state.remote, ...data },
     })),
 
   setSyncCwdDefaults: (data) =>
@@ -1201,6 +1220,9 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     const fileExplorer = data.fileExplorer
       ? { ...DEFAULT_FILE_EXPLORER, ...(data.fileExplorer as Partial<FileExplorerSettings>) }
       : undefined;
+    const remote = data.remote
+      ? { ...DEFAULT_REMOTE, ...(data.remote as Partial<RemoteSettings>) }
+      : undefined;
     // Ensure syncCwdDefaults settings have all fields (backwards compat)
     const syncCwdDefaults = data.syncCwdDefaults
       ? {
@@ -1225,6 +1247,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       dock: _rawDock,
       notifications: _rawNotifications,
       workspaceSelector: _rawWorkspaceSelector,
+      remote: _rawRemote,
       language: _rawLanguage,
       ...rest
     } = data;
@@ -1254,6 +1277,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       ...(issueReporter ? { issueReporter } : {}),
       ...(memo ? { memo } : {}),
       ...(fileExplorer ? { fileExplorer } : {}),
+      ...(remote ? { remote } : {}),
       ...(syncCwdDefaults ? { syncCwdDefaults } : {}),
     }));
   },


### PR DESCRIPTION
## 요약

- ADR-0013 기반 Direct Remote Mode의 `/remote/v1/*` API를 추가했습니다.
- remote auth/token, Origin, IP/CIDR allowlist, exclusive controller lease, heartbeat/release/reclaim 흐름을 구현했습니다.
- active remote lease 시 PC WebView 입력을 막는 overlay와 reclaim command/event를 추가했습니다.
- `settings.remote` 계약과 Remote UI API 계약을 architecture docs에 반영했습니다.

## 검증

- `cargo check`
- `cargo test remote_server --lib`
- `cargo test remote_settings_default_off_and_round_trip --lib`
- `npm run test -- RemoteControlOverlay persist-session locale-parity`
- `npm run build`