### PR TITLE
refactor(remote): 호스트 후보 로직 중복 제거 + Rust 모듈 분리

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-use std::net::IpAddr;
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 
@@ -9,18 +7,6 @@ use crate::constants::*;
 use crate::lock_ext::MutexExt;
 use crate::state::AppState;
 use crate::terminal::{TerminalActivity, TerminalNotification, TerminalStateInfo};
-
-const HOST_KIND_LOOPBACK: &str = "loopback";
-const HOST_KIND_TAILSCALE: &str = "tailscale";
-const HOST_KIND_LAN: &str = "lan";
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct HostCandidate {
-    pub kind: String,
-    pub host: String,
-    pub label: String,
-}
 
 #[tauri::command]
 pub fn greet(name: &str) -> String {
@@ -34,115 +20,6 @@ pub fn get_automation_info(state: State<Arc<AppState>>) -> Result<serde_json::Va
     Ok(serde_json::json!({
         "port": port,
     }))
-}
-
-#[tauri::command]
-pub async fn get_remote_host_candidates() -> Result<Vec<HostCandidate>, String> {
-    tokio::task::spawn_blocking(get_remote_host_candidates_inner)
-        .await
-        .map_err(|e| format!("Failed to collect remote host candidates: {e}"))
-}
-
-pub fn get_remote_host_candidates_inner() -> Vec<HostCandidate> {
-    let mut candidates = Vec::new();
-    candidates.push(host_candidate(
-        HOST_KIND_LOOPBACK,
-        "127.0.0.1",
-        "Localhost 127.0.0.1",
-    ));
-    candidates.extend(detect_tailscale_host_candidates());
-    candidates.extend(detect_lan_host_candidates());
-    dedupe_host_candidates(candidates)
-}
-
-fn host_candidate(kind: &str, host: &str, label: &str) -> HostCandidate {
-    HostCandidate {
-        kind: kind.to_string(),
-        host: host.to_string(),
-        label: label.to_string(),
-    }
-}
-
-fn host_candidate_for_ip(kind: &str, ip: IpAddr) -> HostCandidate {
-    let host = ip.to_string();
-    let prefix = match kind {
-        HOST_KIND_TAILSCALE => "Tailscale",
-        HOST_KIND_LAN => "LAN",
-        _ => "Host",
-    };
-    host_candidate(kind, &host, &format!("{prefix} {host}"))
-}
-
-fn detect_tailscale_host_candidates() -> Vec<HostCandidate> {
-    ["-4", "-6"]
-        .into_iter()
-        .filter_map(|family| {
-            let output = crate::process::headless_command("tailscale")
-                .args(["ip", family])
-                .output()
-                .ok()?;
-            if !output.status.success() {
-                return None;
-            }
-            parse_first_tailscale_ip(&output.stdout)
-                .and_then(|host| host.parse::<IpAddr>().ok())
-                .map(|ip| host_candidate_for_ip(HOST_KIND_TAILSCALE, ip))
-        })
-        .collect()
-}
-
-fn parse_first_tailscale_ip(stdout: &[u8]) -> Option<String> {
-    String::from_utf8_lossy(stdout)
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .map(ToOwned::to_owned)
-}
-
-fn detect_lan_host_candidates() -> Vec<HostCandidate> {
-    let ips = match if_addrs::get_if_addrs() {
-        Ok(addrs) => addrs
-            .into_iter()
-            .filter(|interface| !interface.is_loopback())
-            .map(|interface| interface.ip())
-            .collect(),
-        Err(err) => {
-            tracing::debug!(error = %err, "failed to enumerate network interfaces");
-            Vec::new()
-        }
-    };
-    lan_host_candidates_from_ips(ips)
-}
-
-fn lan_host_candidates_from_ips(ips: Vec<IpAddr>) -> Vec<HostCandidate> {
-    let (mut ipv4, mut ipv6): (Vec<_>, Vec<_>) = ips
-        .into_iter()
-        .filter(|ip| is_lan_candidate_ip(*ip))
-        .partition(|ip| matches!(ip, IpAddr::V4(_)));
-    ipv4.append(&mut ipv6);
-    ipv4.into_iter()
-        .map(|ip| host_candidate_for_ip(HOST_KIND_LAN, ip))
-        .collect()
-}
-
-fn is_lan_candidate_ip(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(ip) => !ip.is_loopback() && !ip.is_link_local() && !ip.is_unspecified(),
-        IpAddr::V6(ip) => {
-            !ip.is_loopback()
-                && !ip.is_unicast_link_local()
-                && !ip.is_unspecified()
-                && !ip.is_multicast()
-        }
-    }
-}
-
-fn dedupe_host_candidates(candidates: Vec<HostCandidate>) -> Vec<HostCandidate> {
-    let mut seen = HashSet::new();
-    candidates
-        .into_iter()
-        .filter(|candidate| seen.insert(candidate.host.clone()))
-        .collect()
 }
 
 #[tauri::command]
@@ -986,7 +863,6 @@ pub fn load_window_geometry() -> Result<Option<WindowGeometry>, String> {
 mod tests {
     use super::*;
     use crate::terminal::{TerminalConfig, TerminalSession};
-    use std::net::{Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn greet_returns_message() {
@@ -1163,57 +1039,6 @@ mod tests {
             split_shell_prefix(r#"cmd "unclosed arg"#),
             vec!["cmd", "unclosed arg"]
         );
-    }
-
-    #[test]
-    fn parse_first_tailscale_ip_uses_first_non_empty_line() {
-        assert_eq!(
-            parse_first_tailscale_ip(b"\n  100.64.0.2 \n100.64.0.3\n").as_deref(),
-            Some("100.64.0.2")
-        );
-        assert_eq!(parse_first_tailscale_ip(b"\n \t \n"), None);
-    }
-
-    #[test]
-    fn lan_host_candidates_filter_loopback_and_link_local() {
-        let candidates = lan_host_candidates_from_ips(vec![
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            IpAddr::V4(Ipv4Addr::new(169, 254, 10, 20)),
-            IpAddr::V4(Ipv4Addr::new(192, 168, 0, 44)),
-            IpAddr::V6(Ipv6Addr::LOCALHOST),
-            IpAddr::V6("fe80::1".parse().unwrap()),
-            IpAddr::V6("fd7a:115c:a1e0::7".parse().unwrap()),
-        ]);
-
-        let hosts: Vec<_> = candidates
-            .iter()
-            .map(|candidate| candidate.host.as_str())
-            .collect();
-        assert_eq!(hosts, vec!["192.168.0.44", "fd7a:115c:a1e0::7"]);
-        assert!(candidates
-            .iter()
-            .all(|candidate| candidate.kind == HOST_KIND_LAN));
-    }
-
-    #[test]
-    fn dedupe_host_candidates_preserves_first_occurrence() {
-        let candidates = dedupe_host_candidates(vec![
-            host_candidate(HOST_KIND_LOOPBACK, "127.0.0.1", "Localhost"),
-            host_candidate(HOST_KIND_LAN, "192.168.0.2", "LAN 192.168.0.2"),
-            host_candidate(HOST_KIND_TAILSCALE, "192.168.0.2", "Tailscale duplicate"),
-        ]);
-
-        assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[1].kind, HOST_KIND_LAN);
-        assert_eq!(candidates[1].label, "LAN 192.168.0.2");
-    }
-
-    #[test]
-    fn get_remote_host_candidates_always_starts_with_loopback() {
-        let candidates = get_remote_host_candidates_inner();
-        assert!(!candidates.is_empty());
-        assert_eq!(candidates[0].kind, HOST_KIND_LOOPBACK);
-        assert_eq!(candidates[0].host, "127.0.0.1");
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,10 +2,12 @@ mod claude_session;
 mod file_ops;
 mod ipc_dispatch;
 mod misc;
+mod remote_hosts;
 mod terminal;
 
 pub use claude_session::*;
 pub use file_ops::*;
 pub use ipc_dispatch::*;
 pub use misc::*;
+pub use remote_hosts::*;
 pub use terminal::*;

--- a/src-tauri/src/commands/remote_hosts.rs
+++ b/src-tauri/src/commands/remote_hosts.rs
@@ -1,0 +1,180 @@
+use std::collections::HashSet;
+use std::net::IpAddr;
+
+const HOST_KIND_LOOPBACK: &str = "loopback";
+const HOST_KIND_TAILSCALE: &str = "tailscale";
+const HOST_KIND_LAN: &str = "lan";
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostCandidate {
+    pub kind: String,
+    pub host: String,
+    pub label: String,
+}
+
+#[tauri::command]
+pub async fn get_remote_host_candidates() -> Result<Vec<HostCandidate>, String> {
+    tokio::task::spawn_blocking(get_remote_host_candidates_inner)
+        .await
+        .map_err(|e| format!("Failed to collect remote host candidates: {e}"))
+}
+
+pub fn get_remote_host_candidates_inner() -> Vec<HostCandidate> {
+    let mut candidates = Vec::new();
+    candidates.push(host_candidate(
+        HOST_KIND_LOOPBACK,
+        "127.0.0.1",
+        "Localhost 127.0.0.1",
+    ));
+    candidates.extend(detect_tailscale_host_candidates());
+    candidates.extend(detect_lan_host_candidates());
+    dedupe_host_candidates(candidates)
+}
+
+fn host_candidate(kind: &str, host: &str, label: &str) -> HostCandidate {
+    HostCandidate {
+        kind: kind.to_string(),
+        host: host.to_string(),
+        label: label.to_string(),
+    }
+}
+
+fn host_candidate_for_ip(kind: &str, ip: IpAddr) -> HostCandidate {
+    let host = ip.to_string();
+    let prefix = match kind {
+        HOST_KIND_TAILSCALE => "Tailscale",
+        HOST_KIND_LAN => "LAN",
+        _ => "Host",
+    };
+    host_candidate(kind, &host, &format!("{prefix} {host}"))
+}
+
+fn detect_tailscale_host_candidates() -> Vec<HostCandidate> {
+    ["-4", "-6"]
+        .into_iter()
+        .filter_map(|family| {
+            let output = crate::process::headless_command("tailscale")
+                .args(["ip", family])
+                .output()
+                .ok()?;
+            if !output.status.success() {
+                return None;
+            }
+            parse_first_tailscale_ip(&output.stdout)
+                .and_then(|host| host.parse::<IpAddr>().ok())
+                .map(|ip| host_candidate_for_ip(HOST_KIND_TAILSCALE, ip))
+        })
+        .collect()
+}
+
+fn parse_first_tailscale_ip(stdout: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn detect_lan_host_candidates() -> Vec<HostCandidate> {
+    let ips = match if_addrs::get_if_addrs() {
+        Ok(addrs) => addrs
+            .into_iter()
+            .filter(|interface| !interface.is_loopback())
+            .map(|interface| interface.ip())
+            .collect(),
+        Err(err) => {
+            tracing::debug!(error = %err, "failed to enumerate network interfaces");
+            Vec::new()
+        }
+    };
+    lan_host_candidates_from_ips(ips)
+}
+
+fn lan_host_candidates_from_ips(ips: Vec<IpAddr>) -> Vec<HostCandidate> {
+    let (mut ipv4, mut ipv6): (Vec<_>, Vec<_>) = ips
+        .into_iter()
+        .filter(|ip| is_lan_candidate_ip(*ip))
+        .partition(|ip| matches!(ip, IpAddr::V4(_)));
+    ipv4.append(&mut ipv6);
+    ipv4.into_iter()
+        .map(|ip| host_candidate_for_ip(HOST_KIND_LAN, ip))
+        .collect()
+}
+
+fn is_lan_candidate_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => !ip.is_loopback() && !ip.is_link_local() && !ip.is_unspecified(),
+        IpAddr::V6(ip) => {
+            !ip.is_loopback()
+                && !ip.is_unicast_link_local()
+                && !ip.is_unspecified()
+                && !ip.is_multicast()
+        }
+    }
+}
+
+fn dedupe_host_candidates(candidates: Vec<HostCandidate>) -> Vec<HostCandidate> {
+    let mut seen = HashSet::new();
+    candidates
+        .into_iter()
+        .filter(|candidate| seen.insert(candidate.host.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn parse_first_tailscale_ip_uses_first_non_empty_line() {
+        assert_eq!(
+            parse_first_tailscale_ip(b"\n  100.64.0.2 \n100.64.0.3\n").as_deref(),
+            Some("100.64.0.2")
+        );
+        assert_eq!(parse_first_tailscale_ip(b"\n \t \n"), None);
+    }
+
+    #[test]
+    fn lan_host_candidates_filter_loopback_and_link_local() {
+        let candidates = lan_host_candidates_from_ips(vec![
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(169, 254, 10, 20)),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 0, 44)),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            IpAddr::V6("fe80::1".parse().unwrap()),
+            IpAddr::V6("fd7a:115c:a1e0::7".parse().unwrap()),
+        ]);
+
+        let hosts: Vec<_> = candidates
+            .iter()
+            .map(|candidate| candidate.host.as_str())
+            .collect();
+        assert_eq!(hosts, vec!["192.168.0.44", "fd7a:115c:a1e0::7"]);
+        assert!(candidates
+            .iter()
+            .all(|candidate| candidate.kind == HOST_KIND_LAN));
+    }
+
+    #[test]
+    fn dedupe_host_candidates_preserves_first_occurrence() {
+        let candidates = dedupe_host_candidates(vec![
+            host_candidate(HOST_KIND_LOOPBACK, "127.0.0.1", "Localhost"),
+            host_candidate(HOST_KIND_LAN, "192.168.0.2", "LAN 192.168.0.2"),
+            host_candidate(HOST_KIND_TAILSCALE, "192.168.0.2", "Tailscale duplicate"),
+        ]);
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[1].kind, HOST_KIND_LAN);
+        assert_eq!(candidates[1].label, "LAN 192.168.0.2");
+    }
+
+    #[test]
+    fn get_remote_host_candidates_always_starts_with_loopback() {
+        let candidates = get_remote_host_candidates_inner();
+        assert!(!candidates.is_empty());
+        assert_eq!(candidates[0].kind, HOST_KIND_LOOPBACK);
+        assert_eq!(candidates[0].host, "127.0.0.1");
+    }
+}

--- a/ui/src/components/views/RemoteAccessModal.tsx
+++ b/ui/src/components/views/RemoteAccessModal.tsx
@@ -1,20 +1,17 @@
 import type { ReactNode } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import {
   getRemoteAccessStatus,
   getRemoteControlStatus,
-  getRemoteHostCandidates,
   reclaimRemoteControl,
   setRemoteRuntimeAccess,
-  type HostCandidate,
   type RemoteAccessStatus,
   type RemoteControlStatus,
 } from "@/lib/tauri-api";
 import {
   buildLocalMobileModeUrl,
-  buildRemoteHostOptions,
   buildRemoteUrlWithToken,
   chooseRemoteHost,
   generateRemoteToken,
@@ -27,6 +24,7 @@ import { useSettingsStore } from "@/stores/settings-store";
 import { useUiStore } from "@/stores/ui-store";
 import { ToggleSwitch } from "@/components/ui/ToggleSwitch";
 import { FocusSelect } from "@/components/ui/FormControls";
+import { useRemoteHostOptions } from "@/hooks/useRemoteHostOptions";
 
 function Row({ label, children }: { label: string; children: ReactNode }) {
   return (
@@ -56,32 +54,28 @@ export function RemoteAccessModal() {
   const [port, setPort] = useState<number | null>(null);
   const [accessStatus, setAccessStatus] = useState<RemoteAccessStatus | null>(null);
   const [status, setStatus] = useState<RemoteControlStatus | null>(null);
-  const [hostCandidates, setHostCandidates] = useState<HostCandidate[]>([]);
-  const [lastHost, setLastHost] = useState(() => readLastRemoteHost());
+  const lastHostRef = useRef(readLastRemoteHost());
   const [selectedHost, setSelectedHost] = useState("");
   const [reclaiming, setReclaiming] = useState(false);
   const [actionPending, setActionPending] = useState<"runtime" | "mobile" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
 
-  const hostOptions = useMemo(
-    () => buildRemoteHostOptions(hostCandidates, remote.customHosts),
-    [hostCandidates, remote.customHosts],
-  );
+  const hostOptions = useRemoteHostOptions(remote.customHosts);
+  const resolvedHost = chooseRemoteHost(hostOptions, remote.preferredHost, lastHostRef.current);
 
   useEffect(() => {
     setSelectedHost((current) => {
       if (current && hostOptions.some((option) => option.host === current)) return current;
-      return chooseRemoteHost(hostOptions, remote.preferredHost, lastHost);
+      return resolvedHost;
     });
-  }, [hostOptions, lastHost, remote.preferredHost]);
+  }, [hostOptions, resolvedHost]);
 
   const token = (accessStatus?.effectiveAuthToken ?? remote.authToken).trim();
   const tokenConfigured = token.length > 0;
   const effectiveEnabled = accessStatus?.effectiveEnabled ?? remote.enabled;
   const runtimeEnabled = accessStatus?.runtimeEnabled ?? false;
-  const effectiveSelectedHost =
-    selectedHost || chooseRemoteHost(hostOptions, remote.preferredHost, lastHost);
+  const effectiveSelectedHost = selectedHost || resolvedHost;
   const urlHost = effectiveSelectedHost || "<laymux-host>";
   const urlWithToken = tokenConfigured
     ? buildRemoteUrlWithToken(urlHost, port ?? "...", token)
@@ -95,20 +89,6 @@ export function RemoteAccessModal() {
       })
       .catch(() => {
         // Keep copy disabled rather than exposing a stale or bogus port.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    getRemoteHostCandidates()
-      .then((candidates) => {
-        if (!cancelled) setHostCandidates(candidates);
-      })
-      .catch(() => {
-        if (!cancelled) setHostCandidates([]);
       });
     return () => {
       cancelled = true;
@@ -247,7 +227,6 @@ export function RemoteAccessModal() {
               onChange={(event) => {
                 const host = event.target.value;
                 setSelectedHost(host);
-                setLastHost(host);
                 writeLastRemoteHost(host);
               }}
               className="w-full rounded px-2 py-1 text-[12px]"

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -29,11 +29,9 @@ import {
 } from "@/stores/settings-store";
 import {
   getRemoteAccessStatus,
-  getRemoteHostCandidates,
   setRemoteRuntimeAccess,
   type ExtensionViewer,
   type FileExplorerSettings,
-  type HostCandidate,
   type RemoteSettings,
 } from "@/lib/tauri-api";
 import type { SyncCwdConfig } from "@/lib/sync-cwd-config";
@@ -51,7 +49,6 @@ import { ToggleSwitch } from "@/components/ui/ToggleSwitch";
 import { useRemoteAccessStore } from "@/stores/remote-access-store";
 import {
   appendAllowedIps,
-  buildRemoteHostOptions,
   formatAllowedIps,
   generateRemoteToken,
   LOOPBACK_ALLOWED_IPS,
@@ -60,6 +57,7 @@ import {
   parseAllowedIps,
   TAILSCALE_ALLOWED_IPS,
 } from "@/lib/remote-hosts";
+import { useRemoteHostOptions } from "@/hooks/useRemoteHostOptions";
 
 const cardStyle: React.CSSProperties = {
   background: "var(--bg-overlay)",
@@ -1708,26 +1706,7 @@ function RemoteSection() {
   const [remote, setDraftRemote] = useDraft<RemoteSectionDraft>("remote", storeDraft, (draft) =>
     setRemote(toRemoteSettings(draft)),
   );
-  const [hostCandidates, setHostCandidates] = useState<HostCandidate[]>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-    getRemoteHostCandidates()
-      .then((candidates) => {
-        if (!cancelled) setHostCandidates(candidates);
-      })
-      .catch(() => {
-        if (!cancelled) setHostCandidates([]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const hostOptions = useMemo(
-    () => buildRemoteHostOptions(hostCandidates, remote.customHosts),
-    [hostCandidates, remote.customHosts],
-  );
+  const hostOptions = useRemoteHostOptions(remote.customHosts);
   const preferredAvailable =
     remote.preferredHost === "" ||
     hostOptions.some((option) => option.host === remote.preferredHost);

--- a/ui/src/hooks/useRemoteHostOptions.ts
+++ b/ui/src/hooks/useRemoteHostOptions.ts
@@ -1,0 +1,26 @@
+import { useEffect, useMemo, useState } from "react";
+import { getRemoteHostCandidates, type HostCandidate } from "@/lib/tauri-api";
+import { buildRemoteHostOptions, type RemoteHostOption } from "@/lib/remote-hosts";
+
+export function useRemoteHostOptions(customHosts: string[]): RemoteHostOption[] {
+  const [hostCandidates, setHostCandidates] = useState<HostCandidate[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    getRemoteHostCandidates()
+      .then((candidates) => {
+        if (!cancelled) setHostCandidates(candidates);
+      })
+      .catch(() => {
+        if (!cancelled) setHostCandidates([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return useMemo(
+    () => buildRemoteHostOptions(hostCandidates, customHosts),
+    [customHosts, hostCandidates],
+  );
+}


### PR DESCRIPTION
## 개요

PR #417 리뷰에서 나온 비차단 cleanup 항목 후속 정리. **동작 변경 없음** — 순수 리팩터.

## 변경사항
- **호스트 후보 로직 중복 제거**: RemoteAccessModal 과 SettingsView 에 복붙돼 있던 `getRemoteHostCandidates()` fetch(cancelled guard) + 빈 배열 폴백 + `buildRemoteHostOptions` useMemo 를 공용 훅 `useRemoteHostOptions(customHosts)`(ui/src/hooks) 로 통합.
- **Rust 모듈 분리**: 호스트 후보 기능(`HostCandidate`, async command, 탐지/tailscale/lan/dedupe/helper + 유닛테스트)을 비대한 `commands/misc.rs` 에서 `commands/remote_hosts.rs` 로 이동(AGENTS §14 500줄 규칙). `mod.rs` 등록 + re-export 로 `commands::get_remote_host_candidates` handler 경로 유지.
- **모달 lastHost 단순화**: `lastHost` state/setter/동기 effect 제거 → `useRef(readLastRemoteHost())` 마운트 1회 읽기. 우선순위(preferred > last > first)·재마운트 동작 동일.

## 검증
- `npm test` 전체 통과 (98 files / 2353 tests), `npm run build` 통과
- `cargo test` 전체 통과 (unit + e2e + integration), `cargo build` 통과
- lint-staged(prettier/eslint/rustfmt) + `git diff --check` 통과
- pane 리뷰: 리팩터 범위 동작차/회귀 없음 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RvivEwrZtzTYwH8WvcXNi
