### PR TITLE
fix(cloud): 대시보드 Connect 시 자동 제어권 claim

### DIFF
--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -2220,7 +2220,12 @@
         desktopModeDrawerButton.addEventListener("click", () => requestDesktopMode().catch((err) => setStatus(err.message, true)));
         ctrlCButton.addEventListener("click", () => enqueueInput("\x03"));
         focusTerminalButton.addEventListener("click", () => terminal && terminal.focus());
-        if (localAppMode && autoConnectMode && token()) {
+        // Auto-claim on load when autoConnect=1 is present. This is NOT gated on
+        // localAppMode so the cloud dashboard flow (external browser) also grabs
+        // control on connect — one fewer click. The remote-control enable toggle
+        // still governs: if control is not allowed the claim fails and we stay an
+        // observer with a status hint (no hard error).
+        if (autoConnectMode && token()) {
           setTimeout(() => connect().catch((err) => setStatus(err.message, true)), 0);
         }
         window.addEventListener("beforeunload", () => {

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -257,4 +257,14 @@ mod tests {
             !preferred_terminal.contains("if (preferredTerminalId) {\n            const existing")
         );
     }
+
+    #[test]
+    fn remote_page_auto_claims_on_autoconnect_without_local_app_gate() {
+        // The cloud dashboard flow serves the page in an external browser (not
+        // localApp), so auto-claim must fire on autoConnect=1 alone — otherwise
+        // the user has to click Connect a second time to take control.
+        let html = remote_page_html();
+        assert!(html.contains("if (autoConnectMode && token()) {"));
+        assert!(!html.contains("if (localAppMode && autoConnectMode && token())"));
+    }
 }


### PR DESCRIPTION
## 개요
클라우드 대시보드에서 기기 Connect → Focused UI 진입 후 **"Host has control" 라 한 번 더 Connect 눌러 lease claim** 해야 하던 UX 개선. 자동-claim 이 `localAppMode`(데스크톱 내부 모바일)에만 걸려 클라우드 외부 브라우저는 `autoConnect=1` 이어도 무시됐음.

## 변경
- `page.html` 자동-claim 조건: `localAppMode && autoConnectMode && token()` → `autoConnectMode && token()`. 클라우드 세션도 로드 시 자동 `session/claim` → 대시보드 Connect 한 번으로 제어+터미널.
- `localAppMode` 는 UI(.local-app 클래스 / Desktop Mode 버튼)에만 계속 사용.
- 제어권 게이트 보존: 자동 claim 도 `remote_guard → check_remote_enabled` 를 타므로 "원격 제어 허용" 토글 OFF 면 403 → observer(하드 에러 X). page.rs 테스트 추가.

## 검증
- `cargo test remote_server::page`/`auth` 통과, `git diff --check` 통과. pane 리뷰 clean(게이트 우회 없음 확인).
- 서버측: `/app/connect` redirect 에 `autoConnect=1` 추가(별도 repo #21 머지, dev 라이브).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RvivEwrZtzTYwH8WvcXNi