### PR TITLE
[codex] Add direct remote browser entry

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -38,7 +38,7 @@ UI 다국어는 **react-i18next** 로 구현한다(이슈 #350).
   "remote": {
     "enabled": false,                  // 기본값: 비활성화
     "bindAddress": "0.0.0.0",          // 현재 구현은 Automation 서버 listener를 공유
-    "allowedOrigins": [],              // 비어 있으면 Origin 필터 없음, 값이 있으면 Origin 헤더 필수
+    "allowedOrigins": [],              // 비어 있으면 Origin 필터 없음, 값이 있으면 Origin 일치 검사
     "allowedIps": ["127.0.0.1/32", "::1/128"],
     "authToken": "",                   // enabled=true일 때 필수
     "heartbeatTimeoutSeconds": 15       // 최소 5초로 clamp
@@ -519,7 +519,7 @@ Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Dire
 - `settings.remote.enabled`가 `true`일 때만 응답한다.
 - `settings.remote.authToken`은 필수다. HTTP 요청은 `Authorization: Bearer <token>` 또는 `X-Laymux-Remote-Token`을 사용할 수 있고, WebSocket은 브라우저 제약 때문에 URL-encoded `?token=<token>`도 허용한다.
 - `settings.remote.allowedIps`는 IP/CIDR allowlist다. 기본값은 loopback only이며 Tailscale 직접 접속은 예를 들어 IPv4 `100.64.0.0/10`, IPv6 `fd7a:115c:a1e0::/48`를 명시해야 한다.
-- `settings.remote.allowedOrigins`가 비어 있지 않으면 `Origin` 헤더가 존재하고 정확히 일치해야 한다. 비어 있으면 token 기반 요청을 허용한다.
+- `settings.remote.allowedOrigins`가 비어 있지 않으면 `Origin` 헤더가 존재할 때 정확히 일치해야 한다. 브라우저의 same-origin fetch가 `Origin`을 생략한 경우에 한해 `Sec-Fetch-Site: same-origin`과 `Host`가 허용 origin의 authority와 맞으면 허용한다. 이 예외는 브라우저 호환성용이며 보안 경계는 IP allowlist와 bearer token이다.
 
 ### 13.2 Controller Lease
 

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -503,7 +503,16 @@ claude mcp add-json -s user laymux '{"type":"http","url":"http://<IP>:19280/mcp"
 
 ## 13. Remote UI API
 
-Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Direct Remote Mode 계약이다. 같은 axum 서버에 붙지만 Automation API/MCP와 route namespace, 인증, Origin/CORS, 세션 모델을 분리한다([ADR-0013](../adr/0013-direct-remote-mode.md)). Automation API의 `REGISTERED_ROUTES`/docs 검증 대상이 아니며 `/remote/v1/*` 네임스페이스만 사용한다.
+Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Direct Remote Mode 계약이다. 같은 axum 서버에 붙지만 Automation API/MCP와 route namespace, 인증, Origin/CORS, 세션 모델을 분리한다([ADR-0013](../adr/0013-direct-remote-mode.md)). Automation API의 `REGISTERED_ROUTES`/docs 검증 대상이 아니며 브라우저 entry는 `/remote/`, 제어 API는 `/remote/v1/*` 네임스페이스를 사용한다.
+
+### 13.0 Browser Entry
+
+| Endpoint | Method | 용도 |
+|---|---|---|
+| `/remote` | GET | `/remote/`로 redirect |
+| `/remote/` | GET | 브라우저에서 직접 여는 Direct Remote Mode entry |
+
+`/remote/`는 remote가 켜져 있고 remote IP allowlist를 통과할 때 HTML을 반환한다. 이 문서 자체는 토큰을 요구하지 않지만, 페이지가 호출하는 `/remote/v1/*` 제어 API는 아래 인증 정책을 그대로 따른다. 사용자는 브라우저 주소창에서 `http://<laymux-host>:19280/remote/` 또는 dev의 `:19281/remote/`를 열고 remote token을 입력해 controller lease를 claim한다.
 
 ### 13.1 인증과 접근 제어
 

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -512,7 +512,7 @@ Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Dire
 | `/remote` | GET | `/remote/`로 redirect |
 | `/remote/` | GET | 브라우저에서 직접 여는 Direct Remote Mode entry |
 
-`/remote/`는 remote가 켜져 있고 remote IP allowlist를 통과할 때 HTML을 반환한다. 이 문서 자체는 토큰을 요구하지 않지만, 페이지가 호출하는 `/remote/v1/*` 제어 API는 아래 인증 정책을 그대로 따른다. 사용자는 브라우저 주소창에서 `http://<laymux-host>:19280/remote/` 또는 dev의 `:19281/remote/`를 열고 remote token을 입력해 controller lease를 claim한다.
+`/remote`와 `/remote/`는 remote가 켜져 있고, `remote.authToken`이 설정되어 있으며, remote IP allowlist를 통과할 때 응답한다. 이 HTML 문서 자체는 토큰 값을 요구하지 않지만, 페이지가 호출하는 `/remote/v1/*` 제어 API는 아래 인증 정책을 그대로 따른다. 사용자는 브라우저 주소창에서 `http://<laymux-host>:19280/remote/` 또는 dev의 `:19281/remote/`를 열고 remote token을 입력해 controller lease를 claim한다.
 
 ### 13.1 인증과 접근 제어
 

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -46,7 +46,7 @@ UI 다국어는 **react-i18next** 로 구현한다(이슈 #350).
 }
 ```
 
-Tailscale 직접 접속을 허용하려면 `allowedIps`에 Tailnet 범위(예: `100.64.0.0/10`) 또는 구체적인 peer IP/CIDR를 추가하고 `authToken`을 설정한다. Tailscale은 transport 격리일 뿐 인증을 대체하지 않는다.
+Tailscale 직접 접속을 허용하려면 `allowedIps`에 Tailnet 범위(예: IPv4 `100.64.0.0/10`, IPv6 `fd7a:115c:a1e0::/48`) 또는 구체적인 peer IP/CIDR를 추가하고 `authToken`을 설정한다. Tailscale은 transport 격리일 뿐 인증을 대체하지 않는다.
 
 ### Windows Terminal 호환 항목
 
@@ -518,7 +518,7 @@ Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Dire
 
 - `settings.remote.enabled`가 `true`일 때만 응답한다.
 - `settings.remote.authToken`은 필수다. HTTP 요청은 `Authorization: Bearer <token>` 또는 `X-Laymux-Remote-Token`을 사용할 수 있고, WebSocket은 브라우저 제약 때문에 URL-encoded `?token=<token>`도 허용한다.
-- `settings.remote.allowedIps`는 IP/CIDR allowlist다. 기본값은 loopback only이며 Tailscale 직접 접속은 예를 들어 `100.64.0.0/10`을 명시해야 한다.
+- `settings.remote.allowedIps`는 IP/CIDR allowlist다. 기본값은 loopback only이며 Tailscale 직접 접속은 예를 들어 IPv4 `100.64.0.0/10`, IPv6 `fd7a:115c:a1e0::/48`를 명시해야 한다.
 - `settings.remote.allowedOrigins`가 비어 있지 않으면 `Origin` 헤더가 존재하고 정확히 일치해야 한다. 비어 있으면 token 기반 요청을 허용한다.
 
 ### 13.2 Controller Lease

--- a/src-tauri/src/remote_server/auth.rs
+++ b/src-tauri/src/remote_server/auth.rs
@@ -141,16 +141,61 @@ fn origin_allowed(headers: &HeaderMap, settings: &RemoteSettings) -> bool {
     if settings.allowed_origins.is_empty() {
         return true;
     }
-    let Some(origin) = headers
+    if let Some(origin) = headers
         .get(header::ORIGIN)
         .and_then(|value| value.to_str().ok())
-    else {
-        return false;
-    };
+    {
+        return origin_matches_allowed(origin, settings);
+    }
+
+    missing_origin_allowed_for_same_origin_fetch(headers, settings)
+}
+
+fn origin_matches_allowed(origin: &str, settings: &RemoteSettings) -> bool {
     settings
         .allowed_origins
         .iter()
         .any(|allowed| allowed == "*" || allowed == origin)
+}
+
+fn missing_origin_allowed_for_same_origin_fetch(
+    headers: &HeaderMap,
+    settings: &RemoteSettings,
+) -> bool {
+    if settings
+        .allowed_origins
+        .iter()
+        .any(|allowed| allowed == "*")
+    {
+        return true;
+    }
+
+    if !header_value(headers, "sec-fetch-site")
+        .is_some_and(|value| value.eq_ignore_ascii_case("same-origin"))
+    {
+        return false;
+    }
+
+    let Some(host) = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+
+    settings.allowed_origins.iter().any(|allowed| {
+        allowed_origin_authority(allowed)
+            .as_deref()
+            .is_some_and(|authority| authority.eq_ignore_ascii_case(host))
+    })
+}
+
+fn allowed_origin_authority(origin: &str) -> Option<String> {
+    let uri = origin.parse::<Uri>().ok()?;
+    match (uri.scheme_str(), uri.authority()) {
+        (Some("http" | "https"), Some(authority)) => Some(authority.as_str().to_string()),
+        _ => None,
+    }
 }
 
 pub(crate) fn normalize_ip(ip: IpAddr) -> IpAddr {
@@ -352,6 +397,22 @@ mod tests {
         };
         let headers = HeaderMap::new();
 
+        assert!(!origin_allowed(&headers, &settings));
+    }
+
+    #[test]
+    fn origin_allowlist_accepts_same_origin_fetch_without_origin() {
+        let settings = RemoteSettings {
+            allowed_origins: vec!["http://100.64.0.2:19281".into()],
+            ..RemoteSettings::default()
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert(header::HOST, HeaderValue::from_static("100.64.0.2:19281"));
+        headers.insert("sec-fetch-site", HeaderValue::from_static("same-origin"));
+
+        assert!(origin_allowed(&headers, &settings));
+
+        headers.insert(header::HOST, HeaderValue::from_static("example.com"));
         assert!(!origin_allowed(&headers, &settings));
     }
 }

--- a/src-tauri/src/remote_server/auth.rs
+++ b/src-tauri/src/remote_server/auth.rs
@@ -146,7 +146,7 @@ fn origin_allowed(headers: &HeaderMap, settings: &RemoteSettings) -> bool {
         .any(|allowed| allowed == "*" || allowed == origin)
 }
 
-fn normalize_ip(ip: IpAddr) -> IpAddr {
+pub(crate) fn normalize_ip(ip: IpAddr) -> IpAddr {
     match ip {
         IpAddr::V6(v6) => v6
             .to_ipv4_mapped()
@@ -156,7 +156,7 @@ fn normalize_ip(ip: IpAddr) -> IpAddr {
     }
 }
 
-fn is_remote_ip_allowed(ip: &IpAddr, allowed_ips: &[String]) -> bool {
+pub(crate) fn is_remote_ip_allowed(ip: &IpAddr, allowed_ips: &[String]) -> bool {
     if allowed_ips.is_empty() {
         return ip.is_loopback();
     }

--- a/src-tauri/src/remote_server/auth.rs
+++ b/src-tauri/src/remote_server/auth.rs
@@ -18,24 +18,8 @@ pub(crate) async fn remote_guard(
 ) -> Response {
     let settings = crate::settings::load_settings().remote;
 
-    if !settings.enabled {
-        return json_error(StatusCode::FORBIDDEN, "direct remote mode is disabled");
-    }
-    if settings.auth_token.is_empty() {
-        return json_error(
-            StatusCode::UNAUTHORIZED,
-            "direct remote mode requires remote.authToken",
-        );
-    }
-    let remote_ip = normalize_ip(addr.ip());
-    if !is_remote_ip_allowed(&remote_ip, &settings.allowed_ips) {
-        tracing::warn!(
-            remote_addr = %addr,
-            remote_ip = %remote_ip,
-            allowed_ips = ?settings.allowed_ips,
-            "remote API client IP denied"
-        );
-        return json_error(StatusCode::FORBIDDEN, "remote client IP is not allowed");
+    if let Some(response) = check_remote_base_access(&settings, addr) {
+        return response;
     }
     if !origin_allowed(req.headers(), &settings) {
         return json_error(StatusCode::FORBIDDEN, "remote Origin is not allowed");
@@ -45,6 +29,39 @@ pub(crate) async fn remote_guard(
     }
 
     next.run(req).await
+}
+
+pub(crate) fn check_remote_base_access(
+    settings: &RemoteSettings,
+    addr: SocketAddr,
+) -> Option<Response> {
+    if !settings.enabled {
+        return Some(json_error(
+            StatusCode::FORBIDDEN,
+            "direct remote mode is disabled",
+        ));
+    }
+    if settings.auth_token.is_empty() {
+        return Some(json_error(
+            StatusCode::UNAUTHORIZED,
+            "direct remote mode requires remote.authToken",
+        ));
+    }
+    let remote_ip = normalize_ip(addr.ip());
+    if !is_remote_ip_allowed(&remote_ip, &settings.allowed_ips) {
+        tracing::warn!(
+            remote_addr = %addr,
+            remote_ip = %remote_ip,
+            allowed_ips = ?settings.allowed_ips,
+            "remote client IP denied"
+        );
+        return Some(json_error(
+            StatusCode::FORBIDDEN,
+            "remote client IP is not allowed",
+        ));
+    }
+
+    None
 }
 
 fn remote_token_matches(headers: &HeaderMap, uri: &Uri, settings: &RemoteSettings) -> bool {
@@ -170,6 +187,9 @@ fn missing_origin_allowed_for_same_origin_fetch(
         return true;
     }
 
+    // Browser same-origin GET fetches can omit Origin. Sec-Fetch-Site and Host
+    // are forgeable by non-browser clients, so this is a compatibility path, not
+    // a security boundary; IP allowlist and bearer token remain authoritative.
     if !header_value(headers, "sec-fetch-site")
         .is_some_and(|value| value.eq_ignore_ascii_case("same-origin"))
     {
@@ -191,6 +211,8 @@ fn missing_origin_allowed_for_same_origin_fetch(
 }
 
 fn allowed_origin_authority(origin: &str) -> Option<String> {
+    // Compare only authority for the no-Origin browser compatibility path.
+    // The configured scheme is enforced only when an Origin header is present.
     let uri = origin.parse::<Uri>().ok()?;
     match (uri.scheme_str(), uri.authority()) {
         (Some("http" | "https"), Some(authority)) => Some(authority.as_str().to_string()),
@@ -313,6 +335,20 @@ mod tests {
     }
 
     #[test]
+    fn remote_base_access_rejects_missing_token() {
+        let settings = RemoteSettings {
+            enabled: true,
+            auth_token: String::new(),
+            ..RemoteSettings::default()
+        };
+        let response =
+            check_remote_base_access(&settings, "127.0.0.1:1".parse::<SocketAddr>().unwrap())
+                .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
     fn remote_token_accepts_bearer_header() {
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -414,5 +450,12 @@ mod tests {
 
         headers.insert(header::HOST, HeaderValue::from_static("example.com"));
         assert!(!origin_allowed(&headers, &settings));
+
+        let https_settings = RemoteSettings {
+            allowed_origins: vec!["https://100.64.0.2:19281".into()],
+            ..RemoteSettings::default()
+        };
+        headers.insert(header::HOST, HeaderValue::from_static("100.64.0.2:19281"));
+        assert!(origin_allowed(&headers, &https_settings));
     }
 }

--- a/src-tauri/src/remote_server/auth.rs
+++ b/src-tauri/src/remote_server/auth.rs
@@ -27,7 +27,14 @@ pub(crate) async fn remote_guard(
             "direct remote mode requires remote.authToken",
         );
     }
-    if !is_remote_ip_allowed(&normalize_ip(addr.ip()), &settings.allowed_ips) {
+    let remote_ip = normalize_ip(addr.ip());
+    if !is_remote_ip_allowed(&remote_ip, &settings.allowed_ips) {
+        tracing::warn!(
+            remote_addr = %addr,
+            remote_ip = %remote_ip,
+            allowed_ips = ?settings.allowed_ips,
+            "remote API client IP denied"
+        );
         return json_error(StatusCode::FORBIDDEN, "remote client IP is not allowed");
     }
     if !origin_allowed(req.headers(), &settings) {
@@ -221,8 +228,11 @@ mod tests {
     use axum::http::HeaderValue;
 
     #[test]
-    fn remote_allowlist_matches_tailscale_cidr() {
-        let allowed = vec!["100.64.0.0/10".to_string()];
+    fn remote_allowlist_matches_tailscale_cidrs() {
+        let allowed = vec![
+            "100.64.0.0/10".to_string(),
+            "fd7a:115c:a1e0::/48".to_string(),
+        ];
         assert!(is_remote_ip_allowed(
             &"100.100.10.20".parse::<IpAddr>().unwrap(),
             &allowed
@@ -233,6 +243,14 @@ mod tests {
         ));
         assert!(!is_remote_ip_allowed(
             &"100.128.0.1".parse::<IpAddr>().unwrap(),
+            &allowed
+        ));
+        assert!(is_remote_ip_allowed(
+            &"fd7a:115c:a1e0::5e37:230".parse::<IpAddr>().unwrap(),
+            &allowed
+        ));
+        assert!(!is_remote_ip_allowed(
+            &"fd7b:115c:a1e0::1".parse::<IpAddr>().unwrap(),
             &allowed
         ));
     }

--- a/src-tauri/src/remote_server/mod.rs
+++ b/src-tauri/src/remote_server/mod.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod lease;
+mod page;
 mod routes;
 
 use axum::http::StatusCode;

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -16,7 +16,14 @@ pub(crate) async fn remote_page(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> R
     if !settings.enabled {
         return json_error(StatusCode::FORBIDDEN, "direct remote mode is disabled");
     }
-    if !is_remote_ip_allowed(&normalize_ip(addr.ip()), &settings.allowed_ips) {
+    let remote_ip = normalize_ip(addr.ip());
+    if !is_remote_ip_allowed(&remote_ip, &settings.allowed_ips) {
+        tracing::warn!(
+            remote_addr = %addr,
+            remote_ip = %remote_ip,
+            allowed_ips = ?settings.allowed_ips,
+            "remote page client IP denied"
+        );
         return json_error(StatusCode::FORBIDDEN, "remote client IP is not allowed");
     }
 
@@ -306,7 +313,7 @@ const REMOTE_PAGE_HTML: &str = r#"<!doctype html>
           for (const terminal of data.terminals || []) {
             const option = document.createElement("option");
             option.value = terminal.id;
-            option.textContent = `${terminal.title || terminal.id} · ${terminal.profile} · ${terminal.cwd || ""}`;
+            option.textContent = `${terminal.title || terminal.id} - ${terminal.profile} - ${terminal.cwd || ""}`;
             terminalsSelect.append(option);
           }
           activeTerminalId = terminalsSelect.value || null;

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -1,17 +1,13 @@
 use std::net::SocketAddr;
 
 use axum::extract::ConnectInfo;
-use axum::http::StatusCode;
 use axum::response::{Html, IntoResponse, Redirect, Response};
 
-use crate::settings::models::RemoteSettings;
-
-use super::auth::{is_remote_ip_allowed, normalize_ip};
-use super::json_error;
+use super::auth::check_remote_base_access;
 
 pub(crate) async fn remote_page_redirect(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> Response {
     let settings = crate::settings::load_settings().remote;
-    if let Some(response) = remote_page_access_error(&settings, addr) {
+    if let Some(response) = check_remote_base_access(&settings, addr) {
         return response;
     }
 
@@ -20,41 +16,11 @@ pub(crate) async fn remote_page_redirect(ConnectInfo(addr): ConnectInfo<SocketAd
 
 pub(crate) async fn remote_page(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> Response {
     let settings = crate::settings::load_settings().remote;
-    if let Some(response) = remote_page_access_error(&settings, addr) {
+    if let Some(response) = check_remote_base_access(&settings, addr) {
         return response;
     }
 
     Html(remote_page_html()).into_response()
-}
-
-fn remote_page_access_error(settings: &RemoteSettings, addr: SocketAddr) -> Option<Response> {
-    if !settings.enabled {
-        return Some(json_error(
-            StatusCode::FORBIDDEN,
-            "direct remote mode is disabled",
-        ));
-    }
-    if settings.auth_token.is_empty() {
-        return Some(json_error(
-            StatusCode::UNAUTHORIZED,
-            "direct remote mode requires remote.authToken",
-        ));
-    }
-    let remote_ip = normalize_ip(addr.ip());
-    if !is_remote_ip_allowed(&remote_ip, &settings.allowed_ips) {
-        tracing::warn!(
-            remote_addr = %addr,
-            remote_ip = %remote_ip,
-            allowed_ips = ?settings.allowed_ips,
-            "remote page client IP denied"
-        );
-        return Some(json_error(
-            StatusCode::FORBIDDEN,
-            "remote client IP is not allowed",
-        ));
-    }
-
-    None
 }
 
 fn remote_page_html() -> &'static str {

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -1,0 +1,421 @@
+use std::net::SocketAddr;
+
+use axum::extract::ConnectInfo;
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Redirect, Response};
+
+use super::auth::{is_remote_ip_allowed, normalize_ip};
+use super::json_error;
+
+pub(crate) async fn remote_page_redirect() -> Redirect {
+    Redirect::temporary("/remote/")
+}
+
+pub(crate) async fn remote_page(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> Response {
+    let settings = crate::settings::load_settings().remote;
+    if !settings.enabled {
+        return json_error(StatusCode::FORBIDDEN, "direct remote mode is disabled");
+    }
+    if !is_remote_ip_allowed(&normalize_ip(addr.ip()), &settings.allowed_ips) {
+        return json_error(StatusCode::FORBIDDEN, "remote client IP is not allowed");
+    }
+
+    Html(remote_page_html()).into_response()
+}
+
+fn remote_page_html() -> &'static str {
+    REMOTE_PAGE_HTML
+}
+
+const REMOTE_PAGE_HTML: &str = r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Laymux Remote</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #111318;
+        --panel: #1b2028;
+        --panel-2: #252b35;
+        --border: #394150;
+        --text: #ecf0f8;
+        --muted: #9aa5b5;
+        --accent: #68a7ff;
+        --danger: #ff6b7a;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--text);
+        font: 14px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      button, input, select {
+        font: inherit;
+      }
+      .app {
+        display: grid;
+        grid-template-rows: auto minmax(0, 1fr) auto;
+        min-height: 100vh;
+      }
+      header, footer {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        padding: 10px 12px;
+        border-color: var(--border);
+        background: var(--panel);
+      }
+      header {
+        border-bottom: 1px solid var(--border);
+        flex-wrap: wrap;
+      }
+      footer {
+        border-top: 1px solid var(--border);
+      }
+      h1 {
+        margin: 0 10px 0 0;
+        font-size: 15px;
+        font-weight: 700;
+      }
+      label {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        color: var(--muted);
+      }
+      input, select {
+        min-width: 0;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 7px 8px;
+        background: #0d1015;
+        color: var(--text);
+      }
+      input[type="password"] {
+        width: 180px;
+      }
+      select {
+        width: min(360px, 100%);
+      }
+      button {
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 7px 10px;
+        background: var(--panel-2);
+        color: var(--text);
+        cursor: pointer;
+      }
+      button.primary {
+        border-color: #3d7dd1;
+        background: #1f5fa8;
+      }
+      button.danger {
+        border-color: #8b3440;
+        background: #6a2230;
+      }
+      button:disabled {
+        cursor: default;
+        opacity: 0.55;
+      }
+      main {
+        display: grid;
+        grid-template-rows: auto minmax(0, 1fr);
+        min-height: 0;
+      }
+      .status {
+        min-height: 36px;
+        padding: 8px 12px;
+        color: var(--muted);
+        border-bottom: 1px solid var(--border);
+      }
+      .status.error {
+        color: var(--danger);
+      }
+      pre {
+        margin: 0;
+        min-height: 0;
+        overflow: auto;
+        padding: 12px;
+        white-space: pre-wrap;
+        word-break: break-word;
+        font: 13px/1.35 "Cascadia Mono", Consolas, monospace;
+      }
+      .input-line {
+        flex: 1;
+      }
+      .input-line input {
+        width: 100%;
+      }
+      @media (max-width: 720px) {
+        header {
+          display: grid;
+          grid-template-columns: 1fr;
+        }
+        h1 {
+          margin-right: 0;
+        }
+        label {
+          display: grid;
+          grid-template-columns: 72px minmax(0, 1fr);
+        }
+        input[type="password"], select {
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <header>
+        <h1>Laymux Remote</h1>
+        <label>Token <input id="token" type="password" autocomplete="current-password" /></label>
+        <label>Name <input id="clientName" autocomplete="nickname" value="browser" /></label>
+        <button id="connect" class="primary">Connect</button>
+        <button id="release" class="danger" disabled>Release</button>
+        <select id="terminals" disabled></select>
+      </header>
+      <main>
+        <div id="status" class="status">Enter the remote token, then connect.</div>
+        <pre id="output" aria-label="Terminal output"></pre>
+      </main>
+      <footer>
+        <button id="ctrlC" disabled>Ctrl+C</button>
+        <form id="inputForm" class="input-line">
+          <input id="input" autocomplete="off" placeholder="Type command and press Enter" disabled />
+        </form>
+        <button id="send" disabled>Send</button>
+      </footer>
+    </div>
+    <script>
+      (() => {
+        const $ = (id) => document.getElementById(id);
+        const tokenInput = $("token");
+        const clientNameInput = $("clientName");
+        const connectButton = $("connect");
+        const releaseButton = $("release");
+        const terminalsSelect = $("terminals");
+        const statusEl = $("status");
+        const outputEl = $("output");
+        const inputForm = $("inputForm");
+        const inputEl = $("input");
+        const sendButton = $("send");
+        const ctrlCButton = $("ctrlC");
+        const decoder = new TextDecoder();
+        const tokenKey = "laymux.remote.token";
+        let leaseId = null;
+        let heartbeatTimer = null;
+        let socket = null;
+        let outputText = "";
+        let activeTerminalId = null;
+
+        const params = new URLSearchParams(location.search);
+        tokenInput.value = params.get("token") || localStorage.getItem(tokenKey) || "";
+
+        function setStatus(message, error = false) {
+          statusEl.textContent = message;
+          statusEl.classList.toggle("error", error);
+        }
+
+        function token() {
+          return tokenInput.value.trim();
+        }
+
+        function authHeaders() {
+          return {
+            "authorization": `Bearer ${token()}`,
+            "content-type": "application/json",
+          };
+        }
+
+        async function remoteFetch(path, options = {}) {
+          const response = await fetch(path, {
+            ...options,
+            headers: { ...authHeaders(), ...(options.headers || {}) },
+          });
+          if (!response.ok) {
+            const body = await response.json().catch(() => ({}));
+            throw new Error(body.error || `${response.status} ${response.statusText}`);
+          }
+          return response.json();
+        }
+
+        function setConnected(connected) {
+          releaseButton.disabled = !connected;
+          terminalsSelect.disabled = !connected;
+          inputEl.disabled = !connected || !activeTerminalId;
+          sendButton.disabled = !connected || !activeTerminalId;
+          ctrlCButton.disabled = !connected || !activeTerminalId;
+          connectButton.disabled = connected;
+        }
+
+        function appendOutput(text) {
+          outputText += stripAnsi(text);
+          if (outputText.length > 200000) outputText = outputText.slice(-160000);
+          outputEl.textContent = outputText;
+          outputEl.scrollTop = outputEl.scrollHeight;
+        }
+
+        function stripAnsi(text) {
+          return text
+            .replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, "")
+            .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
+            .replace(/\x1b[=>]/g, "")
+            .replace(/\r/g, "");
+        }
+
+        function stopSocket() {
+          if (socket) {
+            socket.close();
+            socket = null;
+          }
+        }
+
+        function stopHeartbeat() {
+          if (heartbeatTimer) {
+            clearInterval(heartbeatTimer);
+            heartbeatTimer = null;
+          }
+        }
+
+        async function heartbeat() {
+          if (!leaseId) return;
+          await remoteFetch("/remote/v1/session/heartbeat", {
+            method: "POST",
+            body: JSON.stringify({ leaseId }),
+          });
+        }
+
+        function startHeartbeat(timeoutSeconds) {
+          stopHeartbeat();
+          const intervalMs = Math.max(3000, Math.floor(timeoutSeconds * 500));
+          heartbeatTimer = setInterval(() => {
+            heartbeat().catch((err) => {
+              setStatus(`Heartbeat failed: ${err.message}`, true);
+              disconnect(false);
+            });
+          }, intervalMs);
+        }
+
+        async function loadTerminals() {
+          const data = await remoteFetch("/remote/v1/terminals");
+          terminalsSelect.innerHTML = "";
+          for (const terminal of data.terminals || []) {
+            const option = document.createElement("option");
+            option.value = terminal.id;
+            option.textContent = `${terminal.title || terminal.id} · ${terminal.profile} · ${terminal.cwd || ""}`;
+            terminalsSelect.append(option);
+          }
+          activeTerminalId = terminalsSelect.value || null;
+          setConnected(Boolean(leaseId));
+          if (activeTerminalId) openOutput(activeTerminalId);
+        }
+
+        function wsBaseUrl() {
+          const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+          return `${protocol}//${location.host}`;
+        }
+
+        function openOutput(terminalId) {
+          stopSocket();
+          outputText = "";
+          outputEl.textContent = "";
+          const url = `${wsBaseUrl()}/remote/v1/terminals/${encodeURIComponent(terminalId)}/output?leaseId=${encodeURIComponent(leaseId)}&token=${encodeURIComponent(token())}`;
+          socket = new WebSocket(url);
+          socket.binaryType = "arraybuffer";
+          socket.onopen = () => setStatus(`Connected to ${terminalId}`);
+          socket.onmessage = (event) => {
+            if (event.data instanceof ArrayBuffer) appendOutput(decoder.decode(event.data));
+            else appendOutput(String(event.data));
+          };
+          socket.onclose = () => {
+            if (leaseId) setStatus("Output stream closed.", true);
+          };
+          socket.onerror = () => setStatus("Output stream error.", true);
+        }
+
+        async function connect() {
+          if (!token()) {
+            setStatus("Remote token is required.", true);
+            return;
+          }
+          localStorage.setItem(tokenKey, token());
+          setStatus("Claiming remote control...");
+          const status = await remoteFetch("/remote/v1/session/claim", {
+            method: "POST",
+            body: JSON.stringify({ clientName: clientNameInput.value.trim() || "browser" }),
+          });
+          leaseId = status.leaseId;
+          startHeartbeat(status.heartbeatTimeoutSeconds || 15);
+          await loadTerminals();
+        }
+
+        async function write(data) {
+          if (!leaseId || !activeTerminalId) return;
+          await remoteFetch(`/remote/v1/terminals/${encodeURIComponent(activeTerminalId)}/write`, {
+            method: "POST",
+            body: JSON.stringify({ leaseId, data }),
+          });
+        }
+
+        async function release() {
+          if (!leaseId) return;
+          const currentLease = leaseId;
+          disconnect(false);
+          await remoteFetch("/remote/v1/session/release", {
+            method: "POST",
+            body: JSON.stringify({ leaseId: currentLease }),
+          }).catch(() => {});
+          setStatus("Released remote control.");
+        }
+
+        function disconnect(clearStatus = true) {
+          stopSocket();
+          stopHeartbeat();
+          leaseId = null;
+          activeTerminalId = null;
+          setConnected(false);
+          if (clearStatus) setStatus("Disconnected.");
+        }
+
+        connectButton.addEventListener("click", () => connect().catch((err) => setStatus(err.message, true)));
+        releaseButton.addEventListener("click", () => release());
+        terminalsSelect.addEventListener("change", () => {
+          activeTerminalId = terminalsSelect.value || null;
+          setConnected(Boolean(leaseId));
+          if (activeTerminalId) openOutput(activeTerminalId);
+        });
+        inputForm.addEventListener("submit", (event) => {
+          event.preventDefault();
+          const value = inputEl.value;
+          inputEl.value = "";
+          write(`${value}\r`).catch((err) => setStatus(err.message, true));
+        });
+        sendButton.addEventListener("click", () => inputForm.requestSubmit());
+        ctrlCButton.addEventListener("click", () => write("\x03").catch((err) => setStatus(err.message, true)));
+        window.addEventListener("beforeunload", () => {
+          stopSocket();
+          stopHeartbeat();
+        });
+      })();
+    </script>
+  </body>
+</html>
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_page_html_contains_remote_bootstrap() {
+        let html = remote_page_html();
+        assert!(html.contains("Laymux Remote"));
+        assert!(html.contains("/remote/v1/session/claim"));
+        assert!(html.contains("/remote/v1/terminals"));
+        assert!(html.contains("new WebSocket"));
+    }
+}

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -4,17 +4,41 @@ use axum::extract::ConnectInfo;
 use axum::http::StatusCode;
 use axum::response::{Html, IntoResponse, Redirect, Response};
 
+use crate::settings::models::RemoteSettings;
+
 use super::auth::{is_remote_ip_allowed, normalize_ip};
 use super::json_error;
 
-pub(crate) async fn remote_page_redirect() -> Redirect {
-    Redirect::temporary("/remote/")
+pub(crate) async fn remote_page_redirect(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> Response {
+    let settings = crate::settings::load_settings().remote;
+    if let Some(response) = remote_page_access_error(&settings, addr) {
+        return response;
+    }
+
+    Redirect::temporary("/remote/").into_response()
 }
 
 pub(crate) async fn remote_page(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> Response {
     let settings = crate::settings::load_settings().remote;
+    if let Some(response) = remote_page_access_error(&settings, addr) {
+        return response;
+    }
+
+    Html(remote_page_html()).into_response()
+}
+
+fn remote_page_access_error(settings: &RemoteSettings, addr: SocketAddr) -> Option<Response> {
     if !settings.enabled {
-        return json_error(StatusCode::FORBIDDEN, "direct remote mode is disabled");
+        return Some(json_error(
+            StatusCode::FORBIDDEN,
+            "direct remote mode is disabled",
+        ));
+    }
+    if settings.auth_token.is_empty() {
+        return Some(json_error(
+            StatusCode::UNAUTHORIZED,
+            "direct remote mode requires remote.authToken",
+        ));
     }
     let remote_ip = normalize_ip(addr.ip());
     if !is_remote_ip_allowed(&remote_ip, &settings.allowed_ips) {
@@ -24,10 +48,13 @@ pub(crate) async fn remote_page(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> R
             allowed_ips = ?settings.allowed_ips,
             "remote page client IP denied"
         );
-        return json_error(StatusCode::FORBIDDEN, "remote client IP is not allowed");
+        return Some(json_error(
+            StatusCode::FORBIDDEN,
+            "remote client IP is not allowed",
+        ));
     }
 
-    Html(remote_page_html()).into_response()
+    None
 }
 
 fn remote_page_html() -> &'static str {
@@ -276,8 +303,11 @@ const REMOTE_PAGE_HTML: &str = r#"<!doctype html>
 
         function stopSocket() {
           if (socket) {
-            socket.close();
+            const closingSocket = socket;
             socket = null;
+            closingSocket.onclose = null;
+            closingSocket.onerror = null;
+            closingSocket.close();
           }
         }
 
@@ -298,7 +328,7 @@ const REMOTE_PAGE_HTML: &str = r#"<!doctype html>
 
         function startHeartbeat(timeoutSeconds) {
           stopHeartbeat();
-          const intervalMs = Math.max(3000, Math.floor(timeoutSeconds * 500));
+          const intervalMs = Math.max(1000, Math.floor(timeoutSeconds * 333));
           heartbeatTimer = setInterval(() => {
             heartbeat().catch((err) => {
               setStatus(`Heartbeat failed: ${err.message}`, true);
@@ -313,7 +343,9 @@ const REMOTE_PAGE_HTML: &str = r#"<!doctype html>
           for (const terminal of data.terminals || []) {
             const option = document.createElement("option");
             option.value = terminal.id;
-            option.textContent = `${terminal.title || terminal.id} - ${terminal.profile} - ${terminal.cwd || ""}`;
+            option.textContent = [terminal.title || terminal.id, terminal.profile || "", terminal.cwd || ""]
+              .filter(Boolean)
+              .join(" - ");
             terminalsSelect.append(option);
           }
           activeTerminalId = terminalsSelect.value || null;
@@ -331,17 +363,26 @@ const REMOTE_PAGE_HTML: &str = r#"<!doctype html>
           outputText = "";
           outputEl.textContent = "";
           const url = `${wsBaseUrl()}/remote/v1/terminals/${encodeURIComponent(terminalId)}/output?leaseId=${encodeURIComponent(leaseId)}&token=${encodeURIComponent(token())}`;
-          socket = new WebSocket(url);
-          socket.binaryType = "arraybuffer";
-          socket.onopen = () => setStatus(`Connected to ${terminalId}`);
-          socket.onmessage = (event) => {
+          const outputSocket = new WebSocket(url);
+          socket = outputSocket;
+          outputSocket.binaryType = "arraybuffer";
+          outputSocket.onopen = () => {
+            if (socket === outputSocket) setStatus(`Connected to ${terminalId}`);
+          };
+          outputSocket.onmessage = (event) => {
+            if (socket !== outputSocket) return;
             if (event.data instanceof ArrayBuffer) appendOutput(decoder.decode(event.data));
             else appendOutput(String(event.data));
           };
-          socket.onclose = () => {
-            if (leaseId) setStatus("Output stream closed.", true);
+          outputSocket.onclose = () => {
+            if (socket === outputSocket) {
+              socket = null;
+              if (leaseId) setStatus("Output stream closed.", true);
+            }
           };
-          socket.onerror = () => setStatus("Output stream error.", true);
+          outputSocket.onerror = () => {
+            if (socket === outputSocket) setStatus("Output stream error.", true);
+          };
         }
 
         async function connect() {
@@ -351,13 +392,21 @@ const REMOTE_PAGE_HTML: &str = r#"<!doctype html>
           }
           localStorage.setItem(tokenKey, token());
           setStatus("Claiming remote control...");
-          const status = await remoteFetch("/remote/v1/session/claim", {
-            method: "POST",
-            body: JSON.stringify({ clientName: clientNameInput.value.trim() || "browser" }),
-          });
-          leaseId = status.leaseId;
-          startHeartbeat(status.heartbeatTimeoutSeconds || 15);
-          await loadTerminals();
+          try {
+            const status = await remoteFetch("/remote/v1/session/claim", {
+              method: "POST",
+              body: JSON.stringify({ clientName: clientNameInput.value.trim() || "browser" }),
+            });
+            leaseId = status.leaseId;
+            setConnected(true);
+            startHeartbeat(status.heartbeatTimeoutSeconds || 15);
+            await loadTerminals();
+          } catch (err) {
+            const failedLease = leaseId;
+            disconnect(false);
+            if (failedLease) await releaseLease(failedLease).catch(() => {});
+            setStatus(err.message, true);
+          }
         }
 
         async function write(data) {
@@ -371,12 +420,16 @@ const REMOTE_PAGE_HTML: &str = r#"<!doctype html>
         async function release() {
           if (!leaseId) return;
           const currentLease = leaseId;
+          await releaseLease(currentLease);
           disconnect(false);
+          setStatus("Released remote control.");
+        }
+
+        async function releaseLease(id) {
           await remoteFetch("/remote/v1/session/release", {
             method: "POST",
-            body: JSON.stringify({ leaseId: currentLease }),
-          }).catch(() => {});
-          setStatus("Released remote control.");
+            body: JSON.stringify({ leaseId: id }),
+          });
         }
 
         function disconnect(clearStatus = true) {
@@ -389,7 +442,7 @@ const REMOTE_PAGE_HTML: &str = r#"<!doctype html>
         }
 
         connectButton.addEventListener("click", () => connect().catch((err) => setStatus(err.message, true)));
-        releaseButton.addEventListener("click", () => release());
+        releaseButton.addEventListener("click", () => release().catch((err) => setStatus(`Release failed: ${err.message}`, true)));
         terminalsSelect.addEventListener("change", () => {
           activeTerminalId = terminalsSelect.value || null;
           setConnected(Boolean(leaseId));

--- a/src-tauri/src/remote_server/routes.rs
+++ b/src-tauri/src/remote_server/routes.rs
@@ -21,6 +21,7 @@ use super::lease::{
     emit_remote_control_status, get_remote_control_status, prune_expired_lease,
     reclaim_lockout_active, require_active_lease, status_from_state, RemoteControlLease,
 };
+use super::page::{remote_page, remote_page_redirect};
 use super::{internal_error, json_error};
 
 const REMOTE_LEASE_HEADER: &str = "x-laymux-remote-lease";
@@ -76,7 +77,7 @@ struct RemoteQuery {
 }
 
 pub fn build_router() -> Router<ServerState> {
-    Router::new()
+    let api_routes = Router::new()
         .route("/remote/v1/health", get(remote_health))
         .route("/remote/v1/session/status", get(remote_session_status))
         .route("/remote/v1/session/claim", post(remote_session_claim))
@@ -99,7 +100,12 @@ pub fn build_router() -> Router<ServerState> {
             get(remote_terminal_output_ws),
         )
         .layer(middleware::from_fn(remote_guard))
-        .layer(CorsLayer::permissive())
+        .layer(CorsLayer::permissive());
+
+    Router::new()
+        .route("/remote", get(remote_page_redirect))
+        .route("/remote/", get(remote_page))
+        .merge(api_routes)
 }
 
 async fn remote_health() -> Response {

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -977,7 +977,7 @@ pub struct RemoteSettings {
     /// Exact Origin values allowed for browser requests. Empty = no Origin filter.
     #[serde(default)]
     pub allowed_origins: Vec<String>,
-    /// IP/CIDR allowlist for remote clients. Add 100.64.0.0/10 for Tailscale.
+    /// IP/CIDR allowlist for remote clients. Add Tailscale IPv4/IPv6 CIDRs when needed.
     #[serde(default = "default_remote_allowed_ips")]
     pub allowed_ips: Vec<String>,
     /// Bearer token for remote browser clients. Required when remote is enabled.


### PR DESCRIPTION
## Summary
- `/remote` -> `/remote/` 브라우저 진입점을 추가했습니다.
- remote enabled + IP allowlist 를 통과한 요청에 간단한 원격 제어 HTML 페이지를 제공합니다.
- 실제 제어 API(`/remote/v1/*`)는 기존 token/Origin/IP 인증 정책을 유지하고, 문서에 브라우저 진입점과 API 인증 경계를 기록했습니다.

## Validation
- `cargo fmt --check`
- `cargo test remote_server --lib`
- `cargo test automation_server --lib`
- `git diff --check`
- dev run: `curl` 로 `/api/v1/health`, `/remote/`, `/remote/v1/health` 확인
- dev run: `dev-remote-token` 으로 claim/list/release 확인
- Playwright screenshot: 초기/연결된 모바일 remote 페이지 확인