### PR TITLE
[codex] Add MCP dev-only tools and gating

### DIFF
--- a/docs/adr/0017-mcp-dev-only-tools.md
+++ b/docs/adr/0017-mcp-dev-only-tools.md
@@ -1,0 +1,31 @@
+# 0017. MCP dev 전용 툴 노출 정책
+
+- Status: Accepted
+- Date: 2026-07-03
+- Source: 사용자 요구(Phase 2 MCP dev 전용 툴 추가 + 게이팅) · ADR-0002 · ADR-0006 · architecture/api-contracts.md §12.7
+
+## Context
+
+laymux MCP 표면은 에이전트가 IDE를 처음부터 끝까지 조작해 기능 개발 e2e를 구동할 수 있어야 한다. 기존 release MCP 툴은 터미널·워크스페이스·그리드 조작에는 충분하지만, UI 검증에 필요한 hover 시뮬레이션, Settings/Remote Access 모달 제어, hide mode 조작, 설정 일부 쓰기 같은 프론트엔드 bridge 경로가 빠져 있었다.
+
+동시에 이 툴들은 사용자가 실행하는 release 인스턴스의 일반 자동화 표면으로 공개하기에는 성격이 다르다. `simulate_hover`처럼 스크린샷 검증 상태를 강제로 만들거나, `set_pane_view`처럼 pane view config를 직접 바꾸거나, Settings/Remote Access 모달을 임의로 여닫는 동작은 개발·검증 편의가 목적이다. release에서는 기존 안정 툴 표면을 유지하고, dev에서는 기능 개발 루프를 위해 더 넓은 조작면을 제공해야 한다.
+
+release/dev 구분은 ADR-0002의 고정 포트 정책과 일치한다. release는 `19280`, dev는 `19281`이며, 현재 코드는 `automation_port()`가 `cfg!(debug_assertions)`로 포트를 결정한다. MCP 서버는 같은 axum Automation API 아래에 붙으므로 이 런타임 구분을 MCP handler에 전달할 수 있다.
+
+## Decision
+
+MCP 툴에는 release 기본 표면과 dev 전용 표면을 둔다.
+
+- release(`19280`) MCP는 기존 안정 툴만 `tools/list`에 노출한다.
+- laymux-dev(`19281`) MCP는 release 툴에 더해 기능 개발 e2e 구동용 dev 전용 툴을 노출한다.
+- dev 전용 툴은 release에서 `tools/list` 결과에 나오지 않아야 하며, 이름을 직접 `tools/call`로 호출해도 `tool not found`로 거부한다. `get_tool`도 같은 정책을 따른다.
+- `rmcp`의 `#[tool_handler]` 매크로는 `call_tool`/`list_tools`/`get_tool`가 impl에 이미 있으면 생성하지 않으므로, 단일 `ToolRouter`를 유지하고 `McpHandler.is_dev` 기반 런타임 필터를 직접 구현한다. 별도 prod/dev 라우터를 병렬 유지하지 않는다.
+- dev 여부는 Automation API가 바인드한 고정 포트로 판정해 `McpHandler` 생성 시 주입한다. 포트 정책이 바뀌면 MCP 노출 정책도 같은 기준을 따른다.
+
+## Consequences
+
+- 에이전트는 laymux-dev에서 Settings/Remote Access/hover/hide mode/view 전환을 MCP로 제어할 수 있어 UI 기능 개발과 스크린샷 검증 루프를 닫을 수 있다.
+- release 사용자는 dev 검증용 툴을 발견하거나 호출할 수 없다. MCP 클라이언트가 툴 목록을 캐시하더라도 release 서버는 직접 호출을 거부한다.
+- 모든 툴 구현은 계속 `bridge(category,target,method,params)` 얇은 래퍼 패턴을 따른다. bridge/REST 핸들러를 복제하지 않는다.
+- dev 전용 툴 추가 시 `DEV_ONLY_TOOLS` 목록, living doc의 dev 전용 툴 표, 필터 테스트를 함께 갱신해야 한다.
+- 단일 라우터를 유지하므로 schema 생성과 라우팅 중복은 늘지 않지만, 툴 이름 기반 게이팅 목록이 release/dev 계약의 명시적 유지 지점이 된다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ ADR 이 필요한 대표 기준:
 | [0014](0014-mcp-settings-configuration.md) | MCP 설정 구성 — 에이전트가 settings 를 읽고 쓰는 경로 | Accepted |
 | [0015](0015-remote-terminal-state-ownership.md) | Remote 터미널 상태 소유권 — PTY 전역 상태와 surface 로컬 상태 분리 | Accepted |
 | [0016](0016-remote-access-runtime-vs-startup-enable.md) | Remote Access 활성화 — 런타임 허용과 시작 시 허용 분리 | Accepted |
+| [0017](0017-mcp-dev-only-tools.md) | MCP dev 전용 툴 노출 정책 | Accepted |
 
 ## 새 ADR 추가
 

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -336,7 +336,11 @@ Bearer 토큰(`key`) 필드는 없다 — 인증은 IP allowlist 미들웨어가
 | Tool 정의 | `#[tool]` derive 매크로 — JSON Schema 자동 생성 |
 | 인증 | IP allowlist 미들웨어 자동 적용 (인증 헤더 불필요) |
 
-#### Tool 목록 (31개)
+#### Tool 노출 정책
+
+MCP handler 는 `automation_port()` 결과로 dev 여부를 주입받는다. release(`19280`)에서는 운영·사용자 상태 조작에 필요한 안정 툴만 노출하고, laymux-dev(`19281`)에서는 UI 검증/설정 모달/hover 시뮬레이션처럼 기능 개발 e2e 구동에 필요한 dev 전용 툴을 추가 노출한다. dev 전용 툴은 release 의 `tools/list` 결과에서 숨기며, 이름을 직접 호출해도 `tool not found` 로 거부한다([ADR-0017](../adr/0017-mcp-dev-only-tools.md)).
+
+#### Tool 목록 (release 33개 + dev 전용 17개)
 
 **터미널 (8)**:
 
@@ -362,10 +366,12 @@ Bearer 토큰(`key`) 필드는 없다 — 인증은 IP allowlist 미들웨어가
 | `delete_workspace` | bridge_request | 워크스페이스 삭제 |
 | `rename_workspace` | bridge_request | 워크스페이스 이름 변경 |
 
-**그리드/팬 (5)**:
+**그리드/팬 (7)**:
 
 | Tool | 구현 방식 | 설명 |
 |------|-----------|------|
+| `get_grid_state` | bridge_request | 그리드 상태 조회 (`editMode`, `focusedPane`, `activeWorkspaceId`) |
+| `focus_pane` | bridge_request | 인덱스 기반 팬 포커스 |
 | `split_pane` | bridge_request | 팬 분할 (`ready` 필드로 렌더 완료 여부 표시) |
 | `remove_pane` | bridge_request | 팬 제거 |
 | `resize_pane` | bridge_request | 팬 크기 조정 (상대 delta) |
@@ -396,6 +402,28 @@ Bearer 토큰(`key`) 필드는 없다 — 인증은 IP allowlist 미들웨어가
 | `list_memos` | 파일 시스템 | `cache/memo.json`의 모든 `{ key, content }` 항목 (key 알파벳 정렬) |
 | `read_memo` | 파일 시스템 | 특정 키의 메모 내용 조회 (없으면 에러) |
 
+**Dev 전용 (17)** — laymux-dev(`19281`)에서만 `tools/list`와 `tools/call`에 노출:
+
+| Tool | bridge method | 설명 |
+|------|---------------|------|
+| `set_app_theme` | `settings.setAppTheme` | 앱 테마 변경 |
+| `update_profile` | `settings.updateProfile` | 특정 프로필 부분 갱신 |
+| `set_profile_defaults` | `settings.setProfileDefaults` | 프로필 기본값 부분 갱신 |
+| `open_settings` | `ui.openSettings` | Settings 모달 열기 |
+| `close_settings` | `ui.closeSettings` | Settings 모달 닫기 |
+| `toggle_settings` | `ui.toggleSettings` | Settings 모달 토글 |
+| `navigate_settings` | `ui.navigateSettings` | Settings 내부 섹션 이동 |
+| `toggle_remote_access` | `ui.toggleRemoteAccess` | Remote Access 모달 토글 |
+| `open_remote_access` | `ui.openRemoteAccess` | Remote Access 모달 열기 |
+| `close_remote_access` | `ui.closeRemoteAccess` | Remote Access 모달 닫기 |
+| `toggle_notification_panel` | `ui.toggleNotificationPanel` | 알림 패널 토글 |
+| `toggle_hide_mode` | `ui.toggleHideMode` | hide mode 토글 |
+| `toggle_pane_hidden` | `ui.togglePaneHidden` | pane hide 상태 토글 |
+| `toggle_workspace_hidden` | `ui.toggleWorkspaceHidden` | workspace hide 상태 토글 |
+| `simulate_hover` | `grid.simulateHover` | hover UI 검증용 pane hover 상태 시뮬레이션 |
+| `set_edit_mode` | `grid.setEditMode` | grid edit mode 설정 |
+| `set_pane_view` | `panes.setView` | pane view config 직접 변경 |
+
 #### MCP Resources — 구독형 read-only 상태 (issue #202)
 
 tool 폴링 대신 구독 가능한 read-only 상태를 MCP Resources 로 노출한다. 구현은 `automation_server/mcp_resources.rs`(URI 모델·구독 레지스트리) + `mcp.rs`(list/read/subscribe 핸들러).
@@ -418,6 +446,7 @@ tool 폴링 대신 구독 가능한 read-only 상태를 MCP Resources 로 노출
 pub struct McpHandler {
     state: ServerState,           // Arc<AppState> + AppHandle
     tool_router: ToolRouter<Self>,
+    is_dev: bool,                 // release/dev tool gating
     exec_locks: Arc<TokioMutex<HashMap<String, Arc<TokioMutex<()>>>>>,  // per-terminal 세마포어
 }
 

--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -3,11 +3,12 @@
 //! Uses `#[tool]` derive macros for automatic tool definition and JSON-RPC 2.0
 //! handling. Mounted via `nest_service("/mcp", ...)` in the existing axum router.
 
-use rmcp::handler::server::{router::tool::ToolRouter, wrapper::Parameters};
+use rmcp::handler::server::{router::tool::ToolRouter, tool::ToolCallContext, wrapper::Parameters};
 use rmcp::model::{
-    CallToolResult, Content, ListResourceTemplatesResult, ListResourcesResult,
-    PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult, ServerCapabilities,
-    ServerInfo, SubscribeRequestParams, UnsubscribeRequestParams,
+    CallToolRequestParams, CallToolResult, Content, ListResourceTemplatesResult,
+    ListResourcesResult, ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams,
+    ReadResourceResult, ServerCapabilities, ServerInfo, SubscribeRequestParams, Tool,
+    UnsubscribeRequestParams,
 };
 use rmcp::service::{NotificationContext, RequestContext, RoleServer};
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
@@ -375,6 +376,26 @@ struct ScreenshotParam {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct SetEditModeParam {
+    /// Enable or disable grid edit mode.
+    enabled: bool,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct SimulateHoverParam {
+    /// Pane index to mark as hovered. Omit or pass null to clear automation hover.
+    pane_index: Option<u64>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct SetPaneViewParam {
+    /// Pane index (0-based)
+    pane_index: u64,
+    /// View config object, e.g. {"type":"TerminalView","profile":"PowerShell"}.
+    view: Value,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct SendNotificationParam {
     /// Terminal ID (optional — omit for workspace-level notification)
     terminal_id: Option<String>,
@@ -436,6 +457,64 @@ struct ExecuteCommandParam {
     format: Option<String>,
 }
 
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct SetAppThemeParam {
+    /// App theme ID, e.g. "catppuccin-mocha" or "dracula".
+    theme_id: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct UpdateProfileParam {
+    /// Profile index in settings.profiles.
+    index: u64,
+    /// Partial profile object to merge into the selected profile.
+    data: Value,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct SetProfileDefaultsParam {
+    /// Partial profileDefaults object to merge into settings.profileDefaults.
+    data: Value,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct NavigateSettingsParam {
+    /// Settings section key. Defaults to "startup" when omitted.
+    section: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct ToggleWorkspaceHiddenParam {
+    /// Workspace ID to toggle in hide mode.
+    workspace_id: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct TogglePaneHiddenParam {
+    /// Pane ID to toggle in hide mode.
+    pane_id: String,
+}
+
+const DEV_ONLY_TOOLS: &[&str] = &[
+    "set_app_theme",
+    "update_profile",
+    "set_profile_defaults",
+    "open_settings",
+    "close_settings",
+    "toggle_settings",
+    "navigate_settings",
+    "toggle_remote_access",
+    "open_remote_access",
+    "close_remote_access",
+    "toggle_notification_panel",
+    "toggle_hide_mode",
+    "toggle_pane_hidden",
+    "toggle_workspace_hidden",
+    "simulate_hover",
+    "set_edit_mode",
+    "set_pane_view",
+];
+
 // ── MCP Handler ───────────────────────────────────────────────────
 
 /// MCP server handler embedded in the Automation API.
@@ -448,6 +527,7 @@ pub struct McpHandler {
     state: ServerState,
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
+    is_dev: bool,
     /// Per-terminal mutex to serialize execute_command calls on the same terminal.
     exec_locks: Arc<TokioMutex<HashMap<String, Arc<TokioMutex<()>>>>>,
     /// Shared subscription registry: tracks `resources/subscribe` requests so
@@ -460,10 +540,15 @@ pub struct McpHandler {
 }
 
 impl McpHandler {
-    pub fn new(state: ServerState, subscriptions: SharedSubscriptionRegistry) -> Self {
+    pub fn new(
+        state: ServerState,
+        subscriptions: SharedSubscriptionRegistry,
+        is_dev: bool,
+    ) -> Self {
         Self {
             state,
             tool_router: Self::tool_router(),
+            is_dev,
             exec_locks: Arc::new(TokioMutex::new(HashMap::new())),
             subscriptions,
             peer_id: new_peer_id(),
@@ -547,6 +632,40 @@ impl McpHandler {
             chunks.push(b"\r".to_vec());
         }
         chunks
+    }
+
+    fn require_object_param(value: Value, field: &str) -> Result<Value, CallToolResult> {
+        if value.is_object() {
+            Ok(value)
+        } else {
+            Err(CallToolResult::error(vec![Content::text(format!(
+                "'{field}' must be a JSON object"
+            ))]))
+        }
+    }
+
+    fn is_dev_only_tool(name: &str) -> bool {
+        DEV_ONLY_TOOLS.contains(&name)
+    }
+
+    fn is_tool_visible(&self, name: &str) -> bool {
+        self.is_dev || !Self::is_dev_only_tool(name)
+    }
+
+    fn visible_tools_from_router(router: &ToolRouter<Self>, is_dev: bool) -> Vec<Tool> {
+        let mut tools = router.list_all();
+        if !is_dev {
+            tools.retain(|tool| !Self::is_dev_only_tool(tool.name.as_ref()));
+        }
+        tools
+    }
+
+    fn visible_tools(&self) -> Vec<Tool> {
+        Self::visible_tools_from_router(&self.tool_router, self.is_dev)
+    }
+
+    fn tool_not_found() -> ErrorData {
+        ErrorData::invalid_params("tool not found", None)
     }
 
     /// 터미널에 입력을 보낸다. 본문 텍스트와 제출용 CR을 **분리된 write**로 보내며,
@@ -921,7 +1040,7 @@ impl McpHandler {
     /// The inserted value is the flat `TerminalActivity` shape, not `TerminalStateInfo`.
     fn enrich_with_activity(
         app_state: &crate::state::AppState,
-        items: &mut Vec<Value>,
+        items: &mut [Value],
         id_field: &str,
         activity_field: &str,
     ) {
@@ -966,9 +1085,16 @@ impl Drop for McpHandler {
 pub fn create_service(
     state: ServerState,
     subscriptions: SharedSubscriptionRegistry,
+    is_dev: bool,
 ) -> StreamableHttpService<McpHandler, LocalSessionManager> {
     StreamableHttpService::new(
-        move || Ok(McpHandler::new(state.clone(), subscriptions.clone())),
+        move || {
+            Ok(McpHandler::new(
+                state.clone(),
+                subscriptions.clone(),
+                is_dev,
+            ))
+        },
         Arc::new(LocalSessionManager::default()),
         StreamableHttpServerConfig::default().with_allowed_hosts(mcp_allowed_hosts()),
     )
@@ -1554,6 +1680,58 @@ impl McpHandler {
 
     // ── Grid/Pane ──
 
+    /// Get grid state: editMode, focusedPaneIndex, and activeWorkspaceId.
+    #[tool]
+    async fn get_grid_state(&self) -> Result<CallToolResult, ErrorData> {
+        self.bridge("query", "grid", "getState", json!({})).await
+    }
+
+    /// Dev-only: enable or disable grid edit mode for automated layout tests.
+    #[tool]
+    async fn set_edit_mode(
+        &self,
+        Parameters(p): Parameters<SetEditModeParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.bridge(
+            "action",
+            "grid",
+            "setEditMode",
+            json!({ "enabled": p.enabled }),
+        )
+        .await
+    }
+
+    /// Focus a specific pane by index.
+    #[tool]
+    async fn focus_pane(
+        &self,
+        Parameters(p): Parameters<PaneIndexParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.bridge(
+            "action",
+            "grid",
+            "focusPane",
+            json!({ "index": p.pane_index }),
+        )
+        .await
+    }
+
+    /// Dev-only: simulate pane hover state for screenshot/UI verification.
+    /// Pass no pane_index (or null) to clear automation hover.
+    #[tool]
+    async fn simulate_hover(
+        &self,
+        Parameters(p): Parameters<SimulateHoverParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.bridge(
+            "action",
+            "grid",
+            "simulateHover",
+            json!({ "index": p.pane_index }),
+        )
+        .await
+    }
+
     /// Split a pane horizontally or vertically. Returns info about the new pane created.
     /// The response includes a `ready` field: when false, the terminal is allocated but
     /// not yet registered (React render pending). Poll `list_terminals` or wait ~500ms
@@ -1630,6 +1808,35 @@ impl McpHandler {
             "panes",
             "swap",
             json!({ "sourceIndex": p.source_index, "targetIndex": p.target_index }),
+        )
+        .await
+    }
+
+    /// Dev-only: set a pane's view config directly through the frontend bridge.
+    #[tool]
+    async fn set_pane_view(
+        &self,
+        Parameters(p): Parameters<SetPaneViewParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let view = match Self::require_object_param(p.view, "view") {
+            Ok(view) => view,
+            Err(err) => return Ok(err),
+        };
+        if view
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .is_empty()
+        {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "'view.type' is required and must be a non-empty string",
+            )]));
+        }
+        self.bridge(
+            "action",
+            "panes",
+            "setView",
+            json!({ "paneIndex": p.pane_index, "view": view }),
         )
         .await
     }
@@ -1987,6 +2194,171 @@ impl McpHandler {
         }
     }
 
+    // ── Dev-only frontend controls ──
+
+    /// Dev-only: set the app theme by theme ID.
+    #[tool]
+    async fn set_app_theme(
+        &self,
+        Parameters(p): Parameters<SetAppThemeParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if p.theme_id.trim().is_empty() {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "'theme_id' is required and must be non-empty",
+            )]));
+        }
+        self.bridge(
+            "action",
+            "settings",
+            "setAppTheme",
+            json!({ "themeId": p.theme_id }),
+        )
+        .await
+    }
+
+    /// Dev-only: merge profile defaults into settings.profileDefaults.
+    #[tool]
+    async fn set_profile_defaults(
+        &self,
+        Parameters(p): Parameters<SetProfileDefaultsParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let data = match Self::require_object_param(p.data, "data") {
+            Ok(data) => data,
+            Err(err) => return Ok(err),
+        };
+        self.bridge("action", "settings", "setProfileDefaults", data)
+            .await
+    }
+
+    /// Dev-only: merge a partial profile object into settings.profiles[index].
+    #[tool]
+    async fn update_profile(
+        &self,
+        Parameters(p): Parameters<UpdateProfileParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let data = match Self::require_object_param(p.data, "data") {
+            Ok(data) => data,
+            Err(err) => return Ok(err),
+        };
+        self.bridge(
+            "action",
+            "settings",
+            "updateProfile",
+            json!({ "index": p.index, "data": data }),
+        )
+        .await
+    }
+
+    /// Dev-only: open the settings modal.
+    #[tool]
+    async fn open_settings(&self) -> Result<CallToolResult, ErrorData> {
+        self.bridge("action", "ui", "openSettings", json!({})).await
+    }
+
+    /// Dev-only: close the settings modal.
+    #[tool]
+    async fn close_settings(&self) -> Result<CallToolResult, ErrorData> {
+        self.bridge("action", "ui", "closeSettings", json!({}))
+            .await
+    }
+
+    /// Dev-only: toggle the settings modal.
+    #[tool]
+    async fn toggle_settings(&self) -> Result<CallToolResult, ErrorData> {
+        self.bridge("action", "ui", "toggleSettings", json!({}))
+            .await
+    }
+
+    /// Dev-only: navigate the settings modal to a specific section.
+    #[tool]
+    async fn navigate_settings(
+        &self,
+        Parameters(p): Parameters<NavigateSettingsParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.bridge(
+            "action",
+            "ui",
+            "navigateSettings",
+            json!({ "section": p.section.unwrap_or_else(|| "startup".to_string()) }),
+        )
+        .await
+    }
+
+    /// Dev-only: toggle the Remote Access modal.
+    #[tool]
+    async fn toggle_remote_access(&self) -> Result<CallToolResult, ErrorData> {
+        self.bridge("action", "ui", "toggleRemoteAccess", json!({}))
+            .await
+    }
+
+    /// Dev-only: open the Remote Access modal.
+    #[tool]
+    async fn open_remote_access(&self) -> Result<CallToolResult, ErrorData> {
+        self.bridge("action", "ui", "openRemoteAccess", json!({}))
+            .await
+    }
+
+    /// Dev-only: close the Remote Access modal.
+    #[tool]
+    async fn close_remote_access(&self) -> Result<CallToolResult, ErrorData> {
+        self.bridge("action", "ui", "closeRemoteAccess", json!({}))
+            .await
+    }
+
+    /// Dev-only: toggle the notification panel.
+    #[tool]
+    async fn toggle_notification_panel(&self) -> Result<CallToolResult, ErrorData> {
+        self.bridge("action", "ui", "toggleNotificationPanel", json!({}))
+            .await
+    }
+
+    /// Dev-only: toggle workspace/pane hide mode.
+    #[tool]
+    async fn toggle_hide_mode(&self) -> Result<CallToolResult, ErrorData> {
+        self.bridge("action", "ui", "toggleHideMode", json!({}))
+            .await
+    }
+
+    /// Dev-only: toggle whether a workspace is hidden in hide mode.
+    #[tool]
+    async fn toggle_workspace_hidden(
+        &self,
+        Parameters(p): Parameters<ToggleWorkspaceHiddenParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if p.workspace_id.trim().is_empty() {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "'workspace_id' is required and must be non-empty",
+            )]));
+        }
+        self.bridge(
+            "action",
+            "ui",
+            "toggleWorkspaceHidden",
+            json!({ "id": p.workspace_id }),
+        )
+        .await
+    }
+
+    /// Dev-only: toggle whether a pane is hidden in hide mode.
+    #[tool]
+    async fn toggle_pane_hidden(
+        &self,
+        Parameters(p): Parameters<TogglePaneHiddenParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if p.pane_id.trim().is_empty() {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "'pane_id' is required and must be non-empty",
+            )]));
+        }
+        self.bridge(
+            "action",
+            "ui",
+            "togglePaneHidden",
+            json!({ "id": p.pane_id }),
+        )
+        .await
+    }
+
     // ── File viewer ──
 
     /// Open a file in laymux's unified file viewer overlay. This is the same
@@ -2111,6 +2483,37 @@ impl ServerHandler for McpHandler {
                  reply_to=$LX_TERMINAL_ID — a standardized footer tells the agent where to reply"
                     .to_string(),
             )
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if !self.is_tool_visible(request.name.as_ref()) {
+            return Err(Self::tool_not_found());
+        }
+        let tcc = ToolCallContext::new(self, request, context);
+        self.tool_router.call(tcc).await
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        Ok(ListToolsResult {
+            tools: self.visible_tools(),
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    fn get_tool(&self, name: &str) -> Option<Tool> {
+        if !self.is_tool_visible(name) {
+            return None;
+        }
+        self.tool_router.get(name).cloned()
     }
 
     // ── Resources (MCP issue #202) ──────────────────────────────
@@ -3079,6 +3482,68 @@ mod tests {
         let p: ResizePaneParam = serde_json::from_str(json).unwrap();
         assert_eq!(p.dw, Some(0.1));
         assert!(p.dh.is_none());
+    }
+
+    #[test]
+    fn dev_only_tool_names_are_registered() {
+        let router = McpHandler::tool_router();
+        for name in DEV_ONLY_TOOLS {
+            assert!(
+                router.has_route(name),
+                "dev-only tool not registered: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn release_tool_list_hides_dev_only_tools() {
+        let router = McpHandler::tool_router();
+        let release_tools = McpHandler::visible_tools_from_router(&router, false);
+        let release_names: Vec<&str> = release_tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect();
+
+        for name in DEV_ONLY_TOOLS {
+            assert!(
+                !release_names.contains(name),
+                "release MCP list_tools must hide dev-only tool: {name}",
+            );
+        }
+    }
+
+    #[test]
+    fn dev_tool_list_includes_dev_only_tools() {
+        let router = McpHandler::tool_router();
+        let dev_tools = McpHandler::visible_tools_from_router(&router, true);
+        let dev_names: Vec<&str> = dev_tools.iter().map(|tool| tool.name.as_ref()).collect();
+
+        for name in DEV_ONLY_TOOLS {
+            assert!(
+                dev_names.contains(name),
+                "dev MCP list_tools must include dev-only tool: {name}",
+            );
+        }
+    }
+
+    #[test]
+    fn dev_only_param_types_deserialize() {
+        let theme: SetAppThemeParam = serde_json::from_str(r#"{"theme_id":"dracula"}"#).unwrap();
+        assert_eq!(theme.theme_id, "dracula");
+
+        let profile: UpdateProfileParam =
+            serde_json::from_str(r#"{"index":1,"data":{"cursorBlink":false}}"#).unwrap();
+        assert_eq!(profile.index, 1);
+        assert_eq!(profile.data["cursorBlink"], false);
+
+        let defaults: SetProfileDefaultsParam =
+            serde_json::from_str(r#"{"data":{"font":{"size":15}}}"#).unwrap();
+        assert_eq!(defaults.data["font"]["size"], 15);
+
+        let view: SetPaneViewParam =
+            serde_json::from_str(r#"{"pane_index":0,"view":{"type":"MemoView"}}"#).unwrap();
+        assert_eq!(view.pane_index, 0);
+        assert_eq!(view.view["type"], "MemoView");
     }
 
     // ── Resource capability tests (issue #202) ─────────────────────

--- a/src-tauri/src/automation_server/mod.rs
+++ b/src-tauri/src/automation_server/mod.rs
@@ -98,9 +98,10 @@ pub async fn start(app_state: Arc<AppState>, app_handle: AppHandle) -> Result<u1
     let subscriptions = SubscriptionRegistry::new();
     mcp_resources::spawn_resource_event_bridge(app_handle.clone(), subscriptions.clone());
 
-    let app = build_router(server_state, subscriptions);
-
     let port = automation_port();
+    let is_dev = port == DEV_PORT;
+    let app = build_router(server_state, subscriptions, is_dev);
+
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = TcpListener::bind(addr)
         .await
@@ -193,7 +194,11 @@ async fn ip_allowlist_middleware(
     }
 }
 
-pub fn build_router(state: ServerState, subscriptions: SharedSubscriptionRegistry) -> Router {
+pub fn build_router(
+    state: ServerState,
+    subscriptions: SharedSubscriptionRegistry,
+    is_dev: bool,
+) -> Router {
     let automation_routes = Router::new()
         .route("/api/v1/docs", get(api_docs))
         .route("/api/v1/health", get(health))
@@ -260,7 +265,7 @@ pub fn build_router(state: ServerState, subscriptions: SharedSubscriptionRegistr
         .route("/api/v1/screenshot", post(screenshot_capture))
         .nest_service(
             "/mcp",
-            mcp::create_service(state.clone(), subscriptions.clone()),
+            mcp::create_service(state.clone(), subscriptions.clone(), is_dev),
         )
         .route("/api/v1/ui/settings", post(ui_toggle_settings))
         .route("/api/v1/ui/remote-access", post(ui_remote_access))


### PR DESCRIPTION
## What changed

- Added an `is_dev` runtime flag to the embedded MCP handler, derived from the fixed Automation API port (`19281` dev vs `19280` release).
- Added release/dev MCP gating for `tools/list`, `tools/call`, and `get_tool`: dev-only tools are hidden and rejected as `tool not found` outside laymux-dev.
- Added 17 dev-only bridge wrapper tools for settings, settings/remote modals, notifications panel, hide mode, hover simulation, edit mode, and pane view switching.
- Documented the dev-only MCP surface in `docs/architecture/api-contracts.md` and recorded the policy in ADR-0017.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets` (passes; existing warnings remain outside the changed files)
- `cargo test` (916 lib tests + integration suites passed)
- Live dev MCP check on `127.0.0.1:19281`: `tools/list` returned 50 tools with all 17 dev-only tools present, and `set_edit_mode` toggled true/false through the bridge.

Note: `cargo clippy --all-targets -- -D warnings` still fails on pre-existing warnings in unrelated files such as `activity.rs`, `remote_server/*`, `settings/*`, `pty.rs`, and `clipboard_integration.rs`; the warning introduced in this change was fixed.