### PR TITLE
[codex] Sync remote terminal appearance

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -550,6 +550,13 @@ Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Dire
 | `/remote/v1/terminals/{id}/resize` | POST | active `leaseId`로 PTY 크기 변경 |
 | `/remote/v1/terminals/{id}/output?leaseId=...&token=...` | WS | ring buffer tail + 이후 PTY output byte stream |
 
+`/remote/v1/terminals` 응답의 각 terminal 항목은 `appearance`를 포함한다. 이 값은 remote
+브라우저가 settings 전체를 직접 읽지 않도록 backend가 profile/profileDefaults/colorSchemes에서
+해석한 표시 전용 계약이다. 포함 범위는 xterm option으로 바로 적용 가능한 `fontFamily`,
+`fontSize`, `cursorStyle`, 선택적 `cursorWidth`, `theme`이며, Windows Terminal 색상 스킴의
+`purple`/`brightPurple`은 xterm.js의 `magenta`/`brightMagenta`로 매핑한다. 색상 스킴을 찾을 수
+없으면 로컬 `TerminalView`의 기본 테마와 동일한 CampbellClear 기반 fallback을 사용한다.
+
 `write`/`resize`는 JSON body의 `leaseId` 또는 `X-Laymux-Remote-Lease` 헤더가 현재 active lease와 일치해야 한다. 출력 WebSocket도 `leaseId` 쿼리를 요구한다. 이는 인증된 다른 remote peer가 active controller를 우회해 입력을 주입하지 못하게 하는 서버 측 게이트다.
 
 ---

--- a/src-tauri/src/remote_server/appearance.rs
+++ b/src-tauri/src/remote_server/appearance.rs
@@ -1,0 +1,361 @@
+use serde::Serialize;
+
+use crate::settings::models::{ColorScheme, FontSettings, Profile, Settings};
+
+const DEFAULT_COLOR_SCHEME_NAME: &str = "CampbellClear";
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RemoteTerminalAppearance {
+    pub font_family: String,
+    pub font_size: u16,
+    pub cursor_style: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor_width: Option<u16>,
+    pub theme: RemoteTerminalTheme,
+}
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RemoteTerminalTheme {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub foreground: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection_background: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub black: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub red: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub green: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub yellow: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blue: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub magenta: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cyan: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub white: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bright_black: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bright_red: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bright_green: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bright_yellow: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bright_blue: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bright_magenta: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bright_cyan: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bright_white: Option<String>,
+}
+
+pub(super) fn resolve_remote_terminal_appearance(
+    profile_name: &str,
+    settings: &Settings,
+) -> RemoteTerminalAppearance {
+    let profile = settings
+        .profiles
+        .iter()
+        .find(|profile| profile.name == profile_name);
+    let font = profile
+        .and_then(|profile| profile.font.as_ref())
+        .unwrap_or(&settings.profile_defaults.font);
+    let cursor_shape = profile
+        .and_then(|profile| non_empty(&profile.cursor_shape))
+        .or_else(|| non_empty(&settings.profile_defaults.cursor_shape))
+        .unwrap_or("bar");
+    let (cursor_style, cursor_width) = xterm_cursor_options(cursor_shape);
+
+    RemoteTerminalAppearance {
+        font_family: terminal_font_family(font),
+        font_size: if font.size == 0 {
+            FontSettings::default().size
+        } else {
+            font.size
+        },
+        cursor_style: cursor_style.into(),
+        cursor_width,
+        theme: resolve_terminal_theme(profile, settings),
+    }
+}
+
+fn terminal_font_family(font: &FontSettings) -> String {
+    let face = non_empty(&font.face).unwrap_or("Cascadia Mono");
+    let escaped_face = face.replace('\'', "\\'");
+    format!("'{escaped_face}', 'Cascadia Mono', 'Consolas', monospace")
+}
+
+fn xterm_cursor_options(shape: &str) -> (&'static str, Option<u16>) {
+    match shape {
+        "bar" => ("bar", Some(1)),
+        "underscore" => ("underline", None),
+        "filledBox" => ("block", None),
+        _ => ("block", None),
+    }
+}
+
+fn resolve_terminal_theme(profile: Option<&Profile>, settings: &Settings) -> RemoteTerminalTheme {
+    let scheme_name = profile
+        .and_then(|profile| non_empty(&profile.color_scheme))
+        .or_else(|| non_empty(&settings.profile_defaults.color_scheme))
+        .unwrap_or(DEFAULT_COLOR_SCHEME_NAME);
+
+    if let Some(scheme) = settings
+        .color_schemes
+        .iter()
+        .find(|scheme| scheme.name == scheme_name)
+    {
+        return color_scheme_to_xterm_theme(&merge_with_default_color_scheme(scheme));
+    }
+
+    if scheme_name == DEFAULT_COLOR_SCHEME_NAME {
+        return color_scheme_to_xterm_theme(&campbell_clear_color_scheme());
+    }
+
+    default_xterm_theme()
+}
+
+fn color_scheme_to_xterm_theme(scheme: &ColorScheme) -> RemoteTerminalTheme {
+    let mut theme = default_xterm_theme();
+
+    set_if_non_empty(&mut theme.foreground, &scheme.foreground);
+    set_if_non_empty(&mut theme.background, &scheme.background);
+    set_if_non_empty(&mut theme.cursor, &scheme.cursor_color);
+    set_if_non_empty(
+        &mut theme.selection_background,
+        &scheme.selection_background,
+    );
+    set_if_non_empty(&mut theme.black, &scheme.black);
+    set_if_non_empty(&mut theme.red, &scheme.red);
+    set_if_non_empty(&mut theme.green, &scheme.green);
+    set_if_non_empty(&mut theme.yellow, &scheme.yellow);
+    set_if_non_empty(&mut theme.blue, &scheme.blue);
+    set_if_non_empty(&mut theme.magenta, &scheme.purple);
+    set_if_non_empty(&mut theme.cyan, &scheme.cyan);
+    set_if_non_empty(&mut theme.white, &scheme.white);
+    set_if_non_empty(&mut theme.bright_black, &scheme.bright_black);
+    set_if_non_empty(&mut theme.bright_red, &scheme.bright_red);
+    set_if_non_empty(&mut theme.bright_green, &scheme.bright_green);
+    set_if_non_empty(&mut theme.bright_yellow, &scheme.bright_yellow);
+    set_if_non_empty(&mut theme.bright_blue, &scheme.bright_blue);
+    set_if_non_empty(&mut theme.bright_magenta, &scheme.bright_purple);
+    set_if_non_empty(&mut theme.bright_cyan, &scheme.bright_cyan);
+    set_if_non_empty(&mut theme.bright_white, &scheme.bright_white);
+
+    theme
+}
+
+fn default_xterm_theme() -> RemoteTerminalTheme {
+    RemoteTerminalTheme {
+        background: Some("#0C0C0C".into()),
+        foreground: Some("#F0F0F0".into()),
+        cursor: Some("#FFFFFF".into()),
+        selection_background: Some("#232042".into()),
+        ..RemoteTerminalTheme::default()
+    }
+}
+
+fn merge_with_default_color_scheme(scheme: &ColorScheme) -> ColorScheme {
+    let default = default_color_scheme();
+    ColorScheme {
+        name: scheme.name.clone(),
+        foreground: value_or_default(&scheme.foreground, &default.foreground),
+        background: value_or_default(&scheme.background, &default.background),
+        cursor_color: value_or_default(&scheme.cursor_color, &default.cursor_color),
+        selection_background: value_or_default(
+            &scheme.selection_background,
+            &default.selection_background,
+        ),
+        black: value_or_default(&scheme.black, &default.black),
+        red: value_or_default(&scheme.red, &default.red),
+        green: value_or_default(&scheme.green, &default.green),
+        yellow: value_or_default(&scheme.yellow, &default.yellow),
+        blue: value_or_default(&scheme.blue, &default.blue),
+        purple: value_or_default(&scheme.purple, &default.purple),
+        cyan: value_or_default(&scheme.cyan, &default.cyan),
+        white: value_or_default(&scheme.white, &default.white),
+        bright_black: value_or_default(&scheme.bright_black, &default.bright_black),
+        bright_red: value_or_default(&scheme.bright_red, &default.bright_red),
+        bright_green: value_or_default(&scheme.bright_green, &default.bright_green),
+        bright_yellow: value_or_default(&scheme.bright_yellow, &default.bright_yellow),
+        bright_blue: value_or_default(&scheme.bright_blue, &default.bright_blue),
+        bright_purple: value_or_default(&scheme.bright_purple, &default.bright_purple),
+        bright_cyan: value_or_default(&scheme.bright_cyan, &default.bright_cyan),
+        bright_white: value_or_default(&scheme.bright_white, &default.bright_white),
+    }
+}
+
+fn default_color_scheme() -> ColorScheme {
+    ColorScheme {
+        name: String::new(),
+        foreground: "#CCCCCC".into(),
+        background: "#1E1E1E".into(),
+        cursor_color: "#FFFFFF".into(),
+        selection_background: "#264F78".into(),
+        black: "#0C0C0C".into(),
+        red: "#C50F1F".into(),
+        green: "#13A10E".into(),
+        yellow: "#C19C00".into(),
+        blue: "#0037DA".into(),
+        purple: "#881798".into(),
+        cyan: "#3A96DD".into(),
+        white: "#CCCCCC".into(),
+        bright_black: "#767676".into(),
+        bright_red: "#E74856".into(),
+        bright_green: "#16C60C".into(),
+        bright_yellow: "#F9F1A5".into(),
+        bright_blue: "#3B78FF".into(),
+        bright_purple: "#B4009E".into(),
+        bright_cyan: "#61D6D6".into(),
+        bright_white: "#F2F2F2".into(),
+    }
+}
+
+fn campbell_clear_color_scheme() -> ColorScheme {
+    ColorScheme {
+        name: DEFAULT_COLOR_SCHEME_NAME.into(),
+        foreground: "#F0F0F0".into(),
+        background: "#0C0C0C".into(),
+        cursor_color: "#FFFFFF".into(),
+        selection_background: "#232042".into(),
+        black: "#0C0C0C".into(),
+        red: "#C50F1F".into(),
+        green: "#13A10E".into(),
+        yellow: "#C19C00".into(),
+        blue: "#0037DA".into(),
+        purple: "#881798".into(),
+        cyan: "#3A96DD".into(),
+        white: "#F0F0F0".into(),
+        bright_black: "#767676".into(),
+        bright_red: "#E74856".into(),
+        bright_green: "#16C60C".into(),
+        bright_yellow: "#F9F1A5".into(),
+        bright_blue: "#3B78FF".into(),
+        bright_purple: "#B4009E".into(),
+        bright_cyan: "#61D6D6".into(),
+        bright_white: "#FFFFFF".into(),
+    }
+}
+
+fn set_if_non_empty(slot: &mut Option<String>, value: &str) {
+    if let Some(value) = non_empty(value) {
+        *slot = Some(value.into());
+    }
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn value_or_default(value: &str, default: &str) -> String {
+    non_empty(value).unwrap_or(default).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inherits_default_font_and_builtin_campbell_clear_theme() {
+        let mut settings = Settings::default();
+        settings.profile_defaults.font = FontSettings {
+            face: "Fira Code".into(),
+            size: 15,
+            weight: "normal".into(),
+        };
+        settings.profiles = vec![Profile {
+            name: "PowerShell".into(),
+            font: None,
+            ..Profile::default()
+        }];
+
+        let appearance = resolve_remote_terminal_appearance("PowerShell", &settings);
+
+        assert_eq!(
+            appearance.font_family,
+            "'Fira Code', 'Cascadia Mono', 'Consolas', monospace"
+        );
+        assert_eq!(appearance.font_size, 15);
+        assert_eq!(appearance.cursor_style, "bar");
+        assert_eq!(appearance.cursor_width, Some(1));
+        assert_eq!(appearance.theme.background.as_deref(), Some("#0C0C0C"));
+        assert_eq!(appearance.theme.magenta.as_deref(), Some("#881798"));
+        assert_eq!(appearance.theme.bright_white.as_deref(), Some("#FFFFFF"));
+    }
+
+    #[test]
+    fn applies_profile_font_cursor_and_configured_color_scheme() {
+        let mut scheme = default_color_scheme();
+        scheme.name = "RemoteDark".into();
+        scheme.foreground = "#111111".into();
+        scheme.background = "#222222".into();
+        scheme.cursor_color = "#333333".into();
+        scheme.selection_background = "#444444".into();
+        scheme.purple = "#555555".into();
+        scheme.bright_purple = "#666666".into();
+
+        let mut settings = Settings::default();
+        settings.color_schemes = vec![scheme];
+        settings.profiles = vec![Profile {
+            name: "Custom".into(),
+            color_scheme: "RemoteDark".into(),
+            cursor_shape: "filledBox".into(),
+            font: Some(FontSettings {
+                face: "JetBrains Mono".into(),
+                size: 18,
+                weight: "normal".into(),
+            }),
+            ..Profile::default()
+        }];
+
+        let appearance = resolve_remote_terminal_appearance("Custom", &settings);
+
+        assert_eq!(
+            appearance.font_family,
+            "'JetBrains Mono', 'Cascadia Mono', 'Consolas', monospace"
+        );
+        assert_eq!(appearance.font_size, 18);
+        assert_eq!(appearance.cursor_style, "block");
+        assert_eq!(appearance.cursor_width, None);
+        assert_eq!(appearance.theme.foreground.as_deref(), Some("#111111"));
+        assert_eq!(appearance.theme.background.as_deref(), Some("#222222"));
+        assert_eq!(appearance.theme.cursor.as_deref(), Some("#333333"));
+        assert_eq!(
+            appearance.theme.selection_background.as_deref(),
+            Some("#444444")
+        );
+        assert_eq!(appearance.theme.magenta.as_deref(), Some("#555555"));
+        assert_eq!(appearance.theme.bright_magenta.as_deref(), Some("#666666"));
+    }
+
+    #[test]
+    fn maps_underscore_cursor_to_xterm_underline() {
+        let mut settings = Settings::default();
+        settings.profiles = vec![Profile {
+            name: "PowerShell".into(),
+            cursor_shape: "underscore".into(),
+            ..Profile::default()
+        }];
+
+        let appearance = resolve_remote_terminal_appearance("PowerShell", &settings);
+
+        assert_eq!(appearance.cursor_style, "underline");
+        assert_eq!(appearance.cursor_width, None);
+    }
+}

--- a/src-tauri/src/remote_server/mod.rs
+++ b/src-tauri/src/remote_server/mod.rs
@@ -1,3 +1,4 @@
+mod appearance;
 mod assets;
 mod auth;
 mod lease;

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -291,6 +291,7 @@
         let heartbeatTimer = null;
         let socket = null;
         let activeTerminalId = null;
+        let terminalInfoById = new Map();
         let terminal = null;
         let fitAddon = null;
         let resizeObserver = null;
@@ -303,6 +304,36 @@
 
         const params = new URLSearchParams(location.search);
         tokenInput.value = params.get("token") || localStorage.getItem(tokenKey) || "";
+
+        const defaultAppearance = Object.freeze({
+          fontFamily: "'Cascadia Mono', 'Cascadia Mono', 'Consolas', monospace",
+          fontSize: 14,
+          cursorStyle: "bar",
+          cursorWidth: 1,
+          scrollback: 10000,
+          theme: Object.freeze({
+            background: "#0C0C0C",
+            foreground: "#F0F0F0",
+            cursor: "#FFFFFF",
+            selectionBackground: "#232042",
+            black: "#0C0C0C",
+            red: "#C50F1F",
+            green: "#13A10E",
+            yellow: "#C19C00",
+            blue: "#0037DA",
+            magenta: "#881798",
+            cyan: "#3A96DD",
+            white: "#F0F0F0",
+            brightBlack: "#767676",
+            brightRed: "#E74856",
+            brightGreen: "#16C60C",
+            brightYellow: "#F9F1A5",
+            brightBlue: "#3B78FF",
+            brightMagenta: "#B4009E",
+            brightCyan: "#61D6D6",
+            brightWhite: "#FFFFFF"
+          })
+        });
 
         function setStatus(message, error = false) {
           statusEl.textContent = message;
@@ -341,46 +372,69 @@
           connectButton.disabled = connected;
         }
 
-        function ensureTerminal() {
+        function normalizeAppearance(appearance = {}) {
+          const fontSize = Number(appearance.fontSize);
+          const cursorWidth = Number(appearance.cursorWidth);
+          const cursorStyle = ["bar", "underline", "block"].includes(appearance.cursorStyle)
+            ? appearance.cursorStyle
+            : defaultAppearance.cursorStyle;
+          return {
+            fontFamily: appearance.fontFamily || defaultAppearance.fontFamily,
+            fontSize: Number.isFinite(fontSize) && fontSize > 0 ? Math.floor(fontSize) : defaultAppearance.fontSize,
+            cursorStyle,
+            cursorWidth: Number.isFinite(cursorWidth) && cursorWidth > 0 ? Math.floor(cursorWidth) : undefined,
+            scrollback: defaultAppearance.scrollback,
+            theme: { ...defaultAppearance.theme, ...(appearance.theme || {}) },
+          };
+        }
+
+        function terminalOptionsForAppearance(appearance = {}) {
+          const normalized = normalizeAppearance(appearance);
+          const options = {
+            allowProposedApi: false,
+            cols: 80,
+            rows: 24,
+            cursorBlink: true,
+            cursorStyle: normalized.cursorStyle,
+            fontFamily: normalized.fontFamily,
+            fontSize: normalized.fontSize,
+            letterSpacing: 0,
+            scrollback: normalized.scrollback,
+            convertEol: false,
+            theme: normalized.theme,
+          };
+          if (normalized.cursorWidth !== undefined) {
+            options.cursorWidth = normalized.cursorWidth;
+          }
+          return options;
+        }
+
+        function applyTerminalAppearance(appearance = {}) {
+          if (!terminal) return;
+          const options = terminalOptionsForAppearance(appearance);
+          delete options.cols;
+          delete options.rows;
+          terminal.options = options;
+          if (options.cursorWidth === undefined) {
+            try {
+              delete terminal.options.cursorWidth;
+            } catch (_) {
+              terminal.options.cursorWidth = undefined;
+            }
+          }
+          if (typeof terminal.refresh === "function" && terminal.rows > 0) {
+            terminal.refresh(0, terminal.rows - 1);
+          }
+        }
+
+        function ensureTerminal(appearance = {}) {
           if (terminal) return terminal;
           const TerminalCtor = window.Terminal;
           const FitAddonCtor = window.FitAddon && window.FitAddon.FitAddon;
           if (!TerminalCtor || !FitAddonCtor) {
             throw new Error("xterm assets failed to load");
           }
-          terminal = new TerminalCtor({
-            allowProposedApi: false,
-            cols: 80,
-            rows: 24,
-            cursorBlink: true,
-            fontFamily: '"Cascadia Mono", "Cascadia Code", Consolas, monospace',
-            fontSize: 13,
-            letterSpacing: 0,
-            scrollback: 9000,
-            convertEol: false,
-            theme: {
-              background: '#080a0d',
-              foreground: '#eef2f8',
-              cursor: '#f4d35e',
-              selectionBackground: '#2f5f94',
-              black: '#111318',
-              red: '#ff6978',
-              green: '#5fcf8f',
-              yellow: '#f4d35e',
-              blue: '#5ea1ff',
-              magenta: '#c889ff',
-              cyan: '#4fd2d2',
-              white: '#eef2f8',
-              brightBlack: '#586170',
-              brightRed: '#ff8793',
-              brightGreen: '#7ee2a6',
-              brightYellow: '#ffe082',
-              brightBlue: '#82b8ff',
-              brightMagenta: '#d8a4ff',
-              brightCyan: '#7ae5e5',
-              brightWhite: '#ffffff'
-            }
-          });
+          terminal = new TerminalCtor(terminalOptionsForAppearance(appearance));
           fitAddon = new FitAddonCtor();
           terminal.loadAddon(fitAddon);
           terminal.open(terminalHost);
@@ -460,6 +514,7 @@
         async function loadTerminals() {
           const data = await remoteFetch("/remote/v1/terminals");
           const terminals = data.terminals || [];
+          terminalInfoById = new Map(terminals.map((terminalInfo) => [terminalInfo.id, terminalInfo]));
           const previousTerminalId = activeTerminalId;
           terminalsSelect.innerHTML = "";
           for (const terminalInfo of terminals) {
@@ -490,10 +545,12 @@
         }
 
         function openOutput(terminalId) {
-          const term = ensureTerminal();
+          const terminalInfo = terminalInfoById.get(terminalId);
+          const term = ensureTerminal(terminalInfo && terminalInfo.appearance);
           stopSocket();
           stopInputFlush();
           stopResizeFlush();
+          applyTerminalAppearance(terminalInfo && terminalInfo.appearance);
           term.reset();
           lastResizeKey = "";
           const url = `${wsBaseUrl()}/remote/v1/terminals/${encodeURIComponent(terminalId)}/output?leaseId=${encodeURIComponent(leaseId)}&token=${encodeURIComponent(token())}`;

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -42,6 +42,8 @@ mod tests {
         assert!(html.contains("/remote/v1/terminals"));
         assert!(html.contains("new WebSocket"));
         assert!(html.contains("new TerminalCtor"));
+        assert!(html.contains("terminalOptionsForAppearance"));
+        assert!(html.contains("terminalInfo.appearance"));
         assert!(html.contains("inputWriteChain"));
         assert!(html.contains("writeToTerminal(inputTerminalId, inputLeaseId"));
         assert!(html.contains("resizeTerminal(resizeTerminalId, resizeLeaseId"));

--- a/src-tauri/src/remote_server/routes.rs
+++ b/src-tauri/src/remote_server/routes.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 use crate::automation_server::ServerState;
 use crate::lock_ext::MutexExt;
 
+use super::appearance::{resolve_remote_terminal_appearance, RemoteTerminalAppearance};
 use super::assets::{remote_addon_fit_js, remote_xterm_css, remote_xterm_js};
 use super::auth::remote_guard;
 use super::lease::{
@@ -42,6 +43,7 @@ struct RemoteTerminalInfo {
     rows: u16,
     sync_group: String,
     command_running: bool,
+    appearance: RemoteTerminalAppearance,
 }
 
 #[derive(Debug, Deserialize)]
@@ -230,6 +232,7 @@ async fn remote_session_release(
 }
 
 async fn remote_terminals_list(State(server): State<ServerState>) -> Response {
+    let settings = crate::settings::load_settings();
     let terminals = match server.app_state.terminals.lock_or_err() {
         Ok(terminals) => terminals,
         Err(err) => return internal_error(err),
@@ -247,6 +250,7 @@ async fn remote_terminals_list(State(server): State<ServerState>) -> Response {
             rows: session.config.rows,
             sync_group: session.config.sync_group.clone(),
             command_running: session.command_running,
+            appearance: resolve_remote_terminal_appearance(&session.config.profile, &settings),
         })
         .collect();
 


### PR DESCRIPTION
﻿## Summary

- add a remote terminal appearance resolver that maps profile font, cursor shape, and Windows Terminal color schemes into xterm.js options
- include resolved `appearance` in `GET /remote/v1/terminals`
- apply per-terminal appearance when the self-hosted remote xterm is created or switched
- document the new remote terminal appearance contract

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --target-dir target-review remote_server`
- `cargo test --manifest-path src-tauri/Cargo.toml --target-dir target-review`
- dev smoke on `http://127.0.0.1:19281/remote/`: page returned 200 and `/remote/v1/terminals` returned appearance fields such as `fontFamily`, `fontSize`, `cursorStyle`, and theme colors
