### PR TITLE
feat(cloud): relay 기본값 dev/prod 분리 (release=app.laymux.com)

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -57,7 +57,7 @@ Remote Access 모달의 복사 URL 호스트는 `get_remote_host_candidates` Tau
     "preferredHost": "",               // 복사 URL 기본 호스트. 빈 값 = 자동
     "customHosts": [],                  // 감지 후보 외에 URL host select 에 표시할 수동 호스트
     "cloudEnabled": false,              // 클라우드 연결 영속 설정. pairing 전 기본값 false
-    "relayBaseUrl": "https://cloud.laymux.example",
+    "relayBaseUrl": "https://app.laymux.com",  // 기본값: release=https://app.laymux.com, dev(debug)=http://127.0.0.1:8000. 설정에서 변경 가능
     "cloudInstanceId": null,            // relay가 발급한 instance id. 미연결이면 null
     "cloudTunnelUrl": null,             // pairing complete 응답의 WSS tunnel URL. PR3 터널에서 사용
     "cloudServerBaseUrl": null,         // pairing complete 응답의 canonical server base URL

--- a/src-tauri/src/cloud/pairing.rs
+++ b/src-tauri/src/cloud/pairing.rs
@@ -578,6 +578,41 @@ mod tests {
     const TEST_PORT: u16 = 8080;
 
     #[test]
+    fn build_pair_url_targets_prod_pair_desktop() {
+        // With the prod relay base, the desktop must open exactly
+        // https://app.laymux.com/pair/desktop with the pairing query params.
+        let url = build_pair_url(
+            "https://app.laymux.com",
+            "http://127.0.0.1:54321/pair/callback",
+            "state-123",
+            "my-pc",
+        )
+        .unwrap();
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str(), Some("app.laymux.com"));
+        assert_eq!(url.path(), "/pair/desktop");
+        let q: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+        assert_eq!(
+            q.get("redirect_uri").map(String::as_str),
+            Some("http://127.0.0.1:54321/pair/callback")
+        );
+        assert_eq!(q.get("state").map(String::as_str), Some("state-123"));
+        assert_eq!(q.get("name").map(String::as_str), Some("my-pc"));
+    }
+
+    #[test]
+    fn empty_relay_base_url_falls_back_to_build_default() {
+        // An absent/blank relay URL normalizes to the compiled default:
+        // dev(debug) → local relay, release → prod. Tests run in debug.
+        assert_eq!(
+            normalized_relay_base_url("   "),
+            default_cloud_relay_base_url()
+        );
+        #[cfg(debug_assertions)]
+        assert_eq!(normalized_relay_base_url(""), "http://127.0.0.1:8000");
+    }
+
+    #[test]
     fn callback_rejects_state_mismatch() {
         let response = handle_callback_request(
             "GET /pair/callback?code=abc&state=wrong HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",

--- a/src-tauri/src/cloud/pairing.rs
+++ b/src-tauri/src/cloud/pairing.rs
@@ -580,9 +580,9 @@ mod tests {
     #[test]
     fn build_pair_url_targets_prod_pair_desktop() {
         // With the prod relay base, the desktop must open exactly
-        // https://app.laymux.com/pair/desktop with the pairing query params.
+        // <PROD_CLOUD_RELAY_BASE_URL>/pair/desktop with the pairing query params.
         let url = build_pair_url(
-            "https://app.laymux.com",
+            crate::settings::PROD_CLOUD_RELAY_BASE_URL,
             "http://127.0.0.1:54321/pair/callback",
             "state-123",
             "my-pc",
@@ -609,7 +609,10 @@ mod tests {
             default_cloud_relay_base_url()
         );
         #[cfg(debug_assertions)]
-        assert_eq!(normalized_relay_base_url(""), "http://127.0.0.1:8000");
+        assert_eq!(
+            normalized_relay_base_url(""),
+            crate::settings::DEV_CLOUD_RELAY_BASE_URL
+        );
     }
 
     #[test]

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -1035,6 +1035,12 @@ fn default_cloud_auto_reconnect() -> bool {
     true
 }
 
+/// Prod cloud relay base URL (release-build default). LIVE, TLS via Let's Encrypt.
+pub const PROD_CLOUD_RELAY_BASE_URL: &str = "https://app.laymux.com";
+
+/// Local cloud relay base URL (dev/debug-build default) for the local relay server.
+pub const DEV_CLOUD_RELAY_BASE_URL: &str = "http://127.0.0.1:8000";
+
 pub fn default_cloud_relay_base_url() -> String {
     // dev builds default to the local relay server for testing; release builds
     // default to prod. Mirrors the dev/prod split used for the automation port
@@ -1042,9 +1048,9 @@ pub fn default_cloud_relay_base_url() -> String {
     // value already persisted in settings.json is kept (serde default only
     // fills an absent field).
     if cfg!(debug_assertions) {
-        "http://127.0.0.1:8000".into()
+        DEV_CLOUD_RELAY_BASE_URL.into()
     } else {
-        "https://app.laymux.com".into()
+        PROD_CLOUD_RELAY_BASE_URL.into()
     }
 }
 

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -1036,7 +1036,16 @@ fn default_cloud_auto_reconnect() -> bool {
 }
 
 pub fn default_cloud_relay_base_url() -> String {
-    "https://cloud.laymux.example".into()
+    // dev builds default to the local relay server for testing; release builds
+    // default to prod. Mirrors the dev/prod split used for the automation port
+    // (19281/19280 via `debug_assertions`). Overridable in settings, and any
+    // value already persisted in settings.json is kept (serde default only
+    // fills an absent field).
+    if cfg!(debug_assertions) {
+        "http://127.0.0.1:8000".into()
+    } else {
+        "https://app.laymux.com".into()
+    }
 }
 
 impl Default for RemoteSettings {

--- a/ui/src/components/views/SettingsView.test.tsx
+++ b/ui/src/components/views/SettingsView.test.tsx
@@ -1863,7 +1863,7 @@ describe("SettingsView", () => {
       ) as HTMLInputElement;
       fireEvent.change(input, { target: { value: " https://relay.example.test " } });
 
-      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe("https://cloud.laymux.example");
+      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe("https://app.laymux.com");
 
       await user.click(screen.getByTestId("save-settings-btn"));
 
@@ -1995,7 +1995,7 @@ describe("SettingsView", () => {
         );
       });
       expect(relayInput.value).toBe(" https://draft-relay.example.test ");
-      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe("https://cloud.laymux.example");
+      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe("https://app.laymux.com");
 
       await user.click(screen.getByTestId("save-settings-btn"));
 
@@ -2075,7 +2075,7 @@ describe("SettingsView", () => {
       });
       // Mid-flight edit survives; store was not clobbered by a stale-closure sync.
       expect(relayInput.value).toBe(" https://mid-flight.example.test ");
-      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe("https://cloud.laymux.example");
+      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe("https://app.laymux.com");
 
       await user.click(screen.getByTestId("save-settings-btn"));
 
@@ -2106,7 +2106,7 @@ describe("SettingsView", () => {
         expect(mockInvoke).toHaveBeenCalledWith("cloud_disconnect");
       });
       expect(relayInput.value).toBe(" https://draft-relay.example.test ");
-      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe("https://cloud.laymux.example");
+      expect(useSettingsStore.getState().remote.relayBaseUrl).toBe("https://app.laymux.com");
       expect(useSettingsStore.getState().remote.cloudEnabled).toBe(true);
 
       await user.click(screen.getByTestId("save-settings-btn"));

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -492,7 +492,7 @@ const DEFAULT_REMOTE: RemoteSettings = {
   preferredHost: "",
   customHosts: [],
   cloudEnabled: false,
-  relayBaseUrl: "https://cloud.laymux.example",
+  relayBaseUrl: "https://app.laymux.com",
   cloudInstanceId: null,
   cloudTunnelUrl: null,
   cloudServerBaseUrl: null,


### PR DESCRIPTION
## 배경
prod 릴레이 LIVE (https://app.laymux.com). PC laymux 를 prod 대응.

## 변경
- `default_cloud_relay_base_url()` 을 `cfg!(debug_assertions)` 로 분리:
  - release → `PROD_CLOUD_RELAY_BASE_URL` (`https://app.laymux.com`)
  - dev(debug) → `DEV_CLOUD_RELAY_BASE_URL` (`http://127.0.0.1:8000`)
  - 자동화 포트(19281/19280)·keyring service(laymux/laymux-dev)와 동일한 dev/prod 패턴.
- URL 은 **상수 선언**(inline 하드코딩 제거).
- 프론트 `DEFAULT_REMOTE.relayBaseUrl`: 가짜 `cloud.laymux.example` → `app.laymux.com`.
- 기존에 저장된 `relay_base_url` 은 유지(serde default 는 필드 부재 시만 채움).
- 설정 UI 에 relay URL 입력이 이미 있어 전환 자유(dev↔prod).

## 계약 확인
- `tunnelUrl` 은 페어링 complete 응답에서 **서버가 반환**(`wss://app.laymux.com/tunnel...`). 로컬 유도 아님 → 변경 불필요.
- pairing URL: `build_pair_url(prod)` → `https://app.laymux.com/pair/desktop?redirect_uri=...&state=...&name=...` (테스트로 고정).

## 테스트
- backend: settings 67 + cloud 51 green (신규: prod pair/desktop URL 구성, 빈 값→빌드 기본값 폴백).
- frontend: SettingsView + settings-store 233 green.

## 라이브 prod E2E (별도, 사람 필요)
`클라우드 연결` → 브라우저 `app.laymux.com/pair/desktop` → **Google 로그인(사람)** → device token(keyring) → WSS 터널(Bearer) → 대시보드 Connect → 터미널. Google 로그인 구간은 대화형이라 코드/URL 구성까지 자동 검증, 실 로그인은 사람이 수행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)