### PR TITLE
[codex] codify remote terminal ownership

### DIFF
--- a/docs/adr/0015-remote-terminal-state-ownership.md
+++ b/docs/adr/0015-remote-terminal-state-ownership.md
@@ -1,0 +1,35 @@
+# 0015. Remote 터미널 상태 소유권 — PTY 전역 상태와 surface 로컬 상태 분리
+
+- Status: Accepted
+- Date: 2026-06-29
+- Source: Direct Remote Mode 구현 중 제어권 전환 경계에서 PC/remote xterm geometry가 섞인 회귀 · ADR-0013 · architecture/api-contracts.md §13
+
+## Context
+
+Direct Remote Mode는 PC WebView와 browser remote가 같은 PTY session을 번갈아 제어한다. 이때 xterm 렌더러는 surface마다 별도지만 PTY process는 하나다. 처음에는 remote browser의 `fit()`이 만든 `cols/rows`를 backend PTY에 적용하고, PC가 제어권을 가져오면 PC `TerminalView`에서 다시 `fit()`/`refresh()`를 호출하는 식으로 처리했다.
+
+하지만 `fit()`만으로는 충분하지 않다. remote 제어 중 backend PTY 크기는 remote browser 폭으로 바뀌지만, PC xterm 인스턴스의 내부 `cols/rows`는 그 변화를 모를 수 있다. PC 제어권 회수 시 xterm 입장에서는 자기 크기가 바뀌지 않았기 때문에 resize event가 발생하지 않고, backend PTY가 remote geometry에 남아 Claude Code 같은 TUI가 깨진 상태로 보일 수 있다.
+
+또한 width만 문제가 아니다. 입력, resize, focus, renderer cache, IME, selection, scroll position처럼 서로 다른 성질의 상태가 섞여 있다. 어떤 상태가 PTY 전역인지, 어떤 상태가 surface 로컬인지, 어떤 상태가 현재 제어권 owner만 쓸 수 있는지를 명확히 분리해야 한다.
+
+## Decision
+
+터미널 상태를 다음 세 범주로 분리한다.
+
+1. **PTY 전역 상태**: 한 terminal session의 process와 protocol 상태다. PTY process, output byte stream, CWD/title/activity, terminal escape state, 그리고 현재 `cols/rows`가 여기에 속한다. `cols/rows`는 renderer 로컬 값이 아니라 프로세스에 SIGWINCH로 반영되는 전역 상태다.
+2. **surface 로컬 상태**: 각 화면에만 남는 renderer/UI 상태다. DOM pixel size, devicePixelRatio, xterm canvas/WebGL atlas, cell metrics cache, scroll viewport, selection, focus, IME/composition, drawer/open state는 PC와 remote가 공유하지 않는다.
+3. **controller owner 상태**: PTY 전역 상태를 변경할 권한이다. active owner만 stdin write, PTY resize, workspace/pane focus request를 보낼 수 있다.
+
+제어권 규칙은 다음과 같다.
+
+- remote lease가 active이면 browser remote가 PTY write/resize owner다. PC `TerminalView`는 로컬 렌더러 상태를 유지하되 backend PTY에 write/resize를 보내지 않는다.
+- PC가 reclaim하거나 remote lease가 끝나면 PC가 owner가 된다. visible `TerminalView`는 자기 xterm의 현재 `cols/rows`를 backend PTY에 명시적으로 다시 보내고 renderer를 reflow/refresh한다.
+- PC `TerminalView`가 hidden이면 reclaim 시점에는 dirty로 표시하고, 다시 visible이 되는 순간 PC geometry를 backend PTY에 보낸다.
+- remote browser는 lease 상실을 명시적으로 표시하고 write/resize를 중지한다. 재접속하려면 새 lease claim을 해야 한다.
+
+## Consequences
+
+- Claude Code, Codex 같은 TUI는 현재 owner의 geometry 기준으로 PTY를 그린다. remote 제어 중에는 remote width를 쓰고, PC 회수 후에는 PC width로 되돌린다.
+- PC와 remote의 renderer cache, scroll, selection, IME 상태는 서로 덮어쓰지 않는다.
+- 제어권 전환 경계에서는 renderer reflow/refresh가 필수 동작이 된다.
+- 향후 Full UI/Focused UI adapter 리팩터링에서도 `resize`/`write` API는 active owner 경계를 통과해야 하며, renderer 로컬 상태를 원격 계약에 섞지 않는다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ ADR 이 필요한 대표 기준:
 | [0012](0012-focus-entry-clears-requires-action.md) | focus/진입은 requiresAction 알림도 해제 (0010 예외 조항 정정) | Accepted |
 | [0013](0013-direct-remote-mode.md) | 브라우저 원격 접속 — Direct Remote Mode 와 Focused UI | Accepted |
 | [0014](0014-mcp-settings-configuration.md) | MCP 설정 구성 — 에이전트가 settings 를 읽고 쓰는 경로 | Accepted |
+| [0015](0015-remote-terminal-state-ownership.md) | Remote 터미널 상태 소유권 — PTY 전역 상태와 surface 로컬 상태 분리 | Accepted |
 
 ## 새 ADR 추가
 

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -557,6 +557,16 @@ Focused remote UI는 전체 React layout을 복제하지 않고, workspace/dock/
 
 ### 13.4 Terminal Control
 
+Remote terminal control은 상태 소유권을 세 범주로 나눈다([ADR-0015](../adr/0015-remote-terminal-state-ownership.md)).
+
+| 범주 | 예 | 소유/동기화 규칙 |
+|---|---|---|
+| PTY 전역 상태 | PTY process, stdin, output byte stream, CWD/title/activity, terminal escape state, 현재 `cols/rows` | 한 terminal session에 하나만 존재한다. 현재 controller owner만 변경할 수 있다. |
+| surface 로컬 상태 | DOM pixel size, devicePixelRatio, xterm canvas/WebGL atlas, cell metrics cache, scroll viewport, selection, focus, IME/composition, drawer state | PC WebView와 browser remote가 각자 보유한다. Remote API 계약에 섞지 않는다. |
+| controller owner 상태 | active input writer, active resize writer, workspace/pane focus request 권한 | active lease가 있으면 remote가 owner이고, lease가 없으면 PC가 owner다. owner가 아닌 surface는 PTY write/resize를 보내지 않는다. |
+
+`cols/rows`는 surface 로컬 값이 아니라 SIGWINCH로 process에 반영되는 PTY 전역 상태다. 따라서 remote lease가 active인 동안 browser remote의 xterm geometry가 PTY 크기를 결정하고, PC WebView는 로컬 renderer를 유지하되 backend PTY resize를 보내지 않는다. PC가 `reclaim_remote_control`로 제어권을 회수하거나 remote lease가 끝나면 visible `TerminalView`가 자기 xterm의 현재 `cols/rows`를 backend PTY에 명시적으로 다시 보내고 renderer `fit()`/atlas rebuild/`refresh()`를 실행한다. hidden `TerminalView`는 이 복구를 dirty로 보류하고 다시 visible이 되는 순간 소비한다.
+
 | Endpoint | Method | 용도 |
 |---|---|---|
 | `/remote/v1/terminals` | GET | 현재 backend terminal session 목록 |

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -1420,11 +1420,13 @@
         }
 
         function loseRemoteControl(message) {
+          const lostLeaseId = leaseId;
           disconnect(false);
           terminalMetaEl.textContent = "Host has control.";
           setConnectionHint("Host has control. Connect again to request control.", true);
           setStatus(message, true);
           setNavigationOpen(true);
+          if (lostLeaseId) releaseLease(lostLeaseId).catch(() => {});
         }
 
         emptyNav(workspaceListEl, "Not connected.");

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -8,17 +8,38 @@
     <style>
       :root {
         color-scheme: dark;
-        --bg: #101216;
-        --panel: #181c22;
-        --panel-2: #222831;
-        --border: #343b46;
-        --text: #eef2f8;
-        --muted: #9ba6b6;
-        --accent: #5ea1ff;
-        --accent-strong: #1f64ad;
-        --danger: #ff6978;
-        --danger-bg: #652330;
-        --terminal-bg: #080a0d;
+        --bg-base: #1e1e2e;
+        --bg-surface: #181825;
+        --bg-overlay: #313244;
+        --text-primary: #cdd6f4;
+        --text-secondary: #a6adc8;
+        --accent: #89b4fa;
+        --accent-50: rgba(137, 180, 250, 0.5);
+        --accent-20: rgba(137, 180, 250, 0.2);
+        --accent-12: rgba(137, 180, 250, 0.12);
+        --accent-08: rgba(137, 180, 250, 0.08);
+        --green: #a6e3a1;
+        --red: #f38ba8;
+        --yellow: #f9e2af;
+        --border: #313244;
+        --hover-bg: rgba(255, 255, 255, 0.06);
+        --active-bg: rgba(255, 255, 255, 0.04);
+        --backdrop-light: rgba(0, 0, 0, 0.3);
+        --terminal-bg: #0c0c0c;
+        --bg: var(--bg-base);
+        --panel: var(--bg-surface);
+        --panel-2: var(--bg-overlay);
+        --text: var(--text-primary);
+        --muted: var(--text-secondary);
+        --accent-strong: #6c8fd8;
+        --danger: var(--red);
+        --danger-bg: rgba(243, 139, 168, 0.18);
+        --radius-sm: 2px;
+        --radius-md: 3px;
+        --radius-lg: 6px;
+        --fs-xs: 10px;
+        --fs-sm: 11px;
+        --fs-md: 13px;
       }
       * { box-sizing: border-box; }
       html, body { height: 100%; }
@@ -27,7 +48,7 @@
         height: 100%;
         background: var(--bg);
         color: var(--text);
-        font: 14px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font: var(--fs-md)/1.45 "Consolas", "Fira Code", monospace;
         overflow: hidden;
       }
       button, input, select {
@@ -42,21 +63,16 @@
         display: flex;
         gap: 8px;
         align-items: center;
-        padding: 10px 12px;
+        padding: 6px 8px;
         border-color: var(--border);
         background: var(--panel);
       }
       header {
         border-bottom: 1px solid var(--border);
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
       }
       footer {
         border-top: 1px solid var(--border);
-      }
-      h1 {
-        margin: 0 10px 0 0;
-        font-size: 15px;
-        font-weight: 700;
       }
       label {
         display: flex;
@@ -67,21 +83,18 @@
       input, select {
         min-width: 0;
         border: 1px solid var(--border);
-        border-radius: 6px;
-        padding: 7px 8px;
-        background: #0d1015;
+        border-radius: var(--radius-md);
+        padding: 5px 7px;
+        background: var(--bg-base);
         color: var(--text);
       }
       input[type="password"] {
-        width: 180px;
-      }
-      select {
-        width: min(360px, 100%);
+        width: 100%;
       }
       button {
         border: 1px solid var(--border);
-        border-radius: 6px;
-        padding: 7px 10px;
+        border-radius: var(--radius-md);
+        padding: 5px 9px;
         background: var(--panel-2);
         color: var(--text);
         cursor: pointer;
@@ -99,15 +112,19 @@
         opacity: 0.55;
       }
       main {
+        position: relative;
         display: grid;
-        grid-template-rows: auto minmax(0, 1fr);
+        grid-template-rows: minmax(0, 1fr);
         min-height: 0;
       }
       .status {
-        min-height: 36px;
-        padding: 8px 12px;
+        flex: 1 1 auto;
+        min-width: 0;
+        padding: 0;
         color: var(--muted);
-        border-bottom: 1px solid var(--border);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .status.error {
         color: var(--danger);
@@ -115,92 +132,403 @@
       .terminal-shell {
         min-width: 0;
         min-height: 0;
-        padding: 8px;
+        display: grid;
+        grid-template-rows: minmax(0, 1fr);
+        width: 100%;
+        height: 100%;
+        padding: 6px;
         background: var(--terminal-bg);
       }
       .remote-body {
+        position: relative;
         display: grid;
-        grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
-        min-height: 0;
-      }
-      .navigation-panel {
+        grid-template-rows: minmax(0, 1fr);
         min-width: 0;
         min-height: 0;
+        overflow: hidden;
+      }
+      .navigation-panel {
+        position: absolute;
+        inset: 0 auto 0 0;
+        z-index: 20;
+        width: min(360px, calc(100vw - 28px));
+        min-width: 0;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
         overflow: auto;
-        padding: 8px;
+        padding: 0;
         border-right: 1px solid var(--border);
-        background: #11151b;
+        background: var(--bg-surface);
+        box-shadow: 12px 0 32px rgba(0, 0, 0, 0.38);
+        transform: translateX(-104%);
+        transition: transform 140ms ease;
+      }
+      .app.nav-open .navigation-panel {
+        transform: translateX(0);
+      }
+      .nav-scrim {
+        position: absolute;
+        inset: 0;
+        z-index: 10;
+        padding: 0;
+        border: 0;
+        border-radius: 0;
+        background: var(--backdrop-light);
+      }
+      [hidden] {
+        display: none !important;
+      }
+      .menu-button,
+      .drawer-close {
+        width: 28px;
+        height: 24px;
+        display: inline-flex;
+        flex: 0 0 auto;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+        border-color: transparent;
+        background: transparent;
+      }
+      .menu-button:hover,
+      .drawer-close:hover {
+        background: var(--hover-bg);
+      }
+      .menu-button {
+        flex-direction: column;
+        gap: 3px;
+      }
+      .menu-button span {
+        width: 14px;
+        height: 1px;
+        border-radius: 1px;
+        background: var(--text-primary);
+      }
+      .drawer-close {
+        position: relative;
+      }
+      .drawer-close span {
+        position: absolute;
+        width: 13px;
+        height: 1px;
+        border-radius: 1px;
+        background: var(--text-secondary);
+      }
+      .drawer-close span:first-child {
+        transform: rotate(45deg);
+      }
+      .drawer-close span:last-child {
+        transform: rotate(-45deg);
+      }
+      .drawer-header {
+        height: 28px;
+        display: flex;
+        flex: 0 0 auto;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 6px 0 9px;
+        border-bottom: 1px solid var(--border);
+      }
+      .drawer-title {
+        color: var(--text-primary);
+        font-size: var(--fs-md);
+        font-weight: 650;
+      }
+      .connection-title {
+        color: var(--text-secondary);
+        font-size: var(--fs-xs);
+        font-weight: 500;
+        letter-spacing: 0.04em;
+        opacity: 0.72;
+        text-transform: uppercase;
+      }
+      .connection-panel {
+        display: grid;
+        gap: 7px;
+        padding: 8px;
+        border-bottom: 1px solid var(--border);
+        background: rgba(255, 255, 255, 0.015);
+      }
+      .connection-panel:not(.connected) {
+        background: var(--accent-08);
+      }
+      .connection-panel.attention {
+        background: rgba(243, 139, 168, 0.1);
+      }
+      .connection-panel.connected {
+        grid-template-columns: 1fr;
+        background: rgba(255, 255, 255, 0.015);
+      }
+      .connection-panel label {
+        display: grid;
+        grid-template-columns: 48px minmax(0, 1fr);
+        gap: 7px;
+        color: var(--text-secondary);
+        font-size: var(--fs-sm);
+      }
+      .connection-panel.connected label {
+        display: none;
+      }
+      .connection-hint {
+        color: var(--accent);
+        font-size: var(--fs-sm);
+        line-height: 1.35;
+        opacity: 0.9;
+      }
+      .connection-panel.connected .connection-hint {
+        display: none;
+      }
+      .connection-panel.attention .connection-hint {
+        color: var(--danger);
+        font-weight: 700;
+      }
+      .connection-panel input {
+        width: 100%;
+      }
+      .connection-actions {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 6px;
+      }
+      .connection-panel.connected .connection-actions {
+        grid-template-columns: 1fr 1fr;
+      }
+      .connection-panel.connected #connect {
+        display: none;
+      }
+      .connection-actions button {
+        min-width: 0;
+        padding-left: 6px;
+        padding-right: 6px;
       }
       .nav-section + .nav-section {
-        margin-top: 12px;
+        margin-top: 0;
       }
       .nav-section-title {
-        margin: 0 0 6px;
+        margin: 0;
+        padding: 7px 8px 5px;
         color: var(--muted);
-        font-size: 11px;
-        font-weight: 700;
-        letter-spacing: 0;
+        font-size: var(--fs-xs);
+        font-weight: 500;
+        letter-spacing: 0.04em;
+        opacity: 0.72;
         text-transform: uppercase;
       }
       .nav-list {
-        display: grid;
-        gap: 6px;
+        display: flex;
+        min-height: 0;
+        flex: 1 1 auto;
+        flex-direction: column;
+        overflow-y: auto;
       }
-      .nav-item {
+      .workspace-item {
         width: 100%;
         min-width: 0;
-        display: grid;
-        gap: 3px;
-        padding: 7px 8px;
+        flex: 0 0 auto;
+        overflow: hidden;
+        padding: 7px 10px 7px 9px;
         text-align: left;
-        border: 1px solid var(--border);
-        border-radius: 6px;
-        background: #151a22;
+        border: 0;
+        border-left: 3px solid transparent;
+        border-bottom: 1px solid var(--border);
+        border-radius: 0;
+        background: transparent;
         color: var(--text);
+        cursor: pointer;
       }
-      .nav-item.active {
-        border-color: #3d7dd1;
-        background: #17263a;
+      .workspace-item:hover {
+        background: var(--active-bg);
       }
-      .nav-item-title {
+      .workspace-item.active {
+        border-left-color: var(--accent);
+        background: var(--accent-08);
+      }
+      .workspace-item-content {
+        min-height: 0;
+        overflow: hidden;
+      }
+      .workspace-row-primary {
         display: flex;
         min-width: 0;
         align-items: center;
         justify-content: space-between;
         gap: 8px;
       }
-      .nav-item-name {
+      .workspace-primary-left,
+      .workspace-primary-right {
+        display: flex;
         min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        align-items: center;
+        gap: 6px;
       }
-      .nav-badge {
+      .workspace-primary-right {
         flex: 0 0 auto;
-        color: var(--accent);
-        font-size: 12px;
       }
-      .nav-item-meta {
+      .workspace-index {
+        flex: 0 0 auto;
+        min-width: 10px;
+        color: var(--text-primary);
+        font-size: 10px;
+        font-weight: 500;
+        opacity: 0.6;
+      }
+      .workspace-item.active .workspace-index {
+        color: var(--accent);
+        opacity: 0.9;
+      }
+      .workspace-name {
         min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        color: var(--muted);
+        color: var(--text-secondary);
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .workspace-item.active .workspace-name {
+        color: var(--text-primary);
+      }
+      .workspace-terminal-count {
+        flex: 0 0 auto;
+        color: var(--text-secondary);
+        font-size: 9px;
+        line-height: 1.3;
+        padding: 1px 6px;
+        border-radius: var(--radius-sm);
+        background: var(--hover-bg);
+        opacity: 0.7;
+      }
+      .workspace-count-badge {
+        display: inline-flex;
+        flex: 0 0 auto;
+        align-items: center;
+        justify-content: center;
+        min-width: 14px;
+        height: 14px;
+        padding: 0 3px;
+        border-radius: var(--radius-sm);
+        background: var(--accent);
+        color: var(--bg-base);
+        font-size: 10px;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        line-height: 1;
+      }
+      .workspace-pane-list {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        margin-top: 4px;
+      }
+      .workspace-pane-row {
+        width: 100%;
+        min-width: 0;
+        min-height: 18px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 1px 3px 1px 0;
+        border: 0;
+        border-radius: var(--radius-md);
+        background: transparent;
+        color: var(--text-secondary);
+        font-size: var(--fs-sm);
+        line-height: 1.25;
+        text-align: left;
+        cursor: pointer;
+      }
+      .workspace-pane-row:hover:not(:disabled) {
+        background: var(--hover-bg);
+      }
+      .workspace-pane-row:disabled {
+        cursor: default;
+        opacity: 0.72;
+      }
+      .workspace-pane-row.active {
+        background: var(--accent-12);
+        filter: brightness(1.3);
+      }
+      .pane-minimap {
+        flex: 0 0 auto;
+        width: 18px;
+        height: 12px;
+        opacity: 0.5;
+      }
+      .workspace-pane-row.active .pane-minimap {
+        opacity: 1;
+      }
+      .pane-row-main {
+        display: flex;
+        min-width: 0;
+        flex: 1 1 auto;
+        align-items: center;
+        gap: 4px;
+      }
+      .pane-env {
+        flex: 0 0 auto;
+        color: var(--text-secondary);
+        font-size: var(--fs-sm);
+        font-weight: 600;
+        opacity: 0.85;
+      }
+      .pane-activity {
+        flex: 0 0 auto;
+        min-width: 40px;
+        margin-right: 4px;
+        padding: 1px 4px;
+        border-radius: var(--radius-sm);
+        background: var(--active-bg);
+        color: var(--text-secondary);
+        font-size: 9px;
+        text-align: center;
+      }
+      .pane-activity.running {
+        color: var(--yellow);
+        background: var(--accent-12);
+      }
+      .pane-activity.interactive {
+        color: var(--accent);
+        background: var(--accent-12);
+      }
+      .pane-branch {
+        flex: 0 0 auto;
+        color: var(--green);
+      }
+      .pane-path {
+        min-width: 0;
+        overflow: hidden;
+        color: var(--text-secondary);
+        opacity: 0.7;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .pane-view-label {
+        color: var(--text-secondary);
+        font-weight: 600;
+        opacity: 0.4;
+      }
+      .workspace-summary-line {
+        min-height: 18px;
+        margin-top: 2px;
+        padding-left: 18px;
+        color: var(--text-secondary);
         font-size: 12px;
+        opacity: 0.5;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .nav-empty {
+        margin: 0 8px 7px;
         padding: 7px 8px;
         color: var(--muted);
         border: 1px dashed var(--border);
-        border-radius: 6px;
+        border-radius: var(--radius-md);
       }
-      .dock-block {
-        display: grid;
-        gap: 6px;
-      }
-      .dock-title {
-        color: var(--muted);
-        font-size: 12px;
+      .nav-section.locked {
+        opacity: 0.45;
+        pointer-events: none;
       }
       #terminal {
         width: 100%;
@@ -225,12 +553,6 @@
         white-space: nowrap;
         color: var(--muted);
       }
-      .actions {
-        display: flex;
-        gap: 8px;
-        align-items: center;
-        flex-wrap: wrap;
-      }
       .sr-only {
         position: absolute;
         width: 1px;
@@ -251,36 +573,10 @@
       }
       @media (max-width: 820px) {
         header {
-          display: grid;
-          grid-template-columns: 1fr;
-        }
-        h1 {
-          margin-right: 0;
-        }
-        label {
-          display: grid;
-          grid-template-columns: 72px minmax(0, 1fr);
-        }
-        input[type="password"], select {
-          width: 100%;
-        }
-        .actions {
-          display: grid;
-          grid-template-columns: repeat(3, minmax(0, 1fr));
-        }
-        .actions button {
-          min-width: 0;
-          padding-left: 6px;
-          padding-right: 6px;
+          display: flex;
         }
         .remote-body {
-          grid-template-columns: 1fr;
-          grid-template-rows: auto minmax(0, 1fr);
-        }
-        .navigation-panel {
-          max-height: 32vh;
-          border-right: 0;
-          border-bottom: 1px solid var(--border);
+          min-height: 0;
         }
         footer {
           align-items: stretch;
@@ -292,9 +588,6 @@
         }
       }
       @media (max-width: 520px) {
-        .actions {
-          grid-template-columns: 1fr 1fr;
-        }
         footer {
           grid-template-columns: 1fr 1fr;
         }
@@ -303,17 +596,6 @@
         }
         footer button {
           min-width: 0;
-        }
-      }
-      @media (min-width: 821px) {
-        select {
-          flex: 1 1 260px;
-        }
-        .token-label input {
-          width: 180px;
-        }
-        .name-label input {
-          width: 140px;
         }
       }
       @supports (height: 100dvh) {
@@ -341,31 +623,38 @@
   <body>
     <div class="app">
       <header>
-        <h1>Laymux Remote</h1>
-        <label class="token-label">Token <input id="token" type="password" autocomplete="current-password" /></label>
-        <label class="name-label">Name <input id="clientName" autocomplete="nickname" value="browser" /></label>
-        <select id="terminals" disabled></select>
-        <div class="actions">
-          <button id="connect" class="primary">Connect</button>
-          <button id="release" class="danger" disabled>Release</button>
-          <button id="refresh" disabled>Refresh</button>
-        </div>
+        <button id="navToggle" class="menu-button" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="navigationPanel">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <div id="status" class="status">Enter the remote token, then connect.</div>
       </header>
       <main>
-        <div id="status" class="status">Enter the remote token, then connect.</div>
         <div class="remote-body">
-          <aside class="navigation-panel" aria-label="Remote navigation">
-            <section class="nav-section">
+          <button id="navScrim" class="nav-scrim" type="button" aria-label="Close navigation" hidden></button>
+          <aside id="navigationPanel" class="navigation-panel" aria-label="Remote navigation">
+            <div class="drawer-header">
+              <div class="drawer-title">Remote</div>
+              <button id="navClose" class="drawer-close" type="button" aria-label="Close navigation">
+                <span></span>
+                <span></span>
+              </button>
+            </div>
+            <section class="connection-panel" aria-label="Remote connection">
+              <div class="connection-title">Connection</div>
+              <div class="connection-hint">Connect first to load workspaces and control the active terminal.</div>
+              <label>Token <input id="token" type="password" autocomplete="current-password" /></label>
+              <label>Name <input id="clientName" autocomplete="nickname" value="browser" /></label>
+              <div class="connection-actions">
+                <button id="connect" class="primary">Connect</button>
+                <button id="release" class="danger" disabled>Release</button>
+                <button id="refresh" disabled>Refresh</button>
+              </div>
+            </section>
+            <section id="workspaceSection" class="nav-section locked">
               <h2 class="nav-section-title">Workspaces</h2>
               <div id="workspaceList" class="nav-list"></div>
-            </section>
-            <section class="nav-section">
-              <h2 class="nav-section-title">Active Panes</h2>
-              <div id="paneList" class="nav-list"></div>
-            </section>
-            <section class="nav-section">
-              <h2 class="nav-section-title">Docks</h2>
-              <div id="dockList" class="nav-list"></div>
             </section>
           </aside>
           <div class="terminal-shell">
@@ -386,16 +675,20 @@
         const $ = (id) => document.getElementById(id);
         const tokenInput = $("token");
         const clientNameInput = $("clientName");
+        const navToggleButton = $("navToggle");
+        const navCloseButton = $("navClose");
+        const navScrim = $("navScrim");
         const connectButton = $("connect");
         const releaseButton = $("release");
         const refreshButton = $("refresh");
-        const terminalsSelect = $("terminals");
+        const connectionPanel = document.querySelector(".connection-panel");
+        const connectionHint = document.querySelector(".connection-hint");
         const statusEl = $("status");
         const terminalHost = $("terminal");
+        const terminalShell = document.querySelector(".terminal-shell");
         const terminalMetaEl = $("terminalMeta");
+        const workspaceSection = $("workspaceSection");
         const workspaceListEl = $("workspaceList");
-        const paneListEl = $("paneList");
-        const dockListEl = $("dockList");
         const focusTerminalButton = $("focusTerminal");
         const ctrlCButton = $("ctrlC");
         const tokenKey = "laymux.remote.token";
@@ -410,6 +703,7 @@
         let resizeObserver = null;
         let resizeListenerAttached = false;
         let resizeTimer = null;
+        let terminalRefreshFrame = null;
         let lastResizeKey = "";
         let pendingInput = "";
         let inputFlushTimer = null;
@@ -477,12 +771,19 @@
         }
 
         function setConnected(connected) {
+          if (connectionPanel) connectionPanel.classList.toggle("connected", connected);
+          if (connected) setConnectionHint("Connect first to load workspaces and control the active terminal.", false);
+          workspaceSection.classList.toggle("locked", !connected);
           releaseButton.disabled = !connected;
-          terminalsSelect.disabled = !connected;
           refreshButton.disabled = !connected;
           ctrlCButton.disabled = !connected || !activeTerminalId;
           focusTerminalButton.disabled = !connected || !activeTerminalId;
           connectButton.disabled = connected;
+        }
+
+        function setConnectionHint(message, attention = false) {
+          if (connectionHint) connectionHint.textContent = message;
+          if (connectionPanel) connectionPanel.classList.toggle("attention", attention);
         }
 
         function normalizeAppearance(appearance = {}) {
@@ -556,14 +857,12 @@
           if ("ResizeObserver" in window) {
             resizeObserver = new ResizeObserver(() => fitTerminal());
             resizeObserver.observe(terminalHost);
+            if (terminalShell) resizeObserver.observe(terminalShell);
           } else if (!resizeListenerAttached) {
             window.addEventListener("resize", () => fitTerminal());
             resizeListenerAttached = true;
           }
-          requestAnimationFrame(() => {
-            fitTerminal(false);
-            setTimeout(() => fitTerminal(Boolean(activeTerminalId)), 40);
-          });
+          scheduleTerminalFit(Boolean(activeTerminalId));
           return terminal;
         }
 
@@ -612,8 +911,7 @@
           const intervalMs = Math.max(1000, Math.floor(timeoutSeconds * 333));
           heartbeatTimer = setInterval(() => {
             heartbeat().catch((err) => {
-              setStatus(`Heartbeat failed: ${err.message}`, true);
-              disconnect(false);
+              loseRemoteControl(`Control returned to the host. ${err.message}`);
             });
           }, intervalMs);
         }
@@ -649,50 +947,16 @@
           container.append(item);
         }
 
-        function navButton({ title, badge, meta, active = false, disabled = false, onClick }) {
-          const button = document.createElement("button");
-          button.type = "button";
-          button.className = `nav-item${active ? " active" : ""}`;
-          button.disabled = disabled;
-          const titleRow = document.createElement("div");
-          titleRow.className = "nav-item-title";
-          const nameEl = document.createElement("span");
-          nameEl.className = "nav-item-name";
-          nameEl.textContent = title || "Untitled";
-          titleRow.append(nameEl);
-          if (badge) {
-            const badgeEl = document.createElement("span");
-            badgeEl.className = "nav-badge";
-            badgeEl.textContent = badge;
-            titleRow.append(badgeEl);
-          }
-          button.append(titleRow);
-          if (meta) {
-            const metaEl = document.createElement("div");
-            metaEl.className = "nav-item-meta";
-            metaEl.textContent = meta;
-            button.append(metaEl);
-          }
-          if (onClick) button.addEventListener("click", onClick);
-          return button;
-        }
-
-        function renderTerminalSelect(terminals) {
-          terminalsSelect.innerHTML = "";
-          for (const terminalInfo of terminals) {
-            const option = document.createElement("option");
-            option.value = terminalInfo.id;
-            option.textContent = terminalLabel(terminalInfo);
-            option.dataset.cols = String(terminalInfo.cols || "");
-            option.dataset.rows = String(terminalInfo.rows || "");
-            terminalsSelect.append(option);
-          }
+        function setNavigationOpen(open) {
+          document.querySelector(".app").classList.toggle("nav-open", open);
+          navToggleButton.setAttribute("aria-expanded", String(open));
+          navToggleButton.setAttribute("aria-label", open ? "Close navigation" : "Open navigation");
+          navScrim.hidden = !open;
+          scheduleTerminalFit(Boolean(activeTerminalId));
         }
 
         function renderNavigation(data) {
           renderWorkspaceList(data.workspaces || []);
-          renderPaneList((data.activeWorkspace && data.activeWorkspace.panes) || []);
-          renderDockList(data.docks || []);
         }
 
         function renderWorkspaceList(workspaces) {
@@ -701,95 +965,171 @@
             emptyNav(workspaceListEl, "No workspaces.");
             return;
           }
-          for (const workspace of workspaces) {
-            const meta = metaText([
+          const activePanes = (navigationState && navigationState.activeWorkspace && navigationState.activeWorkspace.panes) || [];
+          for (let index = 0; index < workspaces.length; index += 1) {
+            const workspace = workspaces[index];
+            const panes = workspace.isActive ? activePanes : [];
+            workspaceListEl.append(renderWorkspaceItem(workspace, index, panes));
+          }
+        }
+
+        function renderWorkspaceItem(workspace, index, panes) {
+          const item = document.createElement("div");
+          item.className = `workspace-item${workspace.isActive ? " active" : ""}`;
+          item.addEventListener("click", () => {
+            if (!leaseId) return;
+            switchWorkspace(workspace.id).catch((err) => setStatus(err.message, true));
+          });
+
+          const content = document.createElement("div");
+          content.className = "workspace-item-content";
+          item.append(content);
+
+          const row = document.createElement("div");
+          row.className = "workspace-row-primary";
+          content.append(row);
+
+          const left = document.createElement("span");
+          left.className = "workspace-primary-left";
+          row.append(left);
+
+          const indexEl = document.createElement("span");
+          indexEl.className = "workspace-index";
+          indexEl.textContent = index < 9 ? String(index + 1) : "";
+          left.append(indexEl);
+
+          const nameEl = document.createElement("span");
+          nameEl.className = "workspace-name";
+          nameEl.textContent = workspace.name || workspace.id || "Workspace";
+          left.append(nameEl);
+
+          if ((workspace.terminalPaneCount || 0) > 0) {
+            const count = document.createElement("span");
+            count.className = "workspace-terminal-count";
+            count.textContent = String(workspace.terminalPaneCount);
+            left.append(count);
+          }
+
+          const right = document.createElement("span");
+          right.className = "workspace-primary-right";
+          row.append(right);
+          if (!workspace.isActive && (workspace.liveTerminalCount || 0) > 0) {
+            const badge = document.createElement("span");
+            badge.className = "workspace-count-badge";
+            badge.textContent = String(workspace.liveTerminalCount);
+            right.append(badge);
+          }
+
+          if (panes.length > 0) {
+            const paneList = document.createElement("div");
+            paneList.className = "workspace-pane-list";
+            content.append(paneList);
+            panes.forEach((pane, paneIndex) => {
+              paneList.append(renderPaneRow(pane, panes, paneIndex));
+            });
+          } else {
+            const summary = document.createElement("div");
+            summary.className = "workspace-summary-line";
+            summary.textContent = metaText([
               `${workspace.paneCount || 0} panes`,
               `${workspace.liveTerminalCount || 0} live`,
             ]);
-            workspaceListEl.append(navButton({
-              title: workspace.name || workspace.id,
-              badge: workspace.isActive ? "active" : "",
-              meta,
-              active: Boolean(workspace.isActive),
-              disabled: !leaseId || workspace.isActive,
-              onClick: () => switchWorkspace(workspace.id).catch((err) => setStatus(err.message, true)),
-            }));
+            content.append(summary);
           }
+
+          return item;
         }
 
-        function renderPaneList(panes) {
-          paneListEl.innerHTML = "";
-          if (!panes.length) {
-            emptyNav(paneListEl, "No panes.");
-            return;
-          }
-          for (const pane of panes) {
-            const isTerminal = Boolean(pane.terminalId && pane.terminalLive);
+        function renderPaneRow(pane, panes, paneIndex) {
+          const isTerminal = Boolean(pane.terminalId && pane.terminalLive);
+          const isActive = Boolean(isTerminal && pane.terminalId === activeTerminalId);
+          const row = document.createElement("button");
+          row.type = "button";
+          row.className = `workspace-pane-row${isActive ? " active" : ""}`;
+          row.disabled = !leaseId || !isTerminal;
+          row.addEventListener("click", (event) => {
+            event.stopPropagation();
+            if (!isTerminal) return;
+            selectTerminal(pane.terminalId, { focusHost: true, refreshNavigation: true }).catch((err) => setStatus(err.message, true));
+          });
+
+          const minimap = paneMinimapElement(panes, paneIndex);
+          row.append(minimap);
+
+          const main = document.createElement("div");
+          main.className = "pane-row-main";
+          row.append(main);
+
+          if (isTerminal) {
+            const env = document.createElement("span");
+            env.className = "pane-env";
+            env.textContent = shortLabel(pane.profile || pane.title || "TerminalView");
+            main.append(env);
+
             const activity = activityLabel(pane.activity, pane.commandRunning);
-            const meta = metaText([
-              pane.viewType,
-              pane.profile,
-              shortPath(pane.cwd),
-              pane.branch,
-              activity,
-            ]);
-            paneListEl.append(navButton({
-              title: pane.title || pane.terminalId || pane.viewType,
-              badge: pane.paneNumber ? `#${pane.paneNumber}` : "",
-              meta,
-              active: Boolean(pane.terminalId && pane.terminalId === activeTerminalId),
-              disabled: !leaseId || !isTerminal,
-              onClick: isTerminal
-                ? () => selectTerminal(pane.terminalId, { focusHost: true, refreshNavigation: true }).catch((err) => setStatus(err.message, true))
-                : undefined,
-            }));
+            if (activity) {
+              const activityEl = document.createElement("span");
+              const activityType = pane.activity && pane.activity.type === "interactiveApp"
+                ? "interactive"
+                : "running";
+              activityEl.className = `pane-activity ${activityType}`;
+              activityEl.textContent = activity;
+              main.append(activityEl);
+            }
+
+            if (pane.branch) {
+              const branch = document.createElement("span");
+              branch.className = "pane-branch";
+              branch.textContent = pane.branch;
+              main.append(branch);
+            }
+
+            const path = document.createElement("span");
+            path.className = "pane-path";
+            path.textContent = pane.cwd || pane.title || pane.terminalId;
+            main.append(path);
+          } else {
+            const label = document.createElement("span");
+            label.className = "pane-view-label";
+            label.textContent = shortLabel(pane.viewType);
+            main.append(label);
           }
+
+          return row;
         }
 
-        function renderDockList(docks) {
-          dockListEl.innerHTML = "";
-          if (!docks.length) {
-            emptyNav(dockListEl, "No docks.");
-            return;
-          }
-          for (const dock of docks) {
-            const block = document.createElement("div");
-            block.className = "dock-block";
-            const title = document.createElement("div");
-            title.className = "dock-title";
-            title.textContent = metaText([
-              dock.position || "dock",
-              dock.visible ? "" : "hidden",
-              dock.activeView || "",
-            ]);
-            block.append(title);
-            const panes = dock.panes || [];
-            if (!panes.length) {
-              const empty = document.createElement("div");
-              empty.className = "nav-empty";
-              empty.textContent = "No panes.";
-              block.append(empty);
-            }
-            for (const pane of panes) {
-              const isTerminal = Boolean(pane.terminalId && pane.terminalLive);
-              const meta = metaText([
-                pane.viewType,
-                pane.profile,
-                shortPath(pane.cwd),
-                activityLabel(pane.activity, pane.commandRunning),
-              ]);
-              block.append(navButton({
-                title: pane.title || pane.terminalId || pane.viewType,
-                meta,
-                active: Boolean(pane.terminalId && pane.terminalId === activeTerminalId),
-                disabled: !leaseId || !isTerminal,
-                onClick: isTerminal
-                  ? () => selectTerminal(pane.terminalId, { focusHost: false, refreshNavigation: true }).catch((err) => setStatus(err.message, true))
-                  : undefined,
-              }));
-            }
-            dockListEl.append(block);
-          }
+        function paneMinimapElement(panes, highlightIndex) {
+          const width = 18;
+          const height = 12;
+          const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+          svg.setAttribute("class", "pane-minimap");
+          svg.setAttribute("width", String(width));
+          svg.setAttribute("height", String(height));
+          svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+          panes.forEach((pane, index) => {
+            const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+            const highlighted = index === highlightIndex;
+            rect.setAttribute("x", String((Number(pane.x) || 0) * width));
+            rect.setAttribute("y", String((Number(pane.y) || 0) * height));
+            rect.setAttribute("width", String((Number(pane.w) || 1) * width));
+            rect.setAttribute("height", String((Number(pane.h) || 1) * height));
+            rect.setAttribute("fill", highlighted ? "var(--accent)" : "var(--bg-surface)");
+            rect.setAttribute("fill-opacity", highlighted ? "0.6" : "0.3");
+            rect.setAttribute("stroke", "var(--border)");
+            rect.setAttribute("stroke-width", "0.5");
+            svg.append(rect);
+          });
+          const border = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+          border.setAttribute("x", "0");
+          border.setAttribute("y", "0");
+          border.setAttribute("width", String(width));
+          border.setAttribute("height", String(height));
+          border.setAttribute("fill", "none");
+          border.setAttribute("stroke", "var(--text-secondary)");
+          border.setAttribute("stroke-width", "1");
+          border.setAttribute("rx", "1");
+          svg.append(border);
+          return svg;
         }
 
         function isDockTerminalId(terminalId) {
@@ -797,6 +1137,19 @@
           return (navigationState.docks || []).some((dock) =>
             (dock.panes || []).some((pane) => pane.terminalId === terminalId)
           );
+        }
+
+        function shortLabel(label) {
+          if (!label) return "";
+          const known = {
+            TerminalView: "TERM",
+            MemoView: "MEM",
+            FileExplorerView: "FS",
+            SettingsView: "SET",
+            IssueReporterView: "ISS",
+            EmptyView: "---",
+          };
+          return known[label] || String(label).slice(0, 3).toUpperCase();
         }
 
         function preferredTerminal(data, terminals, preferredTerminalId) {
@@ -821,10 +1174,8 @@
           navigationState = data;
           const terminals = data.terminals || [];
           terminalInfoById = new Map(terminals.map((terminalInfo) => [terminalInfo.id, terminalInfo]));
-          renderTerminalSelect(terminals);
           const nextTerminal = preferredTerminal(data, terminals, preferredTerminalId);
           activeTerminalId = nextTerminal ? nextTerminal.id : null;
-          terminalsSelect.value = activeTerminalId || "";
           renderNavigation(data);
           setConnected(Boolean(leaseId));
           if (activeTerminalId) {
@@ -845,6 +1196,7 @@
             body: JSON.stringify({ leaseId, id: workspaceId }),
           });
           await loadNavigation(null);
+          setNavigationOpen(false);
         }
 
         async function focusTerminalOnHost(terminalId) {
@@ -858,7 +1210,6 @@
         async function selectTerminal(terminalId, options = {}) {
           if (!terminalId) return;
           activeTerminalId = terminalId;
-          terminalsSelect.value = terminalId;
           const terminalInfo = terminalInfoById.get(terminalId);
           terminalMetaEl.textContent = terminalInfo ? terminalLabel(terminalInfo) : terminalId;
           setConnected(Boolean(leaseId));
@@ -871,6 +1222,7 @@
             renderNavigation(navigationState);
           }
           openOutput(terminalId);
+          setNavigationOpen(false);
         }
 
         function wsBaseUrl() {
@@ -894,22 +1246,24 @@
           outputSocket.onopen = () => {
             if (socket === outputSocket) {
               setStatus(`Connected to ${terminalId}`);
-              fitTerminal(true);
+              scheduleTerminalFit(true);
               term.focus();
             }
           };
           outputSocket.onmessage = (event) => {
             if (socket !== outputSocket) return;
+            let payload;
             if (event.data instanceof ArrayBuffer) {
-              term.write(new Uint8Array(event.data));
+              payload = new Uint8Array(event.data);
             } else {
-              term.write(String(event.data));
+              payload = String(event.data);
             }
+            term.write(payload, scheduleTerminalRefresh);
           };
           outputSocket.onclose = () => {
             if (socket === outputSocket) {
               socket = null;
-              if (leaseId) setStatus("Output stream closed.", true);
+              if (leaseId) loseRemoteControl("Control returned to the host. Connect again to resume.");
             }
           };
           outputSocket.onerror = () => {
@@ -934,6 +1288,7 @@
             setConnected(true);
             startHeartbeat(status.heartbeatTimeoutSeconds || 15);
             await loadNavigation();
+            setNavigationOpen(false);
           } catch (err) {
             const failedLease = leaseId;
             disconnect(false);
@@ -977,17 +1332,40 @@
 
         function fitTerminal(sendResize = true) {
           if (!terminal || !fitAddon) return;
+          const rect = terminalHost.getBoundingClientRect();
+          if (rect.width < 20 || rect.height < 20) return;
           try {
             fitAddon.fit();
           } catch (err) {
             setStatus(`Fit failed: ${err.message}`, true);
             return;
           }
-          if (sendResize) queueResize(terminal.cols, terminal.rows);
+          if (sendResize && terminal.cols > 0 && terminal.rows > 0) {
+            queueResize(terminal.cols, terminal.rows);
+          }
+          scheduleTerminalRefresh();
+        }
+
+        function scheduleTerminalFit(sendResize = true) {
+          if (!terminal || !fitAddon) return;
+          requestAnimationFrame(() => {
+            fitTerminal(sendResize);
+            setTimeout(() => fitTerminal(sendResize), 160);
+          });
+        }
+
+        function scheduleTerminalRefresh() {
+          if (!terminal || terminal.rows <= 0 || terminalRefreshFrame !== null) return;
+          terminalRefreshFrame = requestAnimationFrame(() => {
+            terminalRefreshFrame = null;
+            if (terminal && terminal.rows > 0) {
+              terminal.refresh(0, terminal.rows - 1);
+            }
+          });
         }
 
         function queueResize(cols, rows) {
-          if (!leaseId || !activeTerminalId || !Number.isFinite(cols) || !Number.isFinite(rows)) return;
+          if (!leaseId || !activeTerminalId || !Number.isFinite(cols) || !Number.isFinite(rows) || cols < 1 || rows < 1) return;
           const resizeTerminalId = activeTerminalId;
           const resizeLeaseId = leaseId;
           const resizeKey = `${resizeTerminalId}:${cols}x${rows}`;
@@ -1015,6 +1393,7 @@
           const currentLease = leaseId;
           await releaseLease(currentLease);
           disconnect(false);
+          setConnectionHint("Connect first to load workspaces and control the active terminal.", false);
           setStatus("Released remote control.");
         }
 
@@ -1034,19 +1413,32 @@
           activeTerminalId = null;
           setConnected(false);
           if (navigationState) renderNavigation(navigationState);
-          if (clearStatus) setStatus("Disconnected.");
+          if (clearStatus) {
+            setConnectionHint("Connect first to load workspaces and control the active terminal.", false);
+            setStatus("Disconnected.");
+          }
+        }
+
+        function loseRemoteControl(message) {
+          disconnect(false);
+          terminalMetaEl.textContent = "Host has control.";
+          setConnectionHint("Host has control. Connect again to request control.", true);
+          setStatus(message, true);
+          setNavigationOpen(true);
         }
 
         emptyNav(workspaceListEl, "Not connected.");
-        emptyNav(paneListEl, "Not connected.");
-        emptyNav(dockListEl, "Not connected.");
+        setNavigationOpen(true);
 
+        navToggleButton.addEventListener("click", () => {
+          const open = navToggleButton.getAttribute("aria-expanded") !== "true";
+          setNavigationOpen(open);
+        });
+        navCloseButton.addEventListener("click", () => setNavigationOpen(false));
+        navScrim.addEventListener("click", () => setNavigationOpen(false));
         connectButton.addEventListener("click", () => connect().catch((err) => setStatus(err.message, true)));
         releaseButton.addEventListener("click", () => release().catch((err) => setStatus(`Release failed: ${err.message}`, true)));
         refreshButton.addEventListener("click", () => loadNavigation().catch((err) => setStatus(err.message, true)));
-        terminalsSelect.addEventListener("change", () => {
-          selectTerminal(terminalsSelect.value || null, { focusHost: true, refreshNavigation: true }).catch((err) => setStatus(err.message, true));
-        });
         ctrlCButton.addEventListener("click", () => enqueueInput("\x03"));
         focusTerminalButton.addEventListener("click", () => terminal && terminal.focus());
         window.addEventListener("beforeunload", () => {

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -50,10 +50,28 @@ mod tests {
         assert!(html.contains("inputWriteChain"));
         assert!(html.contains("writeToTerminal(inputTerminalId, inputLeaseId"));
         assert!(html.contains("resizeTerminal(resizeTerminalId, resizeLeaseId"));
+        assert!(html.contains("const terminalShell = document.querySelector(\".terminal-shell\")"));
+        assert!(html.contains("resizeObserver.observe(terminalShell)"));
+        assert!(html.contains("rect.width < 20 || rect.height < 20"));
+        assert!(html.contains("function scheduleTerminalFit(sendResize = true)"));
+        assert!(html.contains("function scheduleTerminalRefresh()"));
+        assert!(html.contains("function loseRemoteControl(message)"));
+        assert!(html.contains("Control returned to the host"));
+        assert!(html.contains("connection-panel.attention"));
+        assert!(html.contains("Host has control. Connect again to request control."));
+        assert!(html.contains("term.write(payload, scheduleTerminalRefresh)"));
+        assert!(html.contains("cols < 1 || rows < 1"));
+        assert!(html.contains("id=\"navToggle\""));
+        assert!(!html.contains("<h1>Laymux Remote</h1>"));
+        assert!(html.contains("class=\"drawer-header\""));
+        assert!(html.contains("class=\"connection-panel\""));
+        assert!(html.contains("Connect first to load workspaces"));
+        assert!(html.contains("id=\"workspaceSection\""));
+        assert!(html.contains("workspace-item-content"));
+        assert!(html.contains("workspace-pane-row"));
+        assert!(!html.contains("id=\"terminals\""));
+        assert!(!html.contains("id=\"dockList\""));
         assert!(html.contains("function isDockTerminalId(terminalId)"));
-        assert!(html.contains(
-            "selectTerminal(pane.terminalId, { focusHost: false, refreshNavigation: true })"
-        ));
         assert!(html.contains("options.focusHost !== false && !isDockTerminalId(terminalId)"));
     }
 }

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -56,6 +56,8 @@ mod tests {
         assert!(html.contains("function scheduleTerminalFit(sendResize = true)"));
         assert!(html.contains("function scheduleTerminalRefresh()"));
         assert!(html.contains("function loseRemoteControl(message)"));
+        assert!(html.contains("const lostLeaseId = leaseId"));
+        assert!(html.contains("releaseLease(lostLeaseId).catch(() => {})"));
         assert!(html.contains("Control returned to the host"));
         assert!(html.contains("connection-panel.attention"));
         assert!(html.contains("Host has control. Connect again to request control."));

--- a/src-tauri/src/remote_server/routes.rs
+++ b/src-tauri/src/remote_server/routes.rs
@@ -279,6 +279,9 @@ async fn remote_terminal_resize(
     if let Err(response) = require_active_lease(&server.app_state, lease_id) {
         return response;
     }
+    if !terminal_size_is_positive(body.cols, body.rows) {
+        return json_error(StatusCode::BAD_REQUEST, "terminal size must be positive");
+    }
 
     {
         let mut terminals = match server.app_state.terminals.lock_or_err() {
@@ -418,4 +421,21 @@ fn lease_id_from_headers(headers: &HeaderMap) -> Option<&str> {
         .get(REMOTE_LEASE_HEADER)
         .and_then(|value| value.to_str().ok())
         .filter(|value| !value.is_empty())
+}
+
+fn terminal_size_is_positive(cols: u16, rows: u16) -> bool {
+    cols > 0 && rows > 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::terminal_size_is_positive;
+
+    #[test]
+    fn remote_resize_rejects_zero_dimensions() {
+        assert!(!terminal_size_is_positive(0, 24));
+        assert!(!terminal_size_is_positive(80, 0));
+        assert!(!terminal_size_is_positive(0, 0));
+        assert!(terminal_size_is_positive(80, 24));
+    }
 }

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -209,6 +209,18 @@ const mockWriteToTerminal = vi.fn().mockResolvedValue(undefined);
 const mockResizeTerminal = vi.fn().mockResolvedValue(undefined);
 const mockCloseTerminalSession = vi.fn().mockResolvedValue(undefined);
 const mockOnTerminalOutput = vi.fn().mockResolvedValue(vi.fn());
+const mockGetRemoteControlStatus = vi.fn().mockResolvedValue({
+  active: false,
+  leaseId: null,
+  remoteAddr: null,
+  clientName: null,
+  heartbeatTimeoutSeconds: 15,
+});
+let capturedRemoteControlChanged: ((data: { active: boolean }) => void) | null = null;
+const mockOnRemoteControlChanged = vi.fn((callback: (data: { active: boolean }) => void) => {
+  capturedRemoteControlChanged = callback;
+  return Promise.resolve(vi.fn());
+});
 const mockSmartPaste = vi.fn().mockResolvedValue({ pasteType: "none", content: "" });
 const mockClipboardWriteText = vi.fn().mockResolvedValue(undefined);
 const mockSetTerminalCwdSend = vi.fn().mockResolvedValue(undefined);
@@ -226,6 +238,8 @@ vi.mock("@/lib/tauri-api", () => ({
   resizeTerminal: (...args: unknown[]) => mockResizeTerminal(...args),
   closeTerminalSession: (...args: unknown[]) => mockCloseTerminalSession(...args),
   onTerminalOutput: (...args: unknown[]) => mockOnTerminalOutput(...args),
+  getRemoteControlStatus: (...args: unknown[]) => mockGetRemoteControlStatus(...args),
+  onRemoteControlChanged: (...args: unknown[]) => mockOnRemoteControlChanged(...args),
   smartPaste: (...args: unknown[]) => mockSmartPaste(...args),
   clipboardWriteText: (...args: unknown[]) => mockClipboardWriteText(...args),
   setTerminalCwdSend: (...args: unknown[]) => mockSetTerminalCwdSend(...args),
@@ -252,11 +266,19 @@ describe("TerminalView", () => {
     oscHandlers.clear();
     escHandlers.clear();
     mockModes.synchronizedOutputMode = false;
+    capturedRemoteControlChanged = null;
     capturedScrollHandler = null;
     mockBufferActive.cursorX = 0;
     mockBufferActive.cursorY = 0;
     mockBufferActive.baseY = 0;
     mockBufferActive.viewportY = 0;
+    mockGetRemoteControlStatus.mockResolvedValue({
+      active: false,
+      leaseId: null,
+      remoteAddr: null,
+      clientName: null,
+      heartbeatTimeoutSeconds: 15,
+    });
     _resetWebglStagger();
     vi.clearAllMocks();
   });
@@ -2880,6 +2902,73 @@ describe("TerminalView", () => {
       expect(mockClearTextureAtlas).toHaveBeenCalled();
       expect(mockRequestAnimationFrame).toHaveBeenCalled();
     });
+  });
+
+  it("reflows the renderer when remote control returns to the PC", async () => {
+    render(<TerminalView instanceId="t-remote-return" profile="PowerShell" syncGroup="" />);
+
+    await vi.waitFor(() => {
+      expect(mockCreateTerminalSession).toHaveBeenCalled();
+      expect(capturedRemoteControlChanged).toBeTruthy();
+    });
+
+    mockFit.mockClear();
+    mockClearTextureAtlas.mockClear();
+    mockRefresh.mockClear();
+    mockResizeTerminal.mockClear();
+
+    act(() => {
+      capturedRemoteControlChanged?.({ active: true });
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockFit).not.toHaveBeenCalled();
+
+    act(() => {
+      capturedRemoteControlChanged?.({ active: false });
+    });
+
+    await vi.waitFor(() => {
+      expect(mockFit).toHaveBeenCalled();
+      expect(mockClearTextureAtlas).toHaveBeenCalled();
+      expect(mockRefresh).toHaveBeenCalled();
+      expect(mockResizeTerminal).toHaveBeenCalledWith("t-remote-return", 80, 24);
+    });
+  });
+
+  it("does not write or resize the backend while remote control is active", async () => {
+    mockGetRemoteControlStatus.mockResolvedValue({
+      active: true,
+      leaseId: "remote-lease",
+      remoteAddr: "127.0.0.1:1",
+      clientName: "browser",
+      heartbeatTimeoutSeconds: 15,
+    });
+
+    render(<TerminalView instanceId="t-remote-owned" profile="PowerShell" syncGroup="" />);
+
+    await vi.waitFor(() => {
+      expect(mockCreateTerminalSession).toHaveBeenCalled();
+      expect(mockGetRemoteControlStatus).toHaveBeenCalled();
+    });
+
+    mockWriteToTerminal.mockClear();
+    mockResizeTerminal.mockClear();
+
+    const dataHandler = mockOnData.mock.calls.at(-1)?.[0] as ((data: string) => void) | undefined;
+    const resizeHandler = mockOnResize.mock.calls.at(-1)?.[0] as
+      | ((size: { cols: number; rows: number }) => void)
+      | undefined;
+    expect(dataHandler).toBeDefined();
+    expect(resizeHandler).toBeDefined();
+
+    act(() => {
+      dataHandler?.("x");
+      resizeHandler?.({ cols: 120, rows: 40 });
+    });
+
+    expect(mockWriteToTerminal).not.toHaveBeenCalled();
+    expect(mockResizeTerminal).not.toHaveBeenCalled();
   });
 
   // -- Regression: reflow must NOT fire on activity / cursor changes --

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -2936,6 +2936,63 @@ describe("TerminalView", () => {
     });
   });
 
+  it("polls active remote control status and reflows after lease expiration", async () => {
+    vi.useFakeTimers();
+    mockGetRemoteControlStatus
+      .mockResolvedValueOnce({
+        active: true,
+        leaseId: "expired-lease",
+        remoteAddr: "127.0.0.1:1",
+        clientName: "browser",
+        heartbeatTimeoutSeconds: 15,
+      })
+      .mockResolvedValueOnce({
+        active: false,
+        leaseId: null,
+        remoteAddr: null,
+        clientName: null,
+        heartbeatTimeoutSeconds: 15,
+      });
+
+    try {
+      render(<TerminalView instanceId="t-remote-expired" profile="PowerShell" syncGroup="" />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+        await Promise.resolve();
+      });
+
+      await vi.waitFor(() => {
+        expect(mockCreateTerminalSession).toHaveBeenCalled();
+        expect(mockGetRemoteControlStatus).toHaveBeenCalledTimes(1);
+      });
+
+      mockFit.mockClear();
+      mockClearTextureAtlas.mockClear();
+      mockRefresh.mockClear();
+      mockResizeTerminal.mockClear();
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+      });
+
+      expect(mockGetRemoteControlStatus).toHaveBeenCalledTimes(2);
+      expect(mockFit).toHaveBeenCalled();
+      expect(mockClearTextureAtlas).toHaveBeenCalled();
+      expect(mockRefresh).toHaveBeenCalled();
+      expect(mockResizeTerminal).toHaveBeenCalledWith("t-remote-expired", 80, 24);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not write or resize the backend while remote control is active", async () => {
     mockGetRemoteControlStatus.mockResolvedValue({
       active: true,

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -113,6 +113,8 @@ const OUTPUT_IDLE_TIMEOUT_MS = 5000;
  */
 const RESIZE_FIT_DEBOUNCE_MS = 80;
 
+const REMOTE_CONTROL_STATUS_POLL_MS = 3000;
+
 /** Byte-size threshold for the large paste warning dialog. */
 const LARGE_PASTE_THRESHOLD = 5120;
 
@@ -2534,11 +2536,32 @@ export function TerminalView({
   useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | undefined;
+    let pollTimer: ReturnType<typeof setInterval> | undefined;
+
+    const stopPolling = () => {
+      if (pollTimer !== undefined) {
+        clearInterval(pollTimer);
+        pollTimer = undefined;
+      }
+    };
 
     const applyRemoteControlStatus = (status: { active: boolean }) => {
       const wasActive = remoteControlActiveRef.current;
       remoteControlActiveRef.current = status.active;
-      if (status.active || !wasActive) return;
+      if (status.active) {
+        if (pollTimer === undefined) {
+          pollTimer = setInterval(() => {
+            getRemoteControlStatus()
+              .then((next) => {
+                if (!cancelled) applyRemoteControlStatus(next);
+              })
+              .catch(() => {});
+          }, REMOTE_CONTROL_STATUS_POLL_MS);
+        }
+        return;
+      }
+      stopPolling();
+      if (!wasActive) return;
       const term = terminalRef.current;
       if (!term || !openedRef.current) return;
       if (isContainerHiddenRef.current) {
@@ -2551,7 +2574,7 @@ export function TerminalView({
 
     getRemoteControlStatus()
       .then((status) => {
-        if (!cancelled) remoteControlActiveRef.current = status.active;
+        if (!cancelled) applyRemoteControlStatus(status);
       })
       .catch(() => {});
 
@@ -2564,6 +2587,7 @@ export function TerminalView({
 
     return () => {
       cancelled = true;
+      stopPolling();
       unlisten?.();
     };
   }, []);

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -38,6 +38,8 @@ import {
   handleLxMessage,
   markClaudeTerminal,
   markCodexTerminal,
+  getRemoteControlStatus,
+  onRemoteControlChanged,
 } from "@/lib/tauri-api";
 import { colorSchemeToXtermTheme, type WTColorScheme } from "@/lib/color-scheme";
 import { transformPasteContent, prepareSelectionForCopy, formatPastePaths } from "@/lib/smart-text";
@@ -444,11 +446,13 @@ export function TerminalView({
   // container — which would propagate cols/rows=0 through a PTY resize and
   // leave inactive workspaces with garbled glyphs on next show.
   const isContainerHiddenRef = useRef(false);
+  const remoteControlActiveRef = useRef(false);
   // Marks that a reflow trigger fired while the container was hidden. The
   // ResizeObserver's hidden→visible branch consumes this in addition to
   // `prevWasHidden` so the deferred fit() + atlas rebuild fires exactly
   // once when the workspace becomes visible again.
   const reflowDirtyRef = useRef(false);
+  const remoteReturnResizeDirtyRef = useRef(false);
   const overlayCaretUpdaterRef = useRef<(() => void) | null>(null);
   const openedRef = useRef(false);
   // Each xterm rebuild gets a fresh generation, bumped at render time when
@@ -1650,6 +1654,7 @@ export function TerminalView({
 
     // Handle terminal data (user input) — send to backend PTY
     terminal.onData((data) => {
+      if (remoteControlActiveRef.current) return;
       trace("terminal-onData", {
         bytes: data.length,
         preview: JSON.stringify(data.slice(0, 80)),
@@ -1678,6 +1683,7 @@ export function TerminalView({
 
     // Handle terminal resize — notify backend PTY
     terminal.onResize(({ cols, rows }) => {
+      if (remoteControlActiveRef.current) return;
       resizeTerminal(instanceId, cols, rows).catch(() => {});
     });
 
@@ -1980,9 +1986,10 @@ export function TerminalView({
               }
               const message =
                 useSettingsStore.getState().claude.sessionLimitResumeMessage || "go on";
+              if (remoteControlActiveRef.current) return;
               void writeToTerminal(instanceId, message);
               sessionLimitSubmitTimer = setTimeout(() => {
-                void writeToTerminal(instanceId, "\r");
+                if (!remoteControlActiveRef.current) void writeToTerminal(instanceId, "\r");
               }, SESSION_LIMIT_SUBMIT_CR_DELAY_MS);
               useNotificationStore.getState().addNotification({
                 terminalId: instanceId,
@@ -2300,6 +2307,10 @@ export function TerminalView({
         const applyFit = () => {
           if (cancelled) return;
           fitAddon.fit();
+          if (remoteReturnResizeDirtyRef.current) {
+            remoteReturnResizeDirtyRef.current = false;
+            syncBackendSizeFromTerminal(terminal);
+          }
           if (recoveringFromHidden || consumeDirty) {
             // See `prevWasHidden` / `reflowDirtyRef` definitions: the WebGL
             // atlas can go stale while the container is display:none (a DPR
@@ -2498,13 +2509,19 @@ export function TerminalView({
   // back-to-back) compounds with TUI exit bursts (e.g. Codex's `ESC[?1049l`,
   // scrollback re-emit) and is what makes the WebGL atlas race manifest as
   // glyph corruption in adjacent panes.
-  const runTerminalRendererReflow = (term: Terminal) => {
+  const syncBackendSizeFromTerminal = (term: Terminal) => {
+    if (!remoteControlActiveRef.current && term.cols > 0 && term.rows > 0) {
+      resizeTerminal(instanceId, term.cols, term.rows).catch(() => {});
+    }
+  };
+  const runTerminalRendererReflow = (term: Terminal, syncBackendResize = false) => {
     if (terminalReflowFrameRef.current !== null) {
       cancelAnimationFrame(terminalReflowFrameRef.current);
     }
     terminalReflowFrameRef.current = requestAnimationFrame(() => {
       terminalReflowFrameRef.current = null;
       fitAddonRef.current?.fit();
+      if (syncBackendResize) syncBackendSizeFromTerminal(term);
       try {
         (term as unknown as { clearTextureAtlas?: () => void }).clearTextureAtlas?.();
       } catch {
@@ -2514,6 +2531,42 @@ export function TerminalView({
       overlayCaretUpdaterRef.current?.();
     });
   };
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
+    const applyRemoteControlStatus = (status: { active: boolean }) => {
+      const wasActive = remoteControlActiveRef.current;
+      remoteControlActiveRef.current = status.active;
+      if (status.active || !wasActive) return;
+      const term = terminalRef.current;
+      if (!term || !openedRef.current) return;
+      if (isContainerHiddenRef.current) {
+        reflowDirtyRef.current = true;
+        remoteReturnResizeDirtyRef.current = true;
+        return;
+      }
+      runTerminalRendererReflow(term, true);
+    };
+
+    getRemoteControlStatus()
+      .then((status) => {
+        if (!cancelled) remoteControlActiveRef.current = status.active;
+      })
+      .catch(() => {});
+
+    onRemoteControlChanged(applyRemoteControlStatus)
+      .then((cleanup) => {
+        if (cancelled) cleanup();
+        else unlisten = cleanup;
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
   useEffect(() => {
     overlayCaretUpdaterRef.current?.();
   }, [activity, isFocused, font, cursorShape, stabilizeInteractiveCursor]);


### PR DESCRIPTION
## What changed

- Adds ADR-0015 and living architecture docs for remote terminal state ownership.
- Separates PTY-global state, surface-local renderer state, and controller-owner state for Direct Remote Mode.
- Guards PC `TerminalView` so it does not write or resize the backend PTY while a remote lease is active.
- Forces PC geometry back into the backend PTY when control returns to the host, including hidden-pane recovery.
- Makes the remote browser UI show a clearer host-control state after lease loss.
- Keeps remote initial resize behavior so Claude/Codex-style TUIs render against the active remote geometry.

## Why

Remote and PC surfaces were sharing one PTY session but had different renderer geometry. The backend PTY could remain sized for the remote browser after the PC reclaimed control, leaving Claude Code and similar TUIs rendered with the wrong width. The fix is to make ownership explicit: only the active controller changes PTY-global write/resize state, and every control handoff re-declares the new owner's geometry.

## Validation

- `cargo test remote_server`
- `npm run test -- TerminalView.test.tsx`
- `git diff --check`
- Browser smoke check against dev remote confirmed initial remote resize is still sent and the lost-control UI strings are served.