### PR TITLE
Fix #408 desktop mobile remote mode

### DIFF
--- a/docs/adr/0016-remote-access-runtime-vs-startup-enable.md
+++ b/docs/adr/0016-remote-access-runtime-vs-startup-enable.md
@@ -1,0 +1,36 @@
+# 0016. Remote Access 활성화는 런타임 허용과 시작 시 허용을 분리한다
+
+- Status: Accepted
+- Date: 2026-07-01
+- Source: Remote Access 버튼은 "이번 실행 동안만 허용"과 "시작 시 자동 허용"을 구분해야 한다는 사용자 요구
+
+## Context
+
+Direct Remote Mode는 브라우저가 laymux를 직접 제어할 수 있는 네트워크 표면이다. 기존 `settings.remote.enabled`는 `settings.json`에 저장되는 영속 설정이므로, 한 번 켜면 다음 실행에서도 `/remote/` entry가 열린다.
+
+Remote Access 버튼을 단순 영속 토글로 만들면 사용자가 "지금 한 번만 다른 장치에서 붙기 위해 켠" 경우에도 이후 실행마다 remote 표면이 열린다. 반대로 매번 허용해야 하는 방식만 제공하면 항상 원격 접속이 필요한 사용자에게 불편하다. 따라서 보안 기본값과 반복 사용성을 동시에 만족하려면 두 경로를 분리해야 한다.
+
+적용되는 force:
+
+- Remote 인증 토큰과 IP allowlist를 갖춰도 네트워크 표면을 여는 행위 자체는 명시적이어야 한다([ADR-0013](0013-direct-remote-mode.md)).
+- `settings.json`은 사용자가 의도적으로 선택한 구성이고, "이번 실행 동안만 같은 일회성 권한"은 설정 파일에 저장되지 않아야 한다([ADR-0004](0004-settings-vs-ui-state-separation.md)).
+- remote page, vendor asset, `/remote/v1/*` API는 같은 gate를 사용해야 한다. entry만 열리고 API가 막히거나 그 반대가 되면 안 된다.
+
+## Decision
+
+Remote Access 활성화는 두 경로로 분리한다.
+
+- **이번 실행 동안 허용**: `AppState`의 런타임 상태에만 저장한다. 프로세스가 종료되면 사라지고 `settings.json`에는 기록하지 않는다.
+- **시작 시 자동 허용**: 기존 `settings.remote.enabled`를 사용하며 `settings.json`에 저장한다.
+
+remote의 유효 활성 상태는 `settings.remote.enabled || runtimeRemoteAccess.enabled`로 계산한다. remote 인증 토큰은 기존 `settings.remote.authToken`을 우선 사용하고, 영속 토큰이 비어 있을 때만 런타임 허용 토큰을 사용한다. IP allowlist, Origin 정책, heartbeat timeout은 기존 `settings.remote` 계약을 따른다.
+
+모든 remote entry point(`/remote`, `/remote/`, `/remote/vendor/*`, `/remote/v1/*`)는 유효 설정을 같은 함수로 계산해 접근을 제어한다. 런타임 허용이 꺼지고 영속 허용도 꺼진 경우 기존 controller lease를 해제한다.
+
+## Consequences
+
+- 사용자는 일회성 원격 접속을 허용해도 다음 실행에서 remote 표면이 자동으로 열리지 않는다.
+- 상시 원격 접속이 필요한 사용자는 별도 "시작 시 자동 허용"을 켜야 한다.
+- `settings.json`의 `remote.enabled` 의미는 "시작 시 자동 허용"으로 좁아진다. 런타임 허용 상태는 설정 파일과 세션 영속 대상이 아니다.
+- Remote Access UI는 유효 상태, 런타임 허용, 시작 시 허용을 구분해 보여줘야 한다.
+- remote 접근 제어는 설정만 읽지 않고 `AppState` 런타임 상태도 참조한다. 따라서 remote router/page/asset/middleware는 서버 상태를 주입받아 동일한 계산 함수를 사용해야 한다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ ADR 이 필요한 대표 기준:
 | [0013](0013-direct-remote-mode.md) | 브라우저 원격 접속 — Direct Remote Mode 와 Focused UI | Accepted |
 | [0014](0014-mcp-settings-configuration.md) | MCP 설정 구성 — 에이전트가 settings 를 읽고 쓰는 경로 | Accepted |
 | [0015](0015-remote-terminal-state-ownership.md) | Remote 터미널 상태 소유권 — PTY 전역 상태와 surface 로컬 상태 분리 | Accepted |
+| [0016](0016-remote-access-runtime-vs-startup-enable.md) | Remote Access 활성화 — 런타임 허용과 시작 시 허용 분리 | Accepted |
 
 ## 새 ADR 추가
 

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -33,15 +33,25 @@ UI 다국어는 **react-i18next** 로 구현한다(이슈 #350).
 
 브라우저 원격 접속은 명시적 opt-in 설정이다. 기본값은 꺼짐이며, remote API는 Automation API/MCP의 IP allowlist와 별도 인증/Origin/IP 정책을 사용한다([ADR-0013](../adr/0013-direct-remote-mode.md)).
 
+활성화에는 두 경로가 있다([ADR-0016](../adr/0016-remote-access-runtime-vs-startup-enable.md)).
+
+- **이번 실행 동안 허용**: Remote Access 모달에서 켜는 런타임 상태다. `AppState` 에만 저장되며 앱 종료 시 사라지고 `settings.json` 에 기록하지 않는다.
+- **시작 시 자동 허용**: `settings.remote.enabled` 를 `true` 로 저장하는 영속 설정이다. 다음 실행부터 remote entry 가 처음부터 열린다.
+
+remote 의 실효 활성화 상태는 `settings.remote.enabled || runtimeRemoteAccess.enabled` 로 계산한다. 토큰은 `settings.remote.authToken` 을 우선 사용하고, 이 값이 비어 있을 때만 런타임 허용 토큰을 사용한다. IP allowlist, Origin 정책, heartbeat timeout 은 `settings.remote` 계약을 따른다.
+
+Remote Access 모달은 런타임/영속 활성화와 토큰 표시뿐 아니라 `settings.remote.allowedIps`, `settings.remote.autoMobileModeMinWidth` 편집을 제공한다. 변경 내용은 기존 settings store → `persistSession()` → `save_settings` 경로로 `settings.json` 에 저장된다. 데스크톱 앱 내부의 모바일 모드는 기존 `/remote/` Direct Remote UI를 `localApp=1&autoConnect=1` iframe으로 여는 로컬 전용 표시 모드이며, 외부 브라우저 지원을 새로 의미하지 않는다. 해당 iframe은 remote lease를 잡을 수 있으므로 PC WebView의 remote-control overlay는 로컬 모바일 모드가 활성인 동안 숨긴다.
+
 ```jsonc
 {
   "remote": {
-    "enabled": false,                  // 기본값: 비활성화
+    "enabled": false,                  // 시작 시 자동 허용 여부. 기본값: 비활성화
     "bindAddress": "0.0.0.0",          // 현재 구현은 Automation 서버 listener를 공유
     "allowedOrigins": [],              // 비어 있으면 Origin 필터 없음, 값이 있으면 Origin 일치 검사
     "allowedIps": ["127.0.0.1/32", "::1/128"],
     "authToken": "",                   // enabled=true일 때 필수
-    "heartbeatTimeoutSeconds": 15       // 최소 5초로 clamp
+    "heartbeatTimeoutSeconds": 15,      // 최소 5초로 clamp
+    "autoMobileModeMinWidth": 720       // 앱 창 폭이 이 값 이하이면 Remote Access 모달 자동 표시. 0 = 비활성
   }
 }
 ```
@@ -275,6 +285,7 @@ Bearer 토큰(`key`) 필드는 없다 — 인증은 IP allowlist 미들웨어가
 | POST | `/api/v1/notifications` | 알림 생성 |
 | DELETE | `/api/v1/notifications` | 알림 제거 (`ids` 또는 `before`) |
 | POST | `/api/v1/ui/settings` | 설정 모달 토글 |
+| POST | `/api/v1/ui/remote-access` | Remote Access 모달 토글. `{ "open": true/false }` 로 상태를 강제할 수 있음 |
 | POST | `/api/v1/ui/settings/navigate` | 설정 화면 내비게이션 |
 | PUT | `/api/v1/settings/app-theme` | 앱 테마 설정 |
 | POST | `/api/v1/ui/hide-mode/toggle` | hide 모드 토글 |
@@ -302,6 +313,7 @@ Bearer 토큰(`key`) 필드는 없다 — 인증은 IP allowlist 미들웨어가
 - IP allowlist 미들웨어: loopback, RFC 1918 사설 대역(10.x, 172.16-31.x, 192.168.x), link-local(169.254.x, fe80::)만 허용
 - 인증 헤더 불필요 — 로컬/사설 네트워크 IP 제한만으로 보안 확보 (Chrome DevTools, Jupyter 등과 동일 모델)
 - 외부 공인 IP에서 접근 시 403 Forbidden 반환
+- IP allowlist 거절 응답은 laymux 가 관측한 클라이언트 주소를 포함한다: `{ "error": "... client IP: <ip>", "clientIp": "<ip>" }`
 
 ### 12.7 내장 MCP 서버
 
@@ -518,17 +530,18 @@ Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Dire
 | `/remote/vendor/xterm.js` | GET | `/remote/` 전용 xterm.js 브라우저 빌드 |
 | `/remote/vendor/addon-fit.js` | GET | `/remote/` 전용 xterm fit 애드온 |
 
-`/remote`와 `/remote/`는 remote가 켜져 있고, `remote.authToken`이 설정되어 있으며, remote IP allowlist를 통과할 때 응답한다. 이 HTML 문서 자체는 토큰 값을 요구하지 않지만, 페이지가 호출하는 `/remote/v1/*` 제어 API는 아래 인증 정책을 그대로 따른다. 사용자는 브라우저 주소창에서 `http://<laymux-host>:19280/remote/` 또는 dev의 `:19281/remote/`를 열고 remote token을 입력해 controller lease를 claim한다. 편의를 위해 `/remote/#token=<url-encoded-token>`도 허용하며, 이 값은 remote 페이지의 token 입력란을 미리 채우는 용도다. fragment는 HTTP 요청에 포함되지 않으므로 링크 공유용 prefill에는 query string보다 이 형태를 우선 사용한다.
+`/remote`와 `/remote/`는 remote가 실효적으로 켜져 있고(`settings.remote.enabled || runtimeRemoteAccess.enabled`), 실효 remote token이 있으며, remote IP allowlist를 통과할 때 응답한다. 이 HTML 문서 자체는 토큰 값을 요구하지 않지만, 페이지가 호출하는 `/remote/v1/*` 제어 API는 아래 인증 정책을 그대로 따른다. 사용자는 브라우저 주소창에서 `http://<laymux-host>:19280/remote/` 또는 dev의 `:19281/remote/`를 열고 remote token을 입력해 controller lease를 claim한다. 편의를 위해 `/remote/#token=<url-encoded-token>`도 허용하며, 이 값은 remote 페이지의 token 입력란을 미리 채우는 용도다. fragment는 HTTP 요청에 포함되지 않으므로 링크 공유용 prefill에는 query string보다 이 형태를 우선 사용한다.
 
 현재 브라우저 entry는 Rust remote server가 self-hosted xterm.js 자산을 `/remote/vendor/*`에서 제공하는 중간 구현이다. CDN이나 Vite dev server에 의존하지 않으며, 출력 WebSocket의 PTY byte stream을 xterm에 그대로 기록하고 xterm 입력/resize 이벤트를 Remote UI API로 다시 보낸다. ADR-0013의 최종 목표인 같은 React bundle 기반 Full UI/Focused UI 전환과 `RemoteHttpWsClient` adapter 추출은 후속 리팩터링 대상이다.
 
-`/remote/vendor/*`도 `/remote/`와 같은 base access 조건(`enabled`, `authToken` 존재, IP allowlist)을 통과해야 응답한다. 실제 controller 권한은 vendor asset이 아니라 `/remote/v1/*` API의 bearer token + lease 검사에서 결정된다.
+`/remote/vendor/*`도 `/remote/`와 같은 base access 조건(실효 enabled, 실효 token 존재, IP allowlist)을 통과해야 응답한다. 실제 controller 권한은 vendor asset이 아니라 `/remote/v1/*` API의 bearer token + lease 검사에서 결정된다.
 
 ### 13.1 인증과 접근 제어
 
-- `settings.remote.enabled`가 `true`일 때만 응답한다.
-- `settings.remote.authToken`은 필수다. HTTP 요청은 `Authorization: Bearer <token>` 또는 `X-Laymux-Remote-Token`을 사용할 수 있고, WebSocket은 브라우저 제약 때문에 URL-encoded `?token=<token>`도 허용한다.
+- `settings.remote.enabled` 또는 런타임 remote 허용 상태가 `true`일 때만 응답한다.
+- 실효 remote token은 필수다. `settings.remote.authToken`을 우선 사용하고, 이 값이 비어 있을 때만 런타임 허용 토큰을 사용한다. HTTP 요청은 `Authorization: Bearer <token>` 또는 `X-Laymux-Remote-Token`을 사용할 수 있고, WebSocket은 브라우저 제약 때문에 URL-encoded `?token=<token>`도 허용한다.
 - `settings.remote.allowedIps`는 IP/CIDR allowlist다. 기본값은 loopback only이며 Tailscale 직접 접속은 예를 들어 IPv4 `100.64.0.0/10`, IPv6 `fd7a:115c:a1e0::/48`를 명시해야 한다.
+- remote IP allowlist 거절 응답은 laymux 가 관측한 주소와 현재 allowlist를 포함한다: `{ "error": "... <ip>", "remoteIp": "<ip>", "allowedIps": [...] }`
 - `settings.remote.allowedOrigins`가 비어 있지 않으면 `Origin` 헤더가 존재할 때 정확히 일치해야 한다. 브라우저의 same-origin fetch가 `Origin`을 생략한 경우에 한해 `Sec-Fetch-Site: same-origin`과 `Host`가 허용 origin의 authority와 맞으면 허용한다. 이 예외는 브라우저 호환성용이며 보안 경계는 IP allowlist와 bearer token이다.
 
 ### 13.2 Controller Lease

--- a/src-tauri/src/automation_server/handlers_backend.rs
+++ b/src-tauri/src/automation_server/handlers_backend.rs
@@ -208,6 +208,11 @@ pub async fn api_docs() -> impl IntoResponse {
                 "description": "Toggle the settings modal open/closed."
             },
             {
+                "method": "POST", "path": "/api/v1/ui/remote-access",
+                "description": "Toggle the Remote Access modal open/closed. Pass { open: true } or { open: false } to force a state.",
+                "body": { "open": "boolean (optional)" }
+            },
+            {
                 "method": "POST", "path": "/api/v1/ui/settings/navigate",
                 "description": "Navigate within SettingsView to a section.",
                 "body": { "section": "\"startup\" | \"profile-0\" | \"profile-1\" | \"colorSchemes\" | \"keybindings\"" }

--- a/src-tauri/src/automation_server/handlers_bridge.rs
+++ b/src-tauri/src/automation_server/handlers_bridge.rs
@@ -723,6 +723,26 @@ pub async fn ui_toggle_settings(AxumState(state): AxumState<ServerState>) -> imp
     }
 }
 
+pub async fn ui_remote_access(
+    AxumState(state): AxumState<ServerState>,
+    body: Option<Json<serde_json::Value>>,
+) -> impl IntoResponse {
+    let method = match body
+        .as_ref()
+        .and_then(|Json(value)| value.get("open"))
+        .and_then(|value| value.as_bool())
+    {
+        Some(true) => "openRemoteAccess",
+        Some(false) => "closeRemoteAccess",
+        None => "toggleRemoteAccess",
+    };
+
+    match bridge_request(&state, "action", "ui", method, serde_json::json!({})).await {
+        Ok(data) => (StatusCode::OK, Json(data)),
+        Err(e) => e,
+    }
+}
+
 pub async fn ui_navigate_settings(
     AxumState(state): AxumState<ServerState>,
     Json(body): Json<serde_json::Value>,

--- a/src-tauri/src/automation_server/mod.rs
+++ b/src-tauri/src/automation_server/mod.rs
@@ -30,7 +30,6 @@ use crate::state::AppState;
 
 use handlers_backend::*;
 use handlers_bridge::*;
-use helpers::err_json;
 use mcp_resources::{SharedSubscriptionRegistry, SubscriptionRegistry};
 
 /// Shared state for the axum server.
@@ -154,6 +153,26 @@ fn is_local_ip(ip: &IpAddr) -> bool {
     }
 }
 
+fn observed_client_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(v6) => v6
+            .to_ipv4_mapped()
+            .map(IpAddr::V4)
+            .unwrap_or(IpAddr::V6(v6)),
+        other => other,
+    }
+}
+
+fn ip_allowlist_denied_body(client_ip: IpAddr) -> serde_json::Value {
+    let message = format!(
+        "Access denied: only local/private network connections are allowed; client IP: {client_ip}"
+    );
+    serde_json::json!({
+        "error": message,
+        "clientIp": client_ip.to_string(),
+    })
+}
+
 /// IP allowlist middleware — only permits requests from local/private networks.
 /// Replaces Bearer token auth: since this is localhost/WSL communication,
 /// IP restriction provides equivalent security without key management overhead.
@@ -162,14 +181,13 @@ async fn ip_allowlist_middleware(
     req: Request,
     next: Next,
 ) -> Response {
-    if is_local_ip(&addr.ip()) {
+    let client_ip = observed_client_ip(addr.ip());
+    if is_local_ip(&client_ip) {
         next.run(req).await
     } else {
         (
             StatusCode::FORBIDDEN,
-            Json(err_json(
-                "Access denied: only local/private network connections are allowed",
-            )),
+            Json(ip_allowlist_denied_body(client_ip)),
         )
             .into_response()
     }
@@ -245,6 +263,7 @@ pub fn build_router(state: ServerState, subscriptions: SharedSubscriptionRegistr
             mcp::create_service(state.clone(), subscriptions.clone()),
         )
         .route("/api/v1/ui/settings", post(ui_toggle_settings))
+        .route("/api/v1/ui/remote-access", post(ui_remote_access))
         .route("/api/v1/ui/settings/navigate", post(ui_navigate_settings))
         .route("/api/v1/ui/file-viewer", post(ui_open_file_viewer))
         .route("/api/v1/settings/app-theme", put(settings_set_app_theme))
@@ -273,7 +292,7 @@ pub fn build_router(state: ServerState, subscriptions: SharedSubscriptionRegistr
         .layer(CorsLayer::permissive());
 
     automation_routes
-        .merge(crate::remote_server::build_router())
+        .merge(crate::remote_server::build_router(state.clone()))
         .with_state(state)
 }
 
@@ -337,6 +356,22 @@ mod tests {
         assert!(!is_local_ip(&"::ffff:192.168.1.1".parse().unwrap()));
         // ::ffff:8.8.8.8 → rejected (public)
         assert!(!is_local_ip(&"::ffff:8.8.8.8".parse().unwrap()));
+    }
+
+    #[test]
+    fn ip_allowlist_denied_body_includes_observed_client_ip() {
+        let body = ip_allowlist_denied_body("192.168.1.20".parse().unwrap());
+
+        assert_eq!(body["clientIp"], "192.168.1.20");
+        assert!(body["error"].as_str().unwrap().contains("192.168.1.20"));
+    }
+
+    #[test]
+    fn observed_client_ip_normalizes_ipv4_mapped_ipv6() {
+        assert_eq!(
+            observed_client_ip("::ffff:192.168.1.20".parse().unwrap()).to_string(),
+            "192.168.1.20"
+        );
     }
 
     #[test]

--- a/src-tauri/src/automation_server/types.rs
+++ b/src-tauri/src/automation_server/types.rs
@@ -191,6 +191,7 @@ pub const REGISTERED_ROUTES: &[(&str, &str)] = &[
     ("GET", "/api/v1/layouts"),
     ("POST", "/api/v1/screenshot"),
     ("POST", "/api/v1/ui/settings"),
+    ("POST", "/api/v1/ui/remote-access"),
     ("POST", "/api/v1/ui/settings/navigate"),
     ("POST", "/api/v1/ui/file-viewer"),
     ("PUT", "/api/v1/settings/app-theme"),

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -30,6 +30,23 @@ pub fn get_remote_control_status(
 }
 
 #[tauri::command]
+pub fn get_remote_access_status(
+    state: State<Arc<AppState>>,
+) -> Result<crate::remote_server::RemoteAccessStatus, String> {
+    crate::remote_server::get_remote_access_status(&state)
+}
+
+#[tauri::command]
+pub fn set_remote_runtime_access(
+    enabled: bool,
+    auth_token: Option<String>,
+    state: State<Arc<AppState>>,
+    app: AppHandle,
+) -> Result<crate::remote_server::RemoteAccessStatus, String> {
+    crate::remote_server::set_remote_runtime_access(&state, &app, enabled, auth_token)
+}
+
+#[tauri::command]
 pub fn reclaim_remote_control(
     state: State<Arc<AppState>>,
     app: AppHandle,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -168,6 +168,8 @@ pub fn run() {
             commands::load_settings_validated,
             commands::reset_settings,
             commands::get_settings_path,
+            commands::get_remote_access_status,
+            commands::set_remote_runtime_access,
             commands::get_remote_control_status,
             commands::reclaim_remote_control,
         ])

--- a/src-tauri/src/remote_server/access.rs
+++ b/src-tauri/src/remote_server/access.rs
@@ -1,0 +1,167 @@
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+use crate::constants::EVENT_REMOTE_CONTROL_CHANGED;
+use crate::lock_ext::MutexExt;
+use crate::settings::models::RemoteSettings;
+use crate::state::AppState;
+
+use super::lease::{effective_heartbeat_timeout_seconds, status_from_state};
+
+/// Runtime-only Direct Remote Mode gate. This is intentionally not persisted.
+#[derive(Debug, Clone, Default)]
+pub struct RemoteAccessRuntimeState {
+    pub enabled: bool,
+    pub auth_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteAccessStatus {
+    pub effective_enabled: bool,
+    pub persistent_enabled: bool,
+    pub runtime_enabled: bool,
+    pub auth_token_configured: bool,
+    pub effective_auth_token: String,
+}
+
+pub fn get_remote_access_status(app_state: &AppState) -> Result<RemoteAccessStatus, String> {
+    let persistent = crate::settings::load_settings().remote;
+    let runtime = app_state.remote_access.lock_or_err()?;
+    Ok(status_from_settings(&persistent, &runtime))
+}
+
+pub fn set_remote_runtime_access(
+    app_state: &AppState,
+    app_handle: &AppHandle,
+    enabled: bool,
+    auth_token: Option<String>,
+) -> Result<RemoteAccessStatus, String> {
+    let persistent = crate::settings::load_settings().remote;
+    let token = auth_token
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    if enabled && persistent.auth_token.trim().is_empty() && token.is_none() {
+        return Err("runtime remote access requires a token".into());
+    }
+
+    let status = {
+        let mut runtime = app_state.remote_access.lock_or_err()?;
+        runtime.enabled = enabled;
+        runtime.auth_token = if enabled { token } else { None };
+        status_from_settings(&persistent, &runtime)
+    };
+
+    if !status.effective_enabled || !status.auth_token_configured {
+        clear_remote_control_lease(app_state, app_handle)?;
+    }
+
+    Ok(status)
+}
+
+pub(crate) fn effective_remote_settings(app_state: &AppState) -> Result<RemoteSettings, String> {
+    let mut settings = crate::settings::load_settings().remote;
+    let runtime = app_state.remote_access.lock_or_err()?;
+    apply_runtime_access(&mut settings, &runtime);
+    Ok(settings)
+}
+
+fn status_from_settings(
+    persistent: &RemoteSettings,
+    runtime: &RemoteAccessRuntimeState,
+) -> RemoteAccessStatus {
+    let mut effective = persistent.clone();
+    apply_runtime_access(&mut effective, runtime);
+    RemoteAccessStatus {
+        effective_enabled: effective.enabled,
+        persistent_enabled: persistent.enabled,
+        runtime_enabled: runtime.enabled,
+        auth_token_configured: !effective.auth_token.trim().is_empty(),
+        effective_auth_token: effective.auth_token,
+    }
+}
+
+fn apply_runtime_access(settings: &mut RemoteSettings, runtime: &RemoteAccessRuntimeState) {
+    if !runtime.enabled {
+        return;
+    }
+
+    settings.enabled = true;
+    if settings.auth_token.trim().is_empty() {
+        settings.auth_token = runtime.auth_token.clone().unwrap_or_default();
+    }
+}
+
+fn clear_remote_control_lease(app_state: &AppState, app_handle: &AppHandle) -> Result<(), String> {
+    let status = {
+        let settings = crate::settings::load_settings().remote;
+        let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
+        let mut control = app_state.remote_control.lock_or_err()?;
+        control.lease = None;
+        status_from_state(&control, timeout_seconds)
+    };
+
+    if let Err(err) = app_handle.emit(EVENT_REMOTE_CONTROL_CHANGED, status) {
+        tracing::warn!(error = %err, "failed to emit remote-control-changed");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_access_enables_effective_remote_without_persisting_flag() {
+        let persistent = RemoteSettings::default();
+        let runtime = RemoteAccessRuntimeState {
+            enabled: true,
+            auth_token: Some("runtime-token".into()),
+        };
+
+        let status = status_from_settings(&persistent, &runtime);
+
+        assert!(status.effective_enabled);
+        assert!(!status.persistent_enabled);
+        assert!(status.runtime_enabled);
+        assert_eq!(status.effective_auth_token, "runtime-token");
+    }
+
+    #[test]
+    fn persistent_token_takes_precedence_over_runtime_token() {
+        let persistent = RemoteSettings {
+            enabled: true,
+            auth_token: "persistent-token".into(),
+            ..RemoteSettings::default()
+        };
+        let runtime = RemoteAccessRuntimeState {
+            enabled: true,
+            auth_token: Some("runtime-token".into()),
+        };
+
+        let status = status_from_settings(&persistent, &runtime);
+
+        assert!(status.effective_enabled);
+        assert!(status.persistent_enabled);
+        assert!(status.runtime_enabled);
+        assert_eq!(status.effective_auth_token, "persistent-token");
+    }
+
+    #[test]
+    fn disabled_runtime_does_not_override_persistent_remote() {
+        let persistent = RemoteSettings {
+            enabled: true,
+            auth_token: "persistent-token".into(),
+            ..RemoteSettings::default()
+        };
+        let runtime = RemoteAccessRuntimeState::default();
+
+        let status = status_from_settings(&persistent, &runtime);
+
+        assert!(status.effective_enabled);
+        assert!(status.persistent_enabled);
+        assert!(!status.runtime_enabled);
+    }
+}

--- a/src-tauri/src/remote_server/assets.rs
+++ b/src-tauri/src/remote_server/assets.rs
@@ -1,29 +1,60 @@
 use std::net::SocketAddr;
 
-use axum::extract::ConnectInfo;
+use axum::extract::{ConnectInfo, State};
 use axum::http::header;
 use axum::response::{IntoResponse, Response};
 
+use crate::automation_server::ServerState;
+
+use super::access::effective_remote_settings;
 use super::auth::check_remote_base_access;
+use super::internal_error;
 
 const XTERM_JS: &str = include_str!("assets/xterm.js");
 const XTERM_CSS: &str = include_str!("assets/xterm.css");
 const ADDON_FIT_JS: &str = include_str!("assets/addon-fit.js");
 
-pub(crate) async fn remote_xterm_js(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> Response {
-    remote_asset(addr, XTERM_JS, "application/javascript; charset=utf-8")
+pub(crate) async fn remote_xterm_js(
+    State(server): State<ServerState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    remote_asset(
+        &server,
+        addr,
+        XTERM_JS,
+        "application/javascript; charset=utf-8",
+    )
 }
 
-pub(crate) async fn remote_xterm_css(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> Response {
-    remote_asset(addr, XTERM_CSS, "text/css; charset=utf-8")
+pub(crate) async fn remote_xterm_css(
+    State(server): State<ServerState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    remote_asset(&server, addr, XTERM_CSS, "text/css; charset=utf-8")
 }
 
-pub(crate) async fn remote_addon_fit_js(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> Response {
-    remote_asset(addr, ADDON_FIT_JS, "application/javascript; charset=utf-8")
+pub(crate) async fn remote_addon_fit_js(
+    State(server): State<ServerState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    remote_asset(
+        &server,
+        addr,
+        ADDON_FIT_JS,
+        "application/javascript; charset=utf-8",
+    )
 }
 
-fn remote_asset(addr: SocketAddr, body: &'static str, content_type: &'static str) -> Response {
-    let settings = crate::settings::load_settings().remote;
+fn remote_asset(
+    server: &ServerState,
+    addr: SocketAddr,
+    body: &'static str,
+    content_type: &'static str,
+) -> Response {
+    let settings = match effective_remote_settings(&server.app_state) {
+        Ok(settings) => settings,
+        Err(err) => return internal_error(err),
+    };
     if let Some(response) = check_remote_base_access(&settings, addr) {
         return response;
     }

--- a/src-tauri/src/remote_server/auth.rs
+++ b/src-tauri/src/remote_server/auth.rs
@@ -1,22 +1,30 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
-use axum::extract::{ConnectInfo, Request};
+use axum::extract::{ConnectInfo, Request, State};
 use axum::http::{header, HeaderMap, StatusCode, Uri};
 use axum::middleware::Next;
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
 
 use crate::settings::models::RemoteSettings;
 
-use super::json_error;
+use crate::automation_server::ServerState;
+
+use super::access::effective_remote_settings;
+use super::{internal_error, json_error};
 
 const REMOTE_TOKEN_HEADER: &str = "x-laymux-remote-token";
 
 pub(crate) async fn remote_guard(
+    State(server): State<ServerState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     req: Request,
     next: Next,
 ) -> Response {
-    let settings = crate::settings::load_settings().remote;
+    let settings = match effective_remote_settings(&server.app_state) {
+        Ok(settings) => settings,
+        Err(err) => return internal_error(err),
+    };
 
     if let Some(response) = check_remote_base_access(&settings, addr) {
         return response;
@@ -55,10 +63,18 @@ pub(crate) fn check_remote_base_access(
             allowed_ips = ?settings.allowed_ips,
             "remote client IP denied"
         );
-        return Some(json_error(
-            StatusCode::FORBIDDEN,
-            "remote client IP is not allowed",
-        ));
+        let message = format!("remote client IP is not allowed: {remote_ip}");
+        return Some(
+            (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({
+                    "error": message,
+                    "remoteIp": remote_ip.to_string(),
+                    "allowedIps": &settings.allowed_ips,
+                })),
+            )
+                .into_response(),
+        );
     }
 
     None
@@ -346,6 +362,30 @@ mod tests {
                 .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn remote_base_access_rejects_disallowed_ip_with_observed_ip() {
+        let settings = RemoteSettings {
+            enabled: true,
+            auth_token: "secret".into(),
+            allowed_ips: vec!["127.0.0.1/32".into(), "::1/128".into()],
+            ..RemoteSettings::default()
+        };
+        let response =
+            check_remote_base_access(&settings, "100.100.10.20:1".parse::<SocketAddr>().unwrap())
+                .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        let body = axum::body::to_bytes(response.into_body(), 1_000_000)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(body["remoteIp"], "100.100.10.20");
+        assert_eq!(body["allowedIps"][0], "127.0.0.1/32");
+        assert!(body["error"].as_str().unwrap().contains("100.100.10.20"));
     }
 
     #[test]

--- a/src-tauri/src/remote_server/lease.rs
+++ b/src-tauri/src/remote_server/lease.rs
@@ -10,6 +10,7 @@ use crate::lock_ext::MutexExt;
 use crate::settings::models::RemoteSettings;
 use crate::state::AppState;
 
+use super::access::effective_remote_settings;
 use super::{internal_error, json_error};
 
 const MIN_HEARTBEAT_TIMEOUT_SECONDS: u64 = 5;
@@ -40,9 +41,14 @@ pub struct RemoteControlStatus {
 }
 
 pub fn get_remote_control_status(app_state: &AppState) -> Result<RemoteControlStatus, String> {
-    let settings = crate::settings::load_settings().remote;
+    let settings = effective_remote_settings(app_state)?;
     let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
     let mut current = app_state.remote_control.lock_or_err()?;
+    if !settings.enabled || settings.auth_token.trim().is_empty() {
+        current.lease = None;
+        current.reclaim_lockout_until = None;
+        return Ok(status_from_state(&current, timeout_seconds));
+    }
     prune_expired_lease(&mut current.lease, Duration::from_secs(timeout_seconds));
     prune_expired_reclaim_lockout(&mut current, Instant::now());
     Ok(status_from_state(&current, timeout_seconds))
@@ -52,7 +58,7 @@ pub fn reclaim_remote_control(
     app_state: &AppState,
     app_handle: &AppHandle,
 ) -> Result<RemoteControlStatus, String> {
-    let settings = crate::settings::load_settings().remote;
+    let settings = effective_remote_settings(app_state)?;
     let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
     let status = {
         let mut current = app_state.remote_control.lock_or_err()?;
@@ -168,7 +174,7 @@ pub(crate) fn require_active_lease(
 }
 
 pub(crate) fn active_lease_matches(app_state: &AppState, lease_id: &str) -> Result<bool, String> {
-    let settings = crate::settings::load_settings().remote;
+    let settings = effective_remote_settings(app_state)?;
     let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
     active_lease_matches_with_timeout(app_state, lease_id, Duration::from_secs(timeout_seconds))
 }

--- a/src-tauri/src/remote_server/mod.rs
+++ b/src-tauri/src/remote_server/mod.rs
@@ -1,3 +1,4 @@
+mod access;
 mod appearance;
 mod assets;
 mod auth;
@@ -12,6 +13,10 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 
+pub use access::{
+    get_remote_access_status, set_remote_runtime_access, RemoteAccessRuntimeState,
+    RemoteAccessStatus,
+};
 pub use lease::{
     get_remote_control_status, reclaim_remote_control, RemoteControlLease, RemoteControlState,
     RemoteControlStatus,

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -180,7 +180,8 @@
         display: none !important;
       }
       .menu-button,
-      .drawer-close {
+      .drawer-close,
+      .desktop-mode-button {
         width: 28px;
         height: 24px;
         display: inline-flex;
@@ -192,8 +193,17 @@
         background: transparent;
       }
       .menu-button:hover,
-      .drawer-close:hover {
+      .drawer-close:hover,
+      .desktop-mode-button:hover {
         background: var(--hover-bg);
+      }
+      .desktop-mode-button {
+        width: auto;
+        min-width: 34px;
+        padding: 0 8px;
+        color: var(--accent);
+        font-size: var(--fs-sm);
+        font-weight: 650;
       }
       .menu-button {
         flex-direction: column;
@@ -234,6 +244,12 @@
         color: var(--text-primary);
         font-size: var(--fs-md);
         font-weight: 650;
+      }
+      .drawer-header-actions {
+        display: inline-flex;
+        flex: 0 0 auto;
+        align-items: center;
+        gap: 4px;
       }
       .connection-title {
         color: var(--text-secondary);
@@ -631,6 +647,7 @@
           <span></span>
         </button>
         <div id="status" class="status">Enter the remote token, then connect.</div>
+        <button id="desktopModeHeader" class="desktop-mode-button" type="button" hidden>PC</button>
       </header>
       <main>
         <div class="remote-body">
@@ -638,10 +655,13 @@
           <aside id="navigationPanel" class="navigation-panel" aria-label="Remote navigation">
             <div class="drawer-header">
               <div class="drawer-title">Remote</div>
-              <button id="navClose" class="drawer-close" type="button" aria-label="Close navigation">
-                <span></span>
-                <span></span>
-              </button>
+              <div class="drawer-header-actions">
+                <button id="desktopModeDrawer" class="desktop-mode-button" type="button" hidden>PC</button>
+                <button id="navClose" class="drawer-close" type="button" aria-label="Close navigation">
+                  <span></span>
+                  <span></span>
+                </button>
+              </div>
             </div>
             <section class="connection-panel" aria-label="Remote connection">
               <div class="connection-title">Connection</div>
@@ -680,6 +700,8 @@
         const clientNameInput = $("clientName");
         const navToggleButton = $("navToggle");
         const navCloseButton = $("navClose");
+        const desktopModeHeaderButton = $("desktopModeHeader");
+        const desktopModeDrawerButton = $("desktopModeDrawer");
         const navScrim = $("navScrim");
         const connectButton = $("connect");
         const releaseButton = $("release");
@@ -715,11 +737,18 @@
 
         const hashParams = new URLSearchParams(location.hash.replace(/^#/, ""));
         const searchParams = new URLSearchParams(location.search);
+        const localAppMode = searchParams.get("localApp") === "1" || hashParams.get("localApp") === "1";
+        const autoConnectMode = searchParams.get("autoConnect") === "1" || hashParams.get("autoConnect") === "1";
+        const clientNameFromParams = searchParams.get("clientName") || hashParams.get("clientName");
         tokenInput.value =
           hashParams.get("token") ||
           searchParams.get("token") ||
           localStorage.getItem(tokenKey) ||
           "";
+        if (clientNameFromParams) clientNameInput.value = clientNameFromParams;
+        document.querySelector(".app").classList.toggle("local-app", localAppMode);
+        desktopModeHeaderButton.hidden = !localAppMode;
+        desktopModeDrawerButton.hidden = !localAppMode;
 
         const defaultAppearance = Object.freeze({
           fontFamily: "'Cascadia Mono', 'Cascadia Mono', 'Consolas', monospace",
@@ -1547,6 +1576,15 @@
           });
         }
 
+        async function requestDesktopMode() {
+          const currentLease = leaseId;
+          if (currentLease) {
+            await releaseLease(currentLease).catch(() => {});
+            disconnect(false);
+          }
+          window.parent.postMessage({ type: "laymux:desktop-mode" }, "*");
+        }
+
         function disconnect(clearStatus = true) {
           stopSocket();
           stopHeartbeat();
@@ -1585,8 +1623,13 @@
         releaseButton.addEventListener("click", () => release().catch((err) => setStatus(`Release failed: ${err.message}`, true)));
         refreshButton.addEventListener("click", () => loadNavigation().catch((err) => setStatus(err.message, true)));
         copySelectionButton.addEventListener("click", () => copySelectionToClipboard());
+        desktopModeHeaderButton.addEventListener("click", () => requestDesktopMode().catch((err) => setStatus(err.message, true)));
+        desktopModeDrawerButton.addEventListener("click", () => requestDesktopMode().catch((err) => setStatus(err.message, true)));
         ctrlCButton.addEventListener("click", () => enqueueInput("\x03"));
         focusTerminalButton.addEventListener("click", () => terminal && terminal.focus());
+        if (localAppMode && autoConnectMode && token()) {
+          setTimeout(() => connect().catch((err) => setStatus(err.message, true)), 0);
+        }
         window.addEventListener("beforeunload", () => {
           stopSocket();
           stopHeartbeat();

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -1,12 +1,22 @@
 use std::net::SocketAddr;
 
-use axum::extract::ConnectInfo;
+use axum::extract::{ConnectInfo, State};
 use axum::response::{Html, IntoResponse, Redirect, Response};
 
-use super::auth::check_remote_base_access;
+use crate::automation_server::ServerState;
 
-pub(crate) async fn remote_page_redirect(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> Response {
-    let settings = crate::settings::load_settings().remote;
+use super::access::effective_remote_settings;
+use super::auth::check_remote_base_access;
+use super::internal_error;
+
+pub(crate) async fn remote_page_redirect(
+    State(server): State<ServerState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    let settings = match effective_remote_settings(&server.app_state) {
+        Ok(settings) => settings,
+        Err(err) => return internal_error(err),
+    };
     if let Some(response) = check_remote_base_access(&settings, addr) {
         return response;
     }
@@ -14,8 +24,14 @@ pub(crate) async fn remote_page_redirect(ConnectInfo(addr): ConnectInfo<SocketAd
     Redirect::temporary("/remote/").into_response()
 }
 
-pub(crate) async fn remote_page(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> Response {
-    let settings = crate::settings::load_settings().remote;
+pub(crate) async fn remote_page(
+    State(server): State<ServerState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Response {
+    let settings = match effective_remote_settings(&server.app_state) {
+        Ok(settings) => settings,
+        Err(err) => return internal_error(err),
+    };
     if let Some(response) = check_remote_base_access(&settings, addr) {
         return response;
     }
@@ -62,6 +78,15 @@ mod tests {
         assert!(html.contains("function scheduleTerminalFit(sendResize = true)"));
         assert!(html.contains("function scheduleTerminalRefresh()"));
         assert!(html.contains("function loseRemoteControl(message)"));
+        assert!(html.contains("id=\"desktopModeHeader\""));
+        assert!(html.contains("id=\"desktopModeDrawer\""));
+        assert!(html.contains("const localAppMode ="));
+        assert!(html.contains("const autoConnectMode ="));
+        assert!(html.contains("clientNameInput.value = clientNameFromParams"));
+        assert!(html.contains("function requestDesktopMode()"));
+        assert!(
+            html.contains("window.parent.postMessage({ type: \"laymux:desktop-mode\" }, \"*\")")
+        );
         assert!(html.contains("location.hash.replace"));
         assert!(html.contains("const lostLeaseId = leaseId"));
         assert!(html.contains("releaseLease(lostLeaseId).catch(() => {})"));

--- a/src-tauri/src/remote_server/routes.rs
+++ b/src-tauri/src/remote_server/routes.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 use crate::automation_server::ServerState;
 use crate::lock_ext::MutexExt;
 
+use super::access::effective_remote_settings;
 use super::assets::{remote_addon_fit_js, remote_xterm_css, remote_xterm_js};
 use super::auth::remote_guard;
 use super::lease::{
@@ -67,7 +68,7 @@ struct RemoteQuery {
     lease_id: Option<String>,
 }
 
-pub fn build_router() -> Router<ServerState> {
+pub fn build_router(state: ServerState) -> Router<ServerState> {
     let api_routes = Router::new()
         .route("/remote/v1/health", get(remote_health))
         .route("/remote/v1/session/status", get(remote_session_status))
@@ -99,7 +100,7 @@ pub fn build_router() -> Router<ServerState> {
             "/remote/v1/terminals/{id}/output",
             get(remote_terminal_output_ws),
         )
-        .layer(middleware::from_fn(remote_guard))
+        .layer(middleware::from_fn_with_state(state.clone(), remote_guard))
         .layer(CorsLayer::permissive());
 
     Router::new()
@@ -131,7 +132,10 @@ async fn remote_session_claim(
     ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
     Json(body): Json<ClaimRequest>,
 ) -> Response {
-    let settings = crate::settings::load_settings().remote;
+    let settings = match effective_remote_settings(&server.app_state) {
+        Ok(settings) => settings,
+        Err(err) => return internal_error(err),
+    };
     let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
     let status = {
         let mut current = match server.app_state.remote_control.lock_or_err() {
@@ -170,7 +174,10 @@ async fn remote_session_heartbeat(
     State(server): State<ServerState>,
     Json(body): Json<LeaseRequest>,
 ) -> Response {
-    let settings = crate::settings::load_settings().remote;
+    let settings = match effective_remote_settings(&server.app_state) {
+        Ok(settings) => settings,
+        Err(err) => return internal_error(err),
+    };
     let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
     let status = {
         let mut current = match server.app_state.remote_control.lock_or_err() {
@@ -200,7 +207,10 @@ async fn remote_session_release(
     State(server): State<ServerState>,
     Json(body): Json<LeaseRequest>,
 ) -> Response {
-    let settings = crate::settings::load_settings().remote;
+    let settings = match effective_remote_settings(&server.app_state) {
+        Ok(settings) => settings,
+        Err(err) => return internal_error(err),
+    };
     let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
     let status = {
         let mut current = match server.app_state.remote_control.lock_or_err() {
@@ -320,7 +330,10 @@ async fn remote_terminal_output_ws(
     if let Err(response) = require_active_lease(&server.app_state, Some(&lease_id)) {
         return response;
     }
-    let settings = crate::settings::load_settings().remote;
+    let settings = match effective_remote_settings(&server.app_state) {
+        Ok(settings) => settings,
+        Err(err) => return internal_error(err),
+    };
     let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
 
     ws.on_upgrade(move |socket| {

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -252,13 +252,15 @@ mod tests {
         assert!(!legacy.remote.enabled);
         assert_eq!(legacy.remote.allowed_ips, vec!["127.0.0.1/32", "::1/128"]);
         assert_eq!(legacy.remote.heartbeat_timeout_seconds, 15);
+        assert_eq!(legacy.remote.auto_mobile_mode_min_width, 720);
 
         let json = r#"{
           "remote": {
             "enabled": true,
             "allowedIps": ["100.64.0.0/10"],
             "authToken": "secret",
-            "heartbeatTimeoutSeconds": 30
+            "heartbeatTimeoutSeconds": 30,
+            "autoMobileModeMinWidth": 640
           }
         }"#;
         let settings: Settings = serde_json::from_str(json).unwrap();
@@ -266,11 +268,13 @@ mod tests {
         assert_eq!(settings.remote.allowed_ips, vec!["100.64.0.0/10"]);
         assert_eq!(settings.remote.auth_token, "secret");
         assert_eq!(settings.remote.heartbeat_timeout_seconds, 30);
+        assert_eq!(settings.remote.auto_mobile_mode_min_width, 640);
 
         let serialized = serde_json::to_string(&settings).unwrap();
         assert!(serialized.contains("\"remote\""));
         assert!(serialized.contains("\"allowedIps\":[\"100.64.0.0/10\"]"));
         assert!(serialized.contains("\"authToken\":\"secret\""));
+        assert!(serialized.contains("\"autoMobileModeMinWidth\":640"));
     }
 
     #[test]

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -986,6 +986,9 @@ pub struct RemoteSettings {
     /// Seconds before an inactive remote controller lease expires.
     #[serde(default = "default_remote_heartbeat_timeout_seconds")]
     pub heartbeat_timeout_seconds: u64,
+    /// App window width at or below which the Remote Access modal opens automatically. 0 disables.
+    #[serde(default = "default_remote_auto_mobile_mode_min_width")]
+    pub auto_mobile_mode_min_width: u32,
 }
 
 fn default_remote_bind_address() -> String {
@@ -1000,6 +1003,10 @@ fn default_remote_heartbeat_timeout_seconds() -> u64 {
     15
 }
 
+fn default_remote_auto_mobile_mode_min_width() -> u32 {
+    720
+}
+
 impl Default for RemoteSettings {
     fn default() -> Self {
         Self {
@@ -1009,6 +1016,7 @@ impl Default for RemoteSettings {
             allowed_ips: default_remote_allowed_ips(),
             auth_token: String::new(),
             heartbeat_timeout_seconds: default_remote_heartbeat_timeout_seconds(),
+            auto_mobile_mode_min_width: default_remote_auto_mobile_mode_min_width(),
         }
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -23,7 +23,8 @@ use crate::terminal::{SyncGroup, TerminalNotification, TerminalSession};
 /// 8. `sync_groups`
 /// 9. `propagated_terminals`
 /// 10. `pty_handles` / `automation_channels` / `automation_port` / `ipc_socket_path`
-/// 11. `remote_control`
+/// 11. `remote_access`
+/// 12. `remote_control`
 ///
 /// Never acquire a higher-numbered lock while holding a lower-numbered one.
 pub struct AppState {
@@ -72,6 +73,8 @@ pub struct AppState {
     pub notifications: Arc<Mutex<Vec<TerminalNotification>>>,
     /// Auto-incrementing counter for notification IDs.
     pub notification_counter: AtomicU64,
+    /// Runtime-only Direct Remote Mode access gate, separate from persisted settings.
+    pub remote_access: Mutex<crate::remote_server::RemoteAccessRuntimeState>,
     /// Current Direct Remote Mode controller lease plus local reclaim lockout state.
     pub remote_control: Mutex<crate::remote_server::RemoteControlState>,
 }
@@ -93,6 +96,7 @@ impl AppState {
             recently_exited_interactive_app: Arc::new(Mutex::new(HashMap::new())),
             notifications: Arc::new(Mutex::new(Vec::new())),
             notification_counter: AtomicU64::new(1),
+            remote_access: Mutex::new(crate::remote_server::RemoteAccessRuntimeState::default()),
             remote_control: Mutex::new(crate::remote_server::RemoteControlState::default()),
         }
     }
@@ -169,6 +173,10 @@ mod tests {
     #[test]
     fn remote_control_starts_empty() {
         let state = AppState::new();
+        let access = state.remote_access.lock().unwrap();
+        assert!(!access.enabled);
+        assert!(access.auth_token.is_none());
+        drop(access);
         let remote = state.remote_control.lock().unwrap();
         assert!(remote.lease.is_none());
         assert!(remote.reclaim_lockout_until.is_none());

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import { App } from "./App";
+import { loadSettingsValidated } from "@/lib/tauri-api";
 import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useUiStore } from "@/stores/ui-store";
@@ -123,11 +124,32 @@ vi.mock("@/lib/tauri-api", () => {
   };
 });
 
+function loadedSettings(remote?: Partial<ReturnType<typeof useSettingsStore.getState>["remote"]>) {
+  return {
+    defaultProfile: "PowerShell",
+    profiles: [],
+    colorSchemes: [],
+    keybindings: [],
+    layouts: [],
+    workspaces: [],
+    docks: [],
+    remote: {
+      ...useSettingsStore.getInitialState().remote,
+      ...remote,
+    },
+  };
+}
+
 describe("App", () => {
   beforeEach(() => {
     useSettingsStore.setState(useSettingsStore.getInitialState());
     useUiStore.setState(useUiStore.getInitialState());
     useLocalMobileModeStore.setState(useLocalMobileModeStore.getInitialState());
+    vi.mocked(loadSettingsValidated).mockResolvedValue({
+      status: "ok",
+      settings: loadedSettings(),
+      warnings: [],
+    });
     Object.defineProperty(window, "innerWidth", {
       value: 1200,
       configurable: true,
@@ -147,5 +169,23 @@ describe("App", () => {
     // After settings load (async), workspace area appears
     await screen.findByTestId("workspace-area", {}, { timeout: 3000 });
     expect(screen.getByTestId("workspace-area")).toBeInTheDocument();
+  });
+
+  it("does not auto-open Remote Access before disabled loaded settings hydrate", async () => {
+    vi.mocked(loadSettingsValidated).mockResolvedValueOnce({
+      status: "ok",
+      settings: loadedSettings({ autoMobileModeMinWidth: 0 }),
+      warnings: [],
+    });
+    Object.defineProperty(window, "innerWidth", {
+      value: 320,
+      configurable: true,
+    });
+
+    render(<App />);
+
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+    await screen.findByTestId("workspace-area", {}, { timeout: 3000 });
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
   });
 });

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { App } from "./App";
+import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useUiStore } from "@/stores/ui-store";
 
 // Mock @tauri-apps/api/window for useWindowGeometry hook
 vi.mock("@tauri-apps/api/window", () => {
@@ -98,6 +101,21 @@ vi.mock("@/lib/tauri-api", () => {
     onTerminalTitleChanged: vi.fn().mockResolvedValue(unlisten),
     markClaudeTerminal: vi.fn().mockResolvedValue(true),
     onTerminalOutputActivity: vi.fn().mockResolvedValue(unlisten),
+    getRemoteControlStatus: vi.fn().mockResolvedValue({
+      active: false,
+      leaseId: null,
+      remoteAddr: null,
+      clientName: null,
+      heartbeatTimeoutSeconds: 15,
+    }),
+    onRemoteControlChanged: vi.fn().mockResolvedValue(unlisten),
+    reclaimRemoteControl: vi.fn().mockResolvedValue({
+      active: false,
+      leaseId: null,
+      remoteAddr: null,
+      clientName: null,
+      heartbeatTimeoutSeconds: 15,
+    }),
     getTerminalStates: vi.fn().mockResolvedValue({}),
     cleanTerminalOutputCache: vi.fn().mockResolvedValue(undefined),
     loadWindowGeometry: vi.fn().mockResolvedValue(null),
@@ -106,6 +124,16 @@ vi.mock("@/lib/tauri-api", () => {
 });
 
 describe("App", () => {
+  beforeEach(() => {
+    useSettingsStore.setState(useSettingsStore.getInitialState());
+    useUiStore.setState(useUiStore.getInitialState());
+    useLocalMobileModeStore.setState(useLocalMobileModeStore.getInitialState());
+    Object.defineProperty(window, "innerWidth", {
+      value: 1200,
+      configurable: true,
+    });
+  });
+
   it("renders the app root", () => {
     render(<App />);
     expect(screen.getByTestId("app-root")).toBeInTheDocument();

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -13,6 +13,9 @@ import { SettingsRecoveryModal } from "@/components/views/SettingsRecoveryModal"
 import { closeTerminalSession } from "@/lib/tauri-api";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { RemoteControlOverlay } from "@/components/layout/RemoteControlOverlay";
+import { LocalMobileModeOverlay } from "@/components/layout/LocalMobileModeOverlay";
+import { useAutoRemoteAccessPrompt } from "@/hooks/useAutoRemoteAccessPrompt";
+import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
 
 export function App() {
   useKeyboardShortcuts();
@@ -22,6 +25,8 @@ export function App() {
   useWindowGeometry();
   useAppFocus();
   useLanguageSync();
+  useAutoRemoteAccessPrompt();
+  const localMobileModeActive = useLocalMobileModeStore((state) => state.active);
 
   const [recoveryDismissed, setRecoveryDismissed] = useState(false);
 
@@ -111,7 +116,8 @@ export function App() {
           }}
         />
       )}
-      <RemoteControlOverlay />
+      <LocalMobileModeOverlay />
+      {!localMobileModeActive && <RemoteControlOverlay />}
     </div>
   );
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -25,7 +25,7 @@ export function App() {
   useWindowGeometry();
   useAppFocus();
   useLanguageSync();
-  useAutoRemoteAccessPrompt();
+  useAutoRemoteAccessPrompt(loaded);
   const localMobileModeActive = useLocalMobileModeStore((state) => state.active);
 
   const [recoveryDismissed, setRecoveryDismissed] = useState(false);

--- a/ui/src/components/layout/AppLayout.test.tsx
+++ b/ui/src/components/layout/AppLayout.test.tsx
@@ -100,6 +100,13 @@ describe("AppLayout", () => {
     expect(screen.getByTestId("settings-modal")).toBeInTheDocument();
   });
 
+  it("exposes modal overlays as blocking dialogs", () => {
+    useUiStore.getState().openSettingsModal();
+    render(<AppLayout />);
+    const dialog = screen.getByRole("dialog", { name: "Settings" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
   it("closes settings modal when backdrop is clicked", async () => {
     const user = userEvent.setup();
     useUiStore.getState().openSettingsModal();

--- a/ui/src/components/layout/AppLayout.tsx
+++ b/ui/src/components/layout/AppLayout.tsx
@@ -56,6 +56,9 @@ function ModalOverlay({
         onClick={onClose}
       />
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
         className={`relative z-10 flex flex-col overflow-hidden rounded-lg shadow-2xl ${margin} ${size}`}
         style={{
           background: "var(--bg-surface, #181825)",

--- a/ui/src/components/layout/GridEditToolbar.test.tsx
+++ b/ui/src/components/layout/GridEditToolbar.test.tsx
@@ -10,12 +10,14 @@ import { GridEditToolbar } from "./GridEditToolbar";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useDockStore } from "@/stores/dock-store";
 import { useFileViewerStore } from "@/stores/file-viewer-store";
+import { useRemoteAccessStore } from "@/stores/remote-access-store";
 
 describe("GridEditToolbar", () => {
   beforeEach(() => {
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
     useDockStore.setState(useDockStore.getInitialState());
     useFileViewerStore.setState(useFileViewerStore.getInitialState());
+    useRemoteAccessStore.setState(useRemoteAccessStore.getInitialState());
   });
 
   it("always shows export action buttons", () => {

--- a/ui/src/components/layout/GridEditToolbar.tsx
+++ b/ui/src/components/layout/GridEditToolbar.tsx
@@ -4,6 +4,7 @@ import { useDockStore } from "@/stores/dock-store";
 import { useUiStore } from "@/stores/ui-store";
 import { useFileViewerStore } from "@/stores/file-viewer-store";
 import { useSettingsStore } from "@/stores/settings-store";
+import { useRemoteAccessStore } from "@/stores/remote-access-store";
 import type { DockPosition } from "@/stores/types";
 import logoSvg from "@/assets/logo.svg";
 
@@ -19,6 +20,7 @@ export function GridEditToolbar() {
   const toggleRemoteAccessModal = useUiStore((s) => s.toggleRemoteAccessModal);
   const openEmptyFileViewer = useFileViewerStore((s) => s.openEmptyFileViewer);
   const remote = useSettingsStore((s) => s.remote);
+  const remoteAccessStatus = useRemoteAccessStore((s) => s.status);
   const docks = useDockStore((s) => s.docks);
   const toggleDockVisible = useDockStore((s) => s.toggleDockVisible);
   const layoutMode = useDockStore((s) => s.layoutMode);
@@ -26,13 +28,15 @@ export function GridEditToolbar() {
 
   const [maximized, setMaximized] = useState(false);
   const [showSaved, setShowSaved] = useState(false);
-  const remoteTokenConfigured = remote.authToken.trim().length > 0;
-  const remoteButtonColor = remote.enabled
+  const remoteEnabled = remoteAccessStatus?.effectiveEnabled ?? remote.enabled;
+  const remoteTokenConfigured =
+    remoteAccessStatus?.authTokenConfigured ?? remote.authToken.trim().length > 0;
+  const remoteButtonColor = remoteEnabled
     ? remoteTokenConfigured
       ? "var(--accent)"
       : "var(--claude)"
     : "var(--text-secondary)";
-  const remoteButtonTitle = remote.enabled
+  const remoteButtonTitle = remoteEnabled
     ? remoteTokenConfigured
       ? "Remote Access"
       : "Remote Access (token missing)"
@@ -235,7 +239,7 @@ export function GridEditToolbar() {
             border: "none",
             fontFamily: "'Segoe Fluent Icons', 'Segoe MDL2 Assets'",
             fontSize: "var(--fs-xs)",
-            opacity: remote.enabled ? 1 : 0.65,
+            opacity: remoteEnabled ? 1 : 0.65,
           }}
           title={remoteButtonTitle}
           aria-label="Remote Access"

--- a/ui/src/components/layout/LocalMobileModeOverlay.test.tsx
+++ b/ui/src/components/layout/LocalMobileModeOverlay.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
+import { LocalMobileModeOverlay } from "./LocalMobileModeOverlay";
+
+describe("LocalMobileModeOverlay", () => {
+  beforeEach(() => {
+    useLocalMobileModeStore.setState(useLocalMobileModeStore.getInitialState());
+  });
+
+  it("renders the local remote page in a full-screen frame", () => {
+    useLocalMobileModeStore.getState().enter("http://127.0.0.1:19281/remote/?localApp=1");
+
+    render(<LocalMobileModeOverlay />);
+
+    const frame = screen.getByTestId("local-mobile-mode-frame");
+    expect(screen.getByTestId("local-mobile-mode-overlay")).toBeInTheDocument();
+    expect(frame).toHaveAttribute("src", "http://127.0.0.1:19281/remote/?localApp=1");
+  });
+
+  it("exits when the remote page requests desktop mode", async () => {
+    useLocalMobileModeStore.getState().enter("http://127.0.0.1:19281/remote/?localApp=1");
+
+    render(<LocalMobileModeOverlay />);
+
+    window.dispatchEvent(new MessageEvent("message", { data: { type: "laymux:desktop-mode" } }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("local-mobile-mode-overlay")).not.toBeInTheDocument();
+    });
+    expect(useLocalMobileModeStore.getState().active).toBe(false);
+  });
+});

--- a/ui/src/components/layout/LocalMobileModeOverlay.tsx
+++ b/ui/src/components/layout/LocalMobileModeOverlay.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
+
+export function LocalMobileModeOverlay() {
+  const active = useLocalMobileModeStore((state) => state.active);
+  const url = useLocalMobileModeStore((state) => state.url);
+  const exit = useLocalMobileModeStore((state) => state.exit);
+
+  useEffect(() => {
+    if (!active) return;
+
+    const handleMessage = (event: MessageEvent) => {
+      if ((event.data as { type?: string } | null)?.type === "laymux:desktop-mode") {
+        exit();
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [active, exit]);
+
+  if (!active || !url) return null;
+
+  return (
+    <div className="local-mobile-mode-overlay" data-testid="local-mobile-mode-overlay">
+      <iframe
+        className="local-mobile-mode-frame"
+        data-testid="local-mobile-mode-frame"
+        title="Laymux mobile mode"
+        src={url}
+      />
+    </div>
+  );
+}

--- a/ui/src/components/layout/RemoteControlOverlay.test.tsx
+++ b/ui/src/components/layout/RemoteControlOverlay.test.tsx
@@ -14,24 +14,28 @@ vi.mock("@/lib/tauri-api", () => ({
   reclaimRemoteControl: api.reclaimRemoteControl,
 }));
 
-import { useSettingsStore } from "@/stores/settings-store";
 import { RemoteControlOverlay } from "./RemoteControlOverlay";
 
 describe("RemoteControlOverlay", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useSettingsStore.getState().setRemote({ enabled: true });
     api.onRemoteControlChanged.mockResolvedValue(() => {});
   });
 
-  it("does not poll while direct remote mode is disabled", async () => {
-    useSettingsStore.getState().setRemote({ enabled: false });
+  it("subscribes to remote control changes", async () => {
+    api.getRemoteControlStatus.mockResolvedValue({
+      active: false,
+      leaseId: null,
+      remoteAddr: null,
+      clientName: null,
+      heartbeatTimeoutSeconds: 15,
+    });
 
     render(<RemoteControlOverlay />);
     await Promise.resolve();
 
-    expect(api.getRemoteControlStatus).not.toHaveBeenCalled();
-    expect(api.onRemoteControlChanged).not.toHaveBeenCalled();
+    expect(api.getRemoteControlStatus).toHaveBeenCalledTimes(1);
+    expect(api.onRemoteControlChanged).toHaveBeenCalledTimes(1);
   });
 
   it("renders while a remote controller is active", async () => {

--- a/ui/src/components/layout/RemoteControlOverlay.tsx
+++ b/ui/src/components/layout/RemoteControlOverlay.tsx
@@ -5,24 +5,17 @@ import {
   reclaimRemoteControl,
   type RemoteControlStatus,
 } from "@/lib/tauri-api";
-import { useSettingsStore } from "@/stores/settings-store";
 import { useTranslation } from "react-i18next";
 
 const STATUS_POLL_MS = 3000;
 
 export function RemoteControlOverlay() {
   const { t } = useTranslation("common");
-  const remoteEnabled = useSettingsStore((state) => state.remote.enabled);
   const [status, setStatus] = useState<RemoteControlStatus | null>(null);
   const [reclaiming, setReclaiming] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!remoteEnabled) {
-      setStatus(null);
-      return;
-    }
-
     let cancelled = false;
     let unlisten: (() => void) | undefined;
 
@@ -49,10 +42,10 @@ export function RemoteControlOverlay() {
       cancelled = true;
       unlisten?.();
     };
-  }, [remoteEnabled]);
+  }, []);
 
   useEffect(() => {
-    if (!remoteEnabled || !status?.active) return;
+    if (!status?.active) return;
 
     let cancelled = false;
     const refresh = () => {
@@ -70,7 +63,7 @@ export function RemoteControlOverlay() {
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [remoteEnabled, status?.active]);
+  }, [status?.active]);
 
   useEffect(() => {
     if (!status?.active) return;

--- a/ui/src/components/views/RemoteAccessModal.test.tsx
+++ b/ui/src/components/views/RemoteAccessModal.test.tsx
@@ -7,8 +7,16 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
+vi.mock("@/lib/persist-session", () => ({
+  persistSession: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { useSettingsStore } from "@/stores/settings-store";
-import { RemoteAccessModal } from "./RemoteAccessModal";
+import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
+import { useRemoteAccessStore } from "@/stores/remote-access-store";
+import { useUiStore } from "@/stores/ui-store";
+import { persistSession } from "@/lib/persist-session";
+import { buildLocalMobileModeUrl, RemoteAccessModal } from "./RemoteAccessModal";
 
 function setRemote(remote: Partial<ReturnType<typeof useSettingsStore.getState>["remote"]>) {
   useSettingsStore.getState().setRemote({
@@ -18,12 +26,26 @@ function setRemote(remote: Partial<ReturnType<typeof useSettingsStore.getState>[
     allowedIps: ["127.0.0.1/32", "::1/128"],
     authToken: "",
     heartbeatTimeoutSeconds: 15,
+    autoMobileModeMinWidth: 720,
     ...remote,
   });
 }
 
 describe("RemoteAccessModal", () => {
   const writeText = vi.fn().mockResolvedValue(undefined);
+  const mockPersistSession = vi.mocked(persistSession);
+
+  const accessStatus = (runtimeEnabled = false) => {
+    const remote = useSettingsStore.getState().remote;
+    const token = remote.authToken || (runtimeEnabled ? "runtime-token" : "");
+    return {
+      effectiveEnabled: remote.enabled || runtimeEnabled,
+      persistentEnabled: remote.enabled,
+      runtimeEnabled,
+      authTokenConfigured: token.length > 0,
+      effectiveAuthToken: token,
+    };
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -33,6 +55,8 @@ describe("RemoteAccessModal", () => {
     });
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === "get_automation_info") return Promise.resolve({ port: 19281 });
+      if (cmd === "get_remote_access_status") return Promise.resolve(accessStatus());
+      if (cmd === "set_remote_runtime_access") return Promise.resolve(accessStatus(false));
       if (cmd === "get_remote_control_status") {
         return Promise.resolve({ active: false, heartbeatTimeoutSeconds: 15 });
       }
@@ -42,9 +66,12 @@ describe("RemoteAccessModal", () => {
       return Promise.resolve(null);
     });
     setRemote({});
+    useRemoteAccessStore.setState(useRemoteAccessStore.getInitialState());
+    useLocalMobileModeStore.setState(useLocalMobileModeStore.getInitialState());
+    useUiStore.setState(useUiStore.getInitialState());
   });
 
-  it("renders only the token URL and token fields", async () => {
+  it("renders remote state, token URL, and token fields", async () => {
     setRemote({ enabled: true, authToken: "secret", allowedIps: ["100.64.0.0/10"] });
 
     render(<RemoteAccessModal />);
@@ -56,9 +83,38 @@ describe("RemoteAccessModal", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("secret")).toBeInTheDocument();
     expect(screen.queryByText(/LX_AUTOMATION_/)).not.toBeInTheDocument();
-    expect(screen.queryByText("Allowed IPs")).not.toBeInTheDocument();
+    expect(screen.getByText("Allowed IPs")).toBeInTheDocument();
+    expect(screen.getByTestId("remote-allowed-ips-input")).toHaveValue("100.64.0.0/10");
     expect(screen.queryByText("Controller")).not.toBeInTheDocument();
     expect(screen.queryByText("Local URL")).not.toBeInTheDocument();
+  });
+
+  it("opens the PC app itself in local mobile mode", async () => {
+    setRemote({ enabled: true, authToken: "secret" });
+
+    render(<RemoteAccessModal />);
+
+    await screen.findByText("http://<laymux-host>:19281/remote/#token=secret");
+    await userEvent.click(screen.getByTestId("remote-mobile-mode-open"));
+
+    expect(useLocalMobileModeStore.getState().active).toBe(true);
+    expect(useLocalMobileModeStore.getState().url).toBe(buildLocalMobileModeUrl(19281, "secret"));
+    expect(mockInvoke.mock.calls.some(([cmd]) => cmd === "set_remote_runtime_access")).toBe(false);
+  });
+
+  it("enables runtime remote access before opening local mobile mode when needed", async () => {
+    setRemote({ enabled: false, authToken: "secret" });
+
+    render(<RemoteAccessModal />);
+
+    await screen.findByText("http://<laymux-host>:19281/remote/#token=secret");
+    await userEvent.click(screen.getByTestId("remote-mobile-mode-open"));
+
+    expect(mockInvoke).toHaveBeenCalledWith("set_remote_runtime_access", {
+      enabled: true,
+      authToken: "secret",
+    });
+    expect(useLocalMobileModeStore.getState().url).toBe(buildLocalMobileModeUrl(19281, "secret"));
   });
 
   it("copies the token URL and token", async () => {
@@ -79,6 +135,8 @@ describe("RemoteAccessModal", () => {
   it("offers host control reclaim when a remote controller owns the lease", async () => {
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === "get_automation_info") return Promise.resolve({ port: 19281 });
+      if (cmd === "get_remote_access_status") return Promise.resolve(accessStatus());
+      if (cmd === "set_remote_runtime_access") return Promise.resolve(accessStatus(false));
       if (cmd === "get_remote_control_status") {
         return Promise.resolve({ active: true, heartbeatTimeoutSeconds: 15 });
       }
@@ -97,6 +155,100 @@ describe("RemoteAccessModal", () => {
     expect(mockInvoke).toHaveBeenCalledWith("reclaim_remote_control");
     await vi.waitFor(() => {
       expect(screen.queryByTestId("remote-access-reclaim")).not.toBeInTheDocument();
+    });
+  });
+
+  it("enables remote for this run without persisting settings", async () => {
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "get_automation_info") return Promise.resolve({ port: 19281 });
+      if (cmd === "get_remote_access_status") return Promise.resolve(accessStatus(false));
+      if (cmd === "set_remote_runtime_access") {
+        return Promise.resolve({
+          effectiveEnabled: Boolean(args?.enabled),
+          persistentEnabled: false,
+          runtimeEnabled: Boolean(args?.enabled),
+          authTokenConfigured: true,
+          effectiveAuthToken: String(args?.authToken ?? "runtime-token"),
+        });
+      }
+      if (cmd === "get_remote_control_status") {
+        return Promise.resolve({ active: false, heartbeatTimeoutSeconds: 15 });
+      }
+      return Promise.resolve(null);
+    });
+
+    render(<RemoteAccessModal />);
+
+    await userEvent.click(await screen.findByTestId("remote-runtime-toggle"));
+
+    expect(mockInvoke).toHaveBeenCalledWith(
+      "set_remote_runtime_access",
+      expect.objectContaining({ enabled: true, authToken: expect.any(String) }),
+    );
+    expect(mockPersistSession).not.toHaveBeenCalled();
+    expect(useSettingsStore.getState().remote.enabled).toBe(false);
+  });
+
+  it("persists edited remote allowed IPs", async () => {
+    setRemote({ authToken: "secret" });
+
+    render(<RemoteAccessModal />);
+
+    const input = (await screen.findByTestId("remote-allowed-ips-input")) as HTMLTextAreaElement;
+    await userEvent.clear(input);
+    await userEvent.type(input, "127.0.0.1/32{enter}100.64.0.0/10");
+    await userEvent.click(screen.getByTestId("remote-allowed-ips-save"));
+
+    expect(useSettingsStore.getState().remote.allowedIps).toEqual([
+      "127.0.0.1/32",
+      "100.64.0.0/10",
+    ]);
+    expect(mockPersistSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists the automatic mobile mode width threshold", async () => {
+    setRemote({ authToken: "secret", autoMobileModeMinWidth: 720 });
+
+    render(<RemoteAccessModal />);
+
+    const input = (await screen.findByTestId("remote-auto-mobile-width-input")) as HTMLInputElement;
+    await userEvent.clear(input);
+    await userEvent.type(input, "0");
+    await userEvent.click(screen.getByTestId("remote-auto-mobile-width-save"));
+
+    expect(useSettingsStore.getState().remote.autoMobileModeMinWidth).toBe(0);
+    expect(mockPersistSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds the Tailscale remote allowlist preset", async () => {
+    setRemote({ authToken: "secret" });
+
+    render(<RemoteAccessModal />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Add Tailscale" }));
+    await userEvent.click(screen.getByTestId("remote-allowed-ips-save"));
+
+    expect(useSettingsStore.getState().remote.allowedIps).toEqual([
+      "127.0.0.1/32",
+      "::1/128",
+      "100.64.0.0/10",
+      "fd7a:115c:a1e0::/48",
+    ]);
+    expect(mockPersistSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("enables remote on startup through persisted settings", async () => {
+    setRemote({ authToken: "secret" });
+
+    render(<RemoteAccessModal />);
+
+    await userEvent.click(await screen.findByTestId("remote-persistent-toggle"));
+
+    expect(useSettingsStore.getState().remote.enabled).toBe(true);
+    expect(mockPersistSession).toHaveBeenCalledTimes(1);
+    expect(mockInvoke).toHaveBeenCalledWith("set_remote_runtime_access", {
+      enabled: false,
+      authToken: null,
     });
   });
 });

--- a/ui/src/components/views/RemoteAccessModal.tsx
+++ b/ui/src/components/views/RemoteAccessModal.tsx
@@ -1,13 +1,33 @@
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import {
+  getRemoteAccessStatus,
   getRemoteControlStatus,
   reclaimRemoteControl,
+  setRemoteRuntimeAccess,
+  type RemoteAccessStatus,
   type RemoteControlStatus,
 } from "@/lib/tauri-api";
+import { persistSession } from "@/lib/persist-session";
+import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
+import { useRemoteAccessStore } from "@/stores/remote-access-store";
 import { useSettingsStore } from "@/stores/settings-store";
+import { useUiStore } from "@/stores/ui-store";
+
+const LOOPBACK_ALLOWED_IPS = ["127.0.0.1/32", "::1/128"];
+const TAILSCALE_ALLOWED_IPS = ["100.64.0.0/10", "fd7a:115c:a1e0::/48"];
+const LOCAL_MOBILE_CLIENT_NAME = "laymux-mobile";
+
+export function buildLocalMobileModeUrl(port: number, token: string): string {
+  const params = new URLSearchParams({
+    localApp: "1",
+    autoConnect: "1",
+    clientName: LOCAL_MOBILE_CLIENT_NAME,
+  });
+  return `http://127.0.0.1:${port}/remote/?${params.toString()}#token=${encodeURIComponent(token)}`;
+}
 
 function Row({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -28,21 +48,89 @@ function Value({ children }: { children: ReactNode }) {
   );
 }
 
+function generateRemoteToken(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function parseAllowedIps(value: string): string[] {
+  const seen = new Set<string>();
+  return value
+    .split(/[\s,]+/)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .filter((entry) => {
+      if (seen.has(entry)) return false;
+      seen.add(entry);
+      return true;
+    });
+}
+
+function formatAllowedIps(allowedIps: string[]): string {
+  return allowedIps.join("\n");
+}
+
+function appendAllowedIps(current: string, entries: string[]): string {
+  return formatAllowedIps(parseAllowedIps([...parseAllowedIps(current), ...entries].join("\n")));
+}
+
+function sameAllowedIps(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((entry, index) => entry === right[index]);
+}
+
+function normalizeAutoMobileWidth(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, Math.floor(parsed));
+}
+
 export function RemoteAccessModal() {
   const { t } = useTranslation("common");
   const remote = useSettingsStore((state) => state.remote);
+  const setRemote = useSettingsStore((state) => state.setRemote);
+  const closeRemoteAccessModal = useUiStore((state) => state.closeRemoteAccessModal);
+  const enterMobileMode = useLocalMobileModeStore((state) => state.enter);
+  const setRemoteAccessStatus = useRemoteAccessStore((state) => state.setStatus);
   const [port, setPort] = useState<number | null>(null);
+  const [accessStatus, setAccessStatus] = useState<RemoteAccessStatus | null>(null);
   const [status, setStatus] = useState<RemoteControlStatus | null>(null);
   const [reclaiming, setReclaiming] = useState(false);
+  const [actionPending, setActionPending] = useState<
+    "runtime" | "persistent" | "allowedIps" | "autoWidth" | "mobile" | null
+  >(null);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
+  const [allowedIpsDraft, setAllowedIpsDraft] = useState(() => formatAllowedIps(remote.allowedIps));
+  const [autoWidthDraft, setAutoWidthDraft] = useState(() => String(remote.autoMobileModeMinWidth));
 
-  const token = remote.authToken.trim();
+  const token = (accessStatus?.effectiveAuthToken ?? remote.authToken).trim();
   const tokenConfigured = token.length > 0;
+  const effectiveEnabled = accessStatus?.effectiveEnabled ?? remote.enabled;
+  const runtimeEnabled = accessStatus?.runtimeEnabled ?? false;
+  const persistentEnabled = accessStatus?.persistentEnabled ?? remote.enabled;
   const encodedToken = encodeURIComponent(token);
   const urlWithToken = tokenConfigured
     ? `http://<laymux-host>:${port ?? "..."}/remote/#token=${encodedToken}`
     : t("remoteAccess.missing");
+  const allowedIps = parseAllowedIps(allowedIpsDraft);
+  const allowedIpsChanged = !sameAllowedIps(allowedIps, remote.allowedIps);
+  const autoWidth = normalizeAutoMobileWidth(autoWidthDraft);
+  const autoWidthChanged = autoWidth !== remote.autoMobileModeMinWidth;
+
+  useEffect(() => {
+    setAllowedIpsDraft(formatAllowedIps(remote.allowedIps));
+  }, [remote.allowedIps]);
+
+  useEffect(() => {
+    setAutoWidthDraft(String(remote.autoMobileModeMinWidth));
+  }, [remote.autoMobileModeMinWidth]);
+
+  const refreshAccessStatus = useCallback(async () => {
+    const next = await getRemoteAccessStatus();
+    setAccessStatus(next);
+    setRemoteAccessStatus(next);
+  }, [setRemoteAccessStatus]);
 
   useEffect(() => {
     let cancelled = false;
@@ -72,6 +160,26 @@ export function RemoteAccessModal() {
     };
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    getRemoteAccessStatus()
+      .then((next) => {
+        if (!cancelled) {
+          setAccessStatus(next);
+          setRemoteAccessStatus(next);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAccessStatus(null);
+          setRemoteAccessStatus(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [setRemoteAccessStatus]);
+
   const handleReclaim = async () => {
     setReclaiming(true);
     setError(null);
@@ -88,6 +196,106 @@ export function RemoteAccessModal() {
     await navigator.clipboard?.writeText(value);
     setCopied(key);
     window.setTimeout(() => setCopied((current) => (current === key ? null : current)), 1200);
+  };
+
+  const tokenForEnable = () => token || generateRemoteToken();
+
+  const handleToggleRuntimeAccess = async () => {
+    const nextEnabled = !runtimeEnabled;
+    setActionPending("runtime");
+    setError(null);
+    try {
+      const next = await setRemoteRuntimeAccess(nextEnabled, nextEnabled ? tokenForEnable() : null);
+      setAccessStatus(next);
+      setRemoteAccessStatus(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setActionPending(null);
+    }
+  };
+
+  const handleTogglePersistentAccess = async () => {
+    const nextEnabled = !persistentEnabled;
+    setActionPending("persistent");
+    setError(null);
+    try {
+      setRemote({
+        enabled: nextEnabled,
+        ...(nextEnabled && remote.authToken.trim().length === 0
+          ? { authToken: tokenForEnable() }
+          : {}),
+      });
+      await persistSession();
+
+      if (nextEnabled || !runtimeEnabled) {
+        const next = await setRemoteRuntimeAccess(false, null);
+        setAccessStatus(next);
+        setRemoteAccessStatus(next);
+      } else {
+        await refreshAccessStatus();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setActionPending(null);
+    }
+  };
+
+  const handleSaveAllowedIps = async () => {
+    const nextAllowedIps = allowedIps.length > 0 ? allowedIps : LOOPBACK_ALLOWED_IPS;
+    setActionPending("allowedIps");
+    setError(null);
+    try {
+      setRemote({ allowedIps: nextAllowedIps });
+      setAllowedIpsDraft(formatAllowedIps(nextAllowedIps));
+      await persistSession();
+      await refreshAccessStatus();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setActionPending(null);
+    }
+  };
+
+  const handleSaveAutoMobileWidth = async () => {
+    setActionPending("autoWidth");
+    setError(null);
+    try {
+      setRemote({ autoMobileModeMinWidth: autoWidth });
+      setAutoWidthDraft(String(autoWidth));
+      await persistSession();
+      await refreshAccessStatus();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setActionPending(null);
+    }
+  };
+
+  const handleOpenMobileMode = async () => {
+    if (port === null) return;
+    setActionPending("mobile");
+    setError(null);
+    try {
+      let nextToken = token;
+      if (!effectiveEnabled || nextToken.length === 0) {
+        const enableToken = tokenForEnable();
+        const next = await setRemoteRuntimeAccess(true, enableToken);
+        setAccessStatus(next);
+        setRemoteAccessStatus(next);
+        nextToken = (next.effectiveAuthToken || enableToken).trim();
+      }
+      if (nextToken.length === 0) {
+        throw new Error(t("remoteAccess.missingTokenForMobileMode"));
+      }
+      enterMobileMode(buildLocalMobileModeUrl(port, nextToken));
+      closeRemoteAccessModal();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setActionPending(null);
+    }
   };
 
   const copyButton = (key: string, value: string) => (
@@ -117,6 +325,9 @@ export function RemoteAccessModal() {
           border: "1px solid var(--border)",
         }}
       >
+        <Row label={t("remoteAccess.state")}>
+          {effectiveEnabled ? t("remoteAccess.enabled") : t("remoteAccess.disabled")}
+        </Row>
         <Row label={t("remoteAccess.urlWithToken")}>
           <div className="flex min-w-0 items-center gap-2">
             <Value>{urlWithToken}</Value>
@@ -133,6 +344,177 @@ export function RemoteAccessModal() {
             t("remoteAccess.missing")
           )}
         </Row>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          data-testid="remote-mobile-mode-open"
+          onClick={() => void handleOpenMobileMode()}
+          disabled={actionPending !== null || port === null}
+          className="rounded px-3 py-1.5 text-xs"
+          style={{
+            color: "var(--bg-base)",
+            background: "var(--accent)",
+            border: "1px solid var(--accent)",
+            cursor: actionPending !== null || port === null ? "default" : "pointer",
+            opacity: actionPending !== null || port === null ? 0.65 : 1,
+          }}
+        >
+          {actionPending === "mobile"
+            ? t("remoteAccess.openingMobileMode")
+            : t("remoteAccess.openMobileMode")}
+        </button>
+      </div>
+      <div
+        className="mt-3 rounded px-3 py-2"
+        style={{
+          background: "var(--bg-overlay)",
+          border: "1px solid var(--border)",
+        }}
+      >
+        <Row label={t("remoteAccess.allowedIps")}>
+          <div className="flex min-w-0 flex-col gap-2">
+            <textarea
+              data-testid="remote-allowed-ips-input"
+              value={allowedIpsDraft}
+              onChange={(event) => setAllowedIpsDraft(event.target.value)}
+              rows={4}
+              spellCheck={false}
+              className="w-full resize-y rounded px-2 py-1.5 font-mono text-[12px]"
+              placeholder={t("remoteAccess.allowedIpsPlaceholder")}
+              style={{
+                color: "var(--text-primary)",
+                background: "var(--bg-base)",
+                border: "1px solid var(--border)",
+                outline: "none",
+              }}
+            />
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() =>
+                  setAllowedIpsDraft(appendAllowedIps(allowedIpsDraft, TAILSCALE_ALLOWED_IPS))
+                }
+                disabled={actionPending !== null}
+                className="hover-bg rounded px-2 py-1 text-[11px]"
+                style={{
+                  color: "var(--accent)",
+                  background: "transparent",
+                  border: "1px solid var(--border)",
+                  cursor: actionPending !== null ? "default" : "pointer",
+                  opacity: actionPending !== null ? 0.7 : 1,
+                }}
+              >
+                {t("remoteAccess.addTailscale")}
+              </button>
+              <button
+                type="button"
+                onClick={() => setAllowedIpsDraft(formatAllowedIps(LOOPBACK_ALLOWED_IPS))}
+                disabled={actionPending !== null}
+                className="hover-bg rounded px-2 py-1 text-[11px]"
+                style={{
+                  color: "var(--accent)",
+                  background: "transparent",
+                  border: "1px solid var(--border)",
+                  cursor: actionPending !== null ? "default" : "pointer",
+                  opacity: actionPending !== null ? 0.7 : 1,
+                }}
+              >
+                {t("remoteAccess.resetLoopback")}
+              </button>
+              <button
+                type="button"
+                data-testid="remote-allowed-ips-save"
+                onClick={() => void handleSaveAllowedIps()}
+                disabled={actionPending !== null || !allowedIpsChanged}
+                className="rounded px-2 py-1 text-[11px]"
+                style={{
+                  color: "var(--bg-base)",
+                  background: "var(--accent)",
+                  border: "1px solid var(--accent)",
+                  cursor: actionPending !== null || !allowedIpsChanged ? "default" : "pointer",
+                  opacity: actionPending !== null || !allowedIpsChanged ? 0.55 : 1,
+                }}
+              >
+                {t("remoteAccess.saveAllowedIps")}
+              </button>
+            </div>
+          </div>
+        </Row>
+        <Row label={t("remoteAccess.autoMobileMinWidth")}>
+          <div className="flex min-w-0 flex-col gap-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <input
+                data-testid="remote-auto-mobile-width-input"
+                type="number"
+                min={0}
+                step={1}
+                value={autoWidthDraft}
+                onChange={(event) => setAutoWidthDraft(event.target.value)}
+                className="w-28 rounded px-2 py-1.5 text-[12px]"
+                style={{
+                  color: "var(--text-primary)",
+                  background: "var(--bg-base)",
+                  border: "1px solid var(--border)",
+                  outline: "none",
+                }}
+              />
+              <button
+                type="button"
+                data-testid="remote-auto-mobile-width-save"
+                onClick={() => void handleSaveAutoMobileWidth()}
+                disabled={actionPending !== null || !autoWidthChanged}
+                className="rounded px-2 py-1 text-[11px]"
+                style={{
+                  color: "var(--bg-base)",
+                  background: "var(--accent)",
+                  border: "1px solid var(--accent)",
+                  cursor: actionPending !== null || !autoWidthChanged ? "default" : "pointer",
+                  opacity: actionPending !== null || !autoWidthChanged ? 0.55 : 1,
+                }}
+              >
+                {t("remoteAccess.saveAutoMobileMinWidth")}
+              </button>
+            </div>
+            <div className="text-[11px]" style={{ color: "var(--text-secondary)" }}>
+              {t("remoteAccess.autoMobileMinWidthHint")}
+            </div>
+          </div>
+        </Row>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          data-testid="remote-runtime-toggle"
+          onClick={() => void handleToggleRuntimeAccess()}
+          disabled={actionPending !== null}
+          className="hover-bg rounded px-3 py-1.5 text-xs"
+          style={{
+            color: runtimeEnabled ? "var(--bg-base)" : "var(--accent)",
+            background: runtimeEnabled ? "var(--accent)" : "transparent",
+            border: "1px solid var(--accent)",
+            cursor: actionPending !== null ? "default" : "pointer",
+            opacity: actionPending !== null ? 0.7 : 1,
+          }}
+        >
+          {runtimeEnabled ? t("remoteAccess.runtimeOff") : t("remoteAccess.runtimeOn")}
+        </button>
+        <button
+          type="button"
+          data-testid="remote-persistent-toggle"
+          onClick={() => void handleTogglePersistentAccess()}
+          disabled={actionPending !== null}
+          className="hover-bg rounded px-3 py-1.5 text-xs"
+          style={{
+            color: persistentEnabled ? "var(--bg-base)" : "var(--accent)",
+            background: persistentEnabled ? "var(--accent)" : "transparent",
+            border: "1px solid var(--accent)",
+            cursor: actionPending !== null ? "default" : "pointer",
+            opacity: actionPending !== null ? 0.7 : 1,
+          }}
+        >
+          {persistentEnabled ? t("remoteAccess.persistentOff") : t("remoteAccess.persistentOn")}
+        </button>
       </div>
       {status?.active && (
         <div className="mt-3">

--- a/ui/src/hooks/useAutoRemoteAccessPrompt.test.tsx
+++ b/ui/src/hooks/useAutoRemoteAccessPrompt.test.tsx
@@ -5,8 +5,8 @@ import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useUiStore } from "@/stores/ui-store";
 
-function Probe() {
-  useAutoRemoteAccessPrompt();
+function Probe({ enabled = true }: { enabled?: boolean }) {
+  useAutoRemoteAccessPrompt(enabled);
   return null;
 }
 
@@ -41,6 +41,19 @@ describe("useAutoRemoteAccessPrompt", () => {
     render(<Probe />);
 
     expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+  });
+
+  it("waits until explicitly enabled before checking the narrow-window threshold", () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 720 });
+    setInnerWidth(600);
+
+    const { rerender } = render(<Probe enabled={false} />);
+
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+
+    rerender(<Probe enabled />);
+
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(true);
   });
 
   it("does not open the modal while local mobile mode is already active", () => {

--- a/ui/src/hooks/useAutoRemoteAccessPrompt.test.tsx
+++ b/ui/src/hooks/useAutoRemoteAccessPrompt.test.tsx
@@ -1,0 +1,55 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAutoRemoteAccessPrompt } from "./useAutoRemoteAccessPrompt";
+import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useUiStore } from "@/stores/ui-store";
+
+function Probe() {
+  useAutoRemoteAccessPrompt();
+  return null;
+}
+
+function setInnerWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    value: width,
+    configurable: true,
+  });
+}
+
+describe("useAutoRemoteAccessPrompt", () => {
+  beforeEach(() => {
+    useSettingsStore.setState(useSettingsStore.getInitialState());
+    useUiStore.setState(useUiStore.getInitialState());
+    useLocalMobileModeStore.setState(useLocalMobileModeStore.getInitialState());
+    setInnerWidth(1200);
+  });
+
+  it("opens the Remote Access modal when the app window is narrow", () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 720 });
+    setInnerWidth(600);
+
+    render(<Probe />);
+
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(true);
+  });
+
+  it("does nothing when the threshold is disabled", () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 0 });
+    setInnerWidth(320);
+
+    render(<Probe />);
+
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+  });
+
+  it("does not open the modal while local mobile mode is already active", () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 720 });
+    useLocalMobileModeStore.getState().enter("http://127.0.0.1:19281/remote/?localApp=1");
+    setInnerWidth(600);
+
+    render(<Probe />);
+
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+  });
+});

--- a/ui/src/hooks/useAutoRemoteAccessPrompt.ts
+++ b/ui/src/hooks/useAutoRemoteAccessPrompt.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from "react";
+import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useUiStore } from "@/stores/ui-store";
+
+export function useAutoRemoteAccessPrompt() {
+  const threshold = useSettingsStore((state) => state.remote.autoMobileModeMinWidth);
+  const localMobileModeActive = useLocalMobileModeStore((state) => state.active);
+  const promptedRef = useRef(false);
+
+  useEffect(() => {
+    const check = () => {
+      const width = window.innerWidth;
+      if (!Number.isFinite(threshold) || threshold <= 0) {
+        promptedRef.current = false;
+        return;
+      }
+      if (width > threshold) {
+        promptedRef.current = false;
+        return;
+      }
+      if (promptedRef.current || localMobileModeActive) return;
+
+      useUiStore.getState().openRemoteAccessModal();
+      promptedRef.current = true;
+    };
+
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, [localMobileModeActive, threshold]);
+}

--- a/ui/src/hooks/useAutoRemoteAccessPrompt.ts
+++ b/ui/src/hooks/useAutoRemoteAccessPrompt.ts
@@ -3,12 +3,17 @@ import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useUiStore } from "@/stores/ui-store";
 
-export function useAutoRemoteAccessPrompt() {
+export function useAutoRemoteAccessPrompt(enabled = true) {
   const threshold = useSettingsStore((state) => state.remote.autoMobileModeMinWidth);
   const localMobileModeActive = useLocalMobileModeStore((state) => state.active);
   const promptedRef = useRef(false);
 
   useEffect(() => {
+    if (!enabled) {
+      promptedRef.current = false;
+      return;
+    }
+
     const check = () => {
       const width = window.innerWidth;
       if (!Number.isFinite(threshold) || threshold <= 0) {
@@ -28,5 +33,5 @@ export function useAutoRemoteAccessPrompt() {
     check();
     window.addEventListener("resize", check);
     return () => window.removeEventListener("resize", check);
-  }, [localMobileModeActive, threshold]);
+  }, [enabled, localMobileModeActive, threshold]);
 }

--- a/ui/src/hooks/useAutomationBridge.test.ts
+++ b/ui/src/hooks/useAutomationBridge.test.ts
@@ -63,6 +63,7 @@ describe("handleAutomationRequest", () => {
     useDockStore.setState(useDockStore.getInitialState());
     useTerminalStore.setState(useTerminalStore.getInitialState());
     useNotificationStore.setState(useNotificationStore.getInitialState());
+    useUiStore.setState(useUiStore.getInitialState());
     vi.clearAllMocks();
   });
 
@@ -351,7 +352,6 @@ describe("handleAutomationRequest", () => {
   });
 
   it("toggles notification panel via automation API", () => {
-    useUiStore.setState(useUiStore.getInitialState());
     expect(useUiStore.getState().notificationPanelOpen).toBe(false);
 
     const result = handleAutomationRequest({
@@ -373,6 +373,45 @@ describe("handleAutomationRequest", () => {
       params: {},
     });
     expect(useUiStore.getState().notificationPanelOpen).toBe(false);
+  });
+
+  it("toggles Remote Access modal via automation API", () => {
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+
+    const result = handleAutomationRequest({
+      requestId: "ui-remote",
+      category: "action",
+      target: "ui",
+      method: "toggleRemoteAccess",
+      params: {},
+    });
+
+    expect(result.success).toBe(true);
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(true);
+  });
+
+  it("opens and closes Remote Access modal via automation API", () => {
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+
+    const openResult = handleAutomationRequest({
+      requestId: "ui-remote-open",
+      category: "action",
+      target: "ui",
+      method: "openRemoteAccess",
+      params: {},
+    });
+    expect(openResult.success).toBe(true);
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(true);
+
+    const closeResult = handleAutomationRequest({
+      requestId: "ui-remote-close",
+      category: "action",
+      target: "ui",
+      method: "closeRemoteAccess",
+      params: {},
+    });
+    expect(closeResult.success).toBe(true);
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
   });
 
   it("opens the file viewer via automation API (ui.openFileViewer)", () => {

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -727,6 +727,18 @@ const handlers: HandlerMap = {
       useUiStore.getState().toggleSettingsModal();
       return ok({ toggled: true });
     },
+    toggleRemoteAccess: () => {
+      useUiStore.getState().toggleRemoteAccessModal();
+      return ok({ toggled: true });
+    },
+    openRemoteAccess: () => {
+      useUiStore.getState().openRemoteAccessModal();
+      return ok({ opened: true });
+    },
+    closeRemoteAccess: () => {
+      useUiStore.getState().closeRemoteAccessModal();
+      return ok({ closed: true });
+    },
     toggleNotificationPanel: () => {
       useUiStore.getState().toggleNotificationPanel();
       return ok({ toggled: true });

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -17,11 +17,29 @@
       "reclaiming": "Taking back..."
     },
     "remoteAccess": {
+      "state": "State",
+      "enabled": "On",
+      "disabled": "Off",
       "urlWithToken": "URL + token",
       "token": "Token",
       "missing": "Missing",
       "copy": "Copy",
-      "copied": "Copied"
+      "copied": "Copied",
+      "allowedIps": "Allowed IPs",
+      "allowedIpsPlaceholder": "127.0.0.1/32\n::1/128\n100.64.0.0/10",
+      "addTailscale": "Add Tailscale",
+      "resetLoopback": "Reset Local",
+      "saveAllowedIps": "Save IPs",
+      "runtimeOn": "Allow This Run",
+      "runtimeOff": "Stop This Run",
+      "persistentOn": "Enable on Startup",
+      "persistentOff": "Disable on Startup",
+      "openMobileMode": "Open Mobile Mode",
+      "openingMobileMode": "Opening...",
+      "missingTokenForMobileMode": "Remote token is required for mobile mode.",
+      "autoMobileMinWidth": "Auto mobile width",
+      "autoMobileMinWidthHint": "0 disables. At or below this app window width, Remote Access opens automatically.",
+      "saveAutoMobileMinWidth": "Save width"
     }
   },
   "settings": {

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -17,11 +17,29 @@
       "reclaiming": "가져오는 중..."
     },
     "remoteAccess": {
+      "state": "상태",
+      "enabled": "켜짐",
+      "disabled": "꺼짐",
       "urlWithToken": "URL + 토큰",
       "token": "토큰",
       "missing": "없음",
       "copy": "복사",
-      "copied": "복사됨"
+      "copied": "복사됨",
+      "allowedIps": "허용 IP",
+      "allowedIpsPlaceholder": "127.0.0.1/32\n::1/128\n100.64.0.0/10",
+      "addTailscale": "Tailscale 추가",
+      "resetLoopback": "로컬로 초기화",
+      "saveAllowedIps": "IP 저장",
+      "runtimeOn": "이번 실행 동안 허용",
+      "runtimeOff": "이번 실행 허용 끄기",
+      "persistentOn": "시작 시 자동 허용",
+      "persistentOff": "시작 시 자동 허용 끄기",
+      "openMobileMode": "모바일 모드로 전환",
+      "openingMobileMode": "전환 중...",
+      "missingTokenForMobileMode": "모바일 모드에는 원격 토큰이 필요합니다.",
+      "autoMobileMinWidth": "자동 모바일 폭",
+      "autoMobileMinWidthHint": "0이면 비활성화. 앱 창 폭이 이 값 이하가 되면 Remote Access가 자동으로 열립니다.",
+      "saveAutoMobileMinWidth": "폭 저장"
     }
   },
   "settings": {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -288,6 +288,24 @@
     overflow-wrap: anywhere;
   }
 
+  .local-mobile-mode-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    display: grid;
+    grid-template-rows: minmax(0, 1fr);
+    background: var(--bg-base);
+  }
+
+  .local-mobile-mode-frame {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    border: 0;
+    background: var(--bg-base);
+  }
+
   .workspace-pane-row {
     max-height: var(--pane-row-max-h);
     opacity: 1;

--- a/ui/src/lib/persist-session.test.ts
+++ b/ui/src/lib/persist-session.test.ts
@@ -111,6 +111,7 @@ describe("persistSession", () => {
       allowedIps: ["100.64.0.0/10"],
       authToken: "secret",
       heartbeatTimeoutSeconds: 30,
+      autoMobileModeMinWidth: 640,
     });
 
     await persistSession();
@@ -121,6 +122,7 @@ describe("persistSession", () => {
       allowedIps: ["100.64.0.0/10"],
       authToken: "secret",
       heartbeatTimeoutSeconds: 30,
+      autoMobileModeMinWidth: 640,
     });
   });
 

--- a/ui/src/lib/tauri-api.test.ts
+++ b/ui/src/lib/tauri-api.test.ts
@@ -21,6 +21,8 @@ import {
   handleLxMessage,
   loadSettings,
   saveSettings,
+  getRemoteAccessStatus,
+  setRemoteRuntimeAccess,
   onTerminalOutput,
   onOpenFile,
 } from "./tauri-api";
@@ -158,6 +160,39 @@ describe("tauri-api", () => {
       await saveSettings(settings);
       expect(mockInvoke).toHaveBeenCalledWith("save_settings", {
         settings,
+      });
+    });
+  });
+
+  describe("remote access", () => {
+    it("invokes get_remote_access_status", async () => {
+      const status = {
+        effectiveEnabled: true,
+        persistentEnabled: false,
+        runtimeEnabled: true,
+        authTokenConfigured: true,
+        effectiveAuthToken: "secret",
+      };
+      mockInvoke.mockResolvedValue(status);
+
+      await expect(getRemoteAccessStatus()).resolves.toEqual(status);
+      expect(mockInvoke).toHaveBeenCalledWith("get_remote_access_status");
+    });
+
+    it("invokes set_remote_runtime_access", async () => {
+      mockInvoke.mockResolvedValue({
+        effectiveEnabled: true,
+        persistentEnabled: false,
+        runtimeEnabled: true,
+        authTokenConfigured: true,
+        effectiveAuthToken: "secret",
+      });
+
+      await setRemoteRuntimeAccess(true, "secret");
+
+      expect(mockInvoke).toHaveBeenCalledWith("set_remote_runtime_access", {
+        enabled: true,
+        authToken: "secret",
       });
     });
   });

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -66,6 +66,28 @@ export interface RemoteControlStatus {
   heartbeatTimeoutSeconds: number;
 }
 
+export interface RemoteAccessStatus {
+  effectiveEnabled: boolean;
+  persistentEnabled: boolean;
+  runtimeEnabled: boolean;
+  authTokenConfigured: boolean;
+  effectiveAuthToken: string;
+}
+
+export async function getRemoteAccessStatus(): Promise<RemoteAccessStatus> {
+  return invoke("get_remote_access_status");
+}
+
+export async function setRemoteRuntimeAccess(
+  enabled: boolean,
+  authToken?: string | null,
+): Promise<RemoteAccessStatus> {
+  return invoke("set_remote_runtime_access", {
+    enabled,
+    authToken: authToken ?? null,
+  });
+}
+
 export async function getRemoteControlStatus(): Promise<RemoteControlStatus> {
   return invoke("get_remote_control_status");
 }
@@ -290,6 +312,7 @@ export interface RemoteSettings {
   allowedIps: string[];
   authToken: string;
   heartbeatTimeoutSeconds: number;
+  autoMobileModeMinWidth: number;
 }
 
 export interface Settings {

--- a/ui/src/stores/local-mobile-mode-store.ts
+++ b/ui/src/stores/local-mobile-mode-store.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface LocalMobileModeState {
+  active: boolean;
+  url: string | null;
+  enter: (url: string) => void;
+  exit: () => void;
+}
+
+export const useLocalMobileModeStore = create<LocalMobileModeState>()((set) => ({
+  active: false,
+  url: null,
+  enter: (url) => set({ active: true, url }),
+  exit: () => set({ active: false, url: null }),
+}));

--- a/ui/src/stores/remote-access-store.ts
+++ b/ui/src/stores/remote-access-store.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import type { RemoteAccessStatus } from "@/lib/tauri-api";
+
+interface RemoteAccessState {
+  status: RemoteAccessStatus | null;
+  setStatus: (status: RemoteAccessStatus | null) => void;
+}
+
+export const useRemoteAccessStore = create<RemoteAccessState>()((set) => ({
+  status: null,
+  setStatus: (status) => set({ status }),
+}));

--- a/ui/src/stores/settings-store.test.ts
+++ b/ui/src/stores/settings-store.test.ts
@@ -868,4 +868,27 @@ describe("settings-store", () => {
     // Should keep the default, not blindly accept the invalid value
     expect(useSettingsStore.getState().workspaceSelector.sortOrder).toBe("manual");
   });
+
+  it("has default automatic mobile mode width threshold", () => {
+    expect(useSettingsStore.getState().remote.autoMobileModeMinWidth).toBe(720);
+  });
+
+  it("setRemote updates automatic mobile mode width threshold", () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 0 });
+    expect(useSettingsStore.getState().remote.autoMobileModeMinWidth).toBe(0);
+  });
+
+  it("loadFromSettings fills missing remote automatic mobile mode width with default", () => {
+    useSettingsStore.getState().loadFromSettings({
+      remote: { enabled: true, authToken: "secret" } as any,
+    });
+    expect(useSettingsStore.getState().remote.autoMobileModeMinWidth).toBe(720);
+  });
+
+  it("loadFromSettings preserves explicit remote automatic mobile mode width", () => {
+    useSettingsStore.getState().loadFromSettings({
+      remote: { autoMobileModeMinWidth: 0 } as any,
+    });
+    expect(useSettingsStore.getState().remote.autoMobileModeMinWidth).toBe(0);
+  });
 });

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -488,6 +488,7 @@ const DEFAULT_REMOTE: RemoteSettings = {
   allowedIps: ["127.0.0.1/32", "::1/128"],
   authToken: "",
   heartbeatTimeoutSeconds: 15,
+  autoMobileModeMinWidth: 720,
 };
 
 export const DEFAULT_FONT: FontSettings = { face: "Cascadia Mono", size: 14, weight: "normal" };

--- a/ui/src/stores/ui-store.ts
+++ b/ui/src/stores/ui-store.ts
@@ -55,6 +55,7 @@ interface UiState {
   toggleSettingsModal: () => void;
   toggleNotificationPanel: () => void;
   closeNotificationPanel: () => void;
+  openRemoteAccessModal: () => void;
   toggleRemoteAccessModal: () => void;
   closeRemoteAccessModal: () => void;
   setSettingsNavTarget: (target: string | null) => void;
@@ -108,6 +109,12 @@ export const useUiStore = create<UiState>()((set) => ({
       settingsModalOpen: !state.notificationPanelOpen ? false : state.settingsModalOpen,
     })),
   closeNotificationPanel: () => set({ notificationPanelOpen: false }),
+  openRemoteAccessModal: () =>
+    set({
+      remoteAccessModalOpen: true,
+      settingsModalOpen: false,
+      notificationPanelOpen: false,
+    }),
   toggleRemoteAccessModal: () =>
     set((state) => ({
       remoteAccessModalOpen: !state.remoteAccessModalOpen,


### PR DESCRIPTION
## 요약
- PC 앱 안에서 Remote UI를 iframe으로 띄우는 로컬 모바일 모드를 추가했습니다.
- Remote Access 모달에 모바일 모드 전환, 런타임/시작 시 허용, 허용 IP, 자동 모바일 폭 설정을 묶었습니다.
- 앱 창 폭이 설정값 이하가 되면 Remote Access 모달을 자동으로 열고, 0이면 비활성화합니다.
- remote page에 로컬 앱 모드용 PC 모드 복귀 버튼과 자동 연결 파라미터를 추가했습니다.
- 관련 Automation API와 ADR/architecture 문서를 갱신했습니다.

## 검증
- `npm test`
- `npm run build`
- `cargo test`
- dev Automation API(19281)에서 `POST /api/v1/ui/remote-access` + screenshot으로 Remote Access 모달 렌더 확인

Closes #408