### PR TITLE
fix(remote): 액티비티 배지 색상 데스크톱과 일치

### DIFF
--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -20,6 +20,9 @@
         --accent-08: rgba(137, 180, 250, 0.08);
         --green: #a6e3a1;
         --red: #f38ba8;
+        --claude: #d97757;
+        --codex: #10a37f;
+        --orange-15: rgba(217, 119, 87, 0.15);
         --yellow: #f9e2af;
         --border: #313244;
         --hover-bg: rgba(255, 255, 255, 0.06);
@@ -690,10 +693,18 @@
       }
       .pane-activity.running {
         color: var(--yellow);
-        background: var(--accent-12);
+        background: var(--active-bg);
       }
       .pane-activity.interactive {
         color: var(--accent);
+        background: var(--accent-12);
+      }
+      .pane-activity.claude {
+        color: var(--claude);
+        background: var(--orange-15);
+      }
+      .pane-activity.codex {
+        color: var(--codex);
         background: var(--accent-12);
       }
       .pane-branch {
@@ -2053,6 +2064,19 @@
           return "";
         }
 
+        // Mirror the desktop WorkspaceSelector activity-badge colors: Claude and
+        // Codex keep their brand hue, other interactive apps use the accent, and
+        // command activity uses the running color. Source of truth: formatActivity
+        // in ui/src/lib/workspace-summary.ts.
+        function activityClass(activity) {
+          if (activity && activity.type === "interactiveApp") {
+            if (activity.name === "Claude") return "claude";
+            if (activity.name === "Codex") return "codex";
+            return "interactive";
+          }
+          return "running";
+        }
+
         function metaText(parts) {
           return parts.filter(Boolean).join(" - ");
         }
@@ -2285,10 +2309,7 @@
           const activity = activityLabel(pane.activity, pane.commandRunning);
           if (activity) {
             const activityEl = document.createElement("span");
-            const activityType = pane.activity && pane.activity.type === "interactiveApp"
-              ? "interactive"
-              : "running";
-            activityEl.className = `pane-activity ${activityType}`;
+            activityEl.className = `pane-activity ${activityClass(pane.activity)}`;
             activityEl.textContent = activity;
             main.append(activityEl);
           }
@@ -2440,10 +2461,7 @@
             const activity = activityLabel(pane.activity, pane.commandRunning);
             if (display.activity && activity) {
               const activityEl = document.createElement("span");
-              const activityType = pane.activity && pane.activity.type === "interactiveApp"
-                ? "interactive"
-                : "running";
-              activityEl.className = `pane-activity ${activityType}`;
+              activityEl.className = `pane-activity ${activityClass(pane.activity)}`;
               activityEl.textContent = activity;
               main.append(activityEl);
             }

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -217,6 +217,25 @@ mod tests {
     }
 
     #[test]
+    fn remote_page_activity_badge_colors_match_desktop() {
+        let html = remote_page_html();
+        // Palette vars ported from ui/src/index.css so badges match the desktop.
+        assert!(html.contains("--claude: #d97757;"));
+        assert!(html.contains("--codex: #10a37f;"));
+        assert!(html.contains("--orange-15: rgba(217, 119, 87, 0.15);"));
+        // Per-app badge classes with desktop-matching color + background.
+        assert!(html.contains(".pane-activity.claude {\n        color: var(--claude);\n        background: var(--orange-15);\n      }"));
+        assert!(html.contains(".pane-activity.codex {\n        color: var(--codex);\n        background: var(--accent-12);\n      }"));
+        // running badge background matches desktop (--active-bg, not --accent-12).
+        assert!(html.contains(".pane-activity.running {\n        color: var(--yellow);\n        background: var(--active-bg);\n      }"));
+        // Class selection mirrors formatActivity: Claude/Codex keep brand hue.
+        assert!(html.contains("function activityClass(activity)"));
+        assert!(html.contains("if (activity.name === \"Claude\") return \"claude\";"));
+        assert!(html.contains("if (activity.name === \"Codex\") return \"codex\";"));
+        assert!(html.contains("`pane-activity ${activityClass(pane.activity)}`"));
+    }
+
+    #[test]
     fn remote_page_gate_requires_enabled_for_tunnel_requests() {
         let addr = "203.0.113.10:1".parse::<SocketAddr>().unwrap();
 


### PR DESCRIPTION
## 문제
Focused Remote UI 가 모든 interactiveApp 을 파란 `interactive` 배지 하나로 뭉치고 running 배경에 `--accent-12` 를 써서, Claude·Codex 패널이 데스크톱 WorkspaceSelector 와 색이 달랐다.

## 원인
`page.html` 의 `.pane-activity` 는 `interactive`/`running` 두 클래스뿐 → Claude(주황)·Codex(초록) 구분 없음. running 배경도 데스크톱(`--active-bg`)과 불일치(`--accent-12`).

## 수정
데스크톱 팔레트(`--claude` `#d97757`, `--codex` `#10a37f`, `--orange-15`)를 remote `:root` 로 이식하고 앱별 배지 클래스 추가:

| 상태 | color | background |
|---|---|---|
| Claude | `--claude` | `--orange-15` |
| Codex | `--codex` | `--accent-12` |
| 기타 interactive | `--accent` | `--accent-12` |
| running | `--yellow` | `--active-bg` |

`activityClass()` 가 `formatActivity`(ui/src/lib/workspace-summary.ts) 와 WorkspaceSelectorView 배지 배경 규칙을 그대로 반영한다.

## 검증
- `page.rs` 테스트 추가(팔레트 var·클래스 규칙·`activityClass` 매핑). remote page 테스트 12개 통과.
- Playwright 실브라우저 computed color 측정: Claude=`rgb(217,119,87)`/orange-15, Codex=`rgb(16,163,127)`/accent-12, running=`rgb(249,226,175)`/active-bg, interactive=accent/accent-12 — 데스크톱 값과 정확히 일치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mq9hQgFmQ35YRCVZayicEi