### PR TITLE
feat(ui): surface copy-identifier shortcut in pane badge tooltip

### DIFF
--- a/ui/src/components/ui/PaneNumberBadge.test.tsx
+++ b/ui/src/components/ui/PaneNumberBadge.test.tsx
@@ -41,6 +41,14 @@ describe("PaneNumberBadge", () => {
     expect(mockClipboardWriteText).toHaveBeenCalledWith("lx:pane:Backend:3");
   });
 
+  it("advertises the copy-identifier keyboard shortcut in the tooltip", () => {
+    // Discoverability: the badge tooltip surfaces the equivalent keybinding so users
+    // learn the hands-off path (default Ctrl+Alt+C for pane.copyIdentifier).
+    render(<PaneNumberBadge number={3} workspaceId="ws-a1b2c3d4" workspaceName="Backend" />);
+    const badge = screen.getByTestId("pane-number-badge");
+    expect(badge).toHaveAttribute("title", "Click to copy pane 3 identifier (Ctrl+Alt+C)");
+  });
+
   it("shows a copied checkmark after a successful copy", async () => {
     render(<PaneNumberBadge number={1} workspaceId="ws-x" workspaceName="Default" />);
     fireEvent.click(screen.getByTestId("pane-number-badge"));

--- a/ui/src/components/ui/PaneNumberBadge.tsx
+++ b/ui/src/components/ui/PaneNumberBadge.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { clipboardWriteText } from "@/lib/tauri-api";
 import { formatPaneIdentifier } from "@/lib/pane-numbers";
+import { useResolvedKeybinding } from "@/lib/keybinding-registry";
 
 /**
  * Small badge showing a pane's spatial reading-order number (issue #256).
@@ -30,6 +31,10 @@ export function PaneNumberBadge({
 }) {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Effective keybinding for the same "copy identifier" action, so the tooltip
+  // advertises the keyboard path too. The hook subscribes to the settings store,
+  // so the tooltip refreshes when the user rebinds the action (PR #331 review).
+  const copyKeys = useResolvedKeybinding("pane.copyIdentifier");
 
   const handleCopy = useCallback(async () => {
     // `formatPaneIdentifier` throws on un-normalized (whitespace) names. There's no
@@ -105,7 +110,11 @@ export function PaneNumberBadge({
       // Explicit name: during the copied feedback the child becomes an aria-hidden ✓, which
       // would otherwise leave the button with no accessible name for COPIED_FEEDBACK_MS.
       aria-label={`Copy pane ${number} identifier`}
-      title={copied ? "Pane identifier copied" : `Click to copy pane ${number} identifier`}
+      title={
+        copied
+          ? "Pane identifier copied"
+          : `Click to copy pane ${number} identifier${copyKeys ? ` (${copyKeys})` : ""}`
+      }
       onClick={(e) => {
         // Badge lives inside focusable/clickable bars; don't bubble into pane focus/select.
         e.stopPropagation();


### PR DESCRIPTION
## 요약
Pane 번호 배지는 클릭 시 pane 식별자(`lx:pane:<ws>:<번호>`)를 복사하고, 동일 동작이 키보드 단축키 **Ctrl+Alt+C**(`pane.copyIdentifier`)로도 가능하다. 하지만 배지 hover 툴팁에 단축키 안내가 없어 키보드 경로를 발견하기 어려웠다.

## 변경
- `useResolvedKeybinding("pane.copyIdentifier")` 로 실제 바인딩을 조회해 배지 툴팁에 노출
  - `Click to copy pane 3 identifier` → `Click to copy pane 3 identifier (Ctrl+Alt+C)`
- 훅이 settings store 를 구독하므로 사용자가 리바인드하면 툴팁도 자동 갱신 (하드코딩 아님, PR #331 선례와 동일 패턴)
- 툴팁 단축키 노출 회귀 테스트 1개 추가

## 검증
- tsc `--noEmit` clean
- eslint clean
- `PaneNumberBadge.test.tsx` 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)