### PR TITLE
fix(cloud): stale relay placeholder 자동 마이그레이션

### DIFF
--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -137,6 +137,16 @@ fn migrate_settings(settings: &mut Settings) {
         }
     }
 
+    // Heal stale cloud relay placeholder → build default.
+    // Older builds persisted `https://cloud.laymux.example` (a dead placeholder)
+    // as the relay base URL default. serde's `default` only fills an absent
+    // field, so upgraded installs keep the placeholder and cloud connect opens
+    // the dead host. Rewrite it to the current build default.
+    if settings.remote.relay_base_url.trim().trim_end_matches('/') == LEGACY_CLOUD_RELAY_PLACEHOLDER
+    {
+        settings.remote.relay_base_url = default_cloud_relay_base_url();
+    }
+
     // Deduplicate workspace names
     let mut seen_names: std::collections::HashSet<String> = std::collections::HashSet::new();
     for ws in &mut settings.workspaces {
@@ -514,6 +524,33 @@ mod tests {
             .map(|w| w.name.as_str())
             .collect();
         assert_eq!(names, vec!["Dev", "Dev (2)", "Dev (3)"]);
+    }
+
+    #[test]
+    fn migrate_heals_stale_cloud_relay_placeholder() {
+        let mut settings = Settings::default();
+        settings.remote.relay_base_url = LEGACY_CLOUD_RELAY_PLACEHOLDER.into();
+        migrate_settings(&mut settings);
+        assert_eq!(
+            settings.remote.relay_base_url,
+            default_cloud_relay_base_url()
+        );
+
+        // Trailing slash variant is also healed.
+        settings.remote.relay_base_url = format!("{LEGACY_CLOUD_RELAY_PLACEHOLDER}/");
+        migrate_settings(&mut settings);
+        assert_eq!(
+            settings.remote.relay_base_url,
+            default_cloud_relay_base_url()
+        );
+    }
+
+    #[test]
+    fn migrate_keeps_custom_relay_url() {
+        let mut settings = Settings::default();
+        settings.remote.relay_base_url = "http://127.0.0.1:8000".into();
+        migrate_settings(&mut settings);
+        assert_eq!(settings.remote.relay_base_url, "http://127.0.0.1:8000");
     }
 
     #[test]

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -1041,6 +1041,10 @@ pub const PROD_CLOUD_RELAY_BASE_URL: &str = "https://app.laymux.com";
 /// Local cloud relay base URL (dev/debug-build default) for the local relay server.
 pub const DEV_CLOUD_RELAY_BASE_URL: &str = "http://127.0.0.1:8000";
 
+/// Legacy placeholder relay URL persisted by older builds (ADR-0023). Dead host;
+/// migrated to the current build default on load so cloud connect stops opening it.
+pub const LEGACY_CLOUD_RELAY_PLACEHOLDER: &str = "https://cloud.laymux.example";
+
 pub fn default_cloud_relay_base_url() -> String {
     // dev builds default to the local relay server for testing; release builds
     // default to prod. Mirrors the dev/prod split used for the automation port


### PR DESCRIPTION
## 문제

릴리즈 laymux 에서 클라우드 연결 클릭 시 시스템 브라우저가 죽은 호스트 `https://cloud.laymux.example/pair/desktop?...` 를 연다.

## 원인

- 예전 릴리즈는 relay 기본값으로 placeholder `https://cloud.laymux.example` (ADR-0023) 를 `settings.json` 에 영속화했다.
- 현재 코드 기본값은 `https://app.laymux.com` (prod) / `http://127.0.0.1:8000` (dev) 이지만, serde `default` 는 **absent 필드만** 채운다.
- `normalized_relay_base_url` 은 **빈 문자열만** 치유한다.
- `migrate_settings` 에 placeholder 처리 규칙이 없다.

→ 업그레이드 설치는 stale placeholder 를 계속 들고 있어 연결 시 죽은 호스트를 연다.

## 수정

- `LEGACY_CLOUD_RELAY_PLACEHOLDER` 상수 추가 (`models.rs`).
- `migrate_settings` 에 stale placeholder(± trailing slash) → build default 치유 규칙 추가 (`mod.rs`).
- 다음 settings load 시 자동 복구.

## 테스트

- `migrate_heals_stale_cloud_relay_placeholder` — placeholder(및 trailing slash) 치유 검증.
- `migrate_keeps_custom_relay_url` — 커스텀 URL 은 보존 검증.
- settings 모듈 71 tests green.

## 사용자 즉시 우회 (재빌드 전)

Settings → 릴레이 기본 URL → `https://app.laymux.com` → 저장 → 재연결.

🤖 Generated with [Claude Code](https://claude.com/claude-code)