### PR TITLE
feat(cloud): 클라우드 연결 foundation (설정·keyring·상태·Settings UI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,6 +1974,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "linux-keyutils",
+ "log",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2007,7 @@ dependencies = [
  "clipboard-win",
  "font-kit",
  "if-addrs",
+ "keyring",
  "png 0.17.16",
  "portable-pty",
  "rfd",
@@ -2073,6 +2087,16 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -5953,6 +5977,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/docs/adr/0022-cloud-connection-foundation.md
+++ b/docs/adr/0022-cloud-connection-foundation.md
@@ -1,0 +1,27 @@
+# 0022. Cloud Connection Foundation
+
+- Status: Accepted
+- Date: 2026-07-05
+- Source: cloud connection foundation plan, docs/architecture/api-contracts.md §10
+
+## Context
+
+laymux는 기존 Direct Remote Mode를 유지하면서, 후속 PR에서 cloud relay pairing과 tunnel transport를 추가할 예정이다. 이번 foundation 단계에서는 pairing HTTP, OAuth callback, WSS tunnel 계약이 아직 확정되지 않았으므로 외부 네트워크 계약을 만들지 않는다.
+
+그래도 UI와 backend가 이후 pairing/tunnel 구현을 받을 수 있도록 최소 상태와 저장 위치는 먼저 고정해야 한다. 특히 device token은 장기 인증 재료이므로 사용자가 편집/공유하는 `settings.json`에 저장하면 안 된다.
+
+## Decision
+
+Cloud 연결 상태는 `AppState.cloud`의 `CloudStatus { connected, instanceId, lastError }`로 둔다. Tauri command는 `get_cloud_status`와 `cloud_disconnect`만 제공한다. `cloud_connect_start`와 pairing/tunnel command는 서버 계약이 확정되는 다음 PR에서 추가한다.
+
+Cloud 영속 설정은 `settings.remote`에 additive 필드로 둔다: `cloudEnabled`, `relayBaseUrl`, `cloudInstanceId`, `cloudAutoReconnect`. 기본값은 각각 `false`, `""`, `null`, `true`다. 기존 Direct Remote 설정과 마찬가지로 camelCase settings.json 계약을 따른다.
+
+Device token은 OS keyring에 저장한다. service는 release 빌드에서 `laymux`, debug 빌드에서 `laymux-dev`, account는 `device-token`이다. `cloud_disconnect`는 keyring token을 삭제하고, `cloudEnabled=false`, `cloudInstanceId=null`을 저장하며, `AppState.cloud`를 기본 disconnected 상태로 되돌린다.
+
+## Consequences
+
+`settings.json`에는 cloud 연결 메타데이터와 relay override만 남고 인증 token은 남지 않는다. dev/release build의 keyring service가 분리되어 개발 중 token이 사용자 release 프로필과 섞이지 않는다.
+
+이번 PR의 UI는 상태 표시, relay override 입력, 연결 해제만 제공한다. 로그인/연결 시작 버튼과 자동 재연결 동작은 pairing/tunnel 계약이 확정될 때 추가해야 한다.
+
+keyring 접근은 동기 API이므로 Tauri command에서 blocking 작업을 UI thread 밖으로 보내야 한다. 테스트는 keyring mock credential store를 사용해 실제 OS 자격증명 저장소를 건드리지 않는다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,7 @@ ADR 이 필요한 대표 기준:
 | [0019](0019-remote-notification-interactions.md) | Remote notification interactions use navigation targets and bridge dismissal | Accepted |
 | [0020](0020-remote-dock-terminal-navigation.md) | Remote dock terminal navigation stays separate from workspace navigation | Accepted |
 | [0021](0021-remote-host-candidate-discovery.md) | Remote Host Candidate Discovery | Accepted |
+| [0022](0022-cloud-connection-foundation.md) | Cloud Connection Foundation | Accepted |
 
 ## 새 ADR 추가
 

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -54,11 +54,17 @@ Remote Access 모달의 복사 URL 호스트는 `get_remote_host_candidates` Tau
     "authToken": "",                   // enabled=true일 때 필수
     "heartbeatTimeoutSeconds": 15,      // 최소 5초로 clamp
     "autoMobileModeMinWidth": 720,      // 앱 창 폭이 이 값 이하이면 Remote Access 모달 자동 표시. 0 = 비활성
-    "preferredHost": "",                // 복사 URL 기본 호스트. 빈 값 = 첫 후보 자동 선택
-    "customHosts": []                   // 감지 후보 외에 URL host select 에 표시할 수동 호스트
+    "preferredHost": "",               // 복사 URL 기본 호스트. 빈 값 = 자동
+    "customHosts": [],                  // 감지 후보 외에 URL host select 에 표시할 수동 호스트
+    "cloudEnabled": false,              // 클라우드 연결 영속 설정. pairing 전 기본값 false
+    "relayBaseUrl": "",                // 클라우드 relay override. 빈 값 = 제품 기본값(후속 PR)
+    "cloudInstanceId": null,            // relay가 발급한 instance id. 미연결이면 null
+    "cloudAutoReconnect": true          // 토큰이 있으면 시작 시 자동 재연결(후속 PR에서 사용)
   }
 }
 ```
+
+클라우드 연결 foundation은 Direct Remote Mode와 additive 관계다([ADR-0022](../adr/0022-cloud-connection-foundation.md)). 이번 단계의 Tauri IPC 계약은 `get_cloud_status() -> { connected, instanceId, lastError }` 와 `cloud_disconnect()` 뿐이다. device token은 `settings.json` 에 저장하지 않고 OS keyring service `laymux`(`debug_assertions` 빌드는 `laymux-dev`), account `device-token` 에 저장한다. `cloud_disconnect` 는 keyring token 삭제, `settings.remote.cloudEnabled=false`, `settings.remote.cloudInstanceId=null` 저장, `AppState.cloud` 리셋만 수행하며 pairing HTTP/터널 시작은 아직 제공하지 않는다.
 
 Tailscale 직접 접속을 허용하려면 `allowedIps`에 Tailnet 범위(예: IPv4 `100.64.0.0/10`, IPv6 `fd7a:115c:a1e0::/48`) 또는 구체적인 peer IP/CIDR를 추가하고 `authToken`을 설정한다. Tailscale은 transport 격리일 뿐 인증을 대체하지 않는다.
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ rmcp = { version = "1.4", features = ["server", "transport-streamable-http-serve
 rfd = { version = "0.15", default-features = false }
 base64 = "0.22"
 if-addrs = "0.13"
+keyring = { version = "3", features = ["windows-native", "linux-native"] }
 
 [target.'cfg(windows)'.dependencies]
 clipboard-win = "5"

--- a/src-tauri/src/cloud/commands.rs
+++ b/src-tauri/src/cloud/commands.rs
@@ -1,0 +1,213 @@
+use std::sync::Arc;
+
+use tauri::State;
+
+use super::{keyring_store, CloudStatus};
+use crate::error::AppError;
+use crate::lock_ext::MutexExt;
+use crate::state::AppState;
+
+#[tauri::command]
+pub fn get_cloud_status(state: State<Arc<AppState>>) -> Result<CloudStatus, String> {
+    get_cloud_status_inner(&state).map_err(Into::into)
+}
+
+pub fn get_cloud_status_inner(state: &AppState) -> Result<CloudStatus, AppError> {
+    Ok(state.cloud.lock_or_err()?.clone())
+}
+
+#[tauri::command]
+pub async fn cloud_disconnect(state: State<'_, Arc<AppState>>) -> Result<CloudStatus, String> {
+    let state = state.inner().clone();
+    tokio::task::spawn_blocking(move || cloud_disconnect_inner(&state))
+        .await
+        .map_err(|e| format!("Cloud disconnect task failed: {e}"))?
+        .map_err(Into::into)
+}
+
+pub fn cloud_disconnect_inner(state: &AppState) -> Result<CloudStatus, AppError> {
+    Ok(cloud_disconnect_best_effort(state))
+}
+
+fn cloud_disconnect_best_effort(state: &AppState) -> CloudStatus {
+    let mut errors = Vec::new();
+
+    if let Err(error) = keyring_store::delete_device_token() {
+        errors.push(format!("keyring delete failed: {error}"));
+    }
+
+    let mut settings = crate::settings::load_settings();
+    settings.remote.cloud_enabled = false;
+    settings.remote.cloud_instance_id = None;
+    if let Err(error) = crate::settings::save_settings(&settings).map_err(AppError::Other) {
+        errors.push(format!("settings save failed: {error}"));
+    }
+
+    let mut next_status = disconnected_status(&errors);
+    match state.cloud.lock_or_err() {
+        Ok(mut cloud) => {
+            *cloud = next_status.clone();
+        }
+        Err(error) => {
+            errors.push(format!("state reset failed: {error}"));
+            next_status = disconnected_status(&errors);
+        }
+    }
+
+    next_status
+}
+
+fn disconnected_status(errors: &[String]) -> CloudStatus {
+    CloudStatus {
+        connected: false,
+        instance_id: None,
+        last_error: if errors.is_empty() {
+            None
+        } else {
+            Some(errors.join("; "))
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::path::Path;
+
+    use serial_test::serial;
+
+    use super::*;
+    use crate::settings::{load_settings, save_settings, Settings};
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set_path(key: &'static str, value: &Path) -> Self {
+            let previous = env::var(key).ok();
+            env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = &self.previous {
+                env::set_var(self.key, previous);
+            } else {
+                env::remove_var(self.key);
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    fn isolate_settings_dir(dir: &Path) -> EnvVarGuard {
+        EnvVarGuard::set_path("APPDATA", dir)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn isolate_settings_dir(dir: &Path) -> EnvVarGuard {
+        EnvVarGuard::set_path("HOME", dir)
+    }
+
+    #[test]
+    fn get_cloud_status_reads_app_state() {
+        let state = AppState::new();
+        *state.cloud.lock_or_err().unwrap() = CloudStatus {
+            connected: true,
+            instance_id: Some("instance-1".into()),
+            last_error: Some("transient".into()),
+        };
+
+        let status = get_cloud_status_inner(&state).unwrap();
+
+        assert!(status.connected);
+        assert_eq!(status.instance_id.as_deref(), Some("instance-1"));
+        assert_eq!(status.last_error.as_deref(), Some("transient"));
+    }
+
+    #[test]
+    #[serial]
+    fn cloud_disconnect_deletes_token_saves_settings_and_resets_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env_guard = isolate_settings_dir(dir.path());
+        keyring_store::reset_mock_store().unwrap();
+
+        let mut settings = Settings::default();
+        settings.remote.cloud_enabled = true;
+        settings.remote.cloud_instance_id = Some("instance-1".into());
+        settings.remote.relay_base_url = "https://relay.example.test".into();
+        save_settings(&settings).unwrap();
+        keyring_store::set_device_token("device-token").unwrap();
+
+        let state = AppState::new();
+        *state.cloud.lock_or_err().unwrap() = CloudStatus {
+            connected: true,
+            instance_id: Some("instance-1".into()),
+            last_error: Some("old error".into()),
+        };
+
+        let status = cloud_disconnect_inner(&state).unwrap();
+
+        assert_eq!(status, CloudStatus::default());
+        assert_eq!(keyring_store::get_device_token().unwrap(), None);
+        let loaded = load_settings();
+        assert!(!loaded.remote.cloud_enabled);
+        assert_eq!(loaded.remote.cloud_instance_id, None);
+        assert_eq!(loaded.remote.relay_base_url, "https://relay.example.test");
+        assert_eq!(*state.cloud.lock_or_err().unwrap(), CloudStatus::default());
+    }
+
+    #[test]
+    #[serial]
+    fn cloud_disconnect_cleans_settings_and_state_when_keyring_delete_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env_guard = isolate_settings_dir(dir.path());
+        keyring_store::reset_mock_store().unwrap();
+
+        let mut settings = Settings::default();
+        settings.remote.cloud_enabled = true;
+        settings.remote.cloud_instance_id = Some("instance-1".into());
+        save_settings(&settings).unwrap();
+        keyring_store::set_device_token("device-token").unwrap();
+        keyring_store::set_mock_error(keyring::Error::Invalid(
+            "delete".into(),
+            "forced failure".into(),
+        ))
+        .unwrap();
+
+        let state = AppState::new();
+        *state.cloud.lock_or_err().unwrap() = CloudStatus {
+            connected: true,
+            instance_id: Some("instance-1".into()),
+            last_error: Some("old error".into()),
+        };
+
+        let status = cloud_disconnect_inner(&state).unwrap();
+
+        assert!(!status.connected);
+        assert_eq!(status.instance_id, None);
+        assert!(status
+            .last_error
+            .as_deref()
+            .unwrap()
+            .contains("keyring delete failed"));
+        let loaded = load_settings();
+        assert!(!loaded.remote.cloud_enabled);
+        assert_eq!(loaded.remote.cloud_instance_id, None);
+        let state_status = state.cloud.lock_or_err().unwrap().clone();
+        assert!(!state_status.connected);
+        assert_eq!(state_status.instance_id, None);
+        assert!(state_status
+            .last_error
+            .as_deref()
+            .unwrap()
+            .contains("keyring delete failed"));
+        assert_eq!(
+            keyring_store::get_device_token().unwrap().as_deref(),
+            Some("device-token")
+        );
+    }
+}

--- a/src-tauri/src/cloud/keyring_store.rs
+++ b/src-tauri/src/cloud/keyring_store.rs
@@ -1,0 +1,188 @@
+use crate::error::AppError;
+
+const DEVICE_TOKEN_ACCOUNT: &str = "device-token";
+const KEYRING_SERVICE: &str = "laymux";
+const KEYRING_SERVICE_DEV: &str = "laymux-dev";
+
+fn service_name() -> &'static str {
+    if cfg!(debug_assertions) {
+        KEYRING_SERVICE_DEV
+    } else {
+        KEYRING_SERVICE
+    }
+}
+
+fn keyring_error(error: keyring::Error) -> AppError {
+    AppError::Other(format!("Keyring error: {error}"))
+}
+
+enum KeyringStoreError {
+    Keyring(keyring::Error),
+    #[cfg(test)]
+    App(AppError),
+}
+
+impl KeyringStoreError {
+    fn into_app_error(self) -> AppError {
+        match self {
+            Self::Keyring(error) => keyring_error(error),
+            #[cfg(test)]
+            Self::App(error) => error,
+        }
+    }
+}
+
+#[cfg(not(test))]
+fn with_device_token_entry<T>(
+    operation: impl FnOnce(&keyring::Entry) -> keyring::Result<T>,
+) -> Result<T, KeyringStoreError> {
+    let entry = keyring::Entry::new(service_name(), DEVICE_TOKEN_ACCOUNT)
+        .map_err(KeyringStoreError::Keyring)?;
+    operation(&entry).map_err(KeyringStoreError::Keyring)
+}
+
+#[cfg(test)]
+mod test_entry {
+    use std::sync::{Mutex, OnceLock};
+
+    use crate::error::AppError;
+
+    static MOCK_ENTRY: OnceLock<Mutex<keyring::Entry>> = OnceLock::new();
+
+    fn new_mock_entry() -> Result<keyring::Entry, AppError> {
+        keyring::set_default_credential_builder(keyring::mock::default_credential_builder());
+        keyring::Entry::new(super::service_name(), super::DEVICE_TOKEN_ACCOUNT)
+            .map_err(super::keyring_error)
+    }
+
+    pub fn reset_mock_store() -> Result<(), AppError> {
+        let next = new_mock_entry()?;
+        if let Some(entry) = MOCK_ENTRY.get() {
+            let mut guard = entry
+                .lock()
+                .map_err(|e| AppError::Lock(format!("cloud keyring mock: {e}")))?;
+            *guard = next;
+            return Ok(());
+        }
+
+        match MOCK_ENTRY.set(Mutex::new(next)) {
+            Ok(()) => Ok(()),
+            Err(next) => {
+                let entry = MOCK_ENTRY
+                    .get()
+                    .ok_or_else(|| AppError::Other("Keyring mock initialization failed".into()))?;
+                let mut guard = entry
+                    .lock()
+                    .map_err(|e| AppError::Lock(format!("cloud keyring mock: {e}")))?;
+                *guard = next
+                    .into_inner()
+                    .map_err(|e| AppError::Lock(format!("cloud keyring mock: {e}")))?;
+                Ok(())
+            }
+        }
+    }
+
+    pub fn with_entry<T>(
+        operation: impl FnOnce(&keyring::Entry) -> keyring::Result<T>,
+    ) -> Result<T, super::KeyringStoreError> {
+        if MOCK_ENTRY.get().is_none() {
+            reset_mock_store().map_err(super::KeyringStoreError::App)?;
+        }
+        let entry = MOCK_ENTRY
+            .get()
+            .ok_or_else(|| AppError::Other("Keyring mock is not initialized".into()))
+            .map_err(super::KeyringStoreError::App)?;
+        let guard = entry
+            .lock()
+            .map_err(|e| AppError::Lock(format!("cloud keyring mock: {e}")))
+            .map_err(super::KeyringStoreError::App)?;
+        operation(&guard).map_err(super::KeyringStoreError::Keyring)
+    }
+
+    pub fn set_error(error: keyring::Error) -> Result<(), AppError> {
+        if MOCK_ENTRY.get().is_none() {
+            reset_mock_store()?;
+        }
+        let entry = MOCK_ENTRY
+            .get()
+            .ok_or_else(|| AppError::Other("Keyring mock is not initialized".into()))?;
+        let guard = entry
+            .lock()
+            .map_err(|e| AppError::Lock(format!("cloud keyring mock: {e}")))?;
+        let mock = guard
+            .get_credential()
+            .downcast_ref::<keyring::mock::MockCredential>()
+            .ok_or_else(|| AppError::Other("Keyring mock credential is unavailable".into()))?;
+        mock.set_error(error);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn reset_mock_store() -> Result<(), AppError> {
+    test_entry::reset_mock_store()
+}
+
+#[cfg(test)]
+pub(crate) fn set_mock_error(error: keyring::Error) -> Result<(), AppError> {
+    test_entry::set_error(error)
+}
+
+#[cfg(test)]
+fn with_device_token_entry<T>(
+    operation: impl FnOnce(&keyring::Entry) -> keyring::Result<T>,
+) -> Result<T, KeyringStoreError> {
+    test_entry::with_entry(operation)
+}
+
+pub fn get_device_token() -> Result<Option<String>, AppError> {
+    match with_device_token_entry(|entry| entry.get_password()) {
+        Ok(token) => Ok(Some(token)),
+        Err(KeyringStoreError::Keyring(keyring::Error::NoEntry)) => Ok(None),
+        Err(error) => Err(error.into_app_error()),
+    }
+}
+
+pub fn set_device_token(token: &str) -> Result<(), AppError> {
+    with_device_token_entry(|entry| entry.set_password(token))
+        .map_err(KeyringStoreError::into_app_error)
+}
+
+pub fn delete_device_token() -> Result<(), AppError> {
+    match with_device_token_entry(|entry| entry.delete_credential()) {
+        Ok(()) => Ok(()),
+        Err(KeyringStoreError::Keyring(keyring::Error::NoEntry)) => Ok(()),
+        Err(error) => Err(error.into_app_error()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+
+    use super::*;
+
+    #[test]
+    #[serial]
+    fn device_token_round_trip_uses_mock_keyring() {
+        reset_mock_store().unwrap();
+
+        assert_eq!(get_device_token().unwrap(), None);
+        set_device_token("device-token-123").unwrap();
+        assert_eq!(
+            get_device_token().unwrap().as_deref(),
+            Some("device-token-123")
+        );
+        delete_device_token().unwrap();
+        assert_eq!(get_device_token().unwrap(), None);
+    }
+
+    #[test]
+    #[serial]
+    fn delete_device_token_is_idempotent_for_missing_token() {
+        reset_mock_store().unwrap();
+
+        delete_device_token().unwrap();
+        assert_eq!(get_device_token().unwrap(), None);
+    }
+}

--- a/src-tauri/src/cloud/mod.rs
+++ b/src-tauri/src/cloud/mod.rs
@@ -1,0 +1,12 @@
+pub mod commands;
+pub mod keyring_store;
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CloudStatus {
+    pub connected: bool,
+    pub instance_id: Option<String>,
+    pub last_error: Option<String>,
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ mod misc;
 mod remote_hosts;
 mod terminal;
 
+pub use crate::cloud::commands::*;
 pub use claude_session::*;
 pub use file_ops::*;
 pub use ipc_dispatch::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod claude_activity;
 pub mod claude_bullet;
 pub mod cli;
 pub mod clipboard;
+pub mod cloud;
 pub mod codex_activity;
 pub mod commands;
 pub mod constants;
@@ -173,6 +174,8 @@ pub fn run() {
             commands::get_remote_control_status,
             commands::get_remote_host_candidates,
             commands::reclaim_remote_control,
+            commands::get_cloud_status,
+            commands::cloud_disconnect,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -253,6 +253,10 @@ mod tests {
         assert_eq!(legacy.remote.allowed_ips, vec!["127.0.0.1/32", "::1/128"]);
         assert_eq!(legacy.remote.heartbeat_timeout_seconds, 15);
         assert_eq!(legacy.remote.auto_mobile_mode_min_width, 720);
+        assert!(!legacy.remote.cloud_enabled);
+        assert_eq!(legacy.remote.relay_base_url, "");
+        assert_eq!(legacy.remote.cloud_instance_id, None);
+        assert!(legacy.remote.cloud_auto_reconnect);
 
         let json = r#"{
           "remote": {
@@ -260,7 +264,11 @@ mod tests {
             "allowedIps": ["100.64.0.0/10"],
             "authToken": "secret",
             "heartbeatTimeoutSeconds": 30,
-            "autoMobileModeMinWidth": 640
+            "autoMobileModeMinWidth": 640,
+            "cloudEnabled": true,
+            "relayBaseUrl": "https://relay.example.test",
+            "cloudInstanceId": "instance-123",
+            "cloudAutoReconnect": false
           }
         }"#;
         let settings: Settings = serde_json::from_str(json).unwrap();
@@ -269,12 +277,23 @@ mod tests {
         assert_eq!(settings.remote.auth_token, "secret");
         assert_eq!(settings.remote.heartbeat_timeout_seconds, 30);
         assert_eq!(settings.remote.auto_mobile_mode_min_width, 640);
+        assert!(settings.remote.cloud_enabled);
+        assert_eq!(settings.remote.relay_base_url, "https://relay.example.test");
+        assert_eq!(
+            settings.remote.cloud_instance_id.as_deref(),
+            Some("instance-123")
+        );
+        assert!(!settings.remote.cloud_auto_reconnect);
 
         let serialized = serde_json::to_string(&settings).unwrap();
         assert!(serialized.contains("\"remote\""));
         assert!(serialized.contains("\"allowedIps\":[\"100.64.0.0/10\"]"));
         assert!(serialized.contains("\"authToken\":\"secret\""));
         assert!(serialized.contains("\"autoMobileModeMinWidth\":640"));
+        assert!(serialized.contains("\"cloudEnabled\":true"));
+        assert!(serialized.contains("\"relayBaseUrl\":\"https://relay.example.test\""));
+        assert!(serialized.contains("\"cloudInstanceId\":\"instance-123\""));
+        assert!(serialized.contains("\"cloudAutoReconnect\":false"));
     }
 
     #[test]

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -995,6 +995,18 @@ pub struct RemoteSettings {
     /// User-managed host names or IPs that are offered alongside detected candidates.
     #[serde(default)]
     pub custom_hosts: Vec<String>,
+    /// Cloud relay connection is enabled for the current desktop instance.
+    #[serde(default)]
+    pub cloud_enabled: bool,
+    /// Optional cloud relay base URL override. Empty = product default in a later pairing PR.
+    #[serde(default)]
+    pub relay_base_url: String,
+    /// Instance ID assigned by the cloud relay after pairing.
+    #[serde(default)]
+    pub cloud_instance_id: Option<String>,
+    /// Reconnect to the cloud relay automatically on startup when credentials exist.
+    #[serde(default = "default_cloud_auto_reconnect")]
+    pub cloud_auto_reconnect: bool,
 }
 
 fn default_remote_bind_address() -> String {
@@ -1013,6 +1025,10 @@ fn default_remote_auto_mobile_mode_min_width() -> u32 {
     720
 }
 
+fn default_cloud_auto_reconnect() -> bool {
+    true
+}
+
 impl Default for RemoteSettings {
     fn default() -> Self {
         Self {
@@ -1025,6 +1041,10 @@ impl Default for RemoteSettings {
             auto_mobile_mode_min_width: default_remote_auto_mobile_mode_min_width(),
             preferred_host: String::new(),
             custom_hosts: Vec::new(),
+            cloud_enabled: false,
+            relay_base_url: String::new(),
+            cloud_instance_id: None,
+            cloud_auto_reconnect: default_cloud_auto_reconnect(),
         }
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -25,6 +25,7 @@ use crate::terminal::{SyncGroup, TerminalNotification, TerminalSession};
 /// 10. `pty_handles` / `automation_channels` / `automation_port` / `ipc_socket_path`
 /// 11. `remote_access`
 /// 12. `remote_control`
+/// 13. `cloud`
 ///
 /// Never acquire a higher-numbered lock while holding a lower-numbered one.
 pub struct AppState {
@@ -77,6 +78,8 @@ pub struct AppState {
     pub remote_access: Mutex<crate::remote_server::RemoteAccessRuntimeState>,
     /// Current Direct Remote Mode controller lease plus local reclaim lockout state.
     pub remote_control: Mutex<crate::remote_server::RemoteControlState>,
+    /// Runtime cloud relay connection status. Pairing/tunnel workers update this state.
+    pub cloud: Mutex<crate::cloud::CloudStatus>,
 }
 
 impl AppState {
@@ -98,6 +101,7 @@ impl AppState {
             notification_counter: AtomicU64::new(1),
             remote_access: Mutex::new(crate::remote_server::RemoteAccessRuntimeState::default()),
             remote_control: Mutex::new(crate::remote_server::RemoteControlState::default()),
+            cloud: Mutex::new(crate::cloud::CloudStatus::default()),
         }
     }
 }
@@ -180,5 +184,14 @@ mod tests {
         let remote = state.remote_control.lock().unwrap();
         assert!(remote.lease.is_none());
         assert!(remote.reclaim_lockout_until.is_none());
+    }
+
+    #[test]
+    fn cloud_status_starts_disconnected() {
+        let state = AppState::new();
+        let cloud = state.cloud.lock().unwrap();
+        assert!(!cloud.connected);
+        assert!(cloud.instance_id.is_none());
+        assert!(cloud.last_error.is_none());
     }
 }

--- a/src-tauri/tests/e2e_test.rs
+++ b/src-tauri/tests/e2e_test.rs
@@ -192,6 +192,10 @@ fn settings_round_trip_with_full_config() {
             auth_token: "test-remote-token".into(),
             preferred_host: "100.64.0.2".into(),
             custom_hosts: vec!["devbox.tailnet.ts.net".into(), "192.168.0.44".into()],
+            cloud_enabled: true,
+            relay_base_url: "https://relay.example.test".into(),
+            cloud_instance_id: Some("instance-test".into()),
+            cloud_auto_reconnect: false,
             ..RemoteSettings::default()
         },
         sync_cwd_defaults: None,

--- a/ui/src/components/views/SettingsView.test.tsx
+++ b/ui/src/components/views/SettingsView.test.tsx
@@ -38,9 +38,16 @@ function remoteAccessStatus(runtimeEnabled = false, runtimeToken = "") {
   };
 }
 
+let mockCloudStatus = {
+  connected: false,
+  instanceId: null as string | null,
+  lastError: null as string | null,
+};
+
 describe("SettingsView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCloudStatus = { connected: false, instanceId: null, lastError: null };
     mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
       if (cmd === "list_system_monospace_fonts") {
         return Promise.resolve(["Cascadia Mono", "Fira Code", "Consolas"]);
@@ -59,6 +66,13 @@ describe("SettingsView", () => {
         const runtimeEnabled = Boolean(args?.enabled);
         const runtimeToken = typeof args?.authToken === "string" ? args.authToken : "";
         return Promise.resolve(remoteAccessStatus(runtimeEnabled, runtimeToken));
+      }
+      if (cmd === "get_cloud_status") {
+        return Promise.resolve(mockCloudStatus);
+      }
+      if (cmd === "cloud_disconnect") {
+        mockCloudStatus = { connected: false, instanceId: null, lastError: null };
+        return Promise.resolve(mockCloudStatus);
       }
       return Promise.resolve(undefined);
     });
@@ -1815,6 +1829,101 @@ describe("SettingsView", () => {
         runtimeEnabled: false,
         effectiveAuthToken: "secret",
       });
+    });
+
+    it("renders cloud connection status and saves the relay override", async () => {
+      const user = userEvent.setup();
+      render(<SettingsView />);
+
+      await user.click(screen.getByTestId("nav-remote"));
+
+      expect(await screen.findByText("Cloud Connection")).toBeInTheDocument();
+      expect(await screen.findByTestId("remote-settings-cloud-status")).toHaveTextContent(
+        "Disconnected",
+      );
+      const input = screen.getByTestId(
+        "remote-settings-cloud-relay-base-url-input",
+      ) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: " https://relay.example.test " } });
+
+      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe("");
+
+      await user.click(screen.getByTestId("save-settings-btn"));
+
+      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe("https://relay.example.test");
+    });
+
+    it("disconnects cloud status and mirrors persisted cloud fields in the store", async () => {
+      mockCloudStatus = { connected: true, instanceId: "instance-1", lastError: null };
+      useSettingsStore.getState().setRemote({
+        cloudEnabled: true,
+        cloudInstanceId: "instance-1",
+      });
+      const user = userEvent.setup();
+      render(<SettingsView />);
+
+      await user.click(screen.getByTestId("nav-remote"));
+      expect(await screen.findByTestId("remote-settings-cloud-status")).toHaveTextContent(
+        "Connected (instance-1)",
+      );
+      await user.click(await screen.findByTestId("remote-settings-cloud-disconnect"));
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith("cloud_disconnect");
+      });
+      expect(screen.getByTestId("remote-settings-cloud-status")).toHaveTextContent("Disconnected");
+      expect(useSettingsStore.getState().remote.cloudEnabled).toBe(false);
+      expect(useSettingsStore.getState().remote.cloudInstanceId).toBeNull();
+    });
+
+    it("shows cloud disconnect when persisted cloud settings remain but runtime is disconnected", async () => {
+      mockCloudStatus = { connected: false, instanceId: null, lastError: null };
+      useSettingsStore.getState().setRemote({
+        cloudEnabled: true,
+        cloudInstanceId: "instance-1",
+      });
+      const user = userEvent.setup();
+      render(<SettingsView />);
+
+      await user.click(screen.getByTestId("nav-remote"));
+
+      expect(await screen.findByTestId("remote-settings-cloud-status")).toHaveTextContent(
+        "Disconnected",
+      );
+      expect(screen.getByTestId("remote-settings-cloud-disconnect")).toBeInTheDocument();
+    });
+
+    it("preserves unsaved remote draft edits when cloud disconnect updates cloud fields", async () => {
+      mockCloudStatus = { connected: false, instanceId: null, lastError: null };
+      useSettingsStore.getState().setRemote({
+        cloudEnabled: true,
+        cloudInstanceId: "instance-1",
+      });
+      const user = userEvent.setup();
+      render(<SettingsView />);
+
+      await user.click(screen.getByTestId("nav-remote"));
+      const relayInput = (await screen.findByTestId(
+        "remote-settings-cloud-relay-base-url-input",
+      )) as HTMLInputElement;
+      fireEvent.change(relayInput, { target: { value: " https://draft-relay.example.test " } });
+
+      await user.click(screen.getByTestId("remote-settings-cloud-disconnect"));
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith("cloud_disconnect");
+      });
+      expect(relayInput.value).toBe(" https://draft-relay.example.test ");
+      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe("");
+      expect(useSettingsStore.getState().remote.cloudEnabled).toBe(true);
+
+      await user.click(screen.getByTestId("save-settings-btn"));
+
+      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe(
+        "https://draft-relay.example.test",
+      );
+      expect(useSettingsStore.getState().remote.cloudEnabled).toBe(false);
+      expect(useSettingsStore.getState().remote.cloudInstanceId).toBeNull();
     });
   });
 

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -28,8 +28,11 @@ import {
   type LanguageSetting,
 } from "@/stores/settings-store";
 import {
+  cloudDisconnect,
+  getCloudStatus,
   getRemoteAccessStatus,
   setRemoteRuntimeAccess,
+  type CloudStatus,
   type ExtensionViewer,
   type FileExplorerSettings,
   type RemoteSettings,
@@ -1673,6 +1676,7 @@ function toRemoteSettings(draft: RemoteSectionDraft): RemoteSettings {
     ...remote,
     authToken: remote.authToken.trim(),
     preferredHost: remote.preferredHost.trim(),
+    relayBaseUrl: remote.relayBaseUrl.trim(),
     customHosts,
     allowedIps: allowedIps.length > 0 ? allowedIps : LOOPBACK_ALLOWED_IPS,
     autoMobileModeMinWidth: normalizeAutoMobileWidth(remote.autoMobileModeMinWidth),
@@ -1710,9 +1714,36 @@ function RemoteSection() {
   const preferredAvailable =
     remote.preferredHost === "" ||
     hostOptions.some((option) => option.host === remote.preferredHost);
+  const remoteDraftChanged = useMemo(
+    () => JSON.stringify(remote) !== JSON.stringify(storeDraft),
+    [remote, storeDraft],
+  );
+  const [cloudStatus, setCloudStatus] = useState<CloudStatus | null>(null);
+  const [cloudStatusError, setCloudStatusError] = useState<string | null>(null);
+  const [cloudDisconnectPending, setCloudDisconnectPending] = useState(false);
 
   const update = (partial: Partial<RemoteSectionDraft>) =>
     setDraftRemote((prev) => ({ ...prev, ...partial }));
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getCloudStatus()
+      .then((status) => {
+        if (cancelled) return;
+        setCloudStatus(status);
+        setCloudStatusError(null);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setCloudStatus(null);
+        setCloudStatusError(error instanceof Error ? error.message : String(error));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleToggleEnabled = (enabled: boolean) => {
     update({
@@ -1739,6 +1770,40 @@ function RemoteSection() {
       ...(remote.preferredHost === host ? { preferredHost: "" } : {}),
     });
   };
+
+  const handleCloudDisconnect = async () => {
+    setCloudDisconnectPending(true);
+    setCloudStatusError(null);
+    try {
+      const status = await cloudDisconnect();
+      setCloudStatus(status);
+      if (remoteDraftChanged) {
+        setDraftRemote((prev) => ({ ...prev, cloudEnabled: false, cloudInstanceId: null }));
+      } else if (storeRemote.cloudEnabled || storeRemote.cloudInstanceId) {
+        setRemote({ cloudEnabled: false, cloudInstanceId: null });
+      }
+    } catch (error) {
+      setCloudStatusError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setCloudDisconnectPending(false);
+    }
+  };
+
+  const cloudStatusText = cloudStatusError
+    ? t("remote.cloudStatusError", { error: cloudStatusError })
+    : cloudStatus?.lastError
+      ? t("remote.cloudStatusError", { error: cloudStatus.lastError })
+      : cloudStatus?.connected
+        ? cloudStatus.instanceId
+          ? t("remote.cloudStatusConnectedWithInstance", { instanceId: cloudStatus.instanceId })
+          : t("remote.cloudStatusConnected")
+        : t("remote.cloudStatusDisconnected");
+  const showCloudDisconnect =
+    remote.cloudEnabled ||
+    Boolean(remote.cloudInstanceId) ||
+    Boolean(cloudStatus?.connected) ||
+    Boolean(cloudStatus?.instanceId) ||
+    Boolean(cloudStatus?.lastError);
 
   return (
     <div>
@@ -1904,6 +1969,52 @@ function RemoteSection() {
               </option>
             ))}
           </FocusSelect>
+        </SettingRow>
+      </SubGroup>
+
+      <SubGroup title={t("remote.groupCloud")}>
+        <SettingRow label={t("remote.cloudStatus")}>
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <span
+              data-testid="remote-settings-cloud-status"
+              className="min-w-0 text-[12px]"
+              style={{
+                color:
+                  cloudStatusError || cloudStatus?.lastError ? "var(--red)" : "var(--text-primary)",
+              }}
+            >
+              {cloudStatusText}
+            </span>
+            {showCloudDisconnect && (
+              <button
+                type="button"
+                data-testid="remote-settings-cloud-disconnect"
+                onClick={handleCloudDisconnect}
+                disabled={cloudDisconnectPending}
+                className="hover-bg rounded px-2 py-1 text-[11px] disabled:cursor-not-allowed disabled:opacity-50"
+                style={{
+                  color: "var(--red)",
+                  background: "transparent",
+                  border: "1px solid var(--border)",
+                  cursor: cloudDisconnectPending ? "not-allowed" : "pointer",
+                }}
+              >
+                {cloudDisconnectPending
+                  ? t("remote.cloudDisconnecting")
+                  : t("remote.cloudDisconnect")}
+              </button>
+            )}
+          </div>
+        </SettingRow>
+
+        <SettingRow label={t("remote.cloudRelayBaseUrl")} desc={t("remote.cloudRelayBaseUrlDesc")}>
+          <FocusInput
+            data-testid="remote-settings-cloud-relay-base-url-input"
+            className={inputCls}
+            placeholder="https://relay.example.com"
+            value={remote.relayBaseUrl}
+            onChange={(event) => update({ relayBaseUrl: event.target.value })}
+          />
         </SettingRow>
       </SubGroup>
     </div>

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -292,6 +292,7 @@
       "title": "Remote",
       "groupAccess": "Access",
       "groupHosts": "Hosts",
+      "groupCloud": "Cloud Connection",
       "enabled": "Enable on Startup",
       "enabledDesc": "Open Direct Remote Mode automatically on the next app start. A token is generated when this is enabled without one.",
       "allowedIps": "Allowed IPs",
@@ -307,7 +308,16 @@
       "addCustomHost": "Add Host",
       "preferredHost": "Default Host",
       "preferredHostDesc": "Host preselected in Remote Access URLs. Automatic uses the last selected host, then the first available candidate.",
-      "hostAuto": "Automatic"
+      "hostAuto": "Automatic",
+      "cloudStatus": "Status",
+      "cloudStatusConnected": "Connected",
+      "cloudStatusConnectedWithInstance": "Connected ({{instanceId}})",
+      "cloudStatusDisconnected": "Disconnected",
+      "cloudStatusError": "Error: {{error}}",
+      "cloudRelayBaseUrl": "Relay Base URL",
+      "cloudRelayBaseUrlDesc": "Optional relay override for cloud pairing. Empty uses the product default in a later pairing release.",
+      "cloudDisconnect": "Disconnect",
+      "cloudDisconnecting": "Disconnecting..."
     },
     "workspaces": {
       "title": "Workspaces",

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -292,6 +292,7 @@
       "title": "원격",
       "groupAccess": "접속",
       "groupHosts": "호스트",
+      "groupCloud": "클라우드 연결",
       "enabled": "시작 시 자동 허용",
       "enabledDesc": "다음 앱 시작부터 Direct Remote Mode를 자동으로 엽니다. 토큰이 없으면 켤 때 생성합니다.",
       "allowedIps": "허용 IP",
@@ -307,7 +308,16 @@
       "addCustomHost": "호스트 추가",
       "preferredHost": "기본 호스트",
       "preferredHostDesc": "Remote Access URL에 미리 선택할 호스트입니다. 자동은 마지막 선택 호스트를 쓰고, 없으면 첫 후보를 사용합니다.",
-      "hostAuto": "자동"
+      "hostAuto": "자동",
+      "cloudStatus": "상태",
+      "cloudStatusConnected": "연결됨",
+      "cloudStatusConnectedWithInstance": "연결됨 ({{instanceId}})",
+      "cloudStatusDisconnected": "미연결",
+      "cloudStatusError": "오류: {{error}}",
+      "cloudRelayBaseUrl": "릴레이 기본 URL",
+      "cloudRelayBaseUrlDesc": "클라우드 pairing용 릴레이 주소를 재정의합니다. 비워두면 다음 pairing 릴리스에서 제품 기본값을 사용합니다.",
+      "cloudDisconnect": "연결 해제",
+      "cloudDisconnecting": "해제 중..."
     },
     "workspaces": {
       "title": "워크스페이스",

--- a/ui/src/lib/tauri-api.test.ts
+++ b/ui/src/lib/tauri-api.test.ts
@@ -23,6 +23,8 @@ import {
   saveSettings,
   getRemoteAccessStatus,
   getRemoteHostCandidates,
+  getCloudStatus,
+  cloudDisconnect,
   setRemoteRuntimeAccess,
   onTerminalOutput,
   onOpenFile,
@@ -203,6 +205,22 @@ describe("tauri-api", () => {
 
       await expect(getRemoteHostCandidates()).resolves.toEqual(candidates);
       expect(mockInvoke).toHaveBeenCalledWith("get_remote_host_candidates");
+    });
+
+    it("invokes get_cloud_status", async () => {
+      const status = { connected: true, instanceId: "instance-1", lastError: null };
+      mockInvoke.mockResolvedValue(status);
+
+      await expect(getCloudStatus()).resolves.toEqual(status);
+      expect(mockInvoke).toHaveBeenCalledWith("get_cloud_status");
+    });
+
+    it("invokes cloud_disconnect", async () => {
+      const status = { connected: false, instanceId: null, lastError: null };
+      mockInvoke.mockResolvedValue(status);
+
+      await expect(cloudDisconnect()).resolves.toEqual(status);
+      expect(mockInvoke).toHaveBeenCalledWith("cloud_disconnect");
     });
   });
 

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -74,6 +74,12 @@ export interface RemoteAccessStatus {
   effectiveAuthToken: string;
 }
 
+export interface CloudStatus {
+  connected: boolean;
+  instanceId?: string | null;
+  lastError?: string | null;
+}
+
 export async function getRemoteAccessStatus(): Promise<RemoteAccessStatus> {
   return invoke("get_remote_access_status");
 }
@@ -100,6 +106,14 @@ export interface HostCandidate {
 
 export async function getRemoteHostCandidates(): Promise<HostCandidate[]> {
   return invoke("get_remote_host_candidates");
+}
+
+export async function getCloudStatus(): Promise<CloudStatus> {
+  return invoke("get_cloud_status");
+}
+
+export async function cloudDisconnect(): Promise<CloudStatus> {
+  return invoke("cloud_disconnect");
 }
 
 export async function reclaimRemoteControl(): Promise<RemoteControlStatus> {
@@ -325,6 +339,10 @@ export interface RemoteSettings {
   autoMobileModeMinWidth: number;
   preferredHost: string;
   customHosts: string[];
+  cloudEnabled: boolean;
+  relayBaseUrl: string;
+  cloudInstanceId?: string | null;
+  cloudAutoReconnect: boolean;
 }
 
 export interface Settings {

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -491,6 +491,10 @@ const DEFAULT_REMOTE: RemoteSettings = {
   autoMobileModeMinWidth: 720,
   preferredHost: "",
   customHosts: [],
+  cloudEnabled: false,
+  relayBaseUrl: "",
+  cloudInstanceId: null,
+  cloudAutoReconnect: true,
 };
 
 export const DEFAULT_FONT: FontSettings = { face: "Cascadia Mono", size: 14, weight: "normal" };


### PR DESCRIPTION
## 개요

laymux 클라우드 릴레이 접속(kochul2000/laymux-server 연동)의 **계약 무관 foundation**. pairing(loopback OAuth)·네이티브 WSS 터널은 후속 PR. 기존 Tailscale Direct Remote 는 불변(additive).

## 변경사항
- **설정**: `RemoteSettings` 클라우드 필드 추가 — `cloud_enabled`, `relay_base_url`, `cloud_instance_id`, `cloud_auto_reconnect` (`#[serde(default)]` 하위호환). TS/`DEFAULT_REMOTE` 동기.
- **keyring**: device token OS 자격증명 저장소(`cloud/keyring_store.rs`, keyring v3).
- **cloud 모듈**: `CloudStatus`, `get_cloud_status`, `cloud_disconnect`, `AppState.cloud`. `cloud_disconnect` 는 best-effort(keyring/settings/state 정리, 실패는 `lastError` 수집).
- **UI**: Settings>Remote "클라우드 연결" 섹션(상태 / relayBaseUrl override / 연결 해제). 해제 버튼은 persisted/runtime/error 흔적 있으면 노출, 미저장 Remote draft 보존.
- **문서**: ADR-0022(Cloud Relay Transport 결정), api-contracts living doc, i18n en/ko.

## 검증
- `cargo test`/`cargo build` 전체 통과. `npm test` 전체 통과(98 files / 2359), `npm run build` 통과.
- keyring 테스트는 mock 피처(실 자격증명 저장소 미접촉). lint-staged + `git diff --check` 통과.
- pane 리뷰: major 3건(disconnect best-effort / 버튼 노출조건 / dirty draft 보존) 수정 후 clean.

## 후속
- PR2 pairing(loopback OAuth, /pair/desktop→/pair/callback→/api/desktop/pair/complete), PR3 네이티브 WSS 터널. 서버 계약 확정 완료(dev relay 127.0.0.1:8000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RvivEwrZtzTYwH8WvcXNi
