### PR TITLE
Fix Korean IME stuck composition and duplicated syllables

### DIFF
--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -52,7 +52,7 @@ import {
   resolveVisualCaretOwner,
   type CompositionPreviewState,
 } from "@/lib/ime-composition-controller";
-import { shouldDeferTerminalKeyToIme } from "@/lib/ime-key-policy";
+import { shouldBlockTerminalKeyDuringIme, shouldDeferTerminalKeyToIme } from "@/lib/ime-key-policy";
 import {
   applyActivityLeftTuiToShadowCursor,
   applyDec2026ResetToShadowCursor,
@@ -1471,6 +1471,14 @@ export function TerminalView({
     terminal.attachCustomKeyEventHandler((e) => {
       if (e.type !== "keydown") return true;
       if (isLxShortcut(e)) return false;
+
+      // 한/영·한자 등 IME 모드 전환 키가 조합 중 xterm 에 들어가면
+      // CompositionHelper 가 stale 범위로 강제 finalize 해 이미 커밋된
+      // 음절을 재전송한다(한글 중복 입력). xterm 진입 자체를 차단한다 —
+      // preventDefault 는 하지 않으므로 OS IME 모드 전환은 그대로 동작.
+      if (shouldBlockTerminalKeyDuringIme(compositionPreviewRef.current.active, e)) {
+        return false;
+      }
 
       if (shouldDeferTerminalKeyToIme(compositionPreviewRef.current.active, e)) {
         return true;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -383,7 +383,13 @@
   opacity: 0 !important;
 }
 
-.terminal-ime-composition-active .composition-view {
+/* xterm 네이티브 composition view 는 항상 숨긴다 — 조합 프리뷰는 laymux
+   overlay(.terminal-composition-preview)가 전담한다. 조합 활성 클래스에
+   묶으면 compositionend 누락으로 xterm 만 stuck 된 경우(blur 리셋 뒤)
+   클래스가 빠지면서 stale 네이티브 조합 텍스트가 노출된다. visibility 는
+   layout 을 유지하므로 xterm 의 textarea 위치 계산(getBoundingClientRect)은
+   영향받지 않는다. */
+.xterm .composition-view {
   visibility: hidden !important;
 }
 

--- a/ui/src/lib/ime-composition-controller.test.ts
+++ b/ui/src/lib/ime-composition-controller.test.ts
@@ -449,6 +449,36 @@ describe("createImeCompositionController", () => {
     expect(controller.getState().active).toBe(false);
   });
 
+  it("still clears residue when the commit's own input event arrives after compositionend", async () => {
+    const controller = createImeCompositionController({
+      getAnchor: () => ({ cursorX: 0, cursorAbsY: 0 }),
+    });
+    const textarea = document.createElement("textarea");
+    controller.bind(textarea);
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart", { data: "" }));
+    textarea.value = "지";
+    textarea.selectionStart = 1;
+    textarea.dispatchEvent(new CompositionEvent("compositionupdate", { data: "지" }));
+    await tick();
+    textarea.dispatchEvent(new CompositionEvent("compositionend", { data: "지" }));
+
+    // WebView2/Chromium can deliver the commit's own input event after
+    // compositionend. It is composition-side (isComposing=true), not new
+    // user input — it must not defeat the residue clear.
+    const commitInput = new Event("input");
+    Object.defineProperty(commitInput, "isComposing", { value: true });
+    textarea.dispatchEvent(commitInput);
+
+    const commitInsert = new Event("beforeinput");
+    Object.defineProperty(commitInsert, "inputType", { value: "insertCompositionText" });
+    textarea.dispatchEvent(commitInsert);
+    await tick();
+
+    expect(textarea.value).toBe("");
+    expect(controller.getState().active).toBe(false);
+  });
+
   it("keeps the textarea untouched when input races in after compositionend", async () => {
     const controller = createImeCompositionController({
       getAnchor: () => ({ cursorX: 0, cursorAbsY: 0 }),

--- a/ui/src/lib/ime-composition-controller.test.ts
+++ b/ui/src/lib/ime-composition-controller.test.ts
@@ -428,6 +428,79 @@ describe("createImeCompositionController", () => {
     });
   });
 
+  it("clears helper-textarea residue after the deferred finalize", async () => {
+    const controller = createImeCompositionController({
+      getAnchor: () => ({ cursorX: 0, cursorAbsY: 0 }),
+    });
+    const textarea = document.createElement("textarea");
+    controller.bind(textarea);
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart", { data: "" }));
+    textarea.value = "지";
+    textarea.selectionStart = 1;
+    textarea.dispatchEvent(new CompositionEvent("compositionupdate", { data: "지" }));
+    await tick();
+    textarea.dispatchEvent(new CompositionEvent("compositionend", { data: "지" }));
+    await tick();
+
+    // Residue removed: the accumulated value is what desyncs xterm's
+    // substring bookkeeping and re-sends committed syllables.
+    expect(textarea.value).toBe("");
+    expect(controller.getState().active).toBe(false);
+  });
+
+  it("keeps the textarea untouched when input races in after compositionend", async () => {
+    const controller = createImeCompositionController({
+      getAnchor: () => ({ cursorX: 0, cursorAbsY: 0 }),
+    });
+    const textarea = document.createElement("textarea");
+    controller.bind(textarea);
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart", { data: "" }));
+    textarea.value = "지";
+    textarea.selectionStart = 1;
+    textarea.dispatchEvent(new CompositionEvent("compositionupdate", { data: "지" }));
+    await tick();
+    textarea.dispatchEvent(new CompositionEvent("compositionend", { data: "지" }));
+
+    // Keydown before the deferred finalize — xterm's keydown-229 diff path
+    // may hold a snapshot of the current value; clearing would corrupt it.
+    textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "2" }));
+    textarea.value = "지2";
+    textarea.dispatchEvent(new Event("input"));
+    await tick();
+
+    expect(textarea.value).toBe("지2");
+    expect(controller.getState().active).toBe(false);
+  });
+
+  it("resets when the textarea blurs mid-composition (missed compositionend defense)", async () => {
+    const controller = createImeCompositionController({
+      getAnchor: () => ({ cursorX: 5, cursorAbsY: 7 }),
+    });
+    const textarea = document.createElement("textarea");
+    controller.bind(textarea);
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart", { data: "" }));
+    textarea.value = "ㅇ";
+    textarea.selectionStart = 1;
+    textarea.dispatchEvent(new CompositionEvent("compositionupdate", { data: "ㅇ" }));
+    await tick();
+    expect(controller.getState().active).toBe(true);
+
+    // WebView2 + Windows IME can drop compositionend entirely; blur is the
+    // recovery signal (the browser force-commits the composition on blur).
+    textarea.dispatchEvent(new Event("blur"));
+
+    expect(controller.getState()).toMatchObject({
+      active: false,
+      text: "",
+      caretUtf16Index: 0,
+      caretCellOffset: 0,
+      textCellWidth: 0,
+    });
+  });
+
   it("treats consecutive same-tick compositions as carry-over", async () => {
     const controller = createImeCompositionController({
       getAnchor: () => ({ cursorX: 20, cursorAbsY: 736 }),

--- a/ui/src/lib/ime-composition-controller.ts
+++ b/ui/src/lib/ime-composition-controller.ts
@@ -237,6 +237,12 @@ export function createImeCompositionController(
   let pendingTimeout: ReturnType<typeof setTimeout> | null = null;
   let pendingFinalizeTimeout: ReturnType<typeof setTimeout> | null = null;
 
+  // Monotonic counter bumped on every keydown/beforeinput/input the textarea
+  // sees. The deferred finalize compares it against the value captured at
+  // compositionend to decide whether the textarea has been quiet since then
+  // (safe to clear residue) or new input already raced in (leave it alone).
+  let inputActivitySeq = 0;
+
   const emit = () => {
     options.onStateChange?.(state);
   };
@@ -394,13 +400,50 @@ export function createImeCompositionController(
       finalPreviewText: state.text,
     });
 
+    const seqAtEnd = inputActivitySeq;
     pendingFinalizeTimeout = setTimeout(() => {
       pendingFinalizeTimeout = null;
+      // Clear committed residue from the helper textarea. xterm binds its
+      // compositionend listener before ours (terminal.open() vs later bind),
+      // so its finalize timeout is queued first and has already read the
+      // value and sent the final text to the PTY by the time this runs.
+      // Left alone, the value accumulates across composition chains and any
+      // later event-order glitch (missed compositionend, forced finalize)
+      // makes xterm's substring bookkeeping re-send already-committed text —
+      // the Korean syllable-duplication bug. Skip when any key/input event
+      // arrived after compositionend: xterm's keydown-229 diff path may hold
+      // a pre-clear snapshot of the value, and clearing under it would emit
+      // a spurious DEL.
+      if (textarea && textarea.value && inputActivitySeq === seqAtEnd) {
+        traceComposition(options, "ime-composition-finalize-clear", {
+          clearedValue: textarea.value,
+        });
+        textarea.value = "";
+      }
       reset();
     }, 0);
   };
 
+  const handleActivityEvent = () => {
+    inputActivitySeq += 1;
+  };
+
+  const handleBlur = () => {
+    if (phase === "idle") return;
+    // A blur mid-composition means the browser force-committed or aborted
+    // the composition. compositionend normally follows, but WebView2 +
+    // Windows IME can drop it — leaving this controller (and the preview
+    // box) stuck in "composing" until the next focus cycle. Reset here;
+    // xterm clears the textarea itself on blur.
+    traceComposition(options, "ime-composition-blur-reset", {
+      phase,
+      textareaValue: textarea?.value ?? "",
+    });
+    reset();
+  };
+
   const handleInputLikeEvent = () => {
+    inputActivitySeq += 1;
     if (phase === "composing") {
       schedulePreviewSync();
     }
@@ -417,6 +460,8 @@ export function createImeCompositionController(
     textarea.removeEventListener("compositionend", handleCompositionEnd);
     textarea.removeEventListener("beforeinput", handleInputLikeEvent);
     textarea.removeEventListener("input", handleInputLikeEvent);
+    textarea.removeEventListener("keydown", handleActivityEvent);
+    textarea.removeEventListener("blur", handleBlur);
     textarea = null;
   };
 
@@ -430,6 +475,8 @@ export function createImeCompositionController(
       textarea.addEventListener("compositionend", handleCompositionEnd);
       textarea.addEventListener("beforeinput", handleInputLikeEvent);
       textarea.addEventListener("input", handleInputLikeEvent);
+      textarea.addEventListener("keydown", handleActivityEvent);
+      textarea.addEventListener("blur", handleBlur);
     },
     dispose() {
       unbind();

--- a/ui/src/lib/ime-composition-controller.ts
+++ b/ui/src/lib/ime-composition-controller.ts
@@ -442,8 +442,26 @@ export function createImeCompositionController(
     reset();
   };
 
-  const handleInputLikeEvent = () => {
-    inputActivitySeq += 1;
+  // Commit-side input events belong to the composition itself, not to the
+  // user typing something new. WebView2/Chromium can deliver the commit's
+  // beforeinput/input AFTER compositionend — counting those toward
+  // inputActivitySeq would break the quiescence check in the deferred
+  // finalize and leave the textarea residue (the accumulation this
+  // controller exists to remove) in place.
+  const isCompositionSideInput = (event: Event): boolean => {
+    const inputEvent = event as Partial<InputEvent>;
+    return (
+      inputEvent.isComposing === true ||
+      inputEvent.inputType === "insertCompositionText" ||
+      inputEvent.inputType === "insertFromComposition" ||
+      inputEvent.inputType === "deleteCompositionText"
+    );
+  };
+
+  const handleInputLikeEvent = (event: Event) => {
+    if (!isCompositionSideInput(event)) {
+      inputActivitySeq += 1;
+    }
     if (phase === "composing") {
       schedulePreviewSync();
     }

--- a/ui/src/lib/ime-key-policy.test.ts
+++ b/ui/src/lib/ime-key-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldDeferTerminalKeyToIme } from "./ime-key-policy";
+import { shouldBlockTerminalKeyDuringIme, shouldDeferTerminalKeyToIme } from "./ime-key-policy";
 
 describe("shouldDeferTerminalKeyToIme", () => {
   it("returns false when composition is inactive", () => {
@@ -88,5 +88,25 @@ describe("shouldDeferTerminalKeyToIme", () => {
         shiftKey: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("shouldBlockTerminalKeyDuringIme", () => {
+  const noMods = { ctrlKey: false, altKey: false, metaKey: false, shiftKey: false } as const;
+
+  it("blocks IME mode-switch keys while composition is active", () => {
+    for (const key of ["HangulMode", "HanjaMode", "KanaMode", "Convert", "ModeChange"]) {
+      expect(shouldBlockTerminalKeyDuringIme(true, { key, ...noMods })).toBe(true);
+    }
+  });
+
+  it("does not block mode-switch keys when composition is inactive", () => {
+    expect(shouldBlockTerminalKeyDuringIme(false, { key: "HangulMode", ...noMods })).toBe(false);
+  });
+
+  it("does not block regular keys during composition", () => {
+    expect(shouldBlockTerminalKeyDuringIme(true, { key: "a", ...noMods })).toBe(false);
+    expect(shouldBlockTerminalKeyDuringIme(true, { key: "Enter", ...noMods })).toBe(false);
+    expect(shouldBlockTerminalKeyDuringIme(true, { key: "Process", ...noMods })).toBe(false);
   });
 });

--- a/ui/src/lib/ime-key-policy.ts
+++ b/ui/src/lib/ime-key-policy.ts
@@ -19,6 +19,33 @@ const IME_NAVIGATION_KEYS = new Set([
   "Tab",
 ]);
 
+// IME mode-switch keys (한/영 HangulMode, 한자 HanjaMode, Japanese
+// Convert/Kana, generic ModeChange). xterm's CompositionHelper.keydown()
+// only exempts keyCode 229/16/17/18/20 while composing — every other key
+// force-finalizes the composition with a possibly stale textarea range and
+// re-sends already-committed text (Korean syllable duplication). These keys
+// must never reach xterm while a composition is active. Blocking them in
+// attachCustomKeyEventHandler skips xterm's key pipeline without calling
+// preventDefault, so the OS-level IME mode switch itself still works.
+const IME_MODE_SWITCH_KEYS = new Set([
+  "HangulMode",
+  "HanjaMode",
+  "JunjaMode",
+  "KanaMode",
+  "KanjiMode",
+  "Convert",
+  "NonConvert",
+  "ModeChange",
+]);
+
+export function shouldBlockTerminalKeyDuringIme(
+  compositionActive: boolean,
+  event: ImeKeyPolicyEvent,
+): boolean {
+  if (!compositionActive) return false;
+  return IME_MODE_SWITCH_KEYS.has(event.key);
+}
+
 export function shouldDeferTerminalKeyToIme(
   compositionActive: boolean,
   event: ImeKeyPolicyEvent,


### PR DESCRIPTION
## 문제

한글 입력 중 가끔 음절이 중복 입력되고(지지금, 내내가), 조합 프리뷰 박스가 화면에 남아 다른 pane 에 갔다 돌아올 때까지 계속 망가지는 현상.

## 원인 분석

입력 데이터 경로는 laymux 코드가 아니라 xterm.js 내장 `CompositionHelper` 단일 경로다. WebView2 + Windows 한글 IME 에서 `compositionend` 가 누락되거나 이벤트 순서가 꼬이면:

1. **laymux 조합 프리뷰가 stuck** — 컨트롤러의 리셋 경로가 `compositionend → setTimeout` 뿐이라 phase 가 `composing` 에 고정되고 프리뷰 박스가 화면에 남는다.
2. **xterm 의 substring 장부가 desync** — helper textarea 값은 blur/Enter 전까지 누적되는데, `CompositionHelper` 는 `setTimeout(0)` 기반 인덱스 스냅샷으로 커밋 텍스트를 잘라 보낸다. 한 번 어긋나면 이미 커밋된 음절을 다시 전송한다(음절 중복).
3. **한/영·한자 키가 조합을 강제 종결** — 조합 중 keyCode 가 {229, 16, 17, 18, 20} 밖인 키(한/영=21, 한자=25 포함)는 `_finalizeComposition(false)` 로 stale 범위를 즉시 전송하고, 이후 진짜 `compositionend` 가 같은 텍스트를 또 보낸다.

pane 전환 시 회복되는 이유: textarea blur 에서 브라우저가 조합을 강제 커밋하고 xterm 이 `textarea.value = ''` 로 리셋하기 때문 — 이 진단과 정확히 부합.

## 수정

- **`ime-composition-controller`**
  - textarea `blur` 시 컨트롤러 즉시 리셋 — `compositionend` 누락 시 stuck 프리뷰 방어.
  - deferred finalize 시 helper textarea 잔여물 클리어 — 누적 값이 desync 표면 자체다. xterm 의 finalize 타임아웃(먼저 바인딩되어 먼저 실행)이 값을 읽은 뒤에만 실행되며, `compositionend` 이후 key/input 이벤트가 끼어들면(activity 카운터) 클리어를 건너뛴다 — xterm 의 keydown-229 diff 경로가 이전 값 스냅샷을 들고 있을 수 있어 stray DEL 방지.
- **`ime-key-policy`**
  - 조합 중 IME 모드 전환 키(`HangulMode`, `HanjaMode`, `Convert` 등)를 `attachCustomKeyEventHandler` 에서 차단해 xterm 키 파이프라인 진입을 막는다. `preventDefault` 는 하지 않으므로 OS 레벨 한/영 전환은 그대로 동작.

## 테스트

- unit 6개 추가: blur 리셋, finalize 클리어, input race 시 클리어 스킵, 모드 전환 키 차단 정책 3종.
- 전체 unit 스위트 2308개 통과, `tsc --noEmit` 클린, 기존 eslint warning 만 잔존(변경과 무관).
- 실 IME 조합은 프로그래밍 재현 불가 — 한글 연속 타이핑 + 조합 중 한/영 전환 + pane 전환 수동 검증 필요. 재현 시 `localStorage.setItem(laymux:cursor-trace,1)` 로 `ime-composition-*` 트레이스 확인 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WLS6W896HHJGeUDaLnUkw