### PR TITLE
Improve remote reconnect resilience

### DIFF
--- a/docs/adr/0027-remote-connection-graceful-recovery.md
+++ b/docs/adr/0027-remote-connection-graceful-recovery.md
@@ -1,0 +1,32 @@
+# 0027. Remote 연결 유예와 무표시 자동 복구
+
+- Status: Accepted
+- Date: 2026-07-12
+- Source: 사용자 피드백(짧은 Remote 연결 단절이 제어권 상실과 수동 재접속으로 이어짐) · ADR-0013 · ADR-0015 · ADR-0024 · architecture/api-contracts.md §13
+
+## Context
+
+Remote controller lease의 기존 기본 heartbeat timeout은 15초이고 최소값은 5초였다. Cloud tunnel은 연결 실패 시 지수 backoff로 재접속하며, 브라우저 heartbeat 요청 하나도 lease timeout 전체 동안 pending 상태에 머물 수 있었다. 따라서 잠깐의 무선망 전환이나 relay 재접속만으로도 heartbeat를 다시 보낼 기회를 잃고 lease가 만료될 수 있었다.
+
+출력 WebSocket은 lease와 별도로 재접속했지만, close/error를 즉시 표시하고 재접속 시도 시작과 동시에 remote xterm surface를 비웠다. 실제 복구가 수 초 안에 끝나도 사용자는 빈 터미널과 오류 문구를 보고 연결이 끊겼다고 인식했다.
+
+Lease를 잃은 뒤 새 lease를 자동 claim하면, 단절 사이에 PC 사용자가 되찾은 제어권을 브라우저가 다시 가져갈 수 있다. 복구는 기존 lease가 유효한 범위 안에서만 이루어져야 한다.
+
+## Decision
+
+Remote 연결은 기존 controller lease 안에서 짧은 transport 단절을 흡수한다.
+
+- `heartbeatTimeoutSeconds`의 새 기본값은 45초, 서버가 적용하는 최소값은 30초로 한다. PC의 명시적 reclaim은 이 유예와 관계없이 즉시 lease를 끝낸다.
+- 브라우저 heartbeat 주기는 최대 5초로 제한하고, 실패 후에는 1초 뒤 빠르게 재시도하며, 개별 요청 deadline은 최대 4초로 제한한다. 한 요청이 전체 lease 유예를 독점하지 않고 유예 안에서 여러 차례 재시도할 수 있어야 한다.
+- 인증·허용·lease 상실을 확정하는 `401`/`403`/`409`는 즉시 제어권 상실로 처리한다. 네트워크 오류와 output WebSocket close/error는 회복 가능한 transport 오류로 취급하며 기존 lease를 반납하지 않는다.
+- 회복 가능한 오류 표시는 2초 지연한다. 그 안에 복구되면 연결 상태 문구와 terminal surface를 바꾸지 않는다.
+- Output 재접속 동안 기존 xterm surface를 유지한다. 재접속한 stream의 첫 snapshot payload를 적용하기 직전에만 surface를 reset해 중복 tail을 막는다.
+- 서버가 기존 lease의 상실을 확정한 뒤 브라우저가 새 lease를 자동 claim하지 않는다. 사용자가 다시 연결하거나 PC가 명시적으로 제어권을 넘겨야 한다.
+
+## Consequences
+
+짧은 Wi-Fi 전환, 모바일 radio 절전, relay/tunnel 재접속은 대부분 기존 화면과 제어권을 유지한 채 복구된다. 기존 설정에 5~29초가 저장되어 있어도 런타임에서는 30초 유예가 적용되고, 새 설정의 기본값은 45초다.
+
+브라우저가 실제로 사라진 경우 PC의 자동 제어권 복귀는 이전보다 늦어질 수 있다. PC 사용자는 기존 reclaim UI로 즉시 회수할 수 있으므로 명시적 복구 경로는 지연되지 않는다.
+
+전송 결과가 모호한 terminal write를 자동 재전송하지는 않는다. 중복 명령 입력 위험 없이 자동 재전송하려면 별도의 요청 식별자와 exactly-once 계약이 필요하며 이 결정의 범위가 아니다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,6 +44,7 @@ ADR 이 필요한 대표 기준:
 | [0024](0024-cloud-native-wss-tunnel.md) | Cloud Native WSS Tunnel | Accepted |
 | [0025](0025-dev-terminal-viewport-automation.md) | Dev terminal viewport diagnostics | Accepted |
 | [0026](0026-conpty-width-resize-repaint-filter.md) | ConPTY width resize repaint filter | Accepted |
+| [0027](0027-remote-connection-graceful-recovery.md) | Remote 연결 유예와 무표시 자동 복구 | Accepted |
 
 ## 새 ADR 추가
 

--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -52,7 +52,7 @@ Remote Access 모달의 복사 URL 호스트는 `get_remote_host_candidates` Tau
     "allowedOrigins": [],              // 비어 있으면 Origin 필터 없음, 값이 있으면 Origin 일치 검사
     "allowedIps": ["127.0.0.1/32", "::1/128"],
     "authToken": "",                   // enabled=true일 때 필수
-    "heartbeatTimeoutSeconds": 15,      // 최소 5초로 clamp
+    "heartbeatTimeoutSeconds": 45,      // 기본 45초, 최소 30초로 clamp
     "autoMobileModeMinWidth": 720,      // 앱 창 폭이 이 값 이하이면 Remote Access 모달 자동 표시. 0 = 비활성
     "preferredHost": "",               // 복사 URL 기본 호스트. 빈 값 = 자동
     "customHosts": [],                  // 감지 후보 외에 URL host select 에 표시할 수동 호스트
@@ -617,7 +617,7 @@ Remote UI API는 사람이 브라우저에서 laymux를 조작하기 위한 Dire
 | `/remote/v1/session/heartbeat` | POST | lease heartbeat 갱신 |
 | `/remote/v1/session/release` | POST | remote가 lease 반납 |
 
-`claim` 응답의 `leaseId`가 이후 제어 요청의 권한이다. PC WebView는 `remote-control-changed` Tauri event를 받아 local input overlay를 표시하고, `reclaim_remote_control` Tauri command로 언제든 lease를 해제할 수 있다. PC reclaim은 현재 lease를 해제하고 `heartbeatTimeoutSeconds` 동안 새 remote claim을 `409`로 거절한다. Heartbeat timeout이 지나면 다음 status/control 검사에서 lease는 만료된다.
+`claim` 응답의 `leaseId`가 이후 제어 요청의 권한이다. PC WebView는 `remote-control-changed` Tauri event를 받아 local input overlay를 표시하고, `reclaim_remote_control` Tauri command로 언제든 lease를 해제할 수 있다. PC reclaim은 현재 lease를 해제하고 `heartbeatTimeoutSeconds` 동안 새 remote claim을 `409`로 거절한다. Heartbeat timeout이 지나면 다음 status/control 검사에서 lease는 만료된다. 짧은 transport 단절을 흡수하기 위해 timeout 기본값은 45초이고 30초 미만의 설정도 런타임에서는 30초로 clamp한다([ADR-0027](../adr/0027-remote-connection-graceful-recovery.md)). 이 자동 유예와 무관하게 PC의 명시적 reclaim은 즉시 적용된다.
 
 ### 13.3 Navigation Metadata
 
@@ -670,7 +670,7 @@ Remote terminal control은 상태 소유권을 세 범주로 나눈다([ADR-0015
 
 `write`/`resize`는 JSON body의 `leaseId` 또는 `X-Laymux-Remote-Lease` 헤더가 현재 active lease와 일치해야 한다. 출력 WebSocket도 `leaseId` 쿼리를 요구한다. 이는 인증된 다른 remote peer가 active controller를 우회해 입력을 주입하지 못하게 하는 서버 측 게이트다. Cloud tunnel에서 이 출력 WebSocket을 M5 stream으로 변환할 때 desktop은 같은 `srv-*` stream id로 `stream.open{kind:"websocket.accept"}` 를 먼저 보내고, 그 다음 ring buffer snapshot과 delta를 `stream.data` frame으로 보낸다.
 
-Remote page는 heartbeat와 output WebSocket을 별도 failure domain으로 취급한다. Heartbeat가 `401`/`403`/`409`처럼 권한·lease 상실을 명시하면 즉시 local control로 돌려주지만, 일시적 fetch 실패나 pending 상태로 멈춘 heartbeat request는 `heartbeatTimeoutSeconds`가 지날 때까지 재시도하고 timeout 시 abort/lease 상실 처리한다. Output WebSocket close/error는 곧바로 lease를 반납하지 않고, heartbeat가 active lease를 유지하는 동안 같은 terminal output stream을 지수 backoff로 다시 연다. 재연결 시 서버가 보내는 ring buffer tail을 중복 append하지 않도록 remote xterm surface를 reset한 뒤 다시 붙는다.
+Remote page는 heartbeat와 output WebSocket을 별도 failure domain으로 취급한다. Heartbeat가 `401`/`403`/`409`처럼 권한·lease 상실을 명시하면 즉시 local control로 돌려주지만, 일시적 fetch 실패는 `heartbeatTimeoutSeconds`가 지날 때까지 재시도한다. Heartbeat는 최대 5초마다 보내고 실패 시 1초 뒤 빠르게 재시도하며, 개별 request는 최대 4초에 abort하므로 pending request 하나가 lease 유예 전체를 소진하지 않는다. Output WebSocket close/error는 곧바로 lease를 반납하지 않고, heartbeat가 active lease를 유지하는 동안 같은 terminal output stream을 지수 backoff로 다시 연다. 두 경로의 일시 오류 표시는 2초간 보류해 그 안에 복구되면 기존 연결 문구와 terminal surface를 그대로 유지한다. Output 재접속 중에도 기존 surface를 보존하고, 서버가 보내는 첫 ring buffer snapshot payload를 적용하기 직전에만 reset하여 tail 중복을 막는다. 서버가 기존 lease 상실을 확정한 뒤에는 새 lease를 자동 claim하지 않는다([ADR-0027](../adr/0027-remote-connection-graceful-recovery.md)).
 
 ---
 

--- a/src-tauri/src/cloud/tunnel.rs
+++ b/src-tauri/src/cloud/tunnel.rs
@@ -28,6 +28,9 @@ use tower::ServiceExt;
 
 use super::{keyring_store, CloudStatus};
 use crate::automation_server::ServerState;
+use crate::constants::{
+    DEFAULT_REMOTE_HEARTBEAT_TIMEOUT_SECONDS, MIN_REMOTE_HEARTBEAT_TIMEOUT_SECONDS,
+};
 use crate::error::AppError;
 use crate::lock_ext::MutexExt;
 use crate::remote_server::{self, TunnelAuthorized};
@@ -1372,10 +1375,17 @@ fn terminal_output_delta(
 }
 
 fn remote_output_timeout_seconds(app_state: &AppState) -> u64 {
-    let settings = remote_server::get_remote_control_status(app_state)
-        .map(|status| status.heartbeat_timeout_seconds)
-        .unwrap_or(15);
-    settings.max(5)
+    normalize_remote_output_timeout_seconds(
+        remote_server::get_remote_control_status(app_state)
+            .ok()
+            .map(|status| status.heartbeat_timeout_seconds),
+    )
+}
+
+fn normalize_remote_output_timeout_seconds(timeout_seconds: Option<u64>) -> u64 {
+    timeout_seconds
+        .unwrap_or(DEFAULT_REMOTE_HEARTBEAT_TIMEOUT_SECONDS)
+        .max(MIN_REMOTE_HEARTBEAT_TIMEOUT_SECONDS)
 }
 
 async fn send_stream_data(
@@ -1613,6 +1623,13 @@ mod tests {
         settings.remote.enabled = enabled;
         settings.remote.auth_token = auth_token.into();
         save_settings(&settings).unwrap();
+    }
+
+    #[test]
+    fn remote_output_timeout_uses_shared_reconnect_policy() {
+        assert_eq!(normalize_remote_output_timeout_seconds(None), 45);
+        assert_eq!(normalize_remote_output_timeout_seconds(Some(5)), 30);
+        assert_eq!(normalize_remote_output_timeout_seconds(Some(60)), 60);
     }
 
     fn state_with_terminal_output_and_lease(lease_id: &str) -> Arc<AppState> {

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -46,6 +46,15 @@ pub const ENV_LAYMUX_CURSOR_TRACE: &str = "LAYMUX_CURSOR_TRACE";
 /// How long a propagation flag remains valid before expiring.
 pub const PROPAGATION_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Default inactivity window for a browser remote controller lease.
+/// This spans several cloud-tunnel reconnect attempts while the host keeps an
+/// explicit, immediate reclaim path.
+pub const DEFAULT_REMOTE_HEARTBEAT_TIMEOUT_SECONDS: u64 = 45;
+
+/// Lowest effective remote lease timeout, including for older settings that
+/// persisted the former 5-15 second values.
+pub const MIN_REMOTE_HEARTBEAT_TIMEOUT_SECONDS: u64 = 30;
+
 /// Maximum number of notifications to keep. When exceeded, oldest read
 /// notifications are evicted first. Unread notifications are never evicted.
 pub const MAX_NOTIFICATIONS: usize = 500;

--- a/src-tauri/src/remote_server/lease.rs
+++ b/src-tauri/src/remote_server/lease.rs
@@ -5,15 +5,13 @@ use axum::response::Response;
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
 
-use crate::constants::EVENT_REMOTE_CONTROL_CHANGED;
+use crate::constants::{EVENT_REMOTE_CONTROL_CHANGED, MIN_REMOTE_HEARTBEAT_TIMEOUT_SECONDS};
 use crate::lock_ext::MutexExt;
 use crate::settings::models::RemoteSettings;
 use crate::state::AppState;
 
 use super::access::effective_remote_settings;
 use super::{internal_error, json_error};
-
-const MIN_HEARTBEAT_TIMEOUT_SECONDS: u64 = 5;
 
 /// Internal controller lease for Direct Remote Mode.
 #[derive(Debug, Clone)]
@@ -77,7 +75,7 @@ pub fn reclaim_remote_control(
 pub(crate) fn effective_heartbeat_timeout_seconds(settings: &RemoteSettings) -> u64 {
     settings
         .heartbeat_timeout_seconds
-        .max(MIN_HEARTBEAT_TIMEOUT_SECONDS)
+        .max(MIN_REMOTE_HEARTBEAT_TIMEOUT_SECONDS)
 }
 
 pub(crate) fn status_from_lease(
@@ -266,6 +264,16 @@ mod tests {
         });
         prune_expired_lease(&mut lease, Duration::from_secs(5));
         assert!(lease.is_none());
+    }
+
+    #[test]
+    fn heartbeat_timeout_preserves_a_reconnect_floor() {
+        let mut settings = Settings::default().remote;
+        settings.heartbeat_timeout_seconds = 5;
+        assert_eq!(effective_heartbeat_timeout_seconds(&settings), 30);
+
+        settings.heartbeat_timeout_seconds = 60;
+        assert_eq!(effective_heartbeat_timeout_seconds(&settings), 60);
     }
 
     #[test]

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -959,15 +959,26 @@
         const copySelectionButton = $("copySelection");
         const ctrlCButton = $("ctrlC");
         const tokenKey = "laymux.remote.token";
+        const DEFAULT_HEARTBEAT_TIMEOUT_SECONDS = 45;
+        const HEARTBEAT_INTERVAL_MIN_MS = 1000;
+        const HEARTBEAT_INTERVAL_MAX_MS = 5000;
+        const HEARTBEAT_REQUEST_TIMEOUT_MAX_MS = 4000;
+        const HEARTBEAT_RETRY_DELAY_MS = 1000;
+        const TRANSIENT_CONNECTION_NOTICE_DELAY_MS = 2000;
         let leaseId = null;
         let heartbeatTimer = null;
         let heartbeatAbortController = null;
         let heartbeatInFlight = false;
-        let heartbeatTimeoutMs = 15000;
+        let heartbeatRetryTimer = null;
+        let heartbeatTimeoutMs = DEFAULT_HEARTBEAT_TIMEOUT_SECONDS * 1000;
         let lastHeartbeatOkAt = 0;
         let socket = null;
         let outputReconnectTimer = null;
         let outputReconnectAttempt = 0;
+        let transientConnectionNoticeTimer = null;
+        let transientConnectionNoticeVisible = false;
+        let heartbeatInterrupted = false;
+        let outputInterrupted = false;
         let activeTerminalId = null;
         let terminalInfoById = new Map();
         let navigationState = null;
@@ -1045,6 +1056,46 @@
         function setStatus(message, error = false) {
           statusEl.textContent = message;
           statusEl.classList.toggle("error", error);
+        }
+
+        function hasTransientConnectionInterruption() {
+          return heartbeatInterrupted || outputInterrupted;
+        }
+
+        function scheduleTransientConnectionNotice(domain) {
+          if (domain === "heartbeat") heartbeatInterrupted = true;
+          if (domain === "output") outputInterrupted = true;
+          if (transientConnectionNoticeTimer || transientConnectionNoticeVisible) return;
+          transientConnectionNoticeTimer = setTimeout(() => {
+            transientConnectionNoticeTimer = null;
+            if (!leaseId || !hasTransientConnectionInterruption()) return;
+            transientConnectionNoticeVisible = true;
+            setStatus("Connection interrupted. Reconnecting...", true);
+          }, TRANSIENT_CONNECTION_NOTICE_DELAY_MS);
+        }
+
+        function clearTransientConnectionNotice(domain, recoveredMessage) {
+          if (domain === "heartbeat") heartbeatInterrupted = false;
+          if (domain === "output") outputInterrupted = false;
+          if (hasTransientConnectionInterruption()) return;
+          if (transientConnectionNoticeTimer) {
+            clearTimeout(transientConnectionNoticeTimer);
+            transientConnectionNoticeTimer = null;
+          }
+          if (transientConnectionNoticeVisible) {
+            transientConnectionNoticeVisible = false;
+            setStatus(recoveredMessage || "Connected.");
+          }
+        }
+
+        function resetTransientConnectionNotice() {
+          heartbeatInterrupted = false;
+          outputInterrupted = false;
+          if (transientConnectionNoticeTimer) {
+            clearTimeout(transientConnectionNoticeTimer);
+            transientConnectionNoticeTimer = null;
+          }
+          transientConnectionNoticeVisible = false;
         }
 
         function token() {
@@ -1681,6 +1732,7 @@
 
         function stopSocket(resetReconnect = true) {
           stopOutputReconnect(resetReconnect);
+          if (resetReconnect) clearTransientConnectionNotice("output");
           if (socket) {
             const closingSocket = socket;
             socket = null;
@@ -1694,6 +1746,10 @@
           if (heartbeatTimer) {
             clearInterval(heartbeatTimer);
             heartbeatTimer = null;
+          }
+          if (heartbeatRetryTimer) {
+            clearTimeout(heartbeatRetryTimer);
+            heartbeatRetryTimer = null;
           }
           if (heartbeatAbortController) {
             heartbeatAbortController.abort();
@@ -1717,25 +1773,47 @@
           }
         }
 
+        function heartbeatRequestTimeoutMs() {
+          return Math.min(
+            HEARTBEAT_REQUEST_TIMEOUT_MAX_MS,
+            Math.max(HEARTBEAT_INTERVAL_MIN_MS, Math.floor(heartbeatTimeoutMs / 3))
+          );
+        }
+
         async function heartbeat() {
           if (!leaseId || heartbeatInFlight) return;
+          const heartbeatLeaseId = leaseId;
           heartbeatInFlight = true;
           const controller = typeof AbortController === "function" ? new AbortController() : null;
           heartbeatAbortController = controller;
+          const requestTimeoutMs = heartbeatRequestTimeoutMs();
           const abortTimer = controller
-            ? setTimeout(() => controller.abort(), heartbeatTimeoutMs)
+            ? setTimeout(() => controller.abort(), requestTimeoutMs)
             : null;
           try {
             await remoteFetch("/remote/v1/session/heartbeat", {
               method: "POST",
-              body: JSON.stringify({ leaseId }),
+              body: JSON.stringify({ leaseId: heartbeatLeaseId }),
               ...(controller ? { signal: controller.signal } : {}),
             });
+            if (leaseId !== heartbeatLeaseId || heartbeatAbortController !== controller) return;
             lastHeartbeatOkAt = Date.now();
+            if (heartbeatRetryTimer) {
+              clearTimeout(heartbeatRetryTimer);
+              heartbeatRetryTimer = null;
+            }
+            clearTransientConnectionNotice(
+              "heartbeat",
+              activeTerminalId ? `Connected to ${activeTerminalId}` : "Connected."
+            );
+          } catch (err) {
+            if (leaseId === heartbeatLeaseId && heartbeatAbortController === controller) throw err;
           } finally {
             if (abortTimer) clearTimeout(abortTimer);
-            if (heartbeatAbortController === controller) heartbeatAbortController = null;
-            heartbeatInFlight = false;
+            if (heartbeatAbortController === controller) {
+              heartbeatAbortController = null;
+              heartbeatInFlight = false;
+            }
           }
         }
 
@@ -1747,25 +1825,36 @@
           return Date.now() - lastHeartbeatOkAt >= heartbeatTimeoutMs;
         }
 
+        function scheduleHeartbeatRetry() {
+          if (!leaseId || heartbeatRetryTimer) return;
+          heartbeatRetryTimer = setTimeout(() => {
+            heartbeatRetryTimer = null;
+            heartbeat().catch((err) => handleHeartbeatError(err));
+          }, HEARTBEAT_RETRY_DELAY_MS);
+        }
+
         function handleHeartbeatError(err) {
           if (!leaseId) return;
           if (isFatalRemoteControlError(err) || heartbeatTimedOut()) {
             loseRemoteControl(`Control returned to the host. ${err.message}`);
             return;
           }
-          setStatus(`Connection interrupted. Retrying before lease timeout. ${err.message}`, true);
+          scheduleTransientConnectionNotice("heartbeat");
+          scheduleHeartbeatRetry();
         }
 
         function startHeartbeat(timeoutSeconds) {
           stopHeartbeat();
-          heartbeatTimeoutMs = Math.max(5000, Math.floor(timeoutSeconds * 1000));
+          heartbeatTimeoutMs = Math.max(
+            HEARTBEAT_INTERVAL_MAX_MS,
+            Math.floor(timeoutSeconds * 1000)
+          );
           lastHeartbeatOkAt = Date.now();
-          const intervalMs = Math.max(1000, Math.floor(timeoutSeconds * 333));
+          const intervalMs = Math.min(
+            HEARTBEAT_INTERVAL_MAX_MS,
+            Math.max(HEARTBEAT_INTERVAL_MIN_MS, Math.floor(heartbeatTimeoutMs / 3))
+          );
           heartbeatTimer = setInterval(() => {
-            if (heartbeatTimedOut()) {
-              loseRemoteControl("Control returned to the host. Heartbeat timed out.");
-              return;
-            }
             heartbeat().catch((err) => {
               handleHeartbeatError(err);
             });
@@ -2445,12 +2534,10 @@
           if (outputReconnectTimer) return;
           const delayMs = outputReconnectDelayMs(outputReconnectAttempt);
           outputReconnectAttempt += 1;
-          const delayLabel = delayMs < 1000 ? "shortly" : `in ${Math.ceil(delayMs / 1000)}s`;
-          setStatus(`Output stream disconnected. Reconnecting ${delayLabel}...`, true);
+          scheduleTransientConnectionNotice("output");
           outputReconnectTimer = setTimeout(() => {
             outputReconnectTimer = null;
             if (leaseId !== outputLeaseId || activeTerminalId !== terminalId) return;
-            setStatus("Reconnecting output stream...");
             openOutput(terminalId, { reconnect: true });
           }, delayMs);
         }
@@ -2470,20 +2557,23 @@
             stopResizeFlush();
           }
           applyTerminalAppearance(terminalInfo && terminalInfo.appearance);
-          term.reset();
+          if (!reconnecting) term.reset();
           updateTerminalControls();
           lastResizeKey = "";
           const url = `${wsBaseUrl()}/remote/v1/terminals/${encodeURIComponent(terminalId)}/output?leaseId=${encodeURIComponent(outputLeaseId)}&token=${encodeURIComponent(token())}`;
           const outputSocket = new WebSocket(url);
           let outputTerminalMissing = false;
+          let resetOnNextPayload = reconnecting;
           socket = outputSocket;
           outputSocket.binaryType = "arraybuffer";
           outputSocket.onopen = () => {
             if (socket === outputSocket && leaseId === outputLeaseId && activeTerminalId === terminalId) {
               outputReconnectAttempt = 0;
-              setStatus(`Connected to ${terminalId}`);
+              clearTransientConnectionNotice("output", `Connected to ${terminalId}`);
+              if (!reconnecting) setStatus(`Connected to ${terminalId}`);
               scheduleTerminalFit(true);
               term.focus();
+              if (reconnecting) heartbeat().catch((err) => handleHeartbeatError(err));
             }
           };
           outputSocket.onmessage = (event) => {
@@ -2500,6 +2590,10 @@
                 return;
               }
             }
+            if (resetOnNextPayload) {
+              term.reset();
+              resetOnNextPayload = false;
+            }
             term.write(payload, scheduleTerminalRefresh);
           };
           outputSocket.onclose = () => {
@@ -2513,7 +2607,7 @@
             }
           };
           outputSocket.onerror = () => {
-            if (socket === outputSocket) setStatus("Output stream error. Waiting to reconnect.", true);
+            if (socket === outputSocket) scheduleTransientConnectionNotice("output");
           };
         }
 
@@ -2532,7 +2626,7 @@
             leaseId = status.leaseId;
             ensureTerminal();
             setConnected(true);
-            startHeartbeat(status.heartbeatTimeoutSeconds || 15);
+            startHeartbeat(status.heartbeatTimeoutSeconds || DEFAULT_HEARTBEAT_TIMEOUT_SECONDS);
             await loadNavigation();
             setNavigationOpen(false);
           } catch (err) {
@@ -2666,6 +2760,7 @@
           stopHeartbeat();
           stopInputFlush();
           stopResizeFlush();
+          resetTransientConnectionNotice();
           leaseId = null;
           activeTerminalId = null;
           setConnected(false);

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -127,6 +127,10 @@ mod tests {
         assert!(html.contains("function scheduleOutputReconnect(terminalId, outputLeaseId)"));
         assert!(html.contains("function handleHeartbeatError(err)"));
         assert!(html.contains("let heartbeatAbortController = null;"));
+        assert!(html.contains("const DEFAULT_HEARTBEAT_TIMEOUT_SECONDS = 45;"));
+        assert!(html.contains("const HEARTBEAT_REQUEST_TIMEOUT_MAX_MS = 4000;"));
+        assert!(html.contains("const HEARTBEAT_RETRY_DELAY_MS = 1000;"));
+        assert!(html.contains("const TRANSIENT_CONNECTION_NOTICE_DELAY_MS = 2000;"));
         assert!(html.contains("id=\"desktopModeHeader\""));
         assert!(html.contains("id=\"desktopModeDrawer\""));
         assert!(html.contains("const localAppMode ="));
@@ -231,12 +235,23 @@ mod tests {
         assert!(output_stream.contains("stopSocket(!reconnecting);"));
         assert!(output_stream.contains("scheduleOutputReconnect(terminalId, outputLeaseId);"));
         assert!(output_stream.contains("openOutput(terminalId, { reconnect: true });"));
+        assert!(output_stream.contains("scheduleTransientConnectionNotice"));
+        assert!(output_stream.contains("let resetOnNextPayload = reconnecting;"));
+        assert!(output_stream.contains("if (!reconnecting) term.reset();"));
+        assert!(output_stream.contains("if (resetOnNextPayload)"));
+        assert!(output_stream.contains("term.reset();"));
         assert!(output_stream.contains("let outputTerminalMissing = false;"));
         assert!(output_stream.contains("payload === \"terminal session not found\""));
         assert!(output_stream.contains("loadNavigation(null).catch"));
         assert!(
             !output_stream.contains("loseRemoteControl("),
             "output WebSocket close is recoverable while heartbeat keeps the lease alive"
+        );
+        let reconnect_scheduler =
+            &output_stream[..output_stream.find("function openOutput").unwrap()];
+        assert!(
+            !reconnect_scheduler.contains("setStatus("),
+            "short output interruptions must stay invisible while reconnecting"
         );
     }
 
@@ -257,13 +272,16 @@ mod tests {
         assert!(html.contains("error.status = response.status;"));
         assert!(heartbeat_error.contains("isFatalRemoteControlError(err) || heartbeatTimedOut()"));
         assert!(heartbeat_error.contains("loseRemoteControl(`Control returned to the host."));
-        assert!(heartbeat_error.contains("Retrying before lease timeout"));
+        assert!(heartbeat_error.contains("scheduleTransientConnectionNotice(\"heartbeat\")"));
+        assert!(heartbeat_error.contains("scheduleHeartbeatRetry()"));
         assert!(heartbeat_request.contains("signal: controller.signal"));
+        assert!(heartbeat_request.contains("heartbeatRequestTimeoutMs()"));
         assert!(
-            heartbeat_request.contains("setTimeout(() => controller.abort(), heartbeatTimeoutMs)")
+            heartbeat_request.contains("setTimeout(() => controller.abort(), requestTimeoutMs)")
         );
-        assert!(start_heartbeat.contains("if (heartbeatTimedOut())"));
-        assert!(start_heartbeat.contains(
+        assert!(start_heartbeat.contains("HEARTBEAT_INTERVAL_MAX_MS"));
+        assert!(start_heartbeat.contains("Math.min("));
+        assert!(!start_heartbeat.contains(
             "loseRemoteControl(\"Control returned to the host. Heartbeat timed out.\");"
         ));
         assert!(start_heartbeat.contains("lastHeartbeatOkAt = Date.now();"));

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -261,7 +261,7 @@ mod tests {
         let legacy: Settings = serde_json::from_str("{}").unwrap();
         assert!(!legacy.remote.enabled);
         assert_eq!(legacy.remote.allowed_ips, vec!["127.0.0.1/32", "::1/128"]);
-        assert_eq!(legacy.remote.heartbeat_timeout_seconds, 15);
+        assert_eq!(legacy.remote.heartbeat_timeout_seconds, 45);
         assert_eq!(legacy.remote.auto_mobile_mode_min_width, 720);
         assert!(!legacy.remote.cloud_enabled);
         assert_eq!(

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::constants::DEFAULT_REMOTE_HEARTBEAT_TIMEOUT_SECONDS;
+
 /// Color scheme definition (Windows Terminal compatible).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -1024,7 +1026,7 @@ fn default_remote_allowed_ips() -> Vec<String> {
 }
 
 fn default_remote_heartbeat_timeout_seconds() -> u64 {
-    15
+    DEFAULT_REMOTE_HEARTBEAT_TIMEOUT_SECONDS
 }
 
 fn default_remote_auto_mobile_mode_min_width() -> u32 {

--- a/ui/e2e/remote-reconnect.spec.ts
+++ b/ui/e2e/remote-reconnect.spec.ts
@@ -1,0 +1,245 @@
+import { expect, test, type Page, type WebSocketRoute } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+
+const remoteRoot = fileURLToPath(new URL("../../src-tauri/src/remote_server/", import.meta.url));
+
+const navigation = {
+  activeWorkspace: {
+    id: "ws-1",
+    name: "Main",
+    panes: [
+      {
+        id: "pane-1",
+        location: "workspace",
+        workspaceId: "ws-1",
+        paneIndex: 0,
+        paneNumber: 1,
+        viewType: "terminal",
+        terminalId: "terminal-1",
+        terminalLive: true,
+        title: "Shell",
+        profile: "PowerShell",
+        cwd: "C:\\work",
+        branch: "main",
+        activity: { type: "shell" },
+        outputActive: false,
+        commandRunning: false,
+        isFocused: true,
+        unreadCount: 0,
+        hidden: false,
+        collapsed: false,
+        x: 0,
+        y: 0,
+        w: 1,
+        h: 1,
+      },
+    ],
+  },
+  workspaces: [
+    {
+      id: "ws-1",
+      name: "Main",
+      isActive: true,
+      hidden: false,
+      collapsed: false,
+      paneCount: 1,
+      terminalPaneCount: 1,
+      liveTerminalCount: 1,
+      unreadCount: 0,
+      panes: [
+        {
+          id: "pane-1",
+          location: "workspace",
+          workspaceId: "ws-1",
+          paneIndex: 0,
+          paneNumber: 1,
+          viewType: "terminal",
+          terminalId: "terminal-1",
+          terminalLive: true,
+          title: "Shell",
+          profile: "PowerShell",
+          cwd: "C:\\work",
+          branch: "main",
+          activity: { type: "shell" },
+          outputActive: false,
+          commandRunning: false,
+          isFocused: true,
+          unreadCount: 0,
+          hidden: false,
+          collapsed: false,
+          x: 0,
+          y: 0,
+          w: 1,
+          h: 1,
+        },
+      ],
+    },
+  ],
+  docks: [],
+  terminals: [
+    {
+      id: "terminal-1",
+      title: "Shell",
+      profile: "PowerShell",
+      cwd: "C:\\work",
+      appearance: {},
+    },
+  ],
+  workspaceSelector: { display: {}, pathEllipsis: "start" },
+  notifications: [],
+  unreadNotificationCount: 0,
+};
+
+type RemoteMockOptions = {
+  heartbeatTimeoutSeconds?: number;
+  heartbeatFailures?: number;
+  reconnectPayloadDelayMs?: number;
+};
+
+async function installRemoteMocks(page: Page, options: RemoteMockOptions = {}) {
+  const state = {
+    heartbeatRequests: 0,
+    heartbeatFailuresRemaining: options.heartbeatFailures ?? 0,
+    sockets: [] as WebSocketRoute[],
+  };
+
+  await page.route("http://remote.test/remote/", (route) =>
+    route.fulfill({
+      path: `${remoteRoot}page.html`,
+      contentType: "text/html; charset=utf-8",
+    }),
+  );
+  await page.route("http://remote.test/remote/vendor/xterm.js", (route) =>
+    route.fulfill({
+      path: `${remoteRoot}assets/xterm.js`,
+      contentType: "application/javascript; charset=utf-8",
+    }),
+  );
+  await page.route("http://remote.test/remote/vendor/addon-fit.js", (route) =>
+    route.fulfill({
+      path: `${remoteRoot}assets/addon-fit.js`,
+      contentType: "application/javascript; charset=utf-8",
+    }),
+  );
+  await page.route("http://remote.test/remote/vendor/xterm.css", (route) =>
+    route.fulfill({
+      path: `${remoteRoot}assets/xterm.css`,
+      contentType: "text/css; charset=utf-8",
+    }),
+  );
+  await page.route("http://remote.test/remote/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/remote/v1/session/claim") {
+      await route.fulfill({
+        json: {
+          active: true,
+          leaseId: "lease-1",
+          heartbeatTimeoutSeconds: options.heartbeatTimeoutSeconds ?? 45,
+        },
+      });
+      return;
+    }
+    if (url.pathname === "/remote/v1/session/heartbeat") {
+      state.heartbeatRequests += 1;
+      if (state.heartbeatFailuresRemaining > 0) {
+        state.heartbeatFailuresRemaining -= 1;
+        await route.abort("connectionfailed");
+        return;
+      }
+      await route.fulfill({
+        json: { active: true, leaseId: "lease-1" },
+      });
+      return;
+    }
+    if (url.pathname === "/remote/v1/navigation") {
+      await route.fulfill({ json: navigation });
+      return;
+    }
+    await route.fulfill({ json: {} });
+  });
+
+  await page.routeWebSocket(/\/remote\/v1\/terminals\/terminal-1\/output/, (socket) => {
+    state.sockets.push(socket);
+    const connectionNumber = state.sockets.length;
+    const delay = connectionNumber > 1 ? (options.reconnectPayloadDelayMs ?? 0) : 0;
+    setTimeout(() => {
+      socket.send(
+        Buffer.from(connectionNumber === 1 ? "initial output\r\n" : "restored output\r\n"),
+      );
+    }, delay);
+  });
+
+  return state;
+}
+
+async function instrumentRemotePage(page: Page) {
+  await page.goto("http://remote.test/remote/#token=test-token");
+  await page.evaluate(() => {
+    const target = window as typeof window & {
+      Terminal: { prototype: { reset: () => void } };
+      __remoteResetCount: number;
+      __remoteStatusHistory: string[];
+    };
+    target.__remoteResetCount = 0;
+    target.__remoteStatusHistory = [];
+    const originalReset = target.Terminal.prototype.reset;
+    target.Terminal.prototype.reset = function resetWithCount() {
+      target.__remoteResetCount += 1;
+      return originalReset.call(this);
+    };
+    const status = document.getElementById("status");
+    if (status) {
+      target.__remoteStatusHistory.push(status.textContent || "");
+      new MutationObserver(() => {
+        target.__remoteStatusHistory.push(status.textContent || "");
+      }).observe(status, { childList: true, subtree: true, characterData: true });
+    }
+  });
+}
+
+async function resetCount(page: Page) {
+  return page.evaluate(
+    () => (window as typeof window & { __remoteResetCount: number }).__remoteResetCount,
+  );
+}
+
+async function statusHistory(page: Page) {
+  return page.evaluate(
+    () => (window as typeof window & { __remoteStatusHistory: string[] }).__remoteStatusHistory,
+  );
+}
+
+test("a short output drop reconnects without status noise or an early terminal reset", async ({
+  page,
+}) => {
+  const remote = await installRemoteMocks(page, { reconnectPayloadDelayMs: 600 });
+  await instrumentRemotePage(page);
+
+  await page.locator("#connect").click();
+  await expect(page.locator("#status")).toHaveText("Connected to terminal-1");
+  await expect.poll(() => resetCount(page)).toBe(1);
+
+  await remote.sockets[0].close();
+  await expect.poll(() => remote.sockets.length).toBe(2);
+  await page.waitForTimeout(150);
+
+  expect(await resetCount(page)).toBe(1);
+  await expect(page.locator("#status")).toHaveText("Connected to terminal-1");
+  await expect.poll(() => resetCount(page)).toBe(2);
+  expect(await statusHistory(page)).not.toContain("Connection interrupted. Reconnecting...");
+});
+
+test("one failed heartbeat is retried before the delayed interruption notice", async ({ page }) => {
+  const remote = await installRemoteMocks(page, {
+    heartbeatTimeoutSeconds: 5,
+    heartbeatFailures: 1,
+  });
+  await instrumentRemotePage(page);
+
+  await page.locator("#connect").click();
+  await expect(page.locator("#status")).toHaveText("Connected to terminal-1");
+  await expect.poll(() => remote.heartbeatRequests, { timeout: 5000 }).toBeGreaterThanOrEqual(2);
+
+  await expect(page.locator("#status")).toHaveText("Connected to terminal-1");
+  expect(await statusHistory(page)).not.toContain("Connection interrupted. Reconnecting...");
+});

--- a/ui/src/stores/settings-store.test.ts
+++ b/ui/src/stores/settings-store.test.ts
@@ -886,11 +886,12 @@ describe("settings-store", () => {
     expect(useSettingsStore.getState().remote.customHosts).toEqual(["devbox.tailnet.ts.net"]);
   });
 
-  it("loadFromSettings fills missing remote automatic mobile mode width with default", () => {
+  it("loadFromSettings fills missing remote resilience and mobile defaults", () => {
     useSettingsStore.getState().loadFromSettings({
       remote: { enabled: true, authToken: "secret" } as any,
     });
     expect(useSettingsStore.getState().remote.autoMobileModeMinWidth).toBe(720);
+    expect(useSettingsStore.getState().remote.heartbeatTimeoutSeconds).toBe(45);
     expect(useSettingsStore.getState().remote.preferredHost).toBe("");
     expect(useSettingsStore.getState().remote.customHosts).toEqual([]);
   });

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -487,7 +487,7 @@ const DEFAULT_REMOTE: RemoteSettings = {
   allowedOrigins: [],
   allowedIps: ["127.0.0.1/32", "::1/128"],
   authToken: "",
-  heartbeatTimeoutSeconds: 15,
+  heartbeatTimeoutSeconds: 45,
   autoMobileModeMinWidth: 720,
   preferredHost: "",
   customHosts: [],


### PR DESCRIPTION
## 변경 사항

- Remote lease 기본값을 45초로 늘리고, 기존 저장 설정에도 최소 30초 유효값을 적용했습니다.
- 브라우저 heartbeat 요청 제한시간(4초), 빠른 재시도(1초), 최대 주기(5초)를 분리했습니다.
- 2초 이내의 일시적 연결 끊김은 경고 없이 복구하고, 출력 WebSocket 재연결 중 기존 터미널 화면을 유지합니다.
- ADR/living doc과 Chromium e2e 회귀 테스트를 추가했습니다.

## 원인

기존 구현은 15초 lease와 heartbeat 요청이 같은 수준의 긴 제한시간을 사용해, 짧은 네트워크 지연에도 재시도 여유가 빠르게 소진됐습니다. 또한 출력 WebSocket이 닫히는 즉시 화면과 상태를 초기화해 사용자가 순간적인 단절을 그대로 보게 됐습니다.

## 검증

- Vitest: 101 files / 2,410 tests 통과
- Rust unit/integration 전체 통과
- Playwright: 72 tests 통과
- `npx tsc --noEmit` 통과
- `cargo check --release` 통과
- ESLint: 오류 0개
- dev 포트 19281에서 health/API 및 스크린샷 복구 시나리오 확인