### PR TITLE
[codex] Remote navigation metadata

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -541,7 +541,21 @@ Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Dire
 
 `claim` 응답의 `leaseId`가 이후 제어 요청의 권한이다. PC WebView는 `remote-control-changed` Tauri event를 받아 local input overlay를 표시하고, `reclaim_remote_control` Tauri command로 언제든 lease를 해제할 수 있다. PC reclaim은 현재 lease를 해제하고 `heartbeatTimeoutSeconds` 동안 새 remote claim을 `409`로 거절한다. Heartbeat timeout이 지나면 다음 status/control 검사에서 lease는 만료된다.
 
-### 13.3 Terminal Control
+### 13.3 Navigation Metadata
+
+Focused remote UI는 전체 React layout을 복제하지 않고, workspace/dock/pane 요약과 single terminal stream을 분리한다. 이 요약은 frontend Zustand store가 알고 있는 workspace/dock 구조를 Rust remote server가 bridge로 조회한 뒤 remote 전용 계약으로 축약한 값이다. Remote client는 raw settings나 전체 store를 직접 읽지 않는다.
+
+| Endpoint | Method | 용도 |
+|---|---|---|
+| `/remote/v1/navigation` | GET | workspace 목록, active workspace pane 요약, dock pane 요약, terminal 표시 메타데이터 |
+| `/remote/v1/workspaces/active` | POST | active `leaseId`로 PC WebView의 active workspace 전환 |
+| `/remote/v1/terminals/{id}/focus` | POST | active `leaseId`로 PC WebView의 terminal focus 전환 |
+
+`/remote/v1/navigation`은 bearer token과 IP/Origin gate를 통과해야 하며 lease는 요구하지 않는다. 응답의 `workspaces`는 `{id,name,isActive,paneCount,terminalPaneCount,liveTerminalCount}` 요약이고, `activeWorkspace.panes`와 `docks[].panes`는 `{id,location,workspaceId,paneIndex,paneNumber,viewType,terminalId,terminalLive,title,profile,cwd,branch,activity,outputActive,commandRunning,x,y,w,h}` 형태의 표시 전용 요약이다. `terminals`는 `/remote/v1/terminals` 항목에 frontend bridge의 `workspaceId`, `paneNumber`, `activity`, `isFocused` 등 탐색에 필요한 메타데이터를 병합한 목록이다.
+
+`/remote/v1/workspaces/active` body는 `{ "id": "...", "leaseId": "..." }`, `/remote/v1/terminals/{id}/focus` body는 `{ "leaseId": "..." }`다. 둘 다 `X-Laymux-Remote-Lease` 헤더도 허용하며, 성공 시 `workspace-state-changed` event를 발행해 MCP resource 구독자와 Automation resource cache가 stale 상태에 머물지 않게 한다.
+
+### 13.4 Terminal Control
 
 | Endpoint | Method | 용도 |
 |---|---|---|

--- a/src-tauri/src/remote_server/mod.rs
+++ b/src-tauri/src/remote_server/mod.rs
@@ -2,8 +2,11 @@ mod appearance;
 mod assets;
 mod auth;
 mod lease;
+mod navigation;
+mod navigation_routes;
 mod page;
 mod routes;
+mod terminal_info;
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};

--- a/src-tauri/src/remote_server/navigation.rs
+++ b/src-tauri/src/remote_server/navigation.rs
@@ -1,0 +1,572 @@
+use std::collections::HashMap;
+
+use serde_json::{json, Map, Value};
+
+use super::terminal_info::RemoteTerminalInfo;
+
+const TERMINAL_VIEW: &str = "TerminalView";
+
+pub(super) fn build_remote_navigation_payload(
+    workspaces_data: &Value,
+    active_workspace_data: &Value,
+    docks_data: &Value,
+    terminal_instances_data: &Value,
+    terminals: &[RemoteTerminalInfo],
+) -> Value {
+    let terminal_instances = terminal_instances_data
+        .get("instances")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let frontend_by_id: HashMap<&str, &Value> = terminal_instances
+        .iter()
+        .filter_map(|terminal| string_field(terminal, "id").map(|id| (id, terminal)))
+        .collect();
+    let backend_by_id: HashMap<&str, &RemoteTerminalInfo> = terminals
+        .iter()
+        .map(|terminal| (terminal.id.as_str(), terminal))
+        .collect();
+
+    let active_workspace_id = string_field(workspaces_data, "activeWorkspaceId")
+        .or_else(|| {
+            active_workspace_data
+                .get("workspace")
+                .and_then(|workspace| string_field(workspace, "id"))
+        })
+        .unwrap_or_default();
+
+    let workspaces = workspaces_data
+        .get("workspaces")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .map(|workspace| {
+                    summarize_workspace(workspace, active_workspace_id, terminal_instances)
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let active_workspace = active_workspace_data
+        .get("workspace")
+        .filter(|workspace| !workspace.is_null())
+        .map(|workspace| {
+            summarize_active_workspace(
+                workspace,
+                active_workspace_id,
+                &backend_by_id,
+                &frontend_by_id,
+            )
+        })
+        .unwrap_or(Value::Null);
+
+    let docks = docks_data
+        .get("docks")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .map(|dock| {
+                    summarize_dock(dock, active_workspace_id, &backend_by_id, &frontend_by_id)
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let terminals = terminals
+        .iter()
+        .map(|terminal| {
+            terminal_summary_value(terminal, frontend_by_id.get(terminal.id.as_str()).copied())
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "activeWorkspaceId": active_workspace_id,
+        "workspaces": workspaces,
+        "activeWorkspace": active_workspace,
+        "docks": docks,
+        "terminals": terminals,
+    })
+}
+
+fn summarize_workspace(
+    workspace: &Value,
+    active_workspace_id: &str,
+    terminal_instances: &[Value],
+) -> Value {
+    let id = string_field(workspace, "id").unwrap_or_default();
+    let panes = workspace
+        .get("panes")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let terminal_pane_count = panes
+        .iter()
+        .filter(|pane| view_type(pane) == TERMINAL_VIEW)
+        .count();
+    let live_terminal_count = panes
+        .iter()
+        .filter(|pane| {
+            let pane_id = string_field(pane, "id").unwrap_or_default();
+            if view_type(pane) != TERMINAL_VIEW || pane_id.is_empty() {
+                return false;
+            }
+            let terminal_id = format!("terminal-{pane_id}");
+            terminal_instances
+                .iter()
+                .any(|terminal| string_field(terminal, "id") == Some(terminal_id.as_str()))
+        })
+        .count();
+
+    json!({
+        "id": id,
+        "name": string_field(workspace, "name").unwrap_or("Workspace"),
+        "isActive": id == active_workspace_id,
+        "paneCount": panes.len(),
+        "terminalPaneCount": terminal_pane_count,
+        "liveTerminalCount": live_terminal_count,
+    })
+}
+
+fn summarize_active_workspace(
+    workspace: &Value,
+    active_workspace_id: &str,
+    backend_by_id: &HashMap<&str, &RemoteTerminalInfo>,
+    frontend_by_id: &HashMap<&str, &Value>,
+) -> Value {
+    let panes = workspace
+        .get("panes")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .enumerate()
+                .map(|(index, pane)| {
+                    summarize_pane(
+                        pane,
+                        index,
+                        Some(active_workspace_id),
+                        "workspace",
+                        backend_by_id,
+                        frontend_by_id,
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    json!({
+        "id": string_field(workspace, "id").unwrap_or(active_workspace_id),
+        "name": string_field(workspace, "name").unwrap_or("Workspace"),
+        "focusedPaneIndex": optional_field(workspace, "focusedPaneIndex"),
+        "focusedPaneNumber": optional_field(workspace, "focusedPaneNumber"),
+        "paneCount": panes.len(),
+        "panes": panes,
+    })
+}
+
+fn summarize_dock(
+    dock: &Value,
+    active_workspace_id: &str,
+    backend_by_id: &HashMap<&str, &RemoteTerminalInfo>,
+    frontend_by_id: &HashMap<&str, &Value>,
+) -> Value {
+    let panes = dock
+        .get("panes")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .enumerate()
+                .map(|(index, pane)| {
+                    summarize_pane(
+                        pane,
+                        index,
+                        Some(active_workspace_id),
+                        "dock",
+                        backend_by_id,
+                        frontend_by_id,
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    json!({
+        "position": string_field(dock, "position").unwrap_or("unknown"),
+        "visible": bool_field(dock, "visible").unwrap_or(false),
+        "activeView": optional_field(dock, "activeView"),
+        "views": optional_field(dock, "views"),
+        "size": optional_field(dock, "size"),
+        "paneCount": panes.len(),
+        "panes": panes,
+    })
+}
+
+fn summarize_pane(
+    pane: &Value,
+    fallback_index: usize,
+    workspace_id: Option<&str>,
+    location: &str,
+    backend_by_id: &HashMap<&str, &RemoteTerminalInfo>,
+    frontend_by_id: &HashMap<&str, &Value>,
+) -> Value {
+    let pane_id = string_field(pane, "id").unwrap_or_default();
+    let view_type = view_type(pane);
+    let terminal_id = string_field(pane, "terminalId")
+        .map(str::to_string)
+        .or_else(|| {
+            if view_type == TERMINAL_VIEW && !pane_id.is_empty() {
+                Some(format!("terminal-{pane_id}"))
+            } else {
+                None
+            }
+        });
+    let backend = terminal_id
+        .as_deref()
+        .and_then(|id| backend_by_id.get(id))
+        .copied();
+    let frontend = terminal_id
+        .as_deref()
+        .and_then(|id| frontend_by_id.get(id))
+        .copied();
+    let title = pane_title(&view_type, backend, frontend, terminal_id.as_deref());
+
+    json!({
+        "id": pane_id,
+        "location": location,
+        "workspaceId": workspace_id,
+        "paneIndex": optional_field(pane, "paneIndex").unwrap_or_else(|| json!(fallback_index)),
+        "paneNumber": optional_field(pane, "paneNumber"),
+        "viewType": view_type,
+        "terminalId": terminal_id,
+        "terminalLive": backend.is_some(),
+        "title": title,
+        "profile": terminal_profile(backend, frontend),
+        "cwd": terminal_cwd(backend, frontend),
+        "branch": terminal_branch(backend, frontend),
+        "activity": terminal_activity(backend, frontend),
+        "outputActive": frontend.and_then(|terminal| optional_field(terminal, "outputActive")),
+        "commandRunning": backend.map(|terminal| terminal.command_running).unwrap_or(false),
+        "x": optional_field(pane, "x"),
+        "y": optional_field(pane, "y"),
+        "w": optional_field(pane, "w"),
+        "h": optional_field(pane, "h"),
+    })
+}
+
+fn terminal_summary_value(terminal: &RemoteTerminalInfo, frontend: Option<&Value>) -> Value {
+    let mut value = serde_json::to_value(terminal).unwrap_or_else(|_| Value::Object(Map::new()));
+    let Some(object) = value.as_object_mut() else {
+        return value;
+    };
+
+    for key in [
+        "workspaceId",
+        "label",
+        "paneIndex",
+        "paneNumber",
+        "panePosition",
+        "activity",
+        "outputActive",
+        "activityMessage",
+        "isFocused",
+        "lastActivityAt",
+        "lastCommand",
+        "lastExitCode",
+        "lastCommandAt",
+    ] {
+        if let Some(extra) = frontend.and_then(|terminal| optional_field(terminal, key)) {
+            object.insert(key.to_string(), extra);
+        }
+    }
+
+    value
+}
+
+fn pane_title(
+    view_type: &str,
+    backend: Option<&RemoteTerminalInfo>,
+    frontend: Option<&Value>,
+    terminal_id: Option<&str>,
+) -> String {
+    string_field(frontend.unwrap_or(&Value::Null), "title")
+        .or_else(|| {
+            backend
+                .map(|terminal| terminal.title.as_str())
+                .filter(|title| !title.is_empty())
+        })
+        .or_else(|| string_field(frontend.unwrap_or(&Value::Null), "label"))
+        .or_else(|| {
+            backend
+                .map(|terminal| terminal.profile.as_str())
+                .filter(|profile| !profile.is_empty())
+        })
+        .or(terminal_id)
+        .map(str::to_string)
+        .unwrap_or_else(|| view_label(view_type).to_string())
+}
+
+fn terminal_profile(
+    backend: Option<&RemoteTerminalInfo>,
+    frontend: Option<&Value>,
+) -> Option<String> {
+    backend
+        .map(|terminal| terminal.profile.clone())
+        .or_else(|| string_field(frontend.unwrap_or(&Value::Null), "profile").map(str::to_string))
+}
+
+fn terminal_cwd(backend: Option<&RemoteTerminalInfo>, frontend: Option<&Value>) -> Option<String> {
+    backend
+        .and_then(|terminal| terminal.cwd.clone())
+        .or_else(|| string_field(frontend.unwrap_or(&Value::Null), "cwd").map(str::to_string))
+}
+
+fn terminal_branch(
+    backend: Option<&RemoteTerminalInfo>,
+    frontend: Option<&Value>,
+) -> Option<String> {
+    backend
+        .and_then(|terminal| terminal.branch.clone())
+        .or_else(|| string_field(frontend.unwrap_or(&Value::Null), "branch").map(str::to_string))
+}
+
+fn terminal_activity(backend: Option<&RemoteTerminalInfo>, frontend: Option<&Value>) -> Value {
+    if let Some(activity) = frontend.and_then(|terminal| optional_field(terminal, "activity")) {
+        return activity;
+    }
+    if backend
+        .map(|terminal| terminal.command_running)
+        .unwrap_or(false)
+    {
+        return json!({ "type": "running" });
+    }
+    Value::Null
+}
+
+fn view_type(value: &Value) -> &str {
+    value
+        .get("view")
+        .and_then(|view| string_field(view, "type"))
+        .unwrap_or("EmptyView")
+}
+
+fn view_label(view_type: &str) -> &str {
+    match view_type {
+        "WorkspaceSelectorView" => "Workspace Selector",
+        "SettingsView" => "Settings",
+        "IssueReporterView" => "Issue Reporter",
+        "MemoView" => "Memo",
+        "FileExplorerView" => "File Explorer",
+        "TerminalView" => "Terminal",
+        _ => "Empty",
+    }
+}
+
+fn string_field<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+}
+
+fn bool_field(value: &Value, key: &str) -> Option<bool> {
+    value.get(key).and_then(Value::as_bool)
+}
+
+fn optional_field(value: &Value, key: &str) -> Option<Value> {
+    value.get(key).filter(|item| !item.is_null()).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::appearance::{RemoteTerminalAppearance, RemoteTerminalTheme};
+    use super::*;
+
+    fn terminal(id: &str, title: &str) -> RemoteTerminalInfo {
+        RemoteTerminalInfo {
+            id: id.into(),
+            title: title.into(),
+            profile: "PowerShell".into(),
+            cwd: Some("D:\\Project".into()),
+            branch: Some("main".into()),
+            cols: 120,
+            rows: 32,
+            sync_group: "ws-1".into(),
+            command_running: false,
+            appearance: RemoteTerminalAppearance {
+                font_family: "Cascadia Mono".into(),
+                font_size: 14,
+                cursor_style: "bar".into(),
+                cursor_width: Some(1),
+                theme: RemoteTerminalTheme::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn navigation_payload_summarizes_workspaces_panes_docks_and_terminals() {
+        let workspaces_data = json!({
+            "activeWorkspaceId": "ws-1",
+            "workspaces": [
+                {
+                    "id": "ws-1",
+                    "name": "Main",
+                    "panes": [
+                        { "id": "p1", "view": { "type": "TerminalView" }, "x": 0, "y": 0, "w": 1, "h": 1 },
+                        { "id": "p2", "view": { "type": "MemoView" }, "x": 0, "y": 0, "w": 1, "h": 1 }
+                    ]
+                },
+                { "id": "ws-2", "name": "Side", "panes": [] }
+            ]
+        });
+        let active_workspace_data = json!({
+            "workspace": {
+                "id": "ws-1",
+                "name": "Main",
+                "focusedPaneIndex": 0,
+                "focusedPaneNumber": 1,
+                "panes": [
+                    {
+                        "id": "p1",
+                        "paneIndex": 0,
+                        "paneNumber": 1,
+                        "terminalId": "terminal-p1",
+                        "view": { "type": "TerminalView" },
+                        "x": 0,
+                        "y": 0,
+                        "w": 1,
+                        "h": 1
+                    },
+                    {
+                        "id": "p2",
+                        "paneIndex": 1,
+                        "paneNumber": 2,
+                        "terminalId": null,
+                        "view": { "type": "MemoView" },
+                        "x": 0,
+                        "y": 0,
+                        "w": 1,
+                        "h": 1
+                    }
+                ]
+            }
+        });
+        let docks_data = json!({
+            "docks": [
+                {
+                    "position": "left",
+                    "visible": true,
+                    "activeView": "WorkspaceSelectorView",
+                    "views": ["WorkspaceSelectorView"],
+                    "size": 240,
+                    "panes": [
+                        { "id": "dp1", "view": { "type": "TerminalView" }, "x": 0, "y": 0, "w": 1, "h": 1 }
+                    ]
+                }
+            ]
+        });
+        let terminal_instances_data = json!({
+            "instances": [
+                {
+                    "id": "terminal-p1",
+                    "workspaceId": "ws-1",
+                    "label": "PowerShell",
+                    "title": "frontend title",
+                    "paneIndex": 0,
+                    "paneNumber": 1,
+                    "activity": { "type": "shell" },
+                    "isFocused": true
+                },
+                {
+                    "id": "terminal-dp1",
+                    "workspaceId": "ws-1",
+                    "label": "Dock shell",
+                    "activity": { "type": "running" }
+                }
+            ]
+        });
+        let terminals = vec![
+            terminal("terminal-p1", "backend title"),
+            terminal("terminal-dp1", "dock backend"),
+        ];
+
+        let payload = build_remote_navigation_payload(
+            &workspaces_data,
+            &active_workspace_data,
+            &docks_data,
+            &terminal_instances_data,
+            &terminals,
+        );
+
+        assert_eq!(payload["activeWorkspaceId"], "ws-1");
+        assert_eq!(payload["workspaces"][0]["terminalPaneCount"], 1);
+        assert_eq!(payload["workspaces"][0]["liveTerminalCount"], 1);
+        assert_eq!(
+            payload["activeWorkspace"]["panes"][0]["title"],
+            "frontend title"
+        );
+        assert_eq!(payload["activeWorkspace"]["panes"][0]["terminalLive"], true);
+        assert_eq!(
+            payload["activeWorkspace"]["panes"][1]["viewType"],
+            "MemoView"
+        );
+        assert_eq!(
+            payload["docks"][0]["panes"][0]["terminalId"],
+            "terminal-dp1"
+        );
+        assert_eq!(
+            payload["docks"][0]["panes"][0]["activity"]["type"],
+            "running"
+        );
+        assert_eq!(
+            payload["terminals"][0]["appearance"]["fontFamily"],
+            "Cascadia Mono"
+        );
+        assert_eq!(payload["terminals"][0]["paneNumber"], 1);
+    }
+
+    #[test]
+    fn navigation_payload_keeps_non_terminal_view_summary_without_live_session() {
+        let workspaces_data = json!({
+            "activeWorkspaceId": "ws-1",
+            "workspaces": [
+                {
+                    "id": "ws-1",
+                    "name": "Main",
+                    "panes": [
+                        { "id": "settings", "view": { "type": "SettingsView" } }
+                    ]
+                }
+            ]
+        });
+        let active_workspace_data = json!({
+            "workspace": {
+                "id": "ws-1",
+                "name": "Main",
+                "panes": [
+                    { "id": "settings", "paneIndex": 0, "paneNumber": 1, "view": { "type": "SettingsView" } }
+                ]
+            }
+        });
+
+        let payload = build_remote_navigation_payload(
+            &workspaces_data,
+            &active_workspace_data,
+            &json!({ "docks": [] }),
+            &json!({ "instances": [] }),
+            &[],
+        );
+
+        assert_eq!(
+            payload["activeWorkspace"]["panes"][0]["terminalId"],
+            Value::Null
+        );
+        assert_eq!(
+            payload["activeWorkspace"]["panes"][0]["terminalLive"],
+            false
+        );
+        assert_eq!(payload["activeWorkspace"]["panes"][0]["title"], "Settings");
+    }
+}

--- a/src-tauri/src/remote_server/navigation_routes.rs
+++ b/src-tauri/src/remote_server/navigation_routes.rs
@@ -1,0 +1,208 @@
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Deserialize;
+use serde_json::Value;
+use tauri::Emitter;
+
+use crate::automation_server::helpers::bridge_request;
+use crate::automation_server::ServerState;
+use crate::constants::EVENT_WORKSPACE_STATE_CHANGED;
+
+use super::lease::require_active_lease;
+use super::navigation::build_remote_navigation_payload;
+use super::routes::REMOTE_LEASE_HEADER;
+use super::terminal_info::remote_terminal_infos;
+use super::{internal_error, json_error};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct WorkspaceSwitchRequest {
+    id: String,
+    lease_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct TerminalFocusRequest {
+    lease_id: Option<String>,
+}
+
+pub(super) async fn remote_navigation(State(server): State<ServerState>) -> Response {
+    let workspaces_data = match frontend_bridge_json(
+        &server,
+        "query",
+        "workspaces",
+        "list",
+        serde_json::json!({}),
+    )
+    .await
+    {
+        Ok(data) => data,
+        Err(response) => return response,
+    };
+    let active_workspace_data = match frontend_bridge_json(
+        &server,
+        "query",
+        "workspaces",
+        "getActive",
+        serde_json::json!({}),
+    )
+    .await
+    {
+        Ok(data) => data,
+        Err(response) => return response,
+    };
+    let docks_data = match frontend_bridge_json(
+        &server,
+        "query",
+        "docks",
+        "list",
+        serde_json::json!({}),
+    )
+    .await
+    {
+        Ok(data) => data,
+        Err(response) => return response,
+    };
+    let terminal_instances_data =
+        match frontend_bridge_json(&server, "query", "terminals", "list", serde_json::json!({}))
+            .await
+        {
+            Ok(data) => data,
+            Err(response) => return response,
+        };
+
+    let settings = crate::settings::load_settings();
+    let terminals = match remote_terminal_infos(&server.app_state, &settings) {
+        Ok(terminals) => terminals,
+        Err(err) => return internal_error(err),
+    };
+
+    Json(build_remote_navigation_payload(
+        &workspaces_data,
+        &active_workspace_data,
+        &docks_data,
+        &terminal_instances_data,
+        &terminals,
+    ))
+    .into_response()
+}
+
+pub(super) async fn remote_workspace_switch_active(
+    State(server): State<ServerState>,
+    headers: HeaderMap,
+    Json(body): Json<WorkspaceSwitchRequest>,
+) -> Response {
+    let workspace_id = body.id;
+    if workspace_id.trim().is_empty() {
+        return json_error(StatusCode::BAD_REQUEST, "workspace id is required");
+    }
+
+    let lease_id = body
+        .lease_id
+        .as_deref()
+        .or_else(|| lease_id_from_headers(&headers));
+    if let Err(response) = require_active_lease(&server.app_state, lease_id) {
+        return response;
+    }
+
+    match frontend_bridge_json(
+        &server,
+        "action",
+        "workspaces",
+        "switchActive",
+        serde_json::json!({ "id": workspace_id.clone() }),
+    )
+    .await
+    {
+        Ok(data) => {
+            emit_workspace_state_changed(
+                &server,
+                "remote.workspaces.switchActive",
+                serde_json::json!({ "id": workspace_id }),
+            );
+            Json(data).into_response()
+        }
+        Err(response) => response,
+    }
+}
+
+pub(super) async fn remote_terminal_focus(
+    State(server): State<ServerState>,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<TerminalFocusRequest>,
+) -> Response {
+    let lease_id = body
+        .lease_id
+        .as_deref()
+        .or_else(|| lease_id_from_headers(&headers));
+    if let Err(response) = require_active_lease(&server.app_state, lease_id) {
+        return response;
+    }
+
+    match frontend_bridge_json(
+        &server,
+        "action",
+        "terminals",
+        "setFocus",
+        serde_json::json!({ "id": id.clone() }),
+    )
+    .await
+    {
+        Ok(data) => {
+            emit_workspace_state_changed(
+                &server,
+                "remote.terminals.setFocus",
+                serde_json::json!({ "id": id }),
+            );
+            Json(data).into_response()
+        }
+        Err(response) => response,
+    }
+}
+
+async fn frontend_bridge_json(
+    server: &ServerState,
+    category: &str,
+    target: &str,
+    method: &str,
+    params: Value,
+) -> Result<Value, Response> {
+    match bridge_request(server, category, target, method, params).await {
+        Ok(data) => {
+            if data.get("success").and_then(Value::as_bool) == Some(false) {
+                let message = data
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .unwrap_or("frontend bridge request failed");
+                return Err(json_error(StatusCode::BAD_GATEWAY, message));
+            }
+            Ok(data)
+        }
+        Err(error) => Err(error.into_response()),
+    }
+}
+
+fn emit_workspace_state_changed(server: &ServerState, source: &str, detail: Value) {
+    let payload = serde_json::json!({ "source": source, "detail": detail });
+    if let Err(error) = server
+        .app_handle
+        .emit(EVENT_WORKSPACE_STATE_CHANGED, payload)
+    {
+        tracing::warn!(
+            error = %error,
+            source,
+            "failed to emit workspace-state-changed after remote action"
+        );
+    }
+}
+
+fn lease_id_from_headers(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(REMOTE_LEASE_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+}

--- a/src-tauri/src/remote_server/navigation_routes.rs
+++ b/src-tauri/src/remote_server/navigation_routes.rs
@@ -1,3 +1,4 @@
+use axum::body::Bytes;
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
@@ -133,8 +134,12 @@ pub(super) async fn remote_terminal_focus(
     State(server): State<ServerState>,
     Path(id): Path<String>,
     headers: HeaderMap,
-    Json(body): Json<TerminalFocusRequest>,
+    body: Bytes,
 ) -> Response {
+    let body = match terminal_focus_request_from_body(&body) {
+        Ok(body) => body,
+        Err(_) => return json_error(StatusCode::BAD_REQUEST, "invalid JSON body"),
+    };
     let lease_id = body
         .lease_id
         .as_deref()
@@ -205,4 +210,46 @@ fn lease_id_from_headers(headers: &HeaderMap) -> Option<&str> {
         .get(REMOTE_LEASE_HEADER)
         .and_then(|value| value.to_str().ok())
         .filter(|value| !value.is_empty())
+}
+
+fn terminal_focus_request_from_body(
+    body: &[u8],
+) -> Result<TerminalFocusRequest, serde_json::Error> {
+    if body.iter().all(u8::is_ascii_whitespace) {
+        return Ok(TerminalFocusRequest::default());
+    }
+    serde_json::from_slice(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{HeaderMap, HeaderValue};
+
+    use super::*;
+
+    #[test]
+    fn terminal_focus_request_accepts_empty_body_for_header_lease() {
+        let body = terminal_focus_request_from_body(b"").unwrap();
+        assert!(body.lease_id.is_none());
+
+        let body = terminal_focus_request_from_body(b" \n\t").unwrap();
+        assert!(body.lease_id.is_none());
+    }
+
+    #[test]
+    fn terminal_focus_request_reads_body_lease() {
+        let body = terminal_focus_request_from_body(br#"{"leaseId":"lease-body"}"#).unwrap();
+        assert_eq!(body.lease_id.as_deref(), Some("lease-body"));
+    }
+
+    #[test]
+    fn terminal_focus_header_lease_is_available_without_body_lease() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            REMOTE_LEASE_HEADER,
+            HeaderValue::from_static("lease-header"),
+        );
+
+        assert_eq!(lease_id_from_headers(&headers), Some("lease-header"));
+    }
 }

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -784,12 +784,19 @@
                 active: Boolean(pane.terminalId && pane.terminalId === activeTerminalId),
                 disabled: !leaseId || !isTerminal,
                 onClick: isTerminal
-                  ? () => selectTerminal(pane.terminalId, { focusHost: true, refreshNavigation: true }).catch((err) => setStatus(err.message, true))
+                  ? () => selectTerminal(pane.terminalId, { focusHost: false, refreshNavigation: true }).catch((err) => setStatus(err.message, true))
                   : undefined,
               }));
             }
             dockListEl.append(block);
           }
+        }
+
+        function isDockTerminalId(terminalId) {
+          if (!terminalId || !navigationState) return false;
+          return (navigationState.docks || []).some((dock) =>
+            (dock.panes || []).some((pane) => pane.terminalId === terminalId)
+          );
         }
 
         function preferredTerminal(data, terminals, preferredTerminalId) {
@@ -855,7 +862,7 @@
           const terminalInfo = terminalInfoById.get(terminalId);
           terminalMetaEl.textContent = terminalInfo ? terminalLabel(terminalInfo) : terminalId;
           setConnected(Boolean(leaseId));
-          if (options.focusHost !== false) {
+          if (options.focusHost !== false && !isDockTerminalId(terminalId)) {
             await focusTerminalOnHost(terminalId).catch((err) => setStatus(`Focus failed: ${err.message}`, true));
           }
           if (options.refreshNavigation) {

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -118,6 +118,90 @@
         padding: 8px;
         background: var(--terminal-bg);
       }
+      .remote-body {
+        display: grid;
+        grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+        min-height: 0;
+      }
+      .navigation-panel {
+        min-width: 0;
+        min-height: 0;
+        overflow: auto;
+        padding: 8px;
+        border-right: 1px solid var(--border);
+        background: #11151b;
+      }
+      .nav-section + .nav-section {
+        margin-top: 12px;
+      }
+      .nav-section-title {
+        margin: 0 0 6px;
+        color: var(--muted);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+      .nav-list {
+        display: grid;
+        gap: 6px;
+      }
+      .nav-item {
+        width: 100%;
+        min-width: 0;
+        display: grid;
+        gap: 3px;
+        padding: 7px 8px;
+        text-align: left;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        background: #151a22;
+        color: var(--text);
+      }
+      .nav-item.active {
+        border-color: #3d7dd1;
+        background: #17263a;
+      }
+      .nav-item-title {
+        display: flex;
+        min-width: 0;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+      }
+      .nav-item-name {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .nav-badge {
+        flex: 0 0 auto;
+        color: var(--accent);
+        font-size: 12px;
+      }
+      .nav-item-meta {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .nav-empty {
+        padding: 7px 8px;
+        color: var(--muted);
+        border: 1px dashed var(--border);
+        border-radius: 6px;
+      }
+      .dock-block {
+        display: grid;
+        gap: 6px;
+      }
+      .dock-title {
+        color: var(--muted);
+        font-size: 12px;
+      }
       #terminal {
         width: 100%;
         height: 100%;
@@ -188,6 +272,15 @@
           min-width: 0;
           padding-left: 6px;
           padding-right: 6px;
+        }
+        .remote-body {
+          grid-template-columns: 1fr;
+          grid-template-rows: auto minmax(0, 1fr);
+        }
+        .navigation-panel {
+          max-height: 32vh;
+          border-right: 0;
+          border-bottom: 1px solid var(--border);
         }
         footer {
           align-items: stretch;
@@ -260,8 +353,24 @@
       </header>
       <main>
         <div id="status" class="status">Enter the remote token, then connect.</div>
-        <div class="terminal-shell">
-          <div id="terminal" aria-label="Terminal output"></div>
+        <div class="remote-body">
+          <aside class="navigation-panel" aria-label="Remote navigation">
+            <section class="nav-section">
+              <h2 class="nav-section-title">Workspaces</h2>
+              <div id="workspaceList" class="nav-list"></div>
+            </section>
+            <section class="nav-section">
+              <h2 class="nav-section-title">Active Panes</h2>
+              <div id="paneList" class="nav-list"></div>
+            </section>
+            <section class="nav-section">
+              <h2 class="nav-section-title">Docks</h2>
+              <div id="dockList" class="nav-list"></div>
+            </section>
+          </aside>
+          <div class="terminal-shell">
+            <div id="terminal" aria-label="Terminal output"></div>
+          </div>
         </div>
       </main>
       <footer>
@@ -284,6 +393,9 @@
         const statusEl = $("status");
         const terminalHost = $("terminal");
         const terminalMetaEl = $("terminalMeta");
+        const workspaceListEl = $("workspaceList");
+        const paneListEl = $("paneList");
+        const dockListEl = $("dockList");
         const focusTerminalButton = $("focusTerminal");
         const ctrlCButton = $("ctrlC");
         const tokenKey = "laymux.remote.token";
@@ -292,6 +404,7 @@
         let socket = null;
         let activeTerminalId = null;
         let terminalInfoById = new Map();
+        let navigationState = null;
         let terminal = null;
         let fitAddon = null;
         let resizeObserver = null;
@@ -511,11 +624,60 @@
             .join(" - ");
         }
 
-        async function loadTerminals() {
-          const data = await remoteFetch("/remote/v1/terminals");
-          const terminals = data.terminals || [];
-          terminalInfoById = new Map(terminals.map((terminalInfo) => [terminalInfo.id, terminalInfo]));
-          const previousTerminalId = activeTerminalId;
+        function shortPath(path) {
+          if (!path) return "";
+          const parts = String(path).split(/[\\/]+/).filter(Boolean);
+          return parts[parts.length - 1] || path;
+        }
+
+        function activityLabel(activity, commandRunning) {
+          if (activity && activity.type === "interactiveApp") return activity.name || "Interactive";
+          if (activity && activity.type === "running") return "Running";
+          if (commandRunning) return "Running";
+          return "";
+        }
+
+        function metaText(parts) {
+          return parts.filter(Boolean).join(" - ");
+        }
+
+        function emptyNav(container, text) {
+          container.innerHTML = "";
+          const item = document.createElement("div");
+          item.className = "nav-empty";
+          item.textContent = text;
+          container.append(item);
+        }
+
+        function navButton({ title, badge, meta, active = false, disabled = false, onClick }) {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.className = `nav-item${active ? " active" : ""}`;
+          button.disabled = disabled;
+          const titleRow = document.createElement("div");
+          titleRow.className = "nav-item-title";
+          const nameEl = document.createElement("span");
+          nameEl.className = "nav-item-name";
+          nameEl.textContent = title || "Untitled";
+          titleRow.append(nameEl);
+          if (badge) {
+            const badgeEl = document.createElement("span");
+            badgeEl.className = "nav-badge";
+            badgeEl.textContent = badge;
+            titleRow.append(badgeEl);
+          }
+          button.append(titleRow);
+          if (meta) {
+            const metaEl = document.createElement("div");
+            metaEl.className = "nav-item-meta";
+            metaEl.textContent = meta;
+            button.append(metaEl);
+          }
+          if (onClick) button.addEventListener("click", onClick);
+          return button;
+        }
+
+        function renderTerminalSelect(terminals) {
           terminalsSelect.innerHTML = "";
           for (const terminalInfo of terminals) {
             const option = document.createElement("option");
@@ -525,18 +687,183 @@
             option.dataset.rows = String(terminalInfo.rows || "");
             terminalsSelect.append(option);
           }
-          const nextTerminal = terminals.find((terminalInfo) => terminalInfo.id === previousTerminalId) || terminals[0];
+        }
+
+        function renderNavigation(data) {
+          renderWorkspaceList(data.workspaces || []);
+          renderPaneList((data.activeWorkspace && data.activeWorkspace.panes) || []);
+          renderDockList(data.docks || []);
+        }
+
+        function renderWorkspaceList(workspaces) {
+          workspaceListEl.innerHTML = "";
+          if (!workspaces.length) {
+            emptyNav(workspaceListEl, "No workspaces.");
+            return;
+          }
+          for (const workspace of workspaces) {
+            const meta = metaText([
+              `${workspace.paneCount || 0} panes`,
+              `${workspace.liveTerminalCount || 0} live`,
+            ]);
+            workspaceListEl.append(navButton({
+              title: workspace.name || workspace.id,
+              badge: workspace.isActive ? "active" : "",
+              meta,
+              active: Boolean(workspace.isActive),
+              disabled: !leaseId || workspace.isActive,
+              onClick: () => switchWorkspace(workspace.id).catch((err) => setStatus(err.message, true)),
+            }));
+          }
+        }
+
+        function renderPaneList(panes) {
+          paneListEl.innerHTML = "";
+          if (!panes.length) {
+            emptyNav(paneListEl, "No panes.");
+            return;
+          }
+          for (const pane of panes) {
+            const isTerminal = Boolean(pane.terminalId && pane.terminalLive);
+            const activity = activityLabel(pane.activity, pane.commandRunning);
+            const meta = metaText([
+              pane.viewType,
+              pane.profile,
+              shortPath(pane.cwd),
+              pane.branch,
+              activity,
+            ]);
+            paneListEl.append(navButton({
+              title: pane.title || pane.terminalId || pane.viewType,
+              badge: pane.paneNumber ? `#${pane.paneNumber}` : "",
+              meta,
+              active: Boolean(pane.terminalId && pane.terminalId === activeTerminalId),
+              disabled: !leaseId || !isTerminal,
+              onClick: isTerminal
+                ? () => selectTerminal(pane.terminalId, { focusHost: true, refreshNavigation: true }).catch((err) => setStatus(err.message, true))
+                : undefined,
+            }));
+          }
+        }
+
+        function renderDockList(docks) {
+          dockListEl.innerHTML = "";
+          if (!docks.length) {
+            emptyNav(dockListEl, "No docks.");
+            return;
+          }
+          for (const dock of docks) {
+            const block = document.createElement("div");
+            block.className = "dock-block";
+            const title = document.createElement("div");
+            title.className = "dock-title";
+            title.textContent = metaText([
+              dock.position || "dock",
+              dock.visible ? "" : "hidden",
+              dock.activeView || "",
+            ]);
+            block.append(title);
+            const panes = dock.panes || [];
+            if (!panes.length) {
+              const empty = document.createElement("div");
+              empty.className = "nav-empty";
+              empty.textContent = "No panes.";
+              block.append(empty);
+            }
+            for (const pane of panes) {
+              const isTerminal = Boolean(pane.terminalId && pane.terminalLive);
+              const meta = metaText([
+                pane.viewType,
+                pane.profile,
+                shortPath(pane.cwd),
+                activityLabel(pane.activity, pane.commandRunning),
+              ]);
+              block.append(navButton({
+                title: pane.title || pane.terminalId || pane.viewType,
+                meta,
+                active: Boolean(pane.terminalId && pane.terminalId === activeTerminalId),
+                disabled: !leaseId || !isTerminal,
+                onClick: isTerminal
+                  ? () => selectTerminal(pane.terminalId, { focusHost: true, refreshNavigation: true }).catch((err) => setStatus(err.message, true))
+                  : undefined,
+              }));
+            }
+            dockListEl.append(block);
+          }
+        }
+
+        function preferredTerminal(data, terminals, preferredTerminalId) {
+          if (preferredTerminalId) {
+            const existing = terminals.find((terminalInfo) => terminalInfo.id === preferredTerminalId);
+            if (existing) return existing;
+          }
+          const activePanes = (data.activeWorkspace && data.activeWorkspace.panes) || [];
+          const focusedNumber = data.activeWorkspace && data.activeWorkspace.focusedPaneNumber;
+          const focusedPane = activePanes.find((pane) => pane.paneNumber === focusedNumber && pane.terminalId && pane.terminalLive);
+          const activePane = focusedPane || activePanes.find((pane) => pane.terminalId && pane.terminalLive);
+          if (activePane) return terminals.find((terminalInfo) => terminalInfo.id === activePane.terminalId) || null;
+          for (const dock of data.docks || []) {
+            const dockPane = (dock.panes || []).find((pane) => pane.terminalId && pane.terminalLive);
+            if (dockPane) return terminals.find((terminalInfo) => terminalInfo.id === dockPane.terminalId) || null;
+          }
+          return terminals[0] || null;
+        }
+
+        async function loadNavigation(preferredTerminalId = activeTerminalId, options = {}) {
+          const data = await remoteFetch("/remote/v1/navigation");
+          navigationState = data;
+          const terminals = data.terminals || [];
+          terminalInfoById = new Map(terminals.map((terminalInfo) => [terminalInfo.id, terminalInfo]));
+          renderTerminalSelect(terminals);
+          const nextTerminal = preferredTerminal(data, terminals, preferredTerminalId);
           activeTerminalId = nextTerminal ? nextTerminal.id : null;
           terminalsSelect.value = activeTerminalId || "";
+          renderNavigation(data);
           setConnected(Boolean(leaseId));
           if (activeTerminalId) {
             terminalMetaEl.textContent = terminalLabel(nextTerminal);
-            openOutput(activeTerminalId);
+            if (options.openOutput !== false) openOutput(activeTerminalId);
           } else {
             terminalMetaEl.textContent = "No open terminal sessions.";
             setStatus("No open terminal sessions.", true);
             stopSocket();
           }
+        }
+
+        async function switchWorkspace(workspaceId) {
+          if (!leaseId || !workspaceId) return;
+          setStatus("Switching workspace...");
+          await remoteFetch("/remote/v1/workspaces/active", {
+            method: "POST",
+            body: JSON.stringify({ leaseId, id: workspaceId }),
+          });
+          await loadNavigation(null);
+        }
+
+        async function focusTerminalOnHost(terminalId) {
+          if (!leaseId || !terminalId) return;
+          await remoteFetch(`/remote/v1/terminals/${encodeURIComponent(terminalId)}/focus`, {
+            method: "POST",
+            body: JSON.stringify({ leaseId }),
+          });
+        }
+
+        async function selectTerminal(terminalId, options = {}) {
+          if (!terminalId) return;
+          activeTerminalId = terminalId;
+          terminalsSelect.value = terminalId;
+          const terminalInfo = terminalInfoById.get(terminalId);
+          terminalMetaEl.textContent = terminalInfo ? terminalLabel(terminalInfo) : terminalId;
+          setConnected(Boolean(leaseId));
+          if (options.focusHost !== false) {
+            await focusTerminalOnHost(terminalId).catch((err) => setStatus(`Focus failed: ${err.message}`, true));
+          }
+          if (options.refreshNavigation) {
+            await loadNavigation(terminalId, { openOutput: false }).catch((err) => setStatus(`Refresh failed: ${err.message}`, true));
+          } else if (navigationState) {
+            renderNavigation(navigationState);
+          }
+          openOutput(terminalId);
         }
 
         function wsBaseUrl() {
@@ -599,7 +926,7 @@
             ensureTerminal();
             setConnected(true);
             startHeartbeat(status.heartbeatTimeoutSeconds || 15);
-            await loadTerminals();
+            await loadNavigation();
           } catch (err) {
             const failedLease = leaseId;
             disconnect(false);
@@ -699,18 +1026,19 @@
           leaseId = null;
           activeTerminalId = null;
           setConnected(false);
+          if (navigationState) renderNavigation(navigationState);
           if (clearStatus) setStatus("Disconnected.");
         }
 
+        emptyNav(workspaceListEl, "Not connected.");
+        emptyNav(paneListEl, "Not connected.");
+        emptyNav(dockListEl, "Not connected.");
+
         connectButton.addEventListener("click", () => connect().catch((err) => setStatus(err.message, true)));
         releaseButton.addEventListener("click", () => release().catch((err) => setStatus(`Release failed: ${err.message}`, true)));
-        refreshButton.addEventListener("click", () => loadTerminals().catch((err) => setStatus(err.message, true)));
+        refreshButton.addEventListener("click", () => loadNavigation().catch((err) => setStatus(err.message, true)));
         terminalsSelect.addEventListener("change", () => {
-          activeTerminalId = terminalsSelect.value || null;
-          const selectedOption = terminalsSelect.selectedOptions[0];
-          terminalMetaEl.textContent = selectedOption ? selectedOption.textContent : "No terminal selected.";
-          setConnected(Boolean(leaseId));
-          if (activeTerminalId) openOutput(activeTerminalId);
+          selectTerminal(terminalsSelect.value || null, { focusHost: true, refreshNavigation: true }).catch((err) => setStatus(err.message, true));
         });
         ctrlCButton.addEventListener("click", () => enqueueInput("\x03"));
         focusTerminalButton.addEventListener("click", () => terminal && terminal.focus());

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -39,6 +39,9 @@ mod tests {
         assert!(html.contains("Laymux Remote"));
         assert!(html.contains("/remote/vendor/xterm.js"));
         assert!(html.contains("/remote/v1/session/claim"));
+        assert!(html.contains("/remote/v1/navigation"));
+        assert!(html.contains("/remote/v1/workspaces/active"));
+        assert!(html.contains("/remote/v1/terminals/${encodeURIComponent(terminalId)}/focus"));
         assert!(html.contains("/remote/v1/terminals"));
         assert!(html.contains("new WebSocket"));
         assert!(html.contains("new TerminalCtor"));

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -50,5 +50,10 @@ mod tests {
         assert!(html.contains("inputWriteChain"));
         assert!(html.contains("writeToTerminal(inputTerminalId, inputLeaseId"));
         assert!(html.contains("resizeTerminal(resizeTerminalId, resizeLeaseId"));
+        assert!(html.contains("function isDockTerminalId(terminalId)"));
+        assert!(html.contains(
+            "selectTerminal(pane.terminalId, { focusHost: false, refreshNavigation: true })"
+        ));
+        assert!(html.contains("options.focusHost !== false && !isDockTerminalId(terminalId)"));
     }
 }

--- a/src-tauri/src/remote_server/routes.rs
+++ b/src-tauri/src/remote_server/routes.rs
@@ -7,7 +7,7 @@ use axum::middleware;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tokio::time;
 use tower_http::cors::CorsLayer;
 use uuid::Uuid;
@@ -15,7 +15,6 @@ use uuid::Uuid;
 use crate::automation_server::ServerState;
 use crate::lock_ext::MutexExt;
 
-use super::appearance::{resolve_remote_terminal_appearance, RemoteTerminalAppearance};
 use super::assets::{remote_addon_fit_js, remote_xterm_css, remote_xterm_js};
 use super::auth::remote_guard;
 use super::lease::{
@@ -23,28 +22,17 @@ use super::lease::{
     emit_remote_control_status, get_remote_control_status, prune_expired_lease,
     reclaim_lockout_active, require_active_lease, status_from_state, RemoteControlLease,
 };
+use super::navigation_routes::{
+    remote_navigation, remote_terminal_focus, remote_workspace_switch_active,
+};
 use super::page::{remote_page, remote_page_redirect};
+use super::terminal_info::remote_terminal_infos;
 use super::{internal_error, json_error};
 
-const REMOTE_LEASE_HEADER: &str = "x-laymux-remote-lease";
+pub(super) const REMOTE_LEASE_HEADER: &str = "x-laymux-remote-lease";
 const OUTPUT_INITIAL_BYTES: usize = 64 * 1024;
 const OUTPUT_POLL_MS: u64 = 50;
 const LEASE_CHECK_MS: u64 = 500;
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct RemoteTerminalInfo {
-    id: String,
-    title: String,
-    profile: String,
-    cwd: Option<String>,
-    branch: Option<String>,
-    cols: u16,
-    rows: u16,
-    sync_group: String,
-    command_running: bool,
-    appearance: RemoteTerminalAppearance,
-}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -89,7 +77,16 @@ pub fn build_router() -> Router<ServerState> {
             post(remote_session_heartbeat),
         )
         .route("/remote/v1/session/release", post(remote_session_release))
+        .route("/remote/v1/navigation", get(remote_navigation))
+        .route(
+            "/remote/v1/workspaces/active",
+            post(remote_workspace_switch_active),
+        )
         .route("/remote/v1/terminals", get(remote_terminals_list))
+        .route(
+            "/remote/v1/terminals/{id}/focus",
+            post(remote_terminal_focus),
+        )
         .route(
             "/remote/v1/terminals/{id}/write",
             post(remote_terminal_write),
@@ -233,26 +230,10 @@ async fn remote_session_release(
 
 async fn remote_terminals_list(State(server): State<ServerState>) -> Response {
     let settings = crate::settings::load_settings();
-    let terminals = match server.app_state.terminals.lock_or_err() {
+    let result = match remote_terminal_infos(&server.app_state, &settings) {
         Ok(terminals) => terminals,
         Err(err) => return internal_error(err),
     };
-
-    let result: Vec<RemoteTerminalInfo> = terminals
-        .values()
-        .map(|session| RemoteTerminalInfo {
-            id: session.id.clone(),
-            title: session.title.clone(),
-            profile: session.config.profile.clone(),
-            cwd: session.cwd.clone(),
-            branch: session.branch.clone(),
-            cols: session.config.cols,
-            rows: session.config.rows,
-            sync_group: session.config.sync_group.clone(),
-            command_running: session.command_running,
-            appearance: resolve_remote_terminal_appearance(&session.config.profile, &settings),
-        })
-        .collect();
 
     Json(serde_json::json!({ "terminals": result })).into_response()
 }

--- a/src-tauri/src/remote_server/terminal_info.rs
+++ b/src-tauri/src/remote_server/terminal_info.rs
@@ -1,0 +1,45 @@
+use serde::Serialize;
+
+use crate::lock_ext::MutexExt;
+use crate::settings::models::Settings;
+use crate::state::AppState;
+
+use super::appearance::{resolve_remote_terminal_appearance, RemoteTerminalAppearance};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RemoteTerminalInfo {
+    pub(super) id: String,
+    pub(super) title: String,
+    pub(super) profile: String,
+    pub(super) cwd: Option<String>,
+    pub(super) branch: Option<String>,
+    pub(super) cols: u16,
+    pub(super) rows: u16,
+    pub(super) sync_group: String,
+    pub(super) command_running: bool,
+    pub(super) appearance: RemoteTerminalAppearance,
+}
+
+pub(super) fn remote_terminal_infos(
+    app_state: &AppState,
+    settings: &Settings,
+) -> Result<Vec<RemoteTerminalInfo>, String> {
+    let terminals = app_state.terminals.lock_or_err()?;
+
+    Ok(terminals
+        .values()
+        .map(|session| RemoteTerminalInfo {
+            id: session.id.clone(),
+            title: session.title.clone(),
+            profile: session.config.profile.clone(),
+            cwd: session.cwd.clone(),
+            branch: session.branch.clone(),
+            cols: session.config.cols,
+            rows: session.config.rows,
+            sync_group: session.config.sync_group.clone(),
+            command_running: session.command_running,
+            appearance: resolve_remote_terminal_appearance(&session.config.profile, settings),
+        })
+        .collect())
+}


### PR DESCRIPTION
## Summary
- Add a remote navigation metadata API that summarizes workspaces, active panes, docks, and enriched terminal metadata without exposing raw settings or full frontend store state.
- Add lease-gated remote workspace switching and terminal focus endpoints.
- Update the self-hosted remote page with a focused navigation panel for workspace, active pane, and dock selection.
- Document the new Remote UI API contract in `docs/architecture/api-contracts.md`.

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml remote_server --target-dir target-review`
- Parsed the embedded remote page script with Node.
- Ran `cargo tauri dev` and smoke-tested `/remote/v1/navigation`, `/remote/v1/terminals/{id}/focus`, and lease release on dev port `19281`.
- Captured desktop and mobile Playwright screenshots of `/remote/` after connecting.