### PR TITLE
feat(mcp): write 툴 리턴에 대상 pane activity + capture_ms 응답 캡처

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -477,8 +477,12 @@ impl McpHandler {
     // 지연 뒤 제출용 CR(\r)을 별도 write. Codex TUI는 텍스트+CR을 한 번에 받으면
     // paste로 간주해 CR을 줄바꿈 처리하므로, CR을 분리해 보내야 Enter로 제출된다
     // (#314). WSL PTY는 ~40ms로도 됐으나 Windows ConPTY는 더 큰 간격이 필요.
-    async fn write_input(&self, terminal_id: &str, data: &str, escape: bool, enter: bool)
-        -> Result<usize, CallToolResult> { ... }
+    // 쓰기 직전 pane activity 와 (capture 시) 출력 버퍼 seq 를 per-terminal exec
+    // 락 안에서 원자적으로 샘플링해 WriteOutcome{ bytes, activity, before_seq }로
+    // 반환한다. 락 밖 샘플링이면 같은 세션의 다른 write 가 끼어들어 판정이 오염된다.
+    async fn write_input(&self, terminal_id: &str, data: &str, escape: bool, enter: bool,
+                         reply_to: Option<&str>, capture: bool)
+        -> Result<WriteOutcome, CallToolResult> { ... }
     // 공용 헬퍼: PTY 쓰기
     fn write_pty(&self, terminal_id: &str, data: &[u8]) -> Result<usize, CallToolResult> { ... }
 
@@ -491,10 +495,22 @@ impl McpHandler {
     // AppState 직접 접근 패턴: PTY 입력
     #[tool]
     async fn write_to_terminal(&self, p: WriteTerminalParam) -> Result<CallToolResult, ErrorData> {
-        self.write_input(&p.terminal_id, &p.data, p.escape, p.enter).await...
+        // 리턴: { written, bytes, terminalId, activity, (capture_ms 시) captureMs/response/responseTruncated }
+        let out = self.write_input(&p.terminal_id, &p.data, p.escape, p.enter,
+                                   p.reply_to.as_deref(), p.capture_ms.is_some()).await...
     }
 }
 ```
+
+**`write_to_terminal` / `write_to_neighbor` 리턴 계약** (#426):
+- `activity`: 쓰기 **직전** 대상 pane 상태. `{"type":"shell"}` | `{"type":"running"}` |
+  `{"type":"interactiveApp","name":"Codex"}`. codex/claude 인 줄 알고 보냈는데 shell 로
+  빠진 경우를 호출 즉시 감지하기 위한 필드. 락 안에서 샘플링해 write 와 원자적.
+- `capture_ms`(opt-in): 주면 write 후 그만큼(상한 10000ms) 대기했다가 대상이 새로 낸
+  출력을 ANSI 제거 + tail 절단(상한 2000자)해 반환. `capture_ms` 를 준 호출은 **항상**
+  `captureMs` + `response`(문자열, 캡처 불가 시 `""`) + `responseTruncated`(bool)를 포함
+  — 계약 안정성. 대기는 exec 락 밖에서 하므로 같은 pane 의 다른 write 를 블록하지 않는다.
+- 교차 MCP 세션 write 직렬화는 `exec_locks` 가 세션별 handler 소유라 보장되지 않음(선존 한계).
 
 #### Tool 추가 시
 

--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -93,6 +93,13 @@ struct WriteTerminalParam {
     /// to you via `write_to_terminal`. Only use when the target pane runs an
     /// LLM agent — the footer would garble input to shells or editors.
     reply_to: Option<String>,
+    /// When set, wait this many milliseconds after writing, then include the
+    /// target's new output (produced since the write) as `response` in the
+    /// return — ANSI-stripped and tail-truncated. Useful to immediately catch a
+    /// pane you assumed was an agent but was a bare shell: the shell echoes your
+    /// text and errors (e.g. `command not found`), and that shows up in
+    /// `response`. Clamped to 10000ms. Omit (default) for a non-blocking write.
+    capture_ms: Option<u64>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -115,6 +122,10 @@ struct WriteToNeighborParam {
     /// `data` so the receiving LLM agent knows where to send its result.
     /// See `write_to_terminal` for details.
     reply_to: Option<String>,
+    /// Wait this many ms after writing, then include the neighbor's new output
+    /// as `response` (ANSI-stripped, tail-truncated). See `write_to_terminal`.
+    /// Clamped to 10000ms. Omit for a non-blocking write.
+    capture_ms: Option<u64>,
 }
 
 fn default_true() -> bool {
@@ -578,6 +589,14 @@ impl McpHandler {
     /// PowerShell/Claude Code 에는 무해하다(추가 지연만 발생).
     const ENTER_CR_DELAY_MS: u64 = 300;
 
+    /// Upper bound for `capture_ms` — the caller blocks for at most this long
+    /// waiting to snapshot the target's post-write output.
+    const CAPTURE_MS_MAX: u64 = 10_000;
+
+    /// Max characters returned in a `capture_ms` `response`; the tail is kept so
+    /// shell errors near the prompt survive truncation.
+    const CAPTURE_RESPONSE_MAX_CHARS: usize = 2000;
+
     /// 입력 본문(타이핑될 텍스트)을 준비한다 — 제출용 CR은 포함하지 않는다.
     /// CR은 `write_input`이 별도 write로 보낸다([`Self::ENTER_CR_DELAY_MS`] 참조).
     ///
@@ -945,6 +964,66 @@ impl McpHandler {
         serde_json::to_value(&info.activity).unwrap_or(json!(null))
     }
 
+    /// Current write sequence number for a terminal's output buffer, used to
+    /// bracket a `capture_ms` window. `None` if the terminal is unknown or the
+    /// lock is poisoned (capture is best-effort and simply skipped).
+    fn buffer_write_seq(&self, terminal_id: &str) -> Option<u64> {
+        let buffers = self.state.app_state.output_buffers.lock_or_err().ok()?;
+        buffers.get(terminal_id).map(|buf| buf.write_seq())
+    }
+
+    /// Read output produced since `before_seq`, ANSI-stripped and tail-truncated
+    /// to `CAPTURE_RESPONSE_MAX_CHARS` (the tail is kept so shell errors near the
+    /// prompt survive). Returns `(response, truncated)`; empty when nothing new.
+    fn capture_response_since(&self, terminal_id: &str, before_seq: u64) -> (String, bool) {
+        let Ok(buffers) = self.state.app_state.output_buffers.lock_or_err() else {
+            return (String::new(), false);
+        };
+        let Some(buf) = buffers.get(terminal_id) else {
+            return (String::new(), false);
+        };
+        let raw = buf.bytes_since(before_seq);
+        let text = super::helpers::strip_ansi(&String::from_utf8_lossy(&raw));
+        let trimmed = text.trim();
+        let total = trimmed.chars().count();
+        if total > Self::CAPTURE_RESPONSE_MAX_CHARS {
+            let tail: String = trimmed
+                .chars()
+                .skip(total - Self::CAPTURE_RESPONSE_MAX_CHARS)
+                .collect();
+            (tail, true)
+        } else {
+            (trimmed.to_string(), false)
+        }
+    }
+
+    /// If `capture_ms` was requested, block up to `CAPTURE_MS_MAX`, then inject
+    /// `response` / `responseTruncated` / `captureMs` into a write tool's result.
+    /// No-op when `capture_ms` is unset or the pre-write sequence was unavailable.
+    async fn apply_capture(
+        &self,
+        result: &mut serde_json::Value,
+        terminal_id: &str,
+        capture_ms: Option<u64>,
+        before_seq: Option<u64>,
+    ) {
+        let Some(ms) = capture_ms else { return };
+        let ms = ms.min(Self::CAPTURE_MS_MAX);
+        tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+        let Some(obj) = result.as_object_mut() else {
+            return;
+        };
+        obj.insert("captureMs".to_string(), json!(ms));
+        let Some(seq) = before_seq else {
+            return;
+        };
+        let (response, truncated) = self.capture_response_since(terminal_id, seq);
+        obj.insert("response".to_string(), json!(response));
+        if truncated {
+            obj.insert("responseTruncated".to_string(), json!(true));
+        }
+    }
+
     /// Resolve the workspace containing the given terminal from the bridge terminal list.
     async fn terminal_workspace_id(&self, terminal_id: &str) -> Result<String, CallToolResult> {
         let data = self
@@ -1229,6 +1308,9 @@ impl McpHandler {
     /// (non-interactive command), or `{"type":"interactiveApp","name":"Codex"}`
     /// (a TUI). Check it right after sending to catch the case where a pane you
     /// assumed was an agent (Codex/Claude) had actually dropped to a shell.
+    /// Pass `capture_ms` to additionally block that long and return the target's
+    /// new output as `response` — e.g. the shell's `command not found` when your
+    /// prompt landed on a bare shell instead of an agent.
     #[tool]
     async fn write_to_terminal(
         &self,
@@ -1249,6 +1331,9 @@ impl McpHandler {
         // Detect the pane's activity BEFORE writing — after the write the
         // buffer is dirtied by our own input, poisoning the shell/TUI verdict.
         let activity = self.detect_activity_json(&terminal_id);
+        // Bracket the output buffer before writing so `capture_ms` can read only
+        // the new bytes the write produced.
+        let before_seq = p.capture_ms.and(self.buffer_write_seq(&terminal_id));
         match self
             .write_input(
                 &terminal_id,
@@ -1259,14 +1344,19 @@ impl McpHandler {
             )
             .await
         {
-            Ok(bytes) => Ok(json_result(&json!({
-                "written": true,
-                "bytes": bytes,
-                "bytesWritten": bytes,
-                "enter": p.enter,
-                "terminalId": terminal_id,
-                "activity": activity,
-            }))),
+            Ok(bytes) => {
+                let mut result = json!({
+                    "written": true,
+                    "bytes": bytes,
+                    "bytesWritten": bytes,
+                    "enter": p.enter,
+                    "terminalId": terminal_id,
+                    "activity": activity,
+                });
+                self.apply_capture(&mut result, &terminal_id, p.capture_ms, before_seq)
+                    .await;
+                Ok(json_result(&result))
+            }
             Err(e) => Ok(e),
         }
     }
@@ -1276,7 +1366,8 @@ impl McpHandler {
     /// of the neighbor you want to send to. Like `write_to_terminal`, input is
     /// submitted by default; pass `enter: false` to type without submitting.
     /// The return includes the neighbor's pre-write `activity` (shell / running /
-    /// interactiveApp) — see `write_to_terminal` for how to use it.
+    /// interactiveApp) and, when `capture_ms` is set, its post-write `response` —
+    /// see `write_to_terminal` for how to use them.
     #[tool]
     async fn write_to_neighbor(
         &self,
@@ -1313,6 +1404,7 @@ impl McpHandler {
         // 2. Detect neighbor activity BEFORE writing (see write_to_terminal),
         // then write.
         let activity = self.detect_activity_json(&target_id);
+        let before_seq = p.capture_ms.and(self.buffer_write_seq(&target_id));
         match self
             .write_input(
                 &target_id,
@@ -1323,14 +1415,19 @@ impl McpHandler {
             )
             .await
         {
-            Ok(bytes) => Ok(json_result(&json!({
-                "written": true,
-                "bytes": bytes,
-                "enter": p.enter,
-                "targetTerminalId": target_id,
-                "direction": p.direction.to_string(),
-                "activity": activity,
-            }))),
+            Ok(bytes) => {
+                let mut result = json!({
+                    "written": true,
+                    "bytes": bytes,
+                    "enter": p.enter,
+                    "targetTerminalId": target_id,
+                    "direction": p.direction.to_string(),
+                    "activity": activity,
+                });
+                self.apply_capture(&mut result, &target_id, p.capture_ms, before_seq)
+                    .await;
+                Ok(json_result(&result))
+            }
             Err(e) => Ok(e),
         }
     }
@@ -3351,6 +3448,28 @@ mod tests {
         let json = r#"{"terminal_id":"t1","direction":"right","data":"hello","enter":false}"#;
         let p: WriteToNeighborParam = serde_json::from_str(json).unwrap();
         assert!(!p.enter);
+    }
+
+    #[test]
+    fn write_terminal_capture_ms_defaults_to_none() {
+        // capture_ms 생략 시 응답 캡처 없이 논블로킹 write (기존 동작 유지).
+        let json = r#"{"terminal_id":"t1","data":"hello"}"#;
+        let p: WriteTerminalParam = serde_json::from_str(json).unwrap();
+        assert_eq!(p.capture_ms, None);
+    }
+
+    #[test]
+    fn write_terminal_capture_ms_parsed() {
+        let json = r#"{"terminal_id":"t1","data":"hello","capture_ms":1500}"#;
+        let p: WriteTerminalParam = serde_json::from_str(json).unwrap();
+        assert_eq!(p.capture_ms, Some(1500));
+    }
+
+    #[test]
+    fn write_to_neighbor_capture_ms_parsed() {
+        let json = r#"{"terminal_id":"t1","direction":"below","data":"hello","capture_ms":800}"#;
+        let p: WriteToNeighborParam = serde_json::from_str(json).unwrap();
+        assert_eq!(p.capture_ms, Some(800));
     }
 
     #[test]

--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -927,6 +927,24 @@ impl McpHandler {
         }
     }
 
+    /// Detect a terminal's current activity (shell / running / interactiveApp)
+    /// as a JSON value. Used to surface the pre-write pane state in the
+    /// `write_to_terminal`/`write_to_neighbor` return so callers immediately
+    /// notice when a pane they assumed was a TUI (Codex/Claude) has dropped to
+    /// a shell prompt. Best-effort: a poisoned buffer lock yields `null`.
+    fn detect_activity_json(&self, terminal_id: &str) -> serde_json::Value {
+        let app_state = &self.state.app_state;
+        let Ok(buffers) = app_state.output_buffers.lock_or_err() else {
+            return json!(null);
+        };
+        let info = crate::activity::detect_terminal_state(
+            app_state,
+            terminal_id,
+            buffers.get(terminal_id),
+        );
+        serde_json::to_value(&info.activity).unwrap_or(json!(null))
+    }
+
     /// Resolve the workspace containing the given terminal from the bridge terminal list.
     async fn terminal_workspace_id(&self, terminal_id: &str) -> Result<String, CallToolResult> {
         let data = self
@@ -1206,6 +1224,11 @@ impl McpHandler {
     /// When messaging another LLM agent pane, pass `reply_to` with your own
     /// terminal ID ($LX_TERMINAL_ID) — a standardized footer is appended
     /// telling the agent where to send its result back.
+    /// The return includes `activity` — the target pane's state sampled just
+    /// BEFORE the write: `{"type":"shell"}` (bare prompt), `{"type":"running"}`
+    /// (non-interactive command), or `{"type":"interactiveApp","name":"Codex"}`
+    /// (a TUI). Check it right after sending to catch the case where a pane you
+    /// assumed was an agent (Codex/Claude) had actually dropped to a shell.
     #[tool]
     async fn write_to_terminal(
         &self,
@@ -1223,6 +1246,9 @@ impl McpHandler {
             Ok(id) => id,
             Err(e) => return Ok(e),
         };
+        // Detect the pane's activity BEFORE writing — after the write the
+        // buffer is dirtied by our own input, poisoning the shell/TUI verdict.
+        let activity = self.detect_activity_json(&terminal_id);
         match self
             .write_input(
                 &terminal_id,
@@ -1239,6 +1265,7 @@ impl McpHandler {
                 "bytesWritten": bytes,
                 "enter": p.enter,
                 "terminalId": terminal_id,
+                "activity": activity,
             }))),
             Err(e) => Ok(e),
         }
@@ -1248,6 +1275,8 @@ impl McpHandler {
     /// in a single call. Pass your own terminal_id (from $LX_TERMINAL_ID) and the direction
     /// of the neighbor you want to send to. Like `write_to_terminal`, input is
     /// submitted by default; pass `enter: false` to type without submitting.
+    /// The return includes the neighbor's pre-write `activity` (shell / running /
+    /// interactiveApp) — see `write_to_terminal` for how to use it.
     #[tool]
     async fn write_to_neighbor(
         &self,
@@ -1281,7 +1310,9 @@ impl McpHandler {
             ))]));
         };
 
-        // 2. Write to the neighbor
+        // 2. Detect neighbor activity BEFORE writing (see write_to_terminal),
+        // then write.
+        let activity = self.detect_activity_json(&target_id);
         match self
             .write_input(
                 &target_id,
@@ -1298,6 +1329,7 @@ impl McpHandler {
                 "enter": p.enter,
                 "targetTerminalId": target_id,
                 "direction": p.direction.to_string(),
+                "activity": activity,
             }))),
             Err(e) => Ok(e),
         }

--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -132,6 +132,15 @@ fn default_true() -> bool {
     true
 }
 
+/// Result of [`McpHandler::write_input`]: bytes sent plus the pre-write state
+/// sampled atomically under the per-terminal exec lock (`activity` always;
+/// `before_seq` only when capture was requested).
+struct WriteOutcome {
+    bytes: usize,
+    activity: serde_json::Value,
+    before_seq: Option<u64>,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct PaneLocator {
     workspace_name: String,
@@ -691,7 +700,13 @@ impl McpHandler {
     /// 청크 사이에 [`Self::ENTER_CR_DELAY_MS`] 지연을 둔다(#314 — Codex paste 오인
     /// 방지). 같은 터미널에 대한 write/execute 는 per-terminal 락으로 직렬화하여,
     /// 분리된 body+CR 시퀀스 사이에 다른 호출이 끼어들어 `bodyA bodyB \r \r` 처럼
-    /// 인터리브되는 것을 막는다. 총 전송 바이트 수를 반환한다.
+    /// 인터리브되는 것을 막는다.
+    ///
+    /// 쓰기 직전 pane activity 와 (capture 시) 출력 버퍼 seq 를 **락 안에서** 샘플링해
+    /// [`WriteOutcome`]에 담아 돌려준다. 락 밖에서 샘플링하면 이 세션의 다른 write 가
+    /// 락을 먼저 잡아 그 사이에 끼어들 수 있어, activity/seq 가 실제 "이 write 직전"이
+    /// 아니게 된다. 락 안 샘플링으로 그 경합을 막는다. (교차 MCP 세션 직렬화는
+    /// `exec_locks` 가 세션별이라 여전히 보장되지 않는다 — 별도 이슈.)
     async fn write_input(
         &self,
         terminal_id: &str,
@@ -699,12 +714,15 @@ impl McpHandler {
         escape: bool,
         enter: bool,
         reply_to: Option<&str>,
-    ) -> Result<usize, CallToolResult> {
+        capture: bool,
+    ) -> Result<WriteOutcome, CallToolResult> {
         let chunks = Self::plan_input_writes(data, escape, enter, reply_to);
         // body+CR 시퀀스를 원자적으로 보내기 위해 execute_command 와 동일한
         // per-terminal 락으로 직렬화한다.
         let lock = self.terminal_exec_lock(terminal_id).await;
         let _guard = lock.lock().await;
+        // 락을 잡은 뒤, 쓰기 직전 상태를 원자적으로 샘플링한다.
+        let (activity, before_seq) = self.sample_activity_and_seq(terminal_id, capture);
         let mut total = 0usize;
         for (i, chunk) in chunks.iter().enumerate() {
             // 청크(=본문 다음의 CR) 앞에만 지연을 둔다. lone CR/본문만일 때는
@@ -714,7 +732,11 @@ impl McpHandler {
             }
             total += self.write_pty(terminal_id, chunk)?;
         }
-        Ok(total)
+        Ok(WriteOutcome {
+            bytes: total,
+            activity,
+            before_seq,
+        })
     }
 
     /// Write bytes to a terminal PTY. Returns (bytes_written) or error.
@@ -946,60 +968,66 @@ impl McpHandler {
         }
     }
 
-    /// Detect a terminal's current activity (shell / running / interactiveApp)
-    /// as a JSON value. Used to surface the pre-write pane state in the
-    /// `write_to_terminal`/`write_to_neighbor` return so callers immediately
-    /// notice when a pane they assumed was a TUI (Codex/Claude) has dropped to
-    /// a shell prompt. Best-effort: a poisoned buffer lock yields `null`.
-    fn detect_activity_json(&self, terminal_id: &str) -> serde_json::Value {
+    /// Sample a terminal's pre-write state in a single `output_buffers` lock:
+    /// its activity (shell / running / interactiveApp) as JSON, and — when
+    /// `want_seq` — the current output-buffer write sequence to bracket a
+    /// `capture_ms` window. Call this while holding the per-terminal exec lock so
+    /// the sample is atomic w.r.t. this terminal's write ordering. Best-effort: a
+    /// poisoned lock yields `(null, None)`.
+    fn sample_activity_and_seq(
+        &self,
+        terminal_id: &str,
+        want_seq: bool,
+    ) -> (serde_json::Value, Option<u64>) {
         let app_state = &self.state.app_state;
         let Ok(buffers) = app_state.output_buffers.lock_or_err() else {
-            return json!(null);
+            return (json!(null), None);
         };
-        let info = crate::activity::detect_terminal_state(
-            app_state,
-            terminal_id,
-            buffers.get(terminal_id),
-        );
-        serde_json::to_value(&info.activity).unwrap_or(json!(null))
-    }
-
-    /// Current write sequence number for a terminal's output buffer, used to
-    /// bracket a `capture_ms` window. `None` if the terminal is unknown or the
-    /// lock is poisoned (capture is best-effort and simply skipped).
-    fn buffer_write_seq(&self, terminal_id: &str) -> Option<u64> {
-        let buffers = self.state.app_state.output_buffers.lock_or_err().ok()?;
-        buffers.get(terminal_id).map(|buf| buf.write_seq())
-    }
-
-    /// Read output produced since `before_seq`, ANSI-stripped and tail-truncated
-    /// to `CAPTURE_RESPONSE_MAX_CHARS` (the tail is kept so shell errors near the
-    /// prompt survive). Returns `(response, truncated)`; empty when nothing new.
-    fn capture_response_since(&self, terminal_id: &str, before_seq: u64) -> (String, bool) {
-        let Ok(buffers) = self.state.app_state.output_buffers.lock_or_err() else {
-            return (String::new(), false);
-        };
-        let Some(buf) = buffers.get(terminal_id) else {
-            return (String::new(), false);
-        };
-        let raw = buf.bytes_since(before_seq);
-        let text = super::helpers::strip_ansi(&String::from_utf8_lossy(&raw));
-        let trimmed = text.trim();
-        let total = trimmed.chars().count();
-        if total > Self::CAPTURE_RESPONSE_MAX_CHARS {
-            let tail: String = trimmed
-                .chars()
-                .skip(total - Self::CAPTURE_RESPONSE_MAX_CHARS)
-                .collect();
-            (tail, true)
+        let buf = buffers.get(terminal_id);
+        let info = crate::activity::detect_terminal_state(app_state, terminal_id, buf);
+        let activity = serde_json::to_value(&info.activity).unwrap_or(json!(null));
+        let seq = if want_seq {
+            buf.map(|b| b.write_seq())
         } else {
-            (trimmed.to_string(), false)
+            None
+        };
+        (activity, seq)
+    }
+
+    /// Copy the raw bytes produced since `before_seq` under the buffer lock, then
+    /// release it before the (potentially large) ANSI strip + tail truncation so
+    /// a noisy TUI's snapshot doesn't stall PTY callbacks pushing into the buffer.
+    /// Returns `(response, truncated)`; empty string when nothing new / unknown.
+    fn capture_response_since(&self, terminal_id: &str, before_seq: u64) -> (String, bool) {
+        let raw = {
+            let Ok(buffers) = self.state.app_state.output_buffers.lock_or_err() else {
+                return (String::new(), false);
+            };
+            match buffers.get(terminal_id) {
+                Some(buf) => buf.bytes_since(before_seq),
+                None => return (String::new(), false),
+            }
+        }; // buffer lock released here
+        let text = super::helpers::strip_ansi(&String::from_utf8_lossy(&raw));
+        Self::truncate_tail(text.trim(), Self::CAPTURE_RESPONSE_MAX_CHARS)
+    }
+
+    /// Keep at most `max` trailing chars of `s`. Returns `(text, truncated)`.
+    /// The tail is kept so shell errors near the prompt survive truncation.
+    fn truncate_tail(s: &str, max: usize) -> (String, bool) {
+        let total = s.chars().count();
+        if total > max {
+            (s.chars().skip(total - max).collect(), true)
+        } else {
+            (s.to_string(), false)
         }
     }
 
     /// If `capture_ms` was requested, block up to `CAPTURE_MS_MAX`, then inject
-    /// `response` / `responseTruncated` / `captureMs` into a write tool's result.
-    /// No-op when `capture_ms` is unset or the pre-write sequence was unavailable.
+    /// `captureMs` plus `response` / `responseTruncated` into a write tool's
+    /// result. `response` is always present when `capture_ms` is set (empty
+    /// string if the pre-write sequence was unavailable) so the return contract
+    /// is stable. No-op when `capture_ms` is unset.
     async fn apply_capture(
         &self,
         result: &mut serde_json::Value,
@@ -1014,14 +1042,12 @@ impl McpHandler {
             return;
         };
         obj.insert("captureMs".to_string(), json!(ms));
-        let Some(seq) = before_seq else {
-            return;
+        let (response, truncated) = match before_seq {
+            Some(seq) => self.capture_response_since(terminal_id, seq),
+            None => (String::new(), false),
         };
-        let (response, truncated) = self.capture_response_since(terminal_id, seq);
         obj.insert("response".to_string(), json!(response));
-        if truncated {
-            obj.insert("responseTruncated".to_string(), json!(true));
-        }
+        obj.insert("responseTruncated".to_string(), json!(truncated));
     }
 
     /// Resolve the workspace containing the given terminal from the bridge terminal list.
@@ -1328,12 +1354,8 @@ impl McpHandler {
             Ok(id) => id,
             Err(e) => return Ok(e),
         };
-        // Detect the pane's activity BEFORE writing — after the write the
-        // buffer is dirtied by our own input, poisoning the shell/TUI verdict.
-        let activity = self.detect_activity_json(&terminal_id);
-        // Bracket the output buffer before writing so `capture_ms` can read only
-        // the new bytes the write produced.
-        let before_seq = p.capture_ms.and(self.buffer_write_seq(&terminal_id));
+        // Activity + capture start-seq are sampled inside write_input under the
+        // per-terminal exec lock, atomic with the write itself.
         match self
             .write_input(
                 &terminal_id,
@@ -1341,19 +1363,20 @@ impl McpHandler {
                 p.escape,
                 p.enter,
                 p.reply_to.as_deref(),
+                p.capture_ms.is_some(),
             )
             .await
         {
-            Ok(bytes) => {
+            Ok(outcome) => {
                 let mut result = json!({
                     "written": true,
-                    "bytes": bytes,
-                    "bytesWritten": bytes,
+                    "bytes": outcome.bytes,
+                    "bytesWritten": outcome.bytes,
                     "enter": p.enter,
                     "terminalId": terminal_id,
-                    "activity": activity,
+                    "activity": outcome.activity,
                 });
-                self.apply_capture(&mut result, &terminal_id, p.capture_ms, before_seq)
+                self.apply_capture(&mut result, &terminal_id, p.capture_ms, outcome.before_seq)
                     .await;
                 Ok(json_result(&result))
             }
@@ -1401,10 +1424,8 @@ impl McpHandler {
             ))]));
         };
 
-        // 2. Detect neighbor activity BEFORE writing (see write_to_terminal),
-        // then write.
-        let activity = self.detect_activity_json(&target_id);
-        let before_seq = p.capture_ms.and(self.buffer_write_seq(&target_id));
+        // 2. Write to the neighbor. Activity + capture start-seq are sampled
+        // inside write_input under the per-terminal exec lock (see write_to_terminal).
         match self
             .write_input(
                 &target_id,
@@ -1412,19 +1433,20 @@ impl McpHandler {
                 p.escape,
                 p.enter,
                 p.reply_to.as_deref(),
+                p.capture_ms.is_some(),
             )
             .await
         {
-            Ok(bytes) => {
+            Ok(outcome) => {
                 let mut result = json!({
                     "written": true,
-                    "bytes": bytes,
+                    "bytes": outcome.bytes,
                     "enter": p.enter,
                     "targetTerminalId": target_id,
                     "direction": p.direction.to_string(),
-                    "activity": activity,
+                    "activity": outcome.activity,
                 });
-                self.apply_capture(&mut result, &target_id, p.capture_ms, before_seq)
+                self.apply_capture(&mut result, &target_id, p.capture_ms, outcome.before_seq)
                     .await;
                 Ok(json_result(&result))
             }
@@ -2222,7 +2244,10 @@ impl McpHandler {
         let mut failed = Vec::new();
 
         for id in &p.terminal_ids {
-            match self.write_input(id, &p.data, p.escape, p.enter, None).await {
+            match self
+                .write_input(id, &p.data, p.escape, p.enter, None, false)
+                .await
+            {
                 Ok(_) => written.push(id.clone()),
                 Err(_) => failed.push(json!({ "id": id, "error": "not found or write failed" })),
             }
@@ -3470,6 +3495,43 @@ mod tests {
         let json = r#"{"terminal_id":"t1","direction":"below","data":"hello","capture_ms":800}"#;
         let p: WriteToNeighborParam = serde_json::from_str(json).unwrap();
         assert_eq!(p.capture_ms, Some(800));
+    }
+
+    #[test]
+    fn truncate_tail_keeps_short_text_verbatim() {
+        let (out, trunc) = McpHandler::truncate_tail("short output", 2000);
+        assert_eq!(out, "short output");
+        assert!(!trunc);
+    }
+
+    #[test]
+    fn truncate_tail_keeps_the_tail_when_over_max() {
+        let s: String = (0..50).map(|i| char::from(b'a' + (i % 26) as u8)).collect();
+        let (out, trunc) = McpHandler::truncate_tail(&s, 10);
+        assert!(trunc);
+        assert_eq!(out.chars().count(), 10);
+        // Tail kept, not head: the last 10 chars of the source.
+        let expected: String = s.chars().skip(50 - 10).collect();
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn truncate_tail_is_char_boundary_safe_for_multibyte() {
+        // 5 multi-byte chars, cap at 2 → must not panic and must yield 2 chars.
+        let (out, trunc) = McpHandler::truncate_tail("가나다라마", 2);
+        assert!(trunc);
+        assert_eq!(out, "라마");
+    }
+
+    #[test]
+    fn capture_response_pipeline_strips_ansi_then_truncates() {
+        // strip_ansi + truncate_tail is the response pipeline; verify ANSI removal
+        // composes with tail truncation without splitting escape sequences.
+        let raw = "\x1b[31mERROR\x1b[0m: command not found";
+        let stripped = super::super::helpers::strip_ansi(raw);
+        let (out, trunc) = McpHandler::truncate_tail(stripped.trim(), 2000);
+        assert_eq!(out, "ERROR: command not found");
+        assert!(!trunc);
     }
 
     #[test]


### PR DESCRIPTION
## 문제
다른 pane 에 지시를 보낼 때, codex/claude TUI 인 줄 알고 보냈는데 실제론 shell 로 빠져있는 경우가 있다. `write_to_terminal`/`write_to_neighbor` 리턴은 쓰기 성공 확인만 담아 이 mismatch 를 호출 즉시 알 수 없었다.

## 변경 (2단계)

### 1) 리턴에 대상 pane `activity` (쓰기 직전)
```json
{"written": true, "bytes": N, "terminalId": "...", "activity": {"type": "shell"}}
```
- `{"type":"shell"}` — 셸 프롬프트 (agent 아님)
- `{"type":"running"}` — 비대화 명령 실행중
- `{"type":"interactiveApp","name":"Codex"}` — TUI 정상

**핵심**: 감지는 `write_input` 전에 1회. 쓴 뒤엔 내 입력이 버퍼를 더럽혀 판정이 오염된다.

### 2) `capture_ms` — 쓰기 직후 응답 캡처 (opt-in)
`activity` 가 shell-drop 을 플래그해도 *무슨 일이 났는지*(예: 셸이 프롬프트를 명령으로 오인해 낸 `command not found`)는 안 보였다. `capture_ms` 를 주면 write 후 그만큼 대기했다가 대상 새 출력을 ANSI 제거 + tail 절단해 `response` 로 리턴.
```json
{"activity":{"type":"shell"}, "captureMs":1500,
 "response":"fix the login bug please\r\nCommand 'fix' not found, did you mean: ..."}
```
- 델타는 쓰기 직전 `write_seq` 로 구간을 잡아 내 입력이 만든 출력만 캡처
- 생략 시(기본) 기존처럼 논블로킹, `response` 없음
- 상한: capture_ms 10000ms, response 2000자(tail 유지)

## 구현
`src-tauri/src/automation_server/mcp.rs`:
- `detect_activity_json()` — 버퍼 lock → `detect_terminal_state` → JSON
- `buffer_write_seq()` / `capture_response_since()` / `apply_capture()`
- `WriteTerminalParam` / `WriteToNeighborParam` 에 `capture_ms: Option<u64>`
- 두 툴 리턴에 `activity` + (opt) `response`/`captureMs`/`responseTruncated`
- 두 툴 docstring 갱신

## 검증 (dev 19281, 실제 MCP 호출)
- `cargo check` 통과, mcp 테스트 88개 green (+3)
- 라이브 E2E:
  - `write_to_terminal` → shell pane → `activity {type:shell}` ✅
  - `write_to_terminal` → Claude TUI → `activity {interactiveApp,Claude}` ✅
  - `write_to_neighbor` → Claude TUI → 동일 ✅
  - **shell + capture_ms** → NL 프롬프트가 `Command 'fix' not found` 로 잡힘 ✅
  - default(capture_ms 없음) → `response` 없음, 0.1s 논블로킹 ✅
  - TUI + capture_ms → activity interactiveApp + ANSI 제거된 clean response ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)