### PR TITLE
fix(mcp): per-terminal write 락을 프로세스 전역(AppState)으로 이동 (#427)

### DIFF
--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -750,7 +750,17 @@ impl McpHandler {
             if i > 0 {
                 tokio::time::sleep(std::time::Duration::from_millis(Self::ENTER_CR_DELAY_MS)).await;
             }
-            total += self.write_pty(terminal_id, chunk)?;
+            match self.write_pty(terminal_id, chunk) {
+                Ok(n) => total += n,
+                Err(e) => {
+                    // 쓰기 도중 터미널이 사라졌다면(close 와 경합) 방금 재생성됐을
+                    // 수 있는 락 엔트리를 정리한다(#427).
+                    if !self.terminal_exists(terminal_id) {
+                        self.remove_terminal_lock(terminal_id);
+                    }
+                    return Err(e);
+                }
+            }
         }
         Ok(WriteOutcome {
             bytes: total,
@@ -769,6 +779,22 @@ impl McpHandler {
             .lock_or_err()
             .map(|ptys| ptys.contains_key(terminal_id))
             .unwrap_or(false)
+    }
+
+    /// Drop a terminal's entry from the shared `exec_locks` table. Called when a
+    /// write discovers the terminal vanished mid-flight — the pre-write
+    /// `terminal_exists` check can race a concurrent `close_terminal_session`
+    /// (close removes the entry, then this call recreated it), so self-heal here
+    /// rather than leak the recreated entry (#427). Safe while holding the
+    /// per-terminal guard: the guard keeps its own `Arc`; the map only drops a ref.
+    fn remove_terminal_lock(&self, terminal_id: &str) {
+        let mut map = self
+            .state
+            .app_state
+            .exec_locks
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        map.remove(terminal_id);
     }
 
     /// Write bytes to a terminal PTY. Returns (bytes_written) or error.
@@ -1606,6 +1632,9 @@ impl McpHandler {
                     buf.write_seq()
                 }
                 None => {
+                    // Vanished after the pre-lock existence check (raced close):
+                    // purge the possibly-recreated lock entry (#427).
+                    self.remove_terminal_lock(&p.terminal_id);
                     return Ok(CallToolResult::error(vec![Content::text(format!(
                         "Terminal '{}' not found",
                         p.terminal_id

--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -156,6 +156,25 @@ fn get_or_create_terminal_lock(
         .clone()
 }
 
+/// Remove `terminal_id`'s entry, but only if it is still the exact `expected`
+/// lock. A stale write that saw the terminal vanish must not delete a *different*
+/// lock that a same-id terminal recreated in the meantime (id reuse + close
+/// race), which would split serialization for the new terminal (#427).
+fn remove_terminal_lock_if(
+    locks: &crate::state::SharedExecLocks,
+    terminal_id: &str,
+    expected: &Arc<TokioMutex<()>>,
+) {
+    let mut map = locks.lock().unwrap_or_else(|e| e.into_inner());
+    let is_ours = map
+        .get(terminal_id)
+        .map(|cur| Arc::ptr_eq(cur, expected))
+        .unwrap_or(false);
+    if is_ours {
+        map.remove(terminal_id);
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct PaneLocator {
     workspace_name: String,
@@ -754,9 +773,9 @@ impl McpHandler {
                 Ok(n) => total += n,
                 Err(e) => {
                     // 쓰기 도중 터미널이 사라졌다면(close 와 경합) 방금 재생성됐을
-                    // 수 있는 락 엔트리를 정리한다(#427).
+                    // 수 있는 락 엔트리를 정리한다(#427). 단 우리가 든 락일 때만.
                     if !self.terminal_exists(terminal_id) {
-                        self.remove_terminal_lock(terminal_id);
+                        self.remove_terminal_lock(terminal_id, &lock);
                     }
                     return Err(e);
                 }
@@ -781,20 +800,14 @@ impl McpHandler {
             .unwrap_or(false)
     }
 
-    /// Drop a terminal's entry from the shared `exec_locks` table. Called when a
-    /// write discovers the terminal vanished mid-flight — the pre-write
-    /// `terminal_exists` check can race a concurrent `close_terminal_session`
-    /// (close removes the entry, then this call recreated it), so self-heal here
-    /// rather than leak the recreated entry (#427). Safe while holding the
-    /// per-terminal guard: the guard keeps its own `Arc`; the map only drops a ref.
-    fn remove_terminal_lock(&self, terminal_id: &str) {
-        let mut map = self
-            .state
-            .app_state
-            .exec_locks
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        map.remove(terminal_id);
+    /// Drop the per-terminal lock `held` for `terminal_id` when a write finds the
+    /// terminal vanished mid-flight — the pre-write `terminal_exists` check can
+    /// race a concurrent `close_terminal_session`, leaving an entry we recreated.
+    /// Only removes when the table still holds *our* lock (`Arc::ptr_eq`), so a
+    /// same-id terminal recreated after us keeps its own lock (#427). Safe under
+    /// the per-terminal guard: the guard keeps its `Arc`; the map drops a ref.
+    fn remove_terminal_lock(&self, terminal_id: &str, held: &Arc<TokioMutex<()>>) {
+        remove_terminal_lock_if(&self.state.app_state.exec_locks, terminal_id, held);
     }
 
     /// Write bytes to a terminal PTY. Returns (bytes_written) or error.
@@ -1633,8 +1646,9 @@ impl McpHandler {
                 }
                 None => {
                     // Vanished after the pre-lock existence check (raced close):
-                    // purge the possibly-recreated lock entry (#427).
-                    self.remove_terminal_lock(&p.terminal_id);
+                    // purge the possibly-recreated lock entry, but only if it is
+                    // still ours (#427).
+                    self.remove_terminal_lock(&p.terminal_id, &lock);
                     return Ok(CallToolResult::error(vec![Content::text(format!(
                         "Terminal '{}' not found",
                         p.terminal_id
@@ -3606,6 +3620,30 @@ mod tests {
             !Arc::ptr_eq(&first, &second),
             "a re-created lock after removal must be a distinct Arc"
         );
+    }
+
+    #[test]
+    fn remove_terminal_lock_if_only_drops_the_matching_arc() {
+        // id reuse + close race (#427): a stale write must not delete a lock
+        // that a same-id terminal recreated after it.
+        let state = Arc::new(crate::state::AppState::new());
+        let stale = get_or_create_terminal_lock(&state.exec_locks, "t1");
+        // Simulate close + same-id recreation: table now holds a DIFFERENT Arc.
+        state.exec_locks.lock().unwrap().remove("t1");
+        let current = get_or_create_terminal_lock(&state.exec_locks, "t1");
+        assert!(!Arc::ptr_eq(&stale, &current));
+
+        // Stale write tries to purge with its old Arc → must be a no-op.
+        remove_terminal_lock_if(&state.exec_locks, "t1", &stale);
+        let after = get_or_create_terminal_lock(&state.exec_locks, "t1");
+        assert!(
+            Arc::ptr_eq(&current, &after),
+            "purge with a stale Arc must not evict the current lock"
+        );
+
+        // Purge with the matching Arc → removes it.
+        remove_terminal_lock_if(&state.exec_locks, "t1", &current);
+        assert_eq!(state.exec_locks.lock().unwrap().len(), 0);
     }
 
     #[test]

--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -143,13 +143,14 @@ struct WriteOutcome {
 
 /// Get or create the per-terminal serialization lock from a shared table.
 /// Same `terminal_id` → the same `Arc` (so all callers serialize); distinct
-/// ids → distinct locks. Free fn so it can be unit-tested without an
-/// `McpHandler` (which needs a Tauri `AppHandle`).
-async fn get_or_create_terminal_lock(
+/// ids → distinct locks. The outer table mutex is `std` and held only for this
+/// get/insert (never across `.await`). Free fn so it can be unit-tested without
+/// an `McpHandler` (which needs a Tauri `AppHandle`).
+fn get_or_create_terminal_lock(
     locks: &crate::state::SharedExecLocks,
     terminal_id: &str,
 ) -> Arc<TokioMutex<()>> {
-    let mut map = locks.lock().await;
+    let mut map = locks.lock().unwrap_or_else(|e| e.into_inner());
     map.entry(terminal_id.to_string())
         .or_insert_with(|| Arc::new(TokioMutex::new(())))
         .clone()
@@ -592,7 +593,7 @@ impl McpHandler {
     /// the shared `Arc<AppState>` (see [`crate::state::SharedExecLocks`]) so this
     /// holds across MCP sessions, not just within one handler (#427).
     async fn terminal_exec_lock(&self, terminal_id: &str) -> Arc<TokioMutex<()>> {
-        get_or_create_terminal_lock(&self.state.app_state.exec_locks, terminal_id).await
+        get_or_create_terminal_lock(&self.state.app_state.exec_locks, terminal_id)
     }
 
     /// 제출(`enter=true`) 시 텍스트와 종료 CR 사이의 지연(ms).
@@ -713,10 +714,10 @@ impl McpHandler {
     /// 인터리브되는 것을 막는다.
     ///
     /// 쓰기 직전 pane activity 와 (capture 시) 출력 버퍼 seq 를 **락 안에서** 샘플링해
-    /// [`WriteOutcome`]에 담아 돌려준다. 락 밖에서 샘플링하면 이 세션의 다른 write 가
-    /// 락을 먼저 잡아 그 사이에 끼어들 수 있어, activity/seq 가 실제 "이 write 직전"이
-    /// 아니게 된다. 락 안 샘플링으로 그 경합을 막는다. (교차 MCP 세션 직렬화는
-    /// `exec_locks` 가 세션별이라 여전히 보장되지 않는다 — 별도 이슈.)
+    /// [`WriteOutcome`]에 담아 돌려준다. 락 밖에서 샘플링하면 다른 write 가 락을
+    /// 먼저 잡아 그 사이에 끼어들 수 있어, activity/seq 가 실제 "이 write 직전"이
+    /// 아니게 된다. 락 안 샘플링으로 그 경합을 막는다. 락 테이블이 프로세스 전역
+    /// (`AppState::exec_locks`)이라 직렬화는 MCP 세션과 무관하게 성립한다(#427).
     async fn write_input(
         &self,
         terminal_id: &str,
@@ -727,6 +728,15 @@ impl McpHandler {
         capture: bool,
     ) -> Result<WriteOutcome, CallToolResult> {
         let chunks = Self::plan_input_writes(data, escape, enter, reply_to);
+        // 존재하지 않는 터미널이면 락 엔트리를 만들기 전에 거른다 — 전역 exec_locks
+        // 테이블이 무효/닫힌 id 호출만으로 커지지 않도록(#427). write_pty 도 동일한
+        // not-found 를 내지만, 그 전에 이미 락이 삽입된 뒤다.
+        if !self.terminal_exists(terminal_id) {
+            return Err(CallToolResult::error(vec![Content::text(format!(
+                "Terminal '{}' not found",
+                terminal_id
+            ))]));
+        }
         // body+CR 시퀀스를 원자적으로 보내기 위해 execute_command 와 동일한
         // per-terminal 락으로 직렬화한다.
         let lock = self.terminal_exec_lock(terminal_id).await;
@@ -747,6 +757,18 @@ impl McpHandler {
             activity,
             before_seq,
         })
+    }
+
+    /// True if the terminal has a live PTY handle. Used to reject writes to
+    /// unknown/closed ids before an `exec_locks` entry is created (#427). A
+    /// poisoned lock is treated as "not present" (writes are fatal anyway).
+    fn terminal_exists(&self, terminal_id: &str) -> bool {
+        self.state
+            .app_state
+            .pty_handles
+            .lock_or_err()
+            .map(|ptys| ptys.contains_key(terminal_id))
+            .unwrap_or(false)
     }
 
     /// Write bytes to a terminal PTY. Returns (bytes_written) or error.
@@ -1554,6 +1576,15 @@ impl McpHandler {
 
         let timeout_ms = p.timeout_ms.unwrap_or(10_000).min(60_000);
         let strip = matches!(p.format.as_deref(), Some("text"));
+
+        // Reject unknown/closed terminals before creating a lock entry so the
+        // process-global exec_locks table can't grow from invalid ids (#427).
+        if !self.terminal_exists(&p.terminal_id) {
+            return Ok(CallToolResult::error(vec![Content::text(format!(
+                "Terminal '{}' not found",
+                p.terminal_id
+            ))]));
+        }
 
         // Acquire per-terminal lock to serialize concurrent execute_command calls
         let lock = self.terminal_exec_lock(&p.terminal_id).await;
@@ -3507,24 +3538,44 @@ mod tests {
         assert_eq!(p.capture_ms, Some(800));
     }
 
-    #[tokio::test]
-    async fn exec_locks_are_shared_across_appstate_clones() {
+    #[test]
+    fn exec_locks_are_shared_across_appstate_clones() {
         // Two MCP handlers in different sessions hold clones of the same
         // Arc<AppState>; the exec-lock table lives there, so the same terminal
         // must resolve to the SAME lock Arc across them (cross-session
         // serialization — #427). Different terminals get different locks.
         let a = Arc::new(crate::state::AppState::new());
         let b = a.clone(); // second session's ServerState.app_state
-        let la = get_or_create_terminal_lock(&a.exec_locks, "t1").await;
-        let lb = get_or_create_terminal_lock(&b.exec_locks, "t1").await;
+        let la = get_or_create_terminal_lock(&a.exec_locks, "t1");
+        let lb = get_or_create_terminal_lock(&b.exec_locks, "t1");
         assert!(
             Arc::ptr_eq(&la, &lb),
             "same terminal across shared AppState must yield one lock"
         );
-        let lc = get_or_create_terminal_lock(&a.exec_locks, "t2").await;
+        let lc = get_or_create_terminal_lock(&a.exec_locks, "t2");
         assert!(
             !Arc::ptr_eq(&la, &lc),
             "different terminals must get distinct locks"
+        );
+    }
+
+    #[test]
+    fn exec_locks_entry_is_dropped_after_removal() {
+        // Mirrors close_terminal_session cleanup (#427): once an entry is
+        // removed from the table, the next get_or_create makes a fresh lock, so
+        // the table does not retain entries for closed terminals forever.
+        let state = Arc::new(crate::state::AppState::new());
+        let first = get_or_create_terminal_lock(&state.exec_locks, "t1");
+        state.exec_locks.lock().unwrap().remove("t1");
+        assert_eq!(
+            state.exec_locks.lock().unwrap().len(),
+            0,
+            "removal must empty the table"
+        );
+        let second = get_or_create_terminal_lock(&state.exec_locks, "t1");
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "a re-created lock after removal must be a distinct Arc"
         );
     }
 

--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -141,6 +141,20 @@ struct WriteOutcome {
     before_seq: Option<u64>,
 }
 
+/// Get or create the per-terminal serialization lock from a shared table.
+/// Same `terminal_id` → the same `Arc` (so all callers serialize); distinct
+/// ids → distinct locks. Free fn so it can be unit-tested without an
+/// `McpHandler` (which needs a Tauri `AppHandle`).
+async fn get_or_create_terminal_lock(
+    locks: &crate::state::SharedExecLocks,
+    terminal_id: &str,
+) -> Arc<TokioMutex<()>> {
+    let mut map = locks.lock().await;
+    map.entry(terminal_id.to_string())
+        .or_insert_with(|| Arc::new(TokioMutex::new(())))
+        .clone()
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct PaneLocator {
     workspace_name: String,
@@ -548,8 +562,6 @@ pub struct McpHandler {
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
     is_dev: bool,
-    /// Per-terminal mutex to serialize execute_command calls on the same terminal.
-    exec_locks: Arc<TokioMutex<HashMap<String, Arc<TokioMutex<()>>>>>,
     /// Shared subscription registry: tracks `resources/subscribe` requests so
     /// the Tauri→MCP event bridge can push `notifications/resources/updated`
     /// to the correct peers.
@@ -569,7 +581,6 @@ impl McpHandler {
             state,
             tool_router: Self::tool_router(),
             is_dev,
-            exec_locks: Arc::new(TokioMutex::new(HashMap::new())),
             subscriptions,
             peer_id: new_peer_id(),
         }
@@ -577,12 +588,11 @@ impl McpHandler {
 
     /// Get or create a per-terminal lock serializing execute_command and
     /// write_input (so a split body+CR sequence is not interleaved by another
-    /// concurrent write/exec to the same terminal — #314).
+    /// concurrent write/exec to the same terminal — #314). The table lives on
+    /// the shared `Arc<AppState>` (see [`crate::state::SharedExecLocks`]) so this
+    /// holds across MCP sessions, not just within one handler (#427).
     async fn terminal_exec_lock(&self, terminal_id: &str) -> Arc<TokioMutex<()>> {
-        let mut map = self.exec_locks.lock().await;
-        map.entry(terminal_id.to_string())
-            .or_insert_with(|| Arc::new(TokioMutex::new(())))
-            .clone()
+        get_or_create_terminal_lock(&self.state.app_state.exec_locks, terminal_id).await
     }
 
     /// 제출(`enter=true`) 시 텍스트와 종료 CR 사이의 지연(ms).
@@ -3495,6 +3505,27 @@ mod tests {
         let json = r#"{"terminal_id":"t1","direction":"below","data":"hello","capture_ms":800}"#;
         let p: WriteToNeighborParam = serde_json::from_str(json).unwrap();
         assert_eq!(p.capture_ms, Some(800));
+    }
+
+    #[tokio::test]
+    async fn exec_locks_are_shared_across_appstate_clones() {
+        // Two MCP handlers in different sessions hold clones of the same
+        // Arc<AppState>; the exec-lock table lives there, so the same terminal
+        // must resolve to the SAME lock Arc across them (cross-session
+        // serialization — #427). Different terminals get different locks.
+        let a = Arc::new(crate::state::AppState::new());
+        let b = a.clone(); // second session's ServerState.app_state
+        let la = get_or_create_terminal_lock(&a.exec_locks, "t1").await;
+        let lb = get_or_create_terminal_lock(&b.exec_locks, "t1").await;
+        assert!(
+            Arc::ptr_eq(&la, &lb),
+            "same terminal across shared AppState must yield one lock"
+        );
+        let lc = get_or_create_terminal_lock(&a.exec_locks, "t2").await;
+        assert!(
+            !Arc::ptr_eq(&la, &lc),
+            "different terminals must get distinct locks"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -851,6 +851,13 @@ pub fn close_terminal_session(
         known.remove(&id);
     }
 
+    // Clean up the per-terminal write/exec lock (#427). The table is now
+    // process-global on AppState, so without this it would grow unbounded as
+    // terminals open and close over a long session.
+    if let Ok(mut locks) = state.exec_locks.lock() {
+        locks.remove(&id);
+    }
+
     // Clean up interactive-app grace window (#237) so a new terminal that
     // happens to reuse this ID does not inherit stale detection.
     activity::clear_interactive_app_grace_window(&state, &id);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -84,7 +84,17 @@ pub struct AppState {
     pub cloud_tunnel: Mutex<Option<crate::cloud::tunnel::TunnelControl>>,
     /// Runtime cloud relay connection status. Pairing/tunnel workers update this state.
     pub cloud: Mutex<crate::cloud::CloudStatus>,
+    /// Process-global per-terminal lock table serializing `write_input` /
+    /// `execute_command` on the same terminal (#314). Living on the shared
+    /// `Arc<AppState>` — not on the per-MCP-session handler — is what makes the
+    /// serialization hold **across MCP sessions** (#427). A `tokio::sync::Mutex`
+    /// because it is held across the write's `.await` points.
+    pub exec_locks: SharedExecLocks,
 }
+
+/// Process-global per-terminal write/exec serialization table. See
+/// [`AppState::exec_locks`].
+pub type SharedExecLocks = Arc<tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>;
 
 impl AppState {
     pub fn new() -> Self {
@@ -107,6 +117,7 @@ impl AppState {
             remote_control: Mutex::new(crate::remote_server::RemoteControlState::default()),
             cloud_tunnel: Mutex::new(None),
             cloud: Mutex::new(crate::cloud::CloudStatus::default()),
+            exec_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -27,8 +27,15 @@ use crate::terminal::{SyncGroup, TerminalNotification, TerminalSession};
 /// 12. `remote_control`
 /// 13. `cloud_tunnel`
 /// 14. `cloud`
+/// 15. `exec_locks` (table mutex; held only to get/insert a per-terminal lock,
+///     never across `.await` and never while holding another `AppState` lock)
 ///
 /// Never acquire a higher-numbered lock while holding a lower-numbered one.
+///
+/// The per-terminal locks *inside* `exec_locks` are `tokio::sync::Mutex` because
+/// a writer holds one across `.await` (the body→CR delay); they are acquired
+/// only after the `exec_locks` table mutex has been released, so they sit
+/// outside this ordering.
 pub struct AppState {
     pub terminals: Arc<Mutex<HashMap<String, TerminalSession>>>,
     pub sync_groups: Mutex<HashMap<String, SyncGroup>>,
@@ -87,14 +94,19 @@ pub struct AppState {
     /// Process-global per-terminal lock table serializing `write_input` /
     /// `execute_command` on the same terminal (#314). Living on the shared
     /// `Arc<AppState>` — not on the per-MCP-session handler — is what makes the
-    /// serialization hold **across MCP sessions** (#427). A `tokio::sync::Mutex`
-    /// because it is held across the write's `.await` points.
+    /// serialization hold **across MCP sessions** (#427). Entries are removed on
+    /// terminal close so the table does not grow unbounded.
+    ///
+    /// The outer table is a `std::sync::Mutex` (held only briefly to get/insert,
+    /// never across `.await`, so sync close paths can clean it too); each value
+    /// is a `tokio::sync::Mutex` because a writer holds it across the body→CR
+    /// `.await` delay.
     pub exec_locks: SharedExecLocks,
 }
 
 /// Process-global per-terminal write/exec serialization table. See
 /// [`AppState::exec_locks`].
-pub type SharedExecLocks = Arc<tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>;
+pub type SharedExecLocks = Arc<Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>;
 
 impl AppState {
     pub fn new() -> Self {
@@ -117,7 +129,7 @@ impl AppState {
             remote_control: Mutex::new(crate::remote_server::RemoteControlState::default()),
             cloud_tunnel: Mutex::new(None),
             cloud: Mutex::new(crate::cloud::CloudStatus::default()),
-            exec_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            exec_locks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }


### PR DESCRIPTION
Closes #427.

## 문제
`exec_locks`(per-terminal write/exec 직렬화 테이블, #314)가 `McpHandler` 필드였다. `McpHandler` 는 `StreamableHttpService` 팩토리에서 **MCP 세션마다 새로 생성**되므로, 직렬화는 **동일 세션 내에서만** 성립했다. 서로 다른 MCP 세션이 같은 터미널에 동시에 쓰면 body+CR 시퀀스가 인터리브될 수 있었다(`bodyA bodyB \r \r` → Codex TUI 제출 실패/오입력). PR #426 의 `capture_ms` 응답 window 오염 가능성도 여기서 파생.

## 변경
- 락 테이블을 공유 `Arc<AppState>` 로 이동 → `crate::state::SharedExecLocks`. `AppState` 는 프로세스 전역 단일 인스턴스라 모든 세션의 handler 가 같은 테이블을 공유 → 세션 무관 직렬화.
- `ServerState` 는 건드리지 않음(요청마다 생성되는 tunnel 경로에서 throwaway 테이블이 생기는 함정 회피). remote_server 는 MCP 미탑재라 애초에 exec_locks 불사용.
- `terminal_exec_lock` → free fn `get_or_create_terminal_lock(locks, id)` 로 분리 (AppHandle 없이 테스트 가능).

## 테스트
- `exec_locks_are_shared_across_appstate_clones`: 두 `Arc<AppState>` 클론(=두 세션)이 같은 터미널에 대해 `Arc::ptr_eq` 인 동일 락을, 다른 터미널엔 다른 락을 돌려줌을 검증.
- 93 tests green. dev(19281) 라이브 write 스모크 통과.

## 관계
- #426 (write 리턴 activity + capture_ms) 코덱스 리뷰 P1' 후속. #426 은 세션 내 원자성까지, 본 PR 이 교차 세션 직렬화 완성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)