### PR TITLE
Recover remote page after connection drops

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -668,6 +668,8 @@ Remote terminal control은 상태 소유권을 세 범주로 나눈다([ADR-0015
 
 `write`/`resize`는 JSON body의 `leaseId` 또는 `X-Laymux-Remote-Lease` 헤더가 현재 active lease와 일치해야 한다. 출력 WebSocket도 `leaseId` 쿼리를 요구한다. 이는 인증된 다른 remote peer가 active controller를 우회해 입력을 주입하지 못하게 하는 서버 측 게이트다. Cloud tunnel에서 이 출력 WebSocket을 M5 stream으로 변환할 때 desktop은 같은 `srv-*` stream id로 `stream.open{kind:"websocket.accept"}` 를 먼저 보내고, 그 다음 ring buffer snapshot과 delta를 `stream.data` frame으로 보낸다.
 
+Remote page는 heartbeat와 output WebSocket을 별도 failure domain으로 취급한다. Heartbeat가 `401`/`403`/`409`처럼 권한·lease 상실을 명시하면 즉시 local control로 돌려주지만, 일시적 fetch 실패는 `heartbeatTimeoutSeconds`가 지날 때까지 재시도한다. Output WebSocket close/error는 곧바로 lease를 반납하지 않고, heartbeat가 active lease를 유지하는 동안 같은 terminal output stream을 지수 backoff로 다시 연다. 재연결 시 서버가 보내는 ring buffer tail을 중복 append하지 않도록 remote xterm surface를 reset한 뒤 다시 붙는다.
+
 ---
 
 ## 14. Rust 코드 설계 원칙

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -668,7 +668,7 @@ Remote terminal control은 상태 소유권을 세 범주로 나눈다([ADR-0015
 
 `write`/`resize`는 JSON body의 `leaseId` 또는 `X-Laymux-Remote-Lease` 헤더가 현재 active lease와 일치해야 한다. 출력 WebSocket도 `leaseId` 쿼리를 요구한다. 이는 인증된 다른 remote peer가 active controller를 우회해 입력을 주입하지 못하게 하는 서버 측 게이트다. Cloud tunnel에서 이 출력 WebSocket을 M5 stream으로 변환할 때 desktop은 같은 `srv-*` stream id로 `stream.open{kind:"websocket.accept"}` 를 먼저 보내고, 그 다음 ring buffer snapshot과 delta를 `stream.data` frame으로 보낸다.
 
-Remote page는 heartbeat와 output WebSocket을 별도 failure domain으로 취급한다. Heartbeat가 `401`/`403`/`409`처럼 권한·lease 상실을 명시하면 즉시 local control로 돌려주지만, 일시적 fetch 실패는 `heartbeatTimeoutSeconds`가 지날 때까지 재시도한다. Output WebSocket close/error는 곧바로 lease를 반납하지 않고, heartbeat가 active lease를 유지하는 동안 같은 terminal output stream을 지수 backoff로 다시 연다. 재연결 시 서버가 보내는 ring buffer tail을 중복 append하지 않도록 remote xterm surface를 reset한 뒤 다시 붙는다.
+Remote page는 heartbeat와 output WebSocket을 별도 failure domain으로 취급한다. Heartbeat가 `401`/`403`/`409`처럼 권한·lease 상실을 명시하면 즉시 local control로 돌려주지만, 일시적 fetch 실패나 pending 상태로 멈춘 heartbeat request는 `heartbeatTimeoutSeconds`가 지날 때까지 재시도하고 timeout 시 abort/lease 상실 처리한다. Output WebSocket close/error는 곧바로 lease를 반납하지 않고, heartbeat가 active lease를 유지하는 동안 같은 terminal output stream을 지수 backoff로 다시 연다. 재연결 시 서버가 보내는 ring buffer tail을 중복 append하지 않도록 remote xterm surface를 reset한 뒤 다시 붙는다.
 
 ---
 

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -961,7 +961,11 @@
         const tokenKey = "laymux.remote.token";
         let leaseId = null;
         let heartbeatTimer = null;
+        let heartbeatTimeoutMs = 15000;
+        let lastHeartbeatOkAt = 0;
         let socket = null;
+        let outputReconnectTimer = null;
+        let outputReconnectAttempt = 0;
         let activeTerminalId = null;
         let terminalInfoById = new Map();
         let navigationState = null;
@@ -988,6 +992,8 @@
         const INTERNAL_TOUCH_SCROLL_SLOP_PX = 8;
         const INTERNAL_TOUCH_TAP_SLOP_PX = 18;
         const INTERNAL_TOUCH_MULTI_TAP_DELAY_MS = 320;
+        const OUTPUT_RECONNECT_INITIAL_DELAY_MS = 250;
+        const OUTPUT_RECONNECT_MAX_DELAY_MS = 5000;
 
         const hashParams = new URLSearchParams(location.hash.replace(/^#/, ""));
         const searchParams = new URLSearchParams(location.search);
@@ -1057,7 +1063,9 @@
           });
           if (!response.ok) {
             const body = await response.json().catch(() => ({}));
-            throw new Error(body.error || `${response.status} ${response.statusText}`);
+            const error = new Error(body.error || `${response.status} ${response.statusText}`);
+            error.status = response.status;
+            throw error;
           }
           return response.json();
         }
@@ -1661,7 +1669,16 @@
           return terminal;
         }
 
-        function stopSocket() {
+        function stopOutputReconnect(resetAttempt = true) {
+          if (outputReconnectTimer) {
+            clearTimeout(outputReconnectTimer);
+            outputReconnectTimer = null;
+          }
+          if (resetAttempt) outputReconnectAttempt = 0;
+        }
+
+        function stopSocket(resetReconnect = true) {
+          stopOutputReconnect(resetReconnect);
           if (socket) {
             const closingSocket = socket;
             socket = null;
@@ -1699,14 +1716,33 @@
             method: "POST",
             body: JSON.stringify({ leaseId }),
           });
+          lastHeartbeatOkAt = Date.now();
+        }
+
+        function isFatalRemoteControlError(err) {
+          return err && (err.status === 401 || err.status === 403 || err.status === 409);
+        }
+
+        function heartbeatTimedOut() {
+          return Date.now() - lastHeartbeatOkAt >= heartbeatTimeoutMs;
+        }
+
+        function handleHeartbeatError(err) {
+          if (isFatalRemoteControlError(err) || heartbeatTimedOut()) {
+            loseRemoteControl(`Control returned to the host. ${err.message}`);
+            return;
+          }
+          setStatus(`Connection interrupted. Retrying before lease timeout. ${err.message}`, true);
         }
 
         function startHeartbeat(timeoutSeconds) {
           stopHeartbeat();
+          heartbeatTimeoutMs = Math.max(5000, Math.floor(timeoutSeconds * 1000));
+          lastHeartbeatOkAt = Date.now();
           const intervalMs = Math.max(1000, Math.floor(timeoutSeconds * 333));
           heartbeatTimer = setInterval(() => {
             heartbeat().catch((err) => {
-              loseRemoteControl(`Control returned to the host. ${err.message}`);
+              handleHeartbeatError(err);
             });
           }, intervalMs);
         }
@@ -2372,22 +2408,54 @@
           return `${protocol}//${location.host}`;
         }
 
-        function openOutput(terminalId) {
+        function outputReconnectDelayMs(attempt) {
+          return Math.min(
+            OUTPUT_RECONNECT_MAX_DELAY_MS,
+            OUTPUT_RECONNECT_INITIAL_DELAY_MS * Math.pow(2, attempt)
+          );
+        }
+
+        function scheduleOutputReconnect(terminalId, outputLeaseId) {
+          if (!outputLeaseId || leaseId !== outputLeaseId || activeTerminalId !== terminalId) return;
+          if (outputReconnectTimer) return;
+          const delayMs = outputReconnectDelayMs(outputReconnectAttempt);
+          outputReconnectAttempt += 1;
+          const delayLabel = delayMs < 1000 ? "shortly" : `in ${Math.ceil(delayMs / 1000)}s`;
+          setStatus(`Output stream disconnected. Reconnecting ${delayLabel}...`, true);
+          outputReconnectTimer = setTimeout(() => {
+            outputReconnectTimer = null;
+            if (leaseId !== outputLeaseId || activeTerminalId !== terminalId) return;
+            setStatus("Reconnecting output stream...");
+            openOutput(terminalId, { reconnect: true });
+          }, delayMs);
+        }
+
+        function openOutput(terminalId, options = {}) {
           const terminalInfo = terminalInfoById.get(terminalId);
           const term = ensureTerminal(terminalInfo && terminalInfo.appearance);
-          stopSocket();
-          stopInputFlush();
-          stopResizeFlush();
+          const reconnecting = options.reconnect === true;
+          const outputLeaseId = leaseId;
+          if (!outputLeaseId) {
+            setStatus("Remote control is not active.", true);
+            return;
+          }
+          stopSocket(!reconnecting);
+          if (!reconnecting) {
+            stopInputFlush();
+            stopResizeFlush();
+          }
           applyTerminalAppearance(terminalInfo && terminalInfo.appearance);
           term.reset();
           updateTerminalControls();
           lastResizeKey = "";
-          const url = `${wsBaseUrl()}/remote/v1/terminals/${encodeURIComponent(terminalId)}/output?leaseId=${encodeURIComponent(leaseId)}&token=${encodeURIComponent(token())}`;
+          const url = `${wsBaseUrl()}/remote/v1/terminals/${encodeURIComponent(terminalId)}/output?leaseId=${encodeURIComponent(outputLeaseId)}&token=${encodeURIComponent(token())}`;
           const outputSocket = new WebSocket(url);
+          let outputTerminalMissing = false;
           socket = outputSocket;
           outputSocket.binaryType = "arraybuffer";
           outputSocket.onopen = () => {
-            if (socket === outputSocket) {
+            if (socket === outputSocket && leaseId === outputLeaseId && activeTerminalId === terminalId) {
+              outputReconnectAttempt = 0;
               setStatus(`Connected to ${terminalId}`);
               scheduleTerminalFit(true);
               term.focus();
@@ -2400,17 +2468,27 @@
               payload = new Uint8Array(event.data);
             } else {
               payload = String(event.data);
+              if (payload === "terminal session not found") {
+                outputTerminalMissing = true;
+                setStatus("Terminal session ended. Refreshing navigation...", true);
+                outputSocket.close();
+                return;
+              }
             }
             term.write(payload, scheduleTerminalRefresh);
           };
           outputSocket.onclose = () => {
             if (socket === outputSocket) {
               socket = null;
-              if (leaseId) loseRemoteControl("Control returned to the host. Connect again to resume.");
+              if (outputTerminalMissing) {
+                loadNavigation(null).catch((err) => setStatus(`Refresh failed: ${err.message}`, true));
+                return;
+              }
+              scheduleOutputReconnect(terminalId, outputLeaseId);
             }
           };
           outputSocket.onerror = () => {
-            if (socket === outputSocket) setStatus("Output stream error.", true);
+            if (socket === outputSocket) setStatus("Output stream error. Waiting to reconnect.", true);
           };
         }
 

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -961,6 +961,8 @@
         const tokenKey = "laymux.remote.token";
         let leaseId = null;
         let heartbeatTimer = null;
+        let heartbeatAbortController = null;
+        let heartbeatInFlight = false;
         let heartbeatTimeoutMs = 15000;
         let lastHeartbeatOkAt = 0;
         let socket = null;
@@ -1693,6 +1695,11 @@
             clearInterval(heartbeatTimer);
             heartbeatTimer = null;
           }
+          if (heartbeatAbortController) {
+            heartbeatAbortController.abort();
+            heartbeatAbortController = null;
+          }
+          heartbeatInFlight = false;
         }
 
         function stopInputFlush() {
@@ -1711,12 +1718,25 @@
         }
 
         async function heartbeat() {
-          if (!leaseId) return;
-          await remoteFetch("/remote/v1/session/heartbeat", {
-            method: "POST",
-            body: JSON.stringify({ leaseId }),
-          });
-          lastHeartbeatOkAt = Date.now();
+          if (!leaseId || heartbeatInFlight) return;
+          heartbeatInFlight = true;
+          const controller = typeof AbortController === "function" ? new AbortController() : null;
+          heartbeatAbortController = controller;
+          const abortTimer = controller
+            ? setTimeout(() => controller.abort(), heartbeatTimeoutMs)
+            : null;
+          try {
+            await remoteFetch("/remote/v1/session/heartbeat", {
+              method: "POST",
+              body: JSON.stringify({ leaseId }),
+              ...(controller ? { signal: controller.signal } : {}),
+            });
+            lastHeartbeatOkAt = Date.now();
+          } finally {
+            if (abortTimer) clearTimeout(abortTimer);
+            if (heartbeatAbortController === controller) heartbeatAbortController = null;
+            heartbeatInFlight = false;
+          }
         }
 
         function isFatalRemoteControlError(err) {
@@ -1728,6 +1748,7 @@
         }
 
         function handleHeartbeatError(err) {
+          if (!leaseId) return;
           if (isFatalRemoteControlError(err) || heartbeatTimedOut()) {
             loseRemoteControl(`Control returned to the host. ${err.message}`);
             return;
@@ -1741,6 +1762,10 @@
           lastHeartbeatOkAt = Date.now();
           const intervalMs = Math.max(1000, Math.floor(timeoutSeconds * 333));
           heartbeatTimer = setInterval(() => {
+            if (heartbeatTimedOut()) {
+              loseRemoteControl("Control returned to the host. Heartbeat timed out.");
+              return;
+            }
             heartbeat().catch((err) => {
               handleHeartbeatError(err);
             });

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -126,6 +126,7 @@ mod tests {
         assert!(html.contains("const OUTPUT_RECONNECT_MAX_DELAY_MS"));
         assert!(html.contains("function scheduleOutputReconnect(terminalId, outputLeaseId)"));
         assert!(html.contains("function handleHeartbeatError(err)"));
+        assert!(html.contains("let heartbeatAbortController = null;"));
         assert!(html.contains("id=\"desktopModeHeader\""));
         assert!(html.contains("id=\"desktopModeDrawer\""));
         assert!(html.contains("const localAppMode ="));
@@ -245,12 +246,26 @@ mod tests {
         let start = html.find("function handleHeartbeatError").unwrap();
         let end = start + html[start..].find("function startHeartbeat").unwrap();
         let heartbeat_error = &html[start..end];
+        let heartbeat_start = html.find("async function heartbeat").unwrap();
+        let heartbeat_end = heartbeat_start
+            + html[heartbeat_start..]
+                .find("function isFatalRemoteControlError")
+                .unwrap();
+        let heartbeat_request = &html[heartbeat_start..heartbeat_end];
         let start_heartbeat = &html[html.find("function startHeartbeat").unwrap()..];
 
         assert!(html.contains("error.status = response.status;"));
         assert!(heartbeat_error.contains("isFatalRemoteControlError(err) || heartbeatTimedOut()"));
         assert!(heartbeat_error.contains("loseRemoteControl(`Control returned to the host."));
         assert!(heartbeat_error.contains("Retrying before lease timeout"));
+        assert!(heartbeat_request.contains("signal: controller.signal"));
+        assert!(
+            heartbeat_request.contains("setTimeout(() => controller.abort(), heartbeatTimeoutMs)")
+        );
+        assert!(start_heartbeat.contains("if (heartbeatTimedOut())"));
+        assert!(start_heartbeat.contains(
+            "loseRemoteControl(\"Control returned to the host. Heartbeat timed out.\");"
+        ));
         assert!(start_heartbeat.contains("lastHeartbeatOkAt = Date.now();"));
         assert!(start_heartbeat.contains("handleHeartbeatError(err);"));
     }

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -122,6 +122,10 @@ mod tests {
         assert!(html.contains("function scheduleTerminalFit(sendResize = true)"));
         assert!(html.contains("function scheduleTerminalRefresh()"));
         assert!(html.contains("function loseRemoteControl(message)"));
+        assert!(html.contains("const OUTPUT_RECONNECT_INITIAL_DELAY_MS"));
+        assert!(html.contains("const OUTPUT_RECONNECT_MAX_DELAY_MS"));
+        assert!(html.contains("function scheduleOutputReconnect(terminalId, outputLeaseId)"));
+        assert!(html.contains("function handleHeartbeatError(err)"));
         assert!(html.contains("id=\"desktopModeHeader\""));
         assert!(html.contains("id=\"desktopModeDrawer\""));
         assert!(html.contains("const localAppMode ="));
@@ -213,6 +217,42 @@ mod tests {
         assert!(terminal_branch < workspace_branch);
         assert!(open_notification.contains("await focusTerminalOnHost(notification.terminalId);"));
         assert!(open_notification.contains("await activateWorkspace(notification.workspaceId);"));
+    }
+
+    #[test]
+    fn remote_page_reconnects_output_socket_without_releasing_lease() {
+        let html = remote_page_html();
+        let start = html.find("function scheduleOutputReconnect").unwrap();
+        let end = start + html[start..].find("async function connect").unwrap();
+        let output_stream = &html[start..end];
+
+        assert!(output_stream.contains("const outputLeaseId = leaseId;"));
+        assert!(output_stream.contains("stopSocket(!reconnecting);"));
+        assert!(output_stream.contains("scheduleOutputReconnect(terminalId, outputLeaseId);"));
+        assert!(output_stream.contains("openOutput(terminalId, { reconnect: true });"));
+        assert!(output_stream.contains("let outputTerminalMissing = false;"));
+        assert!(output_stream.contains("payload === \"terminal session not found\""));
+        assert!(output_stream.contains("loadNavigation(null).catch"));
+        assert!(
+            !output_stream.contains("loseRemoteControl("),
+            "output WebSocket close is recoverable while heartbeat keeps the lease alive"
+        );
+    }
+
+    #[test]
+    fn remote_page_heartbeat_tolerates_transient_failures_until_timeout() {
+        let html = remote_page_html();
+        let start = html.find("function handleHeartbeatError").unwrap();
+        let end = start + html[start..].find("function startHeartbeat").unwrap();
+        let heartbeat_error = &html[start..end];
+        let start_heartbeat = &html[html.find("function startHeartbeat").unwrap()..];
+
+        assert!(html.contains("error.status = response.status;"));
+        assert!(heartbeat_error.contains("isFatalRemoteControlError(err) || heartbeatTimedOut()"));
+        assert!(heartbeat_error.contains("loseRemoteControl(`Control returned to the host."));
+        assert!(heartbeat_error.contains("Retrying before lease timeout"));
+        assert!(start_heartbeat.contains("lastHeartbeatOkAt = Date.now();"));
+        assert!(start_heartbeat.contains("handleHeartbeatError(err);"));
     }
 
     #[test]


### PR DESCRIPTION
## 변경 내용

- remote page heartbeat 실패를 즉시 제어권 반납으로 처리하지 않고 `heartbeatTimeoutSeconds`까지 재시도하도록 변경했습니다.
- output WebSocket close/error는 active lease가 유지되는 동안 같은 terminal output stream을 지수 backoff로 자동 재연결합니다.
- terminal session이 실제로 사라진 경우에는 재연결 루프 대신 navigation을 다시 읽도록 분리했습니다.
- Remote UI API living doc에 heartbeat/output stream 복구 정책을 기록했습니다.

## 원인

기존 remote page는 output WebSocket이 닫히면 곧바로 `loseRemoteControl()`을 호출해 lease를 반납했습니다. 그래서 일시적인 네트워크 끊김이나 브라우저 WebSocket 재연결 상황도 사용자가 수동으로 다시 Connect해야 했습니다. Heartbeat도 단일 fetch 실패를 lease 상실처럼 처리했습니다.

## 검증

- `cargo fmt`
- `cargo test remote_server::page`
- `cargo test remote_server::lease`
- `cargo test remote_resize_rejects_zero_dimensions`
- `cargo test remote_server`