### PR TITLE
모바일에서 터미널 텍스트 선택 안됨

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -568,6 +568,8 @@ Remote terminal control은 상태 소유권을 세 범주로 나눈다([ADR-0015
 | surface 로컬 상태 | DOM pixel size, devicePixelRatio, xterm canvas/WebGL atlas, cell metrics cache, scroll viewport, selection, focus, IME/composition, drawer state | PC WebView와 browser remote가 각자 보유한다. Remote API 계약에 섞지 않는다. |
 | controller owner 상태 | active input writer, active resize writer, workspace/pane focus request 권한 | active lease가 있으면 remote가 owner이고, lease가 없으면 PC가 owner다. owner가 아닌 surface는 PTY write/resize를 보내지 않는다. |
 
+브라우저 remote의 모바일 터치 선택은 surface-local 처리다. Remote HTML은 primary touch/pen pointer drag를 xterm의 기존 mouse selection 이벤트로 변환하고, mouse tracking mode에서는 합성 이벤트에 force-selection modifier를 실어 TUI로 입력이 전달되지 않게 한다. 선택된 텍스트는 footer의 `Copy` 버튼으로 브라우저 클립보드에 복사하며, 이 동작은 Remote API 계약이나 PTY 전역 상태를 바꾸지 않는다.
+
 `cols/rows`는 surface 로컬 값이 아니라 SIGWINCH로 process에 반영되는 PTY 전역 상태다. 따라서 remote lease가 active인 동안 browser remote의 xterm geometry가 PTY 크기를 결정하고, PC WebView는 로컬 renderer를 유지하되 backend PTY resize를 보내지 않는다. PC가 `reclaim_remote_control`로 제어권을 회수하거나 remote lease가 끝나면 visible `TerminalView`가 자기 xterm의 현재 `cols/rows`를 backend PTY에 명시적으로 다시 보내고 renderer `fit()`/atlas rebuild/`refresh()`를 실행한다. hidden `TerminalView`는 이 복구를 dirty로 보류하고 다시 visible이 되는 순간 소비한다.
 
 | Endpoint | Method | 용도 |

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -534,10 +534,12 @@
         width: 100%;
         height: 100%;
         min-height: 0;
+        touch-action: none;
       }
       .xterm {
         height: 100%;
         padding: 4px;
+        touch-action: none;
       }
       .xterm .xterm-viewport {
         background-color: transparent;
@@ -581,7 +583,7 @@
         footer {
           align-items: stretch;
           display: grid;
-          grid-template-columns: 1fr auto auto;
+          grid-template-columns: 1fr auto auto auto;
         }
         footer .status-hint {
           align-self: center;
@@ -589,7 +591,7 @@
       }
       @media (max-width: 520px) {
         footer {
-          grid-template-columns: 1fr 1fr;
+          grid-template-columns: 1fr 1fr 1fr;
         }
         footer .status-hint {
           grid-column: 1 / -1;
@@ -663,6 +665,7 @@
         </div>
       </main>
       <footer>
+        <button id="copySelection" disabled>Copy</button>
         <button id="ctrlC" disabled>Ctrl+C</button>
         <button id="focusTerminal" disabled>Keyboard</button>
         <div id="terminalMeta" class="status-hint grow">No terminal selected.</div>
@@ -690,6 +693,7 @@
         const workspaceSection = $("workspaceSection");
         const workspaceListEl = $("workspaceList");
         const focusTerminalButton = $("focusTerminal");
+        const copySelectionButton = $("copySelection");
         const ctrlCButton = $("ctrlC");
         const tokenKey = "laymux.remote.token";
         let leaseId = null;
@@ -781,9 +785,8 @@
           workspaceSection.classList.toggle("locked", !connected);
           releaseButton.disabled = !connected;
           refreshButton.disabled = !connected;
-          ctrlCButton.disabled = !connected || !activeTerminalId;
-          focusTerminalButton.disabled = !connected || !activeTerminalId;
           connectButton.disabled = connected;
+          updateTerminalControls();
         }
 
         function setConnectionHint(message, attention = false) {
@@ -818,6 +821,7 @@
             fontFamily: normalized.fontFamily,
             fontSize: normalized.fontSize,
             letterSpacing: 0,
+            macOptionClickForcesSelection: true,
             scrollback: normalized.scrollback,
             convertEol: false,
             theme: normalized.theme,
@@ -846,6 +850,137 @@
           }
         }
 
+        function hasTerminalSelection() {
+          return Boolean(terminal && typeof terminal.hasSelection === "function" && terminal.hasSelection());
+        }
+
+        function updateTerminalControls() {
+          const canControl = Boolean(leaseId && activeTerminalId);
+          ctrlCButton.disabled = !canControl;
+          focusTerminalButton.disabled = !canControl;
+          copySelectionButton.disabled = !canControl || !hasTerminalSelection();
+        }
+
+        function fallbackCopyText(text) {
+          const textarea = document.createElement("textarea");
+          textarea.value = text;
+          textarea.setAttribute("readonly", "");
+          textarea.style.position = "fixed";
+          textarea.style.left = "-9999px";
+          textarea.style.top = "0";
+          document.body.append(textarea);
+          textarea.focus();
+          textarea.select();
+          try {
+            return Boolean(document.execCommand && document.execCommand("copy"));
+          } finally {
+            textarea.remove();
+          }
+        }
+
+        async function writeClipboardText(text) {
+          if (navigator.clipboard && window.isSecureContext) {
+            await navigator.clipboard.writeText(text);
+            return;
+          }
+          if (!fallbackCopyText(text)) {
+            throw new Error("Clipboard API unavailable");
+          }
+        }
+
+        async function copySelectionToClipboard() {
+          if (!terminal || !terminal.hasSelection()) {
+            updateTerminalControls();
+            return;
+          }
+          const text = terminal.getSelection();
+          if (!text) {
+            updateTerminalControls();
+            return;
+          }
+          try {
+            await writeClipboardText(text);
+            setStatus("Selection copied.");
+          } catch (err) {
+            setStatus(`Copy failed: ${err.message || err}`, true);
+          } finally {
+            updateTerminalControls();
+          }
+        }
+
+        function isTouchSelectionPointer(event) {
+          return event.pointerType === "touch" || event.pointerType === "pen";
+        }
+
+        function shouldForceTouchSelection(term) {
+          const mouseTrackingMode = term && term.modes && term.modes.mouseTrackingMode;
+          return Boolean(mouseTrackingMode && mouseTrackingMode !== "none");
+        }
+
+        function touchSelectionMouseEvent(type, pointerEvent, forceSelection) {
+          return new MouseEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            detail: type === "mousedown" ? 1 : 0,
+            screenX: pointerEvent.screenX,
+            screenY: pointerEvent.screenY,
+            clientX: pointerEvent.clientX,
+            clientY: pointerEvent.clientY,
+            button: 0,
+            buttons: type === "mouseup" ? 0 : 1,
+            shiftKey: forceSelection,
+            altKey: forceSelection,
+          });
+        }
+
+        function dispatchTouchSelectionMouse(target, type, pointerEvent, forceSelection) {
+          target.dispatchEvent(touchSelectionMouseEvent(type, pointerEvent, forceSelection));
+        }
+
+        function installTouchSelectionBridge(term) {
+          const element = term && term.element;
+          if (!element || element.dataset.touchSelectionBridge === "true") return;
+          element.dataset.touchSelectionBridge = "true";
+
+          let activePointerId = null;
+          let forceSelection = false;
+          const pointerOptions = { passive: false };
+
+          element.addEventListener("pointerdown", (event) => {
+            if (!isTouchSelectionPointer(event) || activePointerId !== null || event.isPrimary === false) return;
+            activePointerId = event.pointerId;
+            forceSelection = shouldForceTouchSelection(term);
+            event.preventDefault();
+            event.stopPropagation();
+            element.setPointerCapture?.(event.pointerId);
+            dispatchTouchSelectionMouse(element, "mousedown", event, forceSelection);
+          }, pointerOptions);
+
+          element.addEventListener("pointermove", (event) => {
+            if (event.pointerId !== activePointerId) return;
+            event.preventDefault();
+            event.stopPropagation();
+            dispatchTouchSelectionMouse(document, "mousemove", event, forceSelection);
+          }, pointerOptions);
+
+          const finishTouchSelection = (event) => {
+            if (event.pointerId !== activePointerId) return;
+            event.preventDefault();
+            event.stopPropagation();
+            dispatchTouchSelectionMouse(document, "mouseup", event, forceSelection);
+            if (element.hasPointerCapture?.(event.pointerId)) {
+              element.releasePointerCapture?.(event.pointerId);
+            }
+            activePointerId = null;
+            forceSelection = false;
+            updateTerminalControls();
+          };
+
+          element.addEventListener("pointerup", finishTouchSelection, pointerOptions);
+          element.addEventListener("pointercancel", finishTouchSelection, pointerOptions);
+        }
+
         function ensureTerminal(appearance = {}) {
           if (terminal) return terminal;
           const TerminalCtor = window.Terminal;
@@ -857,8 +992,10 @@
           fitAddon = new FitAddonCtor();
           terminal.loadAddon(fitAddon);
           terminal.open(terminalHost);
+          installTouchSelectionBridge(terminal);
           terminal.onData((data) => enqueueInput(data));
           terminal.onResize(({ cols, rows }) => queueResize(cols, rows));
+          terminal.onSelectionChange(() => updateTerminalControls());
           if ("ResizeObserver" in window) {
             resizeObserver = new ResizeObserver(() => fitTerminal());
             resizeObserver.observe(terminalHost);
@@ -1243,6 +1380,7 @@
           stopResizeFlush();
           applyTerminalAppearance(terminalInfo && terminalInfo.appearance);
           term.reset();
+          updateTerminalControls();
           lastResizeKey = "";
           const url = `${wsBaseUrl()}/remote/v1/terminals/${encodeURIComponent(terminalId)}/output?leaseId=${encodeURIComponent(leaseId)}&token=${encodeURIComponent(token())}`;
           const outputSocket = new WebSocket(url);
@@ -1446,6 +1584,7 @@
         connectButton.addEventListener("click", () => connect().catch((err) => setStatus(err.message, true)));
         releaseButton.addEventListener("click", () => release().catch((err) => setStatus(`Release failed: ${err.message}`, true)));
         refreshButton.addEventListener("click", () => loadNavigation().catch((err) => setStatus(err.message, true)));
+        copySelectionButton.addEventListener("click", () => copySelectionToClipboard());
         ctrlCButton.addEventListener("click", () => enqueueInput("\x03"));
         focusTerminalButton.addEventListener("click", () => terminal && terminal.focus());
         window.addEventListener("beforeunload", () => {

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -50,6 +50,12 @@ mod tests {
         assert!(html.contains("inputWriteChain"));
         assert!(html.contains("writeToTerminal(inputTerminalId, inputLeaseId"));
         assert!(html.contains("resizeTerminal(resizeTerminalId, resizeLeaseId"));
+        assert!(html.contains("touch-action: none"));
+        assert!(html.contains("function installTouchSelectionBridge(term)"));
+        assert!(html.contains("new MouseEvent(type"));
+        assert!(html.contains("mouseTrackingMode !== \"none\""));
+        assert!(html.contains("id=\"copySelection\""));
+        assert!(html.contains("copySelectionToClipboard"));
         assert!(html.contains("const terminalShell = document.querySelector(\".terminal-shell\")"));
         assert!(html.contains("resizeObserver.observe(terminalShell)"));
         assert!(html.contains("rect.width < 20 || rect.height < 20"));


### PR DESCRIPTION
## 변경 요약
- Remote 브라우저 터미널에서 touch/pen 드래그를 xterm mouse selection 이벤트로 변환합니다.
- mouse tracking mode에서는 합성 이벤트에 force-selection modifier를 포함해 TUI 입력으로 전달되지 않게 했습니다.
- 모바일에서 선택 텍스트를 가져갈 수 있도록 remote footer에 Copy 버튼을 추가했습니다.
- remote selection 동작을 architecture living doc에 반영했습니다.

## 테스트
- cargo fmt --check
- cargo test

Fixes #407