### PR TITLE
feat(layout): tune first-install default layout

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -121,6 +121,11 @@ vi.mock("@/lib/tauri-api", () => {
     cleanTerminalOutputCache: vi.fn().mockResolvedValue(undefined),
     loadWindowGeometry: vi.fn().mockResolvedValue(null),
     saveWindowGeometry: vi.fn().mockResolvedValue(undefined),
+    // The right dock now defaults to MemoView on first launch, which mounts
+    // MemoView and loads/saves memo content — stub these so it doesn't throw.
+    loadMemo: vi.fn().mockResolvedValue(""),
+    saveMemo: vi.fn().mockResolvedValue(undefined),
+    clipboardWriteText: vi.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/ui/src/components/layout/GridEditToolbar.test.tsx
+++ b/ui/src/components/layout/GridEditToolbar.test.tsx
@@ -61,6 +61,9 @@ describe("GridEditToolbar", () => {
     const user = userEvent.setup();
     render(<GridEditToolbar />);
 
+    // Top dock is hidden on first install; clicking toggles it on then off.
+    expect(useDockStore.getState().getDock("top")!.visible).toBe(false);
+    await user.click(screen.getByTestId("dock-toggle-top"));
     expect(useDockStore.getState().getDock("top")!.visible).toBe(true);
     await user.click(screen.getByTestId("dock-toggle-top"));
     expect(useDockStore.getState().getDock("top")!.visible).toBe(false);

--- a/ui/src/components/layout/PaneBoundaryHandles.test.tsx
+++ b/ui/src/components/layout/PaneBoundaryHandles.test.tsx
@@ -5,6 +5,16 @@ import { useWorkspaceStore } from "@/stores/workspace-store";
 describe("PaneBoundaryHandles", () => {
   beforeEach(() => {
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
+    // The shipped default workspace now opens as a 2-pane split; these tests
+    // assume a single full pane as their starting point.
+    const st = useWorkspaceStore.getState();
+    useWorkspaceStore.setState({
+      workspaces: st.workspaces.map((w) =>
+        w.id === st.activeWorkspaceId
+          ? { ...w, panes: [{ ...w.panes[0], x: 0, y: 0, w: 1, h: 1 }] }
+          : w,
+      ),
+    });
   });
 
   it("renders nothing when only one pane exists", () => {

--- a/ui/src/components/layout/WorkspaceArea.test.tsx
+++ b/ui/src/components/layout/WorkspaceArea.test.tsx
@@ -19,6 +19,16 @@ import { useNotificationStore } from "@/stores/notification-store";
 describe("WorkspaceArea", () => {
   beforeEach(() => {
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
+    // The shipped default workspace now opens as a 2-pane split; tests that
+    // split from a single pane assume one full pane as the starting point.
+    const ws = useWorkspaceStore.getState();
+    useWorkspaceStore.setState({
+      workspaces: ws.workspaces.map((w) =>
+        w.id === ws.activeWorkspaceId
+          ? { ...w, panes: [{ ...w.panes[0], x: 0, y: 0, w: 1, h: 1 }] }
+          : w,
+      ),
+    });
     useGridStore.setState(useGridStore.getInitialState());
     useUiStore.setState(useUiStore.getInitialState());
     useNotificationStore.setState(useNotificationStore.getInitialState());

--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -2257,13 +2257,24 @@ describe("WorkspaceSelectorView", () => {
       dropEffect: "",
     });
 
-    /** 활성 워크스페이스를 split(2 pane) 하고, 두 번째 워크스페이스를 추가한다. */
+    /** 워크스페이스를 단일 pane 으로 접는다(기본 레이아웃이 2분할이라 명시적 정규화 필요). */
+    const collapseToSinglePane = (id: string) => {
+      useWorkspaceStore.setState((state) => ({
+        workspaces: state.workspaces.map((w) =>
+          w.id === id ? { ...w, panes: [{ ...w.panes[0], x: 0, y: 0, w: 1, h: 1 }] } : w,
+        ),
+      }));
+    };
+
+    /** 활성 워크스페이스를 split(2 pane) 하고, 단일 pane 짜리 두 번째 워크스페이스를 추가한다. */
     const setup = () => {
       const srcId = useWorkspaceStore.getState().workspaces[0].id;
       useWorkspaceStore.getState().setActiveWorkspace(srcId);
+      collapseToSinglePane(srcId);
       useWorkspaceStore.getState().splitPane(0, "vertical");
       useWorkspaceStore.getState().addWorkspace("Target", "default-layout");
       const tgtId = useWorkspaceStore.getState().workspaces[1].id;
+      collapseToSinglePane(tgtId);
       return { srcId, tgtId };
     };
 

--- a/ui/src/hooks/useAutomationBridge.test.ts
+++ b/ui/src/hooks/useAutomationBridge.test.ts
@@ -849,6 +849,16 @@ describe("useAutomationBridge hook", () => {
 describe("identify_caller and enriched responses", () => {
   beforeEach(() => {
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
+    // The shipped default workspace now opens as a 2-pane split; these tests
+    // split from a single pane, so collapse the active workspace to one pane.
+    const st = useWorkspaceStore.getState();
+    useWorkspaceStore.setState({
+      workspaces: st.workspaces.map((w) =>
+        w.id === st.activeWorkspaceId
+          ? { ...w, panes: [{ ...w.panes[0], x: 0, y: 0, w: 1, h: 1 }] }
+          : w,
+      ),
+    });
     useGridStore.setState(useGridStore.getInitialState());
     useTerminalStore.setState(useTerminalStore.getInitialState());
     vi.clearAllMocks();

--- a/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -234,6 +234,13 @@ describe("useKeyboardShortcuts", () => {
     // out of range — so the user always lands on a focused pane.
     useWorkspaceStore.getState().addWorkspace("WS2", "default-layout");
     const ws2 = useWorkspaceStore.getState().workspaces[1];
+    // The default layout now ships 2 panes; collapse WS2 to a single pane so it
+    // is genuinely the "smaller" target for the clamp assertion below.
+    useWorkspaceStore.setState((s) => ({
+      workspaces: s.workspaces.map((w) =>
+        w.id === ws2.id ? { ...w, panes: [{ ...w.panes[0], x: 0, y: 0, w: 1, h: 1 }] } : w,
+      ),
+    }));
     useWorkspaceStore.getState().setActiveWorkspace("ws-default");
     useDockStore.getState().setFocusedDock(null);
     useGridStore.setState({ focusedPaneIndex: 2 });
@@ -656,7 +663,10 @@ describe("useKeyboardShortcuts", () => {
   });
 
   it("Alt+Arrow navigates between docks", () => {
-    // Top dock is visible but has no panes by default — add a view so it's navigable
+    // Top dock is hidden on first install — show it and give it a view so it's navigable.
+    if (!useDockStore.getState().getDock("top")?.visible) {
+      useDockStore.getState().toggleDockVisible("top");
+    }
     useDockStore.getState().setDockActiveView("top", "SettingsView");
     useDockStore.getState().setFocusedDock("left");
     renderHook(() => useKeyboardShortcuts());
@@ -800,10 +810,12 @@ describe("useKeyboardShortcuts", () => {
   });
 
   it("Alt+Arrow in dock when all other docks are hidden stays put", () => {
-    // Hide all docks except left
-    useDockStore.getState().toggleDockVisible("top");
-    useDockStore.getState().toggleDockVisible("bottom");
-    useDockStore.getState().toggleDockVisible("right");
+    // Ensure only the left dock is visible (top/bottom already hidden on first install).
+    for (const pos of ["top", "bottom", "right"] as const) {
+      if (useDockStore.getState().getDock(pos)?.visible) {
+        useDockStore.getState().toggleDockVisible(pos);
+      }
+    }
     useDockStore.getState().setFocusedDock("left");
     renderHook(() => useKeyboardShortcuts());
 
@@ -1255,8 +1267,10 @@ describe("useKeyboardShortcuts", () => {
     fireKey("N", { ctrlKey: true, altKey: true });
 
     const newWs = useWorkspaceStore.getState().workspaces[1];
-    expect(newWs.panes).toHaveLength(1);
+    // Default layout ships a 2-pane split.
+    expect(newWs.panes).toHaveLength(2);
     expect(newWs.panes[0].view.type).toBe("EmptyView");
+    expect(newWs.panes[1].view.type).toBe("EmptyView");
   });
 
   // --- Lowercase Ctrl+Alt letter keys (case-insensitive) ---

--- a/ui/src/stores/dock-store.test.ts
+++ b/ui/src/stores/dock-store.test.ts
@@ -19,6 +19,19 @@ describe("DockStore", () => {
     expect(left?.activeView).toBe("WorkspaceSelectorView");
   });
 
+  it("right dock ships Memo + FileExplorer tabs by default", () => {
+    const right = useDockStore.getInitialState().docks.find((d) => d.position === "right")!;
+    expect(right.activeView).toBe("MemoView");
+    expect(right.views).toEqual(["MemoView", "FileExplorerView"]);
+    expect(right.visible).toBe(true);
+  });
+
+  it("top and bottom docks are hidden on first install", () => {
+    const docks = useDockStore.getInitialState().docks;
+    expect(docks.find((d) => d.position === "top")!.visible).toBe(false);
+    expect(docks.find((d) => d.position === "bottom")!.visible).toBe(false);
+  });
+
   it("sets active view on a dock", () => {
     useDockStore.getState().setDockActiveView("right", "SettingsView");
     const right = useDockStore.getState().getDock("right");

--- a/ui/src/stores/dock-store.ts
+++ b/ui/src/stores/dock-store.ts
@@ -72,10 +72,12 @@ export const useDockStore = create<DockStoreState>()((set, get) => ({
   focusedDock: null,
   focusedDockPaneId: null,
   docks: [
-    makeDock("top", null, 200),
-    makeDock("bottom", null, 200),
+    // First-install defaults: only the left (workspace selector) and right
+    // (memo + file explorer) docks are shown; top/bottom start hidden.
+    { ...makeDock("top", null, 200), visible: false },
+    { ...makeDock("bottom", null, 200), visible: false },
     makeDock("left", "WorkspaceSelectorView", 240),
-    makeDock("right", null, 240),
+    { ...makeDock("right", "MemoView", 240), views: ["MemoView", "FileExplorerView"] },
   ],
 
   getDock: (position) => {

--- a/ui/src/stores/workspace-store.test.ts
+++ b/ui/src/stores/workspace-store.test.ts
@@ -12,10 +12,33 @@ import { persistSession } from "@/lib/persist-session";
 describe("WorkspaceStore", () => {
   beforeEach(() => {
     useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
+    // The shipped default workspace now opens as a 2-pane split (first-install
+    // UX). The pane-manipulation tests below assume a single full pane as their
+    // starting point, so collapse the active workspace to one pane here. The
+    // shipped 2-pane default is asserted separately via getInitialState().
+    const st = useWorkspaceStore.getState();
+    useWorkspaceStore.setState({
+      workspaces: st.workspaces.map((w) =>
+        w.id === st.activeWorkspaceId
+          ? { ...w, panes: [{ ...w.panes[0], x: 0, y: 0, w: 1, h: 1 }] }
+          : w,
+      ),
+    });
     useOverridesStore.setState({ paneOverrides: {}, viewOverrides: {} });
     useCwdPropagateStore.setState({ requests: {} });
     localStorage.clear();
     vi.clearAllMocks();
+  });
+
+  it("ships a 2-pane side-by-side split as the default workspace", () => {
+    const init = useWorkspaceStore.getInitialState();
+    const active = init.workspaces.find((w) => w.id === init.activeWorkspaceId)!;
+    expect(active.panes).toHaveLength(2);
+    expect(active.panes[0].w).toBeCloseTo(0.5);
+    expect(active.panes[0].x).toBeCloseTo(0);
+    expect(active.panes[1].w).toBeCloseTo(0.5);
+    expect(active.panes[1].x).toBeCloseTo(0.5);
+    expect(init.layouts[0].panes).toHaveLength(2);
   });
 
   it("starts with default layout and workspace", () => {
@@ -77,9 +100,7 @@ describe("WorkspaceStore", () => {
     addWorkspace("ToRemove", layouts[0].id);
     const wsId = useWorkspaceStore.getState().workspaces[1].id;
 
-    // 삭제 대상 워크스페이스를 활성화한 뒤 split 으로 다중 pane 을 만든다.
-    useWorkspaceStore.getState().setActiveWorkspace(wsId);
-    useWorkspaceStore.getState().splitPane(0, "horizontal");
+    // 삭제 대상 워크스페이스는 기본 2분할 레이아웃이라 이미 pane 2개를 가진다.
     const victimPanes = useWorkspaceStore.getState().workspaces.find((w) => w.id === wsId)!.panes;
     expect(victimPanes).toHaveLength(2);
     const [paneA, paneB] = victimPanes;
@@ -284,7 +305,16 @@ describe("WorkspaceStore", () => {
 
   // 드래그한 pane 을 다른 워크스페이스로 이동 (issue #380)
   describe("movePaneToWorkspace", () => {
-    /** 활성 워크스페이스를 split 해 2개 pane 으로 만들고, 두 번째 워크스페이스를 추가한다. */
+    /** 워크스페이스를 단일 pane 으로 접는다(기본 레이아웃이 2분할이라 명시적 정규화 필요). */
+    const collapseToSinglePane = (id: string) => {
+      useWorkspaceStore.setState((state) => ({
+        workspaces: state.workspaces.map((w) =>
+          w.id === id ? { ...w, panes: [{ ...w.panes[0], x: 0, y: 0, w: 1, h: 1 }] } : w,
+        ),
+      }));
+    };
+
+    /** 활성 워크스페이스를 split 해 2개 pane 으로 만들고, 단일 pane 짜리 두 번째 워크스페이스를 추가한다. */
     const setupSourceWithTwoPanes = () => {
       const { addWorkspace, layouts, workspaces } = useWorkspaceStore.getState();
       const srcId = workspaces[0].id;
@@ -292,6 +322,7 @@ describe("WorkspaceStore", () => {
       useWorkspaceStore.getState().splitPane(0, "vertical");
       addWorkspace("Target", layouts[0].id);
       const tgtId = useWorkspaceStore.getState().workspaces[1].id;
+      collapseToSinglePane(tgtId);
       return { srcId, tgtId };
     };
 
@@ -352,6 +383,7 @@ describe("WorkspaceStore", () => {
       const srcId = workspaces[0].id; // single pane
       addWorkspace("Target", layouts[0].id);
       const tgtId = useWorkspaceStore.getState().workspaces[1].id;
+      collapseToSinglePane(tgtId);
       const onlyPane = workspaces[0].panes[0];
 
       useWorkspaceStore.getState().movePaneToWorkspace(onlyPane.id, tgtId);

--- a/ui/src/stores/workspace-store.ts
+++ b/ui/src/stores/workspace-store.ts
@@ -46,24 +46,23 @@ function ensureUniqueName(name: string, existing: { name: string }[]): string {
   return `${name}-${n}`;
 }
 
+// First-install default: a two-pane, side-by-side split so the workspace
+// opens ready to hold two views.
 const defaultLayout: Layout = {
   id: "default-layout",
   name: "Default",
-  panes: [{ x: 0, y: 0, w: 1, h: 1, viewType: "EmptyView" }],
+  panes: [
+    { x: 0, y: 0, w: 0.5, h: 1, viewType: "EmptyView" },
+    { x: 0.5, y: 0, w: 0.5, h: 1, viewType: "EmptyView" },
+  ],
 };
 
 const defaultWorkspace: Workspace = {
   id: "ws-default",
   name: "Default",
   panes: [
-    {
-      id: generateId("pane"),
-      x: 0,
-      y: 0,
-      w: 1,
-      h: 1,
-      view: { type: "EmptyView" },
-    },
+    { id: generateId("pane"), x: 0, y: 0, w: 0.5, h: 1, view: { type: "EmptyView" } },
+    { id: generateId("pane"), x: 0.5, y: 0, w: 0.5, h: 1, view: { type: "EmptyView" } },
   ],
 };
 


### PR DESCRIPTION
## 요약
첫 설치 시(디스크 `settings.json`에 저장된 layouts/workspaces/docks가 없을 때만 적용되는) 기본 레이아웃을 개선한다. **동작 로직은 변경 없음 — 초기 상태 리터럴 값만 조정.**

## 변경
- **오른쪽 dock**: Memo + File Explorer 전환 탭으로 구성(기본 활성 = Memo) — `dock-store.ts`
- **top/bottom dock**: 첫 설치 시 숨김. 왼쪽(워크스페이스 선택기)·오른쪽 dock만 표시
- **기본 워크스페이스/레이아웃**: 좌우 2분할(각 50%)로 오픈 — `workspace-store.ts`

## 첫 설치 경로
`useSessionPersistence.ts`는 `settings.json`에 layouts/docks가 있을 때만 하이드레이트한다. 갓 설치 = 해당 값 없음 → 스토어 초기 리터럴이 곧 첫 화면. 그래서 리터럴만 바꿔도 첫 설치 UX가 바뀐다.

## 테스트
- 구 기본값(단일 pane, 빈 dock, top/bottom 표시)을 가정하던 테스트들의 시작 상태를 정규화하고 기대값을 조정
- `App.test`에 `loadMemo`/`saveMemo` mock 추가(오른쪽 dock가 이제 MemoView를 마운트)
- 새 기본값을 문서화하는 테스트 추가(dock 2 + workspace 1)
- 전체 유닛 스위트 2439개 통과, tsc/eslint/prettier 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)