### PR TITLE
Add remote notification interactions

### DIFF
--- a/docs/adr/0019-remote-notification-interactions.md
+++ b/docs/adr/0019-remote-notification-interactions.md
@@ -1,0 +1,38 @@
+# 0019. Remote Notification Interactions Use Navigation Targets and Bridge Dismissal
+
+- Status: Accepted
+- Date: 2026-07-04
+- Source: Remote notification UX follow-up after PR #414; docs/architecture/api-contracts.md section 13.3; ADR-0013, ADR-0018
+
+## Context
+
+PR #414 made `/remote/v1/navigation` expose unread notification counts and made the remote drawer follow desktop WorkspaceSelector ordering and hidden/collapsed state. The focused remote HTML surface still only rendered badges, so a browser remote client could see that notifications existed but could not inspect, mark, or clear them.
+
+Desktop notification behavior is owned by the React/Zustand notification store. The remote page should not mount the full desktop app or duplicate unrelated workspace/pane editing features, but it needs enough notification metadata and actions to consume alerts while controlling the active terminal.
+
+## Decision
+
+`/remote/v1/navigation` includes an additive top-level `notifications` list. Each item summarizes the frontend notification record with display and target metadata: id, title, message, level, created/read timestamps, read state, workspace id/name, terminal id/label, and requires-action state.
+
+The list uses the same ordering as desktop `NotificationPanel`: unread notifications first, and newest insertion order inside unread/read groups. The remote page groups the ordered list by workspace in first-seen order and renders it in the navigation drawer.
+
+Notification taps reuse existing focused remote navigation actions whenever possible:
+
+- workspace-targeted notifications call `/remote/v1/workspaces/active`, which already marks that workspace read;
+- terminal-targeted notifications call `/remote/v1/terminals/{id}/focus`, which already marks that terminal read;
+- target-less notifications call `/remote/v1/notifications/{id}/read`, which marks only that notification id read through the frontend bridge.
+
+Remote mark-all-read and clear-all are explicit controller actions:
+
+- `/remote/v1/notifications/mark-all-read` calls bridge action `notifications.markAllRead`;
+- `DELETE /remote/v1/notifications` reads `notifications.list`, then calls existing bridge action `notifications.clear` with the collected ids.
+
+All notification mutation endpoints require the active remote lease, like workspace switching and terminal focus. `/remote/v1/navigation` remains a token-gated read-only query and does not require a lease.
+
+## Consequences
+
+Browser remote clients can inspect and consume notifications without gaining broader workspace editing, pane editing, file-viewer, settings, token, or TLS responsibilities.
+
+The remote notification API is additive. Existing clients that only use unread counts can ignore the new `notifications` field and mutation endpoints.
+
+The Rust remote server depends on additional frontend bridge notification actions for id-based and all-read dismissal. Clear-all intentionally reuses the existing `notifications.clear` bridge semantics by passing ids rather than introducing a second deletion path.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ ADR 이 필요한 대표 기준:
 | [0016](0016-remote-access-runtime-vs-startup-enable.md) | Remote Access 활성화 — 런타임 허용과 시작 시 허용 분리 | Accepted |
 | [0017](0017-mcp-dev-only-tools.md) | MCP dev 전용 툴 노출 정책 | Accepted |
 | [0018](0018-remote-navigation-ui-state.md) | Remote navigation reflects UI hidden and notification state | Accepted |
+| [0019](0019-remote-notification-interactions.md) | Remote notification interactions use navigation targets and bridge dismissal | Accepted |
 
 ## 새 ADR 추가
 

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -591,12 +591,17 @@ Focused remote UI는 전체 React layout을 복제하지 않고, workspace/dock/
 | Endpoint | Method | 용도 |
 |---|---|---|
 | `/remote/v1/navigation` | GET | workspace 목록, active workspace pane 요약, dock pane 요약, terminal 표시 메타데이터 |
+| `/remote/v1/notifications/{id}/read` | POST | active `leaseId`로 단일 notification id를 읽음 처리 |
+| `/remote/v1/notifications/mark-all-read` | POST | active `leaseId`로 모든 unread notification을 읽음 처리 |
+| `/remote/v1/notifications` | DELETE | active `leaseId`로 모든 notification 제거 |
 | `/remote/v1/workspaces/active` | POST | active `leaseId`로 PC WebView의 active workspace 전환 |
 | `/remote/v1/terminals/{id}/focus` | POST | active `leaseId`로 PC WebView의 terminal focus 전환 |
 
 `/remote/v1/navigation`은 bearer token과 IP/Origin gate를 통과해야 하며 lease는 요구하지 않는다. 응답의 `workspaces`는 PC WebView `WorkspaceSelectorView`와 같은 `workspaceSelector.sortOrder`/`workspaceDisplayOrder` 규칙으로 정렬된 `{id,name,isActive,hidden,collapsed,paneCount,terminalPaneCount,liveTerminalCount,unreadCount,panes}` 요약이다. 숨김 워크스페이스와 숨김 pane은 목록에서 제거하지 않고 `hidden`/`collapsed` 플래그를 내려 PC selector와 같은 접힘 모델을 쓰며, 현재 active workspace는 숨김 상태여도 `collapsed=false`로 유지해 현재 터미널 문맥을 잃지 않는다. `workspaces[].panes`는 active workspace에서만 채우고 inactive workspace는 빈 배열로 둔다. 각 pane 요약은 `{id,location,workspaceId,paneIndex,paneNumber,viewType,terminalId,terminalLive,title,profile,cwd,branch,activity,outputActive,commandRunning,unreadCount,hidden,collapsed,x,y,w,h}` 형태이며, `unreadCount`는 terminal pane에만 부여하고 non-terminal pane은 항상 `0`이다. `activeWorkspace.panes`와 active `workspaces[].panes`는 같은 pane 요약을 쓰고, `docks[].panes`는 workspace 숨김 상태의 영향을 받지 않는다. 최상위 `workspaceSelector`는 remote drawer가 PC selector의 표시 토글/경로 ellipsis와 맞출 수 있게 하는 현재 selector 설정이며, `unreadNotificationCount`는 전체 unread 수다. `terminals`는 `/remote/v1/terminals` 항목에 frontend bridge의 `workspaceId`, `paneNumber`, `activity`, `isFocused` 등 탐색에 필요한 메타데이터를 병합한 목록이다.
 
 `/remote/v1/workspaces/active` body는 `{ "id": "...", "leaseId": "..." }`, `/remote/v1/terminals/{id}/focus` body는 `{ "leaseId": "..." }`다. 둘 다 `X-Laymux-Remote-Lease` 헤더도 허용하며, 성공 시 `workspace-state-changed` event를 발행해 MCP resource 구독자와 Automation resource cache가 stale 상태에 머물지 않게 한다. Remote workspace 전환은 해당 workspace의 unread notification을 읽음 처리하고, remote terminal focus는 해당 terminal의 unread notification을 읽음 처리한다. 이 처리는 focused remote UI의 명시적 navigation action에 대한 소비 동작이며, hidden-mode 편집 자체는 desktop WorkspaceSelectorView와 기존 Automation/MCP `ui.toggle*Hidden` 경로가 담당한다.
+
+`/remote/v1/navigation`은 최상위 `notifications` 목록도 포함한다. 각 항목은 `{id,title,message,level,createdAt,readAt,isRead,workspaceId,workspaceName,terminalId,terminalLabel,requiresAction}` 형태이며 desktop `NotificationPanel`과 같은 규칙으로 정렬한다. 즉 unread notification을 먼저 두고, unread/read 각 그룹 내부는 최신 삽입 순서를 따른다. Remote page는 이 정렬된 목록에서 처음 등장한 workspace 순서대로 그룹화해 표시한다. 알림 tap은 연관 대상이 있으면 기존 navigation action을 재사용한다: workspace 대상은 `/remote/v1/workspaces/active`, terminal 대상은 `/remote/v1/terminals/{id}/focus`를 호출하고, 대상이 없는 알림은 `/remote/v1/notifications/{id}/read`로 해당 id만 읽음 처리한다. Mark-all-read는 frontend bridge `notifications.markAllRead`를 사용하고, clear-all은 `notifications.list`로 id를 수집한 뒤 기존 `notifications.clear`에 ids를 넘긴다. 이 notification endpoint들은 remote controller action이므로 active lease를 요구하지만, `/remote/v1/navigation`은 계속 token-gated read-only query다.
 
 ### 13.4 Terminal Control
 

--- a/src-tauri/src/remote_server/navigation.rs
+++ b/src-tauri/src/remote_server/navigation.rs
@@ -44,11 +44,18 @@ pub(super) fn build_remote_navigation_payload(
         .get("workspaceSelector")
         .unwrap_or(&Value::Null);
     let workspace_sort_order = string_field(workspace_selector, "sortOrder").unwrap_or("manual");
+    let workspace_names = workspace_name_map(workspaces_data, active_workspace_data);
     let notifications = notifications_data
         .get("notifications")
         .and_then(Value::as_array)
         .map(Vec::as_slice)
         .unwrap_or(&[]);
+    let notification_summaries = summarize_notifications(
+        notifications,
+        &workspace_names,
+        &backend_by_id,
+        &frontend_by_id,
+    );
 
     let workspaces = workspaces_data
         .get("workspaces")
@@ -118,6 +125,7 @@ pub(super) fn build_remote_navigation_payload(
         "activeWorkspace": active_workspace,
         "docks": docks,
         "terminals": terminals,
+        "notifications": notification_summaries,
         "workspaceSelector": workspace_selector,
         "unreadNotificationCount": unread_count(notifications, None, None),
     })
@@ -373,6 +381,116 @@ fn terminal_summary_value(terminal: &RemoteTerminalInfo, frontend: Option<&Value
     }
 
     value
+}
+
+fn summarize_notifications(
+    notifications: &[Value],
+    workspace_names: &HashMap<String, String>,
+    backend_by_id: &HashMap<&str, &RemoteTerminalInfo>,
+    frontend_by_id: &HashMap<&str, &Value>,
+) -> Vec<Value> {
+    let mut indexed = notifications.iter().enumerate().collect::<Vec<_>>();
+    indexed.sort_by(|(left_index, left), (right_index, right)| {
+        notification_read_rank(left)
+            .cmp(&notification_read_rank(right))
+            .then_with(|| right_index.cmp(left_index))
+    });
+
+    indexed
+        .into_iter()
+        .map(|(_, notification)| {
+            let workspace_id = string_field(notification, "workspaceId");
+            let terminal_id = string_field(notification, "terminalId");
+            let workspace_name = workspace_id.and_then(|id| workspace_names.get(id));
+            let terminal_label =
+                notification_terminal_label(terminal_id, backend_by_id, frontend_by_id);
+            let title = terminal_label
+                .as_deref()
+                .or_else(|| workspace_name.map(String::as_str))
+                .unwrap_or("Notification");
+            let read_at = optional_field(notification, "readAt");
+            let is_read = read_at.is_some();
+
+            json!({
+                "id": string_field(notification, "id").unwrap_or_default(),
+                "title": title,
+                "message": string_field(notification, "message").unwrap_or_default(),
+                "level": string_field(notification, "level").unwrap_or("info"),
+                "createdAt": number_field(notification, "createdAt").unwrap_or_default(),
+                "readAt": read_at,
+                "isRead": is_read,
+                "workspaceId": workspace_id,
+                "workspaceName": workspace_name,
+                "terminalId": terminal_id,
+                "terminalLabel": terminal_label,
+                "requiresAction": bool_field(notification, "requiresAction").unwrap_or(false),
+            })
+        })
+        .collect()
+}
+
+fn notification_read_rank(notification: &Value) -> u8 {
+    if notification
+        .get("readAt")
+        .is_some_and(|value| !value.is_null())
+    {
+        1
+    } else {
+        0
+    }
+}
+
+fn notification_terminal_label(
+    terminal_id: Option<&str>,
+    backend_by_id: &HashMap<&str, &RemoteTerminalInfo>,
+    frontend_by_id: &HashMap<&str, &Value>,
+) -> Option<String> {
+    let terminal_id = terminal_id?;
+    let frontend = frontend_by_id.get(terminal_id).copied();
+    let backend = backend_by_id.get(terminal_id).copied();
+    string_field(frontend.unwrap_or(&Value::Null), "label")
+        .or_else(|| string_field(frontend.unwrap_or(&Value::Null), "title"))
+        .or_else(|| {
+            backend
+                .map(|terminal| terminal.title.as_str())
+                .filter(|title| !title.is_empty())
+        })
+        .or_else(|| {
+            backend
+                .map(|terminal| terminal.profile.as_str())
+                .filter(|profile| !profile.is_empty())
+        })
+        .or(Some(terminal_id))
+        .map(str::to_string)
+}
+
+fn workspace_name_map(
+    workspaces_data: &Value,
+    active_workspace_data: &Value,
+) -> HashMap<String, String> {
+    let mut names = HashMap::new();
+    if let Some(workspaces) = workspaces_data.get("workspaces").and_then(Value::as_array) {
+        for workspace in workspaces {
+            if let (Some(id), Some(name)) = (
+                string_field(workspace, "id"),
+                string_field(workspace, "name"),
+            ) {
+                names.insert(id.to_string(), name.to_string());
+            }
+        }
+    }
+    if let Some(workspace) = active_workspace_data
+        .get("workspace")
+        .filter(|workspace| !workspace.is_null())
+    {
+        if let (Some(id), Some(name)) = (
+            string_field(workspace, "id"),
+            string_field(workspace, "name"),
+        ) {
+            names.insert(id.to_string(), name.to_string());
+        }
+    }
+    names
 }
 
 fn pane_title(
@@ -953,6 +1071,106 @@ mod tests {
         assert_eq!(payload["activeWorkspace"]["panes"][0]["unreadCount"], 1);
         assert_eq!(payload["activeWorkspace"]["panes"][1]["hidden"], true);
         assert_eq!(payload["activeWorkspace"]["panes"][1]["collapsed"], true);
+
+        let notification_ids = payload["notifications"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|notification| notification["id"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(notification_ids, vec!["n2", "n1", "n3"]);
+        assert_eq!(payload["notifications"][0]["workspaceName"], "Hidden");
+        assert_eq!(payload["notifications"][0]["isRead"], false);
+        assert_eq!(payload["notifications"][2]["isRead"], true);
+    }
+
+    #[test]
+    fn navigation_payload_includes_notification_list_with_desktop_order_and_targets() {
+        let workspaces_data = json!({
+            "activeWorkspaceId": "ws-a",
+            "workspaces": [
+                { "id": "ws-a", "name": "Alpha", "panes": [] },
+                { "id": "ws-b", "name": "Beta", "panes": [] }
+            ]
+        });
+        let active_workspace_data = json!({
+            "workspace": { "id": "ws-a", "name": "Alpha", "panes": [] }
+        });
+        let terminal_instances_data = json!({
+            "instances": [
+                { "id": "terminal-a", "workspaceId": "ws-a", "label": "Shell A" }
+            ]
+        });
+        let notifications = json!({
+            "notifications": [
+                {
+                    "id": "read-old",
+                    "terminalId": "terminal-a",
+                    "workspaceId": "ws-a",
+                    "message": "old read",
+                    "level": "info",
+                    "createdAt": 100,
+                    "readAt": 101
+                },
+                {
+                    "id": "unread-old",
+                    "terminalId": "terminal-a",
+                    "workspaceId": "ws-a",
+                    "message": "old unread",
+                    "level": "warning",
+                    "createdAt": 200,
+                    "readAt": null
+                },
+                {
+                    "id": "unread-new",
+                    "terminalId": "terminal-b",
+                    "workspaceId": "ws-b",
+                    "message": "new unread",
+                    "level": "error",
+                    "createdAt": 300,
+                    "readAt": null,
+                    "requiresAction": true
+                },
+                {
+                    "id": "read-new",
+                    "message": "global read",
+                    "level": "success",
+                    "createdAt": 400,
+                    "readAt": 401
+                }
+            ]
+        });
+
+        let payload = build_remote_navigation_payload(
+            &workspaces_data,
+            &active_workspace_data,
+            &json!({ "docks": [] }),
+            &terminal_instances_data,
+            &notifications,
+            &json!({ "hiddenWorkspaceIds": [], "hiddenPaneIds": [] }),
+            &[terminal("terminal-b", "Backend B")],
+        );
+
+        let notification_ids = payload["notifications"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|notification| notification["id"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            notification_ids,
+            vec!["unread-new", "unread-old", "read-new", "read-old"]
+        );
+        assert_eq!(payload["notifications"][0]["workspaceId"], "ws-b");
+        assert_eq!(payload["notifications"][0]["workspaceName"], "Beta");
+        assert_eq!(payload["notifications"][0]["terminalId"], "terminal-b");
+        assert_eq!(payload["notifications"][0]["terminalLabel"], "Backend B");
+        assert_eq!(payload["notifications"][0]["title"], "Backend B");
+        assert_eq!(payload["notifications"][0]["requiresAction"], true);
+        assert_eq!(payload["notifications"][1]["terminalLabel"], "Shell A");
+        assert_eq!(payload["notifications"][2]["workspaceId"], Value::Null);
+        assert_eq!(payload["notifications"][2]["terminalId"], Value::Null);
+        assert_eq!(payload["notifications"][2]["isRead"], true);
     }
 
     #[test]

--- a/src-tauri/src/remote_server/navigation_routes.rs
+++ b/src-tauri/src/remote_server/navigation_routes.rs
@@ -30,6 +30,12 @@ pub(super) struct TerminalFocusRequest {
     lease_id: Option<String>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct NotificationActionRequest {
+    lease_id: Option<String>,
+}
+
 pub(super) async fn remote_navigation(State(server): State<ServerState>) -> Response {
     let workspaces_data = match frontend_bridge_json(
         &server,
@@ -218,6 +224,141 @@ pub(super) async fn remote_terminal_focus(
     }
 }
 
+pub(super) async fn remote_notification_mark_read(
+    State(server): State<ServerState>,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if id.trim().is_empty() {
+        return json_error(StatusCode::BAD_REQUEST, "notification id is required");
+    }
+    let body = match notification_action_request_from_body(&body) {
+        Ok(body) => body,
+        Err(_) => return json_error(StatusCode::BAD_REQUEST, "invalid JSON body"),
+    };
+    let lease_id = body
+        .lease_id
+        .as_deref()
+        .or_else(|| lease_id_from_headers(&headers));
+    if let Err(response) = require_active_lease(&server.app_state, lease_id) {
+        return response;
+    }
+
+    match frontend_bridge_json(
+        &server,
+        "action",
+        "notifications",
+        "markIdsRead",
+        serde_json::json!({ "ids": [id.clone()] }),
+    )
+    .await
+    {
+        Ok(data) => {
+            emit_workspace_state_changed(
+                &server,
+                "remote.notifications.markRead",
+                serde_json::json!({ "id": id }),
+            );
+            Json(data).into_response()
+        }
+        Err(response) => response,
+    }
+}
+
+pub(super) async fn remote_notifications_mark_all_read(
+    State(server): State<ServerState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let body = match notification_action_request_from_body(&body) {
+        Ok(body) => body,
+        Err(_) => return json_error(StatusCode::BAD_REQUEST, "invalid JSON body"),
+    };
+    let lease_id = body
+        .lease_id
+        .as_deref()
+        .or_else(|| lease_id_from_headers(&headers));
+    if let Err(response) = require_active_lease(&server.app_state, lease_id) {
+        return response;
+    }
+
+    match frontend_bridge_json(
+        &server,
+        "action",
+        "notifications",
+        "markAllRead",
+        serde_json::json!({}),
+    )
+    .await
+    {
+        Ok(data) => {
+            emit_workspace_state_changed(
+                &server,
+                "remote.notifications.markAllRead",
+                serde_json::json!({}),
+            );
+            Json(data).into_response()
+        }
+        Err(response) => response,
+    }
+}
+
+pub(super) async fn remote_notifications_clear(
+    State(server): State<ServerState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let body = match notification_action_request_from_body(&body) {
+        Ok(body) => body,
+        Err(_) => return json_error(StatusCode::BAD_REQUEST, "invalid JSON body"),
+    };
+    let lease_id = body
+        .lease_id
+        .as_deref()
+        .or_else(|| lease_id_from_headers(&headers));
+    if let Err(response) = require_active_lease(&server.app_state, lease_id) {
+        return response;
+    }
+
+    let notifications_data = match frontend_bridge_json(
+        &server,
+        "query",
+        "notifications",
+        "list",
+        serde_json::json!({}),
+    )
+    .await
+    {
+        Ok(data) => data,
+        Err(response) => return response,
+    };
+    let ids = notification_ids(&notifications_data);
+    if ids.is_empty() {
+        return Json(serde_json::json!({ "cleared": 0 })).into_response();
+    }
+
+    match frontend_bridge_json(
+        &server,
+        "action",
+        "notifications",
+        "clear",
+        serde_json::json!({ "ids": ids }),
+    )
+    .await
+    {
+        Ok(data) => {
+            emit_workspace_state_changed(
+                &server,
+                "remote.notifications.clear",
+                serde_json::json!({}),
+            );
+            Json(data).into_response()
+        }
+        Err(response) => response,
+    }
+}
+
 async fn frontend_bridge_json(
     server: &ServerState,
     category: &str,
@@ -270,6 +411,34 @@ fn terminal_focus_request_from_body(
     serde_json::from_slice(body)
 }
 
+fn notification_action_request_from_body(
+    body: &[u8],
+) -> Result<NotificationActionRequest, serde_json::Error> {
+    if body.iter().all(u8::is_ascii_whitespace) {
+        return Ok(NotificationActionRequest::default());
+    }
+    serde_json::from_slice(body)
+}
+
+fn notification_ids(notifications_data: &Value) -> Vec<String> {
+    notifications_data
+        .get("notifications")
+        .and_then(Value::as_array)
+        .map(|notifications| {
+            notifications
+                .iter()
+                .filter_map(|notification| {
+                    notification
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .filter(|id| !id.is_empty())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use axum::http::{HeaderMap, HeaderValue};
@@ -300,5 +469,28 @@ mod tests {
         );
 
         assert_eq!(lease_id_from_headers(&headers), Some("lease-header"));
+    }
+
+    #[test]
+    fn notification_action_request_accepts_empty_body_for_header_lease() {
+        let body = notification_action_request_from_body(b"").unwrap();
+        assert!(body.lease_id.is_none());
+
+        let body = notification_action_request_from_body(b" \n\t").unwrap();
+        assert!(body.lease_id.is_none());
+    }
+
+    #[test]
+    fn notification_ids_ignores_missing_and_empty_ids() {
+        let ids = notification_ids(&serde_json::json!({
+            "notifications": [
+                { "id": "n1" },
+                { "id": "" },
+                { "message": "missing" },
+                { "id": "n2" }
+            ]
+        }));
+
+        assert_eq!(ids, vec!["n1", "n2"]);
     }
 }

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -1741,9 +1741,6 @@
         async function openNotification(notification) {
           if (!leaseId || !notification) return;
           setStatus("Opening notification...");
-          if (notification.workspaceId) {
-            await activateWorkspace(notification.workspaceId);
-          }
           if (notification.terminalId) {
             try {
               await focusTerminalOnHost(notification.terminalId);
@@ -1756,7 +1753,10 @@
             setNavigationOpen(false);
             return;
           }
-          if (!notification.workspaceId) {
+
+          if (notification.workspaceId) {
+            await activateWorkspace(notification.workspaceId);
+          } else {
             await markNotificationRead(notification);
           }
           await loadNavigation(null);

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -450,6 +450,122 @@
         font-variant-numeric: tabular-nums;
         line-height: 1;
       }
+      .notification-tab {
+        width: 100%;
+        min-height: 30px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 6px 8px;
+        border: 0;
+        border-bottom: 1px solid var(--border);
+        border-radius: 0;
+        background: transparent;
+        color: var(--text-primary);
+        text-align: left;
+      }
+      .notification-tab:hover:not(:disabled) {
+        background: var(--hover-bg);
+      }
+      .notification-tab[aria-expanded="true"] {
+        background: var(--accent-08);
+      }
+      .notification-tab-label {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: var(--fs-sm);
+        font-weight: 650;
+      }
+      .notification-panel {
+        display: flex;
+        flex-direction: column;
+        max-height: min(46vh, 360px);
+        border-bottom: 1px solid var(--border);
+        background: rgba(255, 255, 255, 0.012);
+      }
+      .notification-actions {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 6px;
+        padding: 7px 8px;
+        border-bottom: 1px solid var(--border);
+      }
+      .notification-actions button {
+        min-width: 0;
+        padding-left: 6px;
+        padding-right: 6px;
+        font-size: var(--fs-sm);
+      }
+      .notification-list {
+        min-height: 0;
+        overflow-y: auto;
+      }
+      .notification-group-title {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 5px 8px 4px;
+        border-bottom: 1px solid var(--border);
+        background: var(--bg-surface);
+        color: var(--text-secondary);
+        font-size: var(--fs-xs);
+        font-weight: 600;
+      }
+      .notification-item {
+        width: 100%;
+        min-width: 0;
+        display: grid;
+        grid-template-columns: minmax(52px, 72px) minmax(0, 1fr) auto;
+        gap: 7px;
+        align-items: center;
+        padding: 7px 8px;
+        border: 0;
+        border-bottom: 1px solid var(--border);
+        border-radius: 0;
+        background: transparent;
+        color: var(--text-secondary);
+        text-align: left;
+      }
+      .notification-item:hover:not(:disabled) {
+        background: var(--hover-bg);
+      }
+      .notification-item.read {
+        opacity: 0.6;
+      }
+      .notification-source,
+      .notification-message,
+      .notification-time {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: var(--fs-sm);
+      }
+      .notification-source {
+        color: var(--text-secondary);
+        opacity: 0.84;
+      }
+      .notification-message {
+        color: var(--text-primary);
+      }
+      .notification-message.error {
+        color: var(--red);
+      }
+      .notification-message.warning {
+        color: var(--yellow);
+      }
+      .notification-message.success {
+        color: var(--green);
+      }
+      .notification-time {
+        color: var(--text-secondary);
+        font-size: var(--fs-xs);
+        opacity: 0.78;
+      }
       .workspace-pane-list {
         display: flex;
         flex-direction: column;
@@ -711,6 +827,19 @@
                 <button id="refresh" disabled>Refresh</button>
               </div>
             </section>
+            <section id="notificationSection" class="nav-section locked" aria-label="Notifications">
+              <button id="notificationToggle" class="notification-tab" type="button" aria-expanded="false" aria-controls="notificationPanel" disabled>
+                <span class="notification-tab-label">Notifications</span>
+                <span id="notificationBadge" class="workspace-count-badge" hidden>0</span>
+              </button>
+              <div id="notificationPanel" class="notification-panel" hidden>
+                <div class="notification-actions">
+                  <button id="markAllNotificationsRead" type="button" disabled>Mark read</button>
+                  <button id="clearNotifications" class="danger" type="button" disabled>Clear</button>
+                </div>
+                <div id="notificationList" class="notification-list"></div>
+              </div>
+            </section>
             <section id="workspaceSection" class="nav-section locked">
               <h2 class="nav-section-title">Workspaces</h2>
               <div id="workspaceList" class="nav-list"></div>
@@ -751,6 +880,13 @@
         const terminalMetaEl = $("terminalMeta");
         const workspaceSection = $("workspaceSection");
         const workspaceListEl = $("workspaceList");
+        const notificationSection = $("notificationSection");
+        const notificationToggleButton = $("notificationToggle");
+        const notificationBadge = $("notificationBadge");
+        const notificationPanel = $("notificationPanel");
+        const notificationListEl = $("notificationList");
+        const markAllNotificationsReadButton = $("markAllNotificationsRead");
+        const clearNotificationsButton = $("clearNotifications");
         const focusTerminalButton = $("focusTerminal");
         const copySelectionButton = $("copySelection");
         const ctrlCButton = $("ctrlC");
@@ -771,6 +907,7 @@
         let pendingInput = "";
         let inputFlushTimer = null;
         let inputWriteChain = Promise.resolve();
+        let notificationPanelOpen = false;
 
         const hashParams = new URLSearchParams(location.hash.replace(/^#/, ""));
         const searchParams = new URLSearchParams(location.search);
@@ -849,10 +986,13 @@
           if (connectionPanel) connectionPanel.classList.toggle("connected", connected);
           if (connected) setConnectionHint("Connect first to load workspaces and control the active terminal.", false);
           workspaceSection.classList.toggle("locked", !connected);
+          notificationSection.classList.toggle("locked", !connected);
+          notificationToggleButton.disabled = !connected;
           releaseButton.disabled = !connected;
           refreshButton.disabled = !connected;
           connectButton.disabled = connected;
           updateTerminalControls();
+          updateNotificationActions();
         }
 
         function setConnectionHint(message, attention = false) {
@@ -1163,6 +1303,105 @@
           element.style.fontSize = countBadgeFontSize(text);
         }
 
+        function notificationCount() {
+          return ((navigationState && navigationState.notifications) || []).length;
+        }
+
+        function unreadNotificationCount() {
+          return Number((navigationState && navigationState.unreadNotificationCount) || 0);
+        }
+
+        function updateNotificationActions() {
+          const hasNotifications = notificationCount() > 0;
+          const hasUnread = unreadNotificationCount() > 0;
+          markAllNotificationsReadButton.disabled = !leaseId || !hasUnread;
+          clearNotificationsButton.disabled = !leaseId || !hasNotifications;
+        }
+
+        function setNotificationPanelOpen(open) {
+          notificationPanelOpen = Boolean(open);
+          notificationPanel.hidden = !notificationPanelOpen;
+          notificationToggleButton.setAttribute("aria-expanded", String(notificationPanelOpen));
+        }
+
+        function formatNotificationTime(createdAt) {
+          const timestamp = Number(createdAt);
+          if (!Number.isFinite(timestamp) || timestamp <= 0) return "";
+          const diff = Date.now() - timestamp;
+          if (diff < 60000) return "now";
+          if (diff < 3600000) return `${Math.floor(diff / 60000)}m`;
+          if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`;
+          return `${Math.floor(diff / 86400000)}d`;
+        }
+
+        function notificationSource(notification) {
+          return notification.terminalLabel || notification.title || notification.workspaceName || notification.workspaceId || "Notification";
+        }
+
+        function notificationLevelClass(level) {
+          return ["error", "warning", "success", "info"].includes(level) ? level : "info";
+        }
+
+        function renderNotificationPanel(notifications, unreadCount) {
+          const badgeCount = Number(unreadCount) || 0;
+          notificationBadge.hidden = badgeCount <= 0;
+          if (badgeCount > 0) fillCountBadge(notificationBadge, badgeCount);
+          notificationListEl.innerHTML = "";
+          if (!notifications.length) {
+            emptyNav(notificationListEl, "No notifications.");
+            updateNotificationActions();
+            return;
+          }
+
+          const workspaceKeys = [];
+          for (const notification of notifications) {
+            const workspaceKey = notification.workspaceId || "__global__";
+            if (!workspaceKeys.includes(workspaceKey)) {
+              workspaceKeys.push(workspaceKey);
+            }
+          }
+          for (const workspaceKey of workspaceKeys) {
+            const groupNotifications = notifications.filter((notification) => (notification.workspaceId || "__global__") === workspaceKey);
+            const first = groupNotifications[0] || {};
+            const title = document.createElement("div");
+            title.className = "notification-group-title";
+            title.textContent = first.workspaceName || first.workspaceId || "Notifications";
+            notificationListEl.append(title);
+            groupNotifications.forEach((notification) => {
+              notificationListEl.append(renderNotificationItem(notification));
+            });
+          }
+          updateNotificationActions();
+        }
+
+        function renderNotificationItem(notification) {
+          const item = document.createElement("button");
+          item.type = "button";
+          item.className = `notification-item${notification.isRead ? " read" : ""}`;
+          item.disabled = !leaseId;
+          item.dataset.notificationId = notification.id || "";
+          item.addEventListener("click", () => {
+            openNotification(notification).catch((err) => setStatus(err.message || String(err), true));
+          });
+
+          const source = document.createElement("span");
+          source.className = "notification-source";
+          source.textContent = notificationSource(notification);
+          item.append(source);
+
+          const message = document.createElement("span");
+          message.className = `notification-message ${notificationLevelClass(notification.level)}`;
+          message.textContent = notification.message || "";
+          item.append(message);
+
+          const time = document.createElement("span");
+          time.className = "notification-time";
+          time.textContent = formatNotificationTime(notification.createdAt);
+          item.append(time);
+
+          return item;
+        }
+
         function workspaceDisplaySettings() {
           const display = navigationState && navigationState.workspaceSelector && navigationState.workspaceSelector.display;
           return {
@@ -1196,6 +1435,7 @@
         }
 
         function renderNavigation(data) {
+          renderNotificationPanel(data.notifications || [], data.unreadNotificationCount || 0);
           renderWorkspaceList(data.workspaces || []);
         }
 
@@ -1452,13 +1692,73 @@
           }
         }
 
-        async function switchWorkspace(workspaceId) {
+        async function activateWorkspace(workspaceId) {
           if (!leaseId || !workspaceId) return;
-          setStatus("Switching workspace...");
           await remoteFetch("/remote/v1/workspaces/active", {
             method: "POST",
             body: JSON.stringify({ leaseId, id: workspaceId }),
           });
+        }
+
+        async function switchWorkspace(workspaceId) {
+          if (!leaseId || !workspaceId) return;
+          setStatus("Switching workspace...");
+          await activateWorkspace(workspaceId);
+          await loadNavigation(null);
+          setNavigationOpen(false);
+        }
+
+        async function markNotificationRead(notification) {
+          if (!leaseId || !notification || !notification.id) return;
+          await remoteFetch(`/remote/v1/notifications/${encodeURIComponent(notification.id)}/read`, {
+            method: "POST",
+            body: JSON.stringify({ leaseId }),
+          });
+        }
+
+        async function markAllNotificationsRead() {
+          if (!leaseId) return;
+          setStatus("Marking notifications read...");
+          await remoteFetch("/remote/v1/notifications/mark-all-read", {
+            method: "POST",
+            body: JSON.stringify({ leaseId }),
+          });
+          await loadNavigation(activeTerminalId, { openOutput: false });
+          setStatus("Notifications marked read.");
+        }
+
+        async function clearNotifications() {
+          if (!leaseId) return;
+          setStatus("Clearing notifications...");
+          await remoteFetch("/remote/v1/notifications", {
+            method: "DELETE",
+            body: JSON.stringify({ leaseId }),
+          });
+          await loadNavigation(activeTerminalId, { openOutput: false });
+          setStatus("Notifications cleared.");
+        }
+
+        async function openNotification(notification) {
+          if (!leaseId || !notification) return;
+          setStatus("Opening notification...");
+          if (notification.workspaceId) {
+            await activateWorkspace(notification.workspaceId);
+          }
+          if (notification.terminalId) {
+            try {
+              await focusTerminalOnHost(notification.terminalId);
+            } catch (err) {
+              await markNotificationRead(notification).catch(() => {});
+              await loadNavigation(activeTerminalId, { openOutput: false }).catch(() => {});
+              throw err;
+            }
+            await loadNavigation(notification.terminalId);
+            setNavigationOpen(false);
+            return;
+          }
+          if (!notification.workspaceId) {
+            await markNotificationRead(notification);
+          }
           await loadNavigation(null);
           setNavigationOpen(false);
         }
@@ -1704,11 +2004,22 @@
         }
 
         emptyNav(workspaceListEl, "Not connected.");
+        emptyNav(notificationListEl, "Not connected.");
+        setNotificationPanelOpen(false);
         setNavigationOpen(true);
 
         navToggleButton.addEventListener("click", () => {
           const open = navToggleButton.getAttribute("aria-expanded") !== "true";
           setNavigationOpen(open);
+        });
+        notificationToggleButton.addEventListener("click", () => {
+          setNotificationPanelOpen(!notificationPanelOpen);
+        });
+        markAllNotificationsReadButton.addEventListener("click", () => {
+          markAllNotificationsRead().catch((err) => setStatus(`Mark read failed: ${err.message}`, true));
+        });
+        clearNotificationsButton.addEventListener("click", () => {
+          clearNotifications().catch((err) => setStatus(`Clear failed: ${err.message}`, true));
         });
         navCloseButton.addEventListener("click", () => setNavigationOpen(false));
         navScrim.addEventListener("click", () => setNavigationOpen(false));

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -103,6 +103,17 @@ mod tests {
         assert!(html.contains("id=\"workspaceSection\""));
         assert!(html.contains("workspace-item-content"));
         assert!(html.contains("workspace-pane-row"));
+        assert!(html.contains("id=\"notificationSection\""));
+        assert!(html.contains("id=\"notificationToggle\""));
+        assert!(html.contains("id=\"notificationPanel\""));
+        assert!(html.contains("id=\"notificationBadge\""));
+        assert!(html.contains("renderNotificationPanel(data.notifications || []"));
+        assert!(html.contains("/remote/v1/notifications/mark-all-read"));
+        assert!(
+            html.contains("/remote/v1/notifications/${encodeURIComponent(notification.id)}/read")
+        );
+        assert!(html.contains("/remote/v1/notifications\","));
+        assert!(html.contains("function openNotification(notification)"));
         assert!(!html.contains("id=\"terminals\""));
         assert!(!html.contains("id=\"dockList\""));
         assert!(html.contains("function isDockTerminalId(terminalId)"));

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -119,4 +119,26 @@ mod tests {
         assert!(html.contains("function isDockTerminalId(terminalId)"));
         assert!(html.contains("options.focusHost !== false && !isDockTerminalId(terminalId)"));
     }
+
+    #[test]
+    fn remote_page_terminal_notification_focuses_without_prior_workspace_switch() {
+        let html = remote_page_html();
+        let start = html.find("async function openNotification").unwrap();
+        let end = start
+            + html[start..]
+                .find("async function focusTerminalOnHost")
+                .unwrap();
+        let open_notification = &html[start..end];
+
+        let terminal_branch = open_notification
+            .find("if (notification.terminalId)")
+            .unwrap();
+        let workspace_branch = open_notification
+            .find("if (notification.workspaceId)")
+            .unwrap();
+
+        assert!(terminal_branch < workspace_branch);
+        assert!(open_notification.contains("await focusTerminalOnHost(notification.terminalId);"));
+        assert!(open_notification.contains("await activateWorkspace(notification.workspaceId);"));
+    }
 }

--- a/src-tauri/src/remote_server/routes.rs
+++ b/src-tauri/src/remote_server/routes.rs
@@ -5,7 +5,7 @@ use axum::extract::{ConnectInfo, Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::middleware;
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 use tokio::time;
@@ -24,7 +24,8 @@ use super::lease::{
     reclaim_lockout_active, require_active_lease, status_from_state, RemoteControlLease,
 };
 use super::navigation_routes::{
-    remote_navigation, remote_terminal_focus, remote_workspace_switch_active,
+    remote_navigation, remote_notification_mark_read, remote_notifications_clear,
+    remote_notifications_mark_all_read, remote_terminal_focus, remote_workspace_switch_active,
 };
 use super::page::{remote_page, remote_page_redirect};
 use super::terminal_info::remote_terminal_infos;
@@ -79,6 +80,18 @@ pub fn build_router(state: ServerState) -> Router<ServerState> {
         )
         .route("/remote/v1/session/release", post(remote_session_release))
         .route("/remote/v1/navigation", get(remote_navigation))
+        .route(
+            "/remote/v1/notifications/{id}/read",
+            post(remote_notification_mark_read),
+        )
+        .route(
+            "/remote/v1/notifications/mark-all-read",
+            post(remote_notifications_mark_all_read),
+        )
+        .route(
+            "/remote/v1/notifications",
+            delete(remote_notifications_clear),
+        )
         .route(
             "/remote/v1/workspaces/active",
             post(remote_workspace_switch_active),

--- a/ui/src/hooks/useAutomationBridge.test.ts
+++ b/ui/src/hooks/useAutomationBridge.test.ts
@@ -204,6 +204,79 @@ describe("handleAutomationRequest", () => {
     expect(useNotificationStore.getState().notifications[0].readAt).not.toBeNull();
   });
 
+  it("marks notification ids as read", () => {
+    const store = useNotificationStore.getState();
+    const first = store.addNotification({
+      terminalId: "terminal-pane-1",
+      workspaceId: "ws-default",
+      message: "first",
+      requiresAction: true,
+    });
+    const second = store.addNotification({
+      terminalId: "terminal-pane-2",
+      workspaceId: "ws-default",
+      message: "second",
+      requiresAction: true,
+    });
+
+    const result = handleAutomationRequest({
+      requestId: "r9c",
+      category: "action",
+      target: "notifications",
+      method: "markIdsRead",
+      params: { ids: [first.id] },
+    });
+
+    expect(result.success).toBe(true);
+    const notifications = useNotificationStore.getState().notifications;
+    expect(
+      notifications.find((notification) => notification.id === first.id)?.readAt,
+    ).not.toBeNull();
+    expect(notifications.find((notification) => notification.id === second.id)?.readAt).toBeNull();
+  });
+
+  it("marks all unread notifications as read", () => {
+    const now = Date.now();
+    useNotificationStore.setState({
+      notifications: [
+        {
+          id: "unread-1",
+          terminalId: "terminal-pane-1",
+          workspaceId: "ws-default",
+          message: "first",
+          level: "info",
+          createdAt: now - 10,
+          readAt: null,
+        },
+        {
+          id: "read-1",
+          terminalId: "terminal-pane-2",
+          workspaceId: "ws-default",
+          message: "second",
+          level: "info",
+          createdAt: now - 5,
+          readAt: now - 1,
+        },
+      ],
+    });
+
+    const result = handleAutomationRequest({
+      requestId: "r9d",
+      category: "action",
+      target: "notifications",
+      method: "markAllRead",
+      params: {},
+    });
+
+    expect(result.success).toBe(true);
+    expect((result.data as { marked: number }).marked).toBe(1);
+    expect(
+      useNotificationStore
+        .getState()
+        .notifications.every((notification) => notification.readAt !== null),
+    ).toBe(true);
+  });
+
   it("returns UI hidden state for remote navigation", () => {
     useUiStore.getState().toggleWorkspaceHidden("ws-hidden");
     useUiStore.getState().togglePaneHidden("pane-hidden");

--- a/ui/src/hooks/useAutomationBridge.ts
+++ b/ui/src/hooks/useAutomationBridge.ts
@@ -660,6 +660,25 @@ const handlers: HandlerMap = {
       useNotificationStore.getState().markTerminalAsRead(terminalId);
       return ok({ marked: true });
     },
+    markIdsRead: (p) => {
+      const ids = p.ids as unknown;
+      if (!Array.isArray(ids) || !ids.every((value) => typeof value === "string")) {
+        return err("'ids' must be a string array");
+      }
+      if (ids.length === 0) return err("'ids' must not be empty");
+      useNotificationStore.getState().markNotificationsAsRead(ids);
+      return ok({ marked: ids.length });
+    },
+    markAllRead: () => {
+      const unreadIds = useNotificationStore
+        .getState()
+        .notifications.filter((notification) => notification.readAt === null)
+        .map((notification) => notification.id);
+      if (unreadIds.length > 0) {
+        useNotificationStore.getState().markNotificationsAsRead(unreadIds);
+      }
+      return ok({ marked: unreadIds.length });
+    },
     clear: (p) => {
       const ids = p.ids as unknown;
       const before = p.before as unknown;


### PR DESCRIPTION
## Summary
- Add ordered notification summaries to `/remote/v1/navigation` with target/read metadata matching desktop NotificationPanel ordering.
- Add remote notification panel UI with tap-to-focus/read, mark-all-read, and clear-all actions.
- Add bridge/server notification read actions, tests, api-contracts update, and ADR-0019.

## Tests
- `cargo test navigation_payload`
- `cargo test remote_server::page`
- `cargo test remote_server::navigation_routes`
- `npm run test -- useAutomationBridge.test.ts`

Note: existing local `.serena/project.yml` changes were left unstaged and are not part of this PR.