### PR TITLE
feat: unify terminal input mode switching UX

### DIFF
--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -147,48 +147,37 @@
       .status.error {
         color: var(--danger);
       }
+      /* Single toggle button (mirrors the desktop pane-bar toggle): shows the
+         current mode and flips it on click. accent when Composer is active. */
       .input-mode-toggle {
         display: inline-flex;
         flex: 0 0 auto;
-        align-items: stretch;
-        padding: 0;
-        border: 1px solid var(--border);
-        border-radius: var(--radius-md);
-        overflow: hidden;
-      }
-      .input-mode-seg {
-        display: inline-flex;
         align-items: center;
         gap: 5px;
-        border: 0;
-        border-radius: 0;
         padding: 4px 8px;
-        background: transparent;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--panel-2);
         color: var(--muted);
         font-size: var(--fs-sm);
         line-height: 1;
       }
-      .input-mode-seg + .input-mode-seg {
-        border-left: 1px solid var(--border);
-      }
-      .input-mode-seg:hover:not([aria-pressed="true"]) {
+      .input-mode-toggle:hover:not([aria-pressed="true"]) {
         background: var(--hover-bg);
       }
-      .input-mode-seg[aria-pressed="true"] {
+      .input-mode-toggle[aria-pressed="true"] {
         background: var(--accent-20);
         color: var(--accent);
+        border-color: var(--accent-50);
       }
-      .input-mode-seg svg {
+      .input-mode-toggle svg {
         flex: 0 0 auto;
       }
-      /* Very narrow headers collapse the toggle to icons; the button title still
-         names each mode for assistive tech. */
+      /* Very narrow headers collapse the toggle to its icon; the button title
+         still names the mode for assistive tech. */
       @media (max-width: 360px) {
-        .input-mode-seg .seg-label {
+        .input-mode-toggle .seg-label {
           display: none;
-        }
-        .input-mode-seg {
-          padding: 4px 7px;
         }
       }
       .terminal-shell {
@@ -203,48 +192,34 @@
       }
       .terminal-composer {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) auto;
+        grid-template-columns: minmax(0, 1fr);
         grid-template-rows: minmax(72px, auto);
         min-width: 0;
         max-height: 42vh;
-        gap: 6px;
-        padding: 6px 4px 2px;
+        padding: 0;
         border-top: 1px solid var(--border);
         background: var(--terminal-bg);
       }
+      /* Flush editor (mirrors desktop): no outer margin / parent padding, no
+         border or rounding — it fills the strip under the divider. */
       .composer-input {
         width: 100%;
         min-width: 0;
         min-height: 72px;
         max-height: 40vh;
         resize: vertical;
-        border: 1px solid var(--border);
-        border-radius: var(--radius-md);
+        border: 0;
+        border-radius: 0;
         padding: 7px 8px;
-        background: var(--bg-surface);
+        background: var(--bg-base);
         color: var(--text-primary);
         font-size: 16px;
         line-height: 1.4;
         outline: none;
         overflow: auto;
       }
-      .composer-input:focus {
-        border-color: var(--accent-50);
-        box-shadow: 0 0 0 1px var(--accent-20);
-      }
       .composer-input:disabled {
         opacity: 0.6;
-      }
-      .composer-actions {
-        display: flex;
-        flex-direction: column;
-        align-self: stretch;
-        justify-content: flex-end;
-        gap: 6px;
-      }
-      .composer-actions button {
-        flex: 0 0 auto;
-        min-width: 62px;
       }
       .remote-body {
         position: relative;
@@ -929,13 +904,10 @@
         }
         .terminal-composer {
           grid-template-columns: minmax(0, 1fr);
-          grid-template-rows: minmax(64px, auto) auto;
+          grid-template-rows: minmax(64px, auto);
         }
         .composer-input {
           min-height: 64px;
-        }
-        .composer-actions {
-          flex-direction: row;
         }
       }
       @supports (height: 100dvh) {
@@ -1222,16 +1194,10 @@
           <span></span>
         </button>
         <div id="status" class="status">Enter the remote token, then connect.</div>
-        <div id="inputModeToggle" class="input-mode-toggle" role="group" aria-label="Terminal input mode">
-          <button id="inputModeDirect" class="input-mode-seg" type="button" aria-pressed="true" title="Direct input — type straight into the terminal">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><rect x="2.5" y="6" width="19" height="12" rx="2"/><path d="M7 10h.01M11 10h.01M15 10h.01M8.5 14h7" stroke-linecap="round"/></svg>
-            <span class="seg-label">Direct</span>
-          </button>
-          <button id="inputModeComposer" class="input-mode-seg" type="button" aria-pressed="false" title="Composer — draft text, then send to the terminal">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M4 20h4L18.5 9.5a2 2 0 0 0-2.83-2.83L5 17v3z" stroke-linejoin="round"/><path d="M13.5 8.5l2.5 2.5" stroke-linecap="round"/></svg>
-            <span class="seg-label">Composer</span>
-          </button>
-        </div>
+        <button id="inputModeToggle" class="input-mode-toggle" type="button" aria-pressed="false" title="Switch to Composer input">
+          <span id="inputModeIcon" class="input-mode-icon" aria-hidden="true"></span>
+          <span id="inputModeLabel" class="seg-label">Direct</span>
+        </button>
         <button id="desktopModeHeader" class="desktop-mode-button" type="button" hidden>PC</button>
       </header>
       <main>
@@ -1296,11 +1262,8 @@
                 autocomplete="off"
                 autocapitalize="off"
                 spellcheck="false"
-                placeholder="Type here before sending to the terminal"
+                placeholder="Type, then Enter to send · Shift+Enter for a newline"
               ></textarea>
-              <div class="composer-actions" role="group" aria-label="Composer actions">
-                <button id="composerSend" class="primary" type="button">Send</button>
-              </div>
             </section>
           </div>
         </div>
@@ -1350,7 +1313,6 @@
         const terminalMetaEl = $("terminalMeta");
         const terminalComposer = $("terminalComposer");
         const composerInput = $("composerInput");
-        const composerSendButton = $("composerSend");
         const workspaceSection = $("workspaceSection");
         const workspaceListEl = $("workspaceList");
         const dockSection = $("dockSection");
@@ -1367,8 +1329,15 @@
         const clearNotificationsButton = $("clearNotifications");
         const focusTerminalButton = $("focusTerminal");
         const ctrlCButton = $("ctrlC");
-        const inputModeDirectButton = $("inputModeDirect");
-        const inputModeComposerButton = $("inputModeComposer");
+        const inputModeToggleButton = $("inputModeToggle");
+        const inputModeIcon = $("inputModeIcon");
+        const inputModeLabel = $("inputModeLabel");
+        const INPUT_MODE_ICONS = {
+          direct:
+            '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><rect x="2.5" y="6" width="19" height="12" rx="2"/><path d="M7 10h.01M11 10h.01M15 10h.01M8.5 14h7" stroke-linecap="round"/></svg>',
+          composer:
+            '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M4 20h4L18.5 9.5a2 2 0 0 0-2.83-2.83L5 17v3z" stroke-linejoin="round"/><path d="M13.5 8.5l2.5 2.5" stroke-linecap="round"/></svg>',
+        };
         const keyBar = $("keyBar");
         const keyBarToggleButton = $("keyBarToggle");
         const keyBarSettingsButton = $("keyBarSettings");
@@ -1603,9 +1572,11 @@
           const draft = composerDraft();
           const composerMode = currentInputMode() === "composer";
           const canEdit = Boolean(leaseId && activeTerminalId && composerMode);
+          // No Send button anymore; Enter submits. `data-can-send` exposes the same
+          // readiness the button's disabled state used to (for tests / a11y).
           const canCommit = Boolean(canEdit && composerReady && draft && !draft.inFlight);
           composerInput.disabled = !canEdit;
-          composerSendButton.disabled = !canCommit;
+          terminalComposer.dataset.canSend = canCommit ? "true" : "false";
         }
 
         function focusCurrentInputSurface() {
@@ -1622,8 +1593,12 @@
           const composerMode = mode === "composer";
           const draft = composerDraft();
           terminalComposer.hidden = !composerMode;
-          inputModeDirectButton.setAttribute("aria-pressed", composerMode ? "false" : "true");
-          inputModeComposerButton.setAttribute("aria-pressed", composerMode ? "true" : "false");
+          inputModeToggleButton.setAttribute("aria-pressed", composerMode ? "true" : "false");
+          inputModeToggleButton.title = composerMode
+            ? "Switch to Direct input"
+            : "Switch to Composer input";
+          inputModeIcon.innerHTML = INPUT_MODE_ICONS[composerMode ? "composer" : "direct"];
+          inputModeLabel.textContent = composerMode ? "Composer" : "Direct";
           focusTerminalButton.textContent = composerMode ? "Editor" : "Keyboard";
 
           const nextText = draft ? draft.text : "";
@@ -4049,8 +4024,9 @@
         desktopModeDrawerButton.addEventListener("click", () => requestDesktopMode().catch((err) => setStatus(err.message, true)));
         ctrlCButton.addEventListener("click", () => enqueueInput("\x03"));
         focusTerminalButton.addEventListener("click", () => focusCurrentInputSurface());
-        inputModeDirectButton.addEventListener("click", () => setInputMode("direct"));
-        inputModeComposerButton.addEventListener("click", () => setInputMode("composer"));
+        inputModeToggleButton.addEventListener("click", () => {
+          setInputMode(currentInputMode() === "composer" ? "direct" : "composer");
+        });
         composerInput.addEventListener("input", () => {
           const draft = composerDraft();
           if (!draft || draft.text === composerInput.value) return;
@@ -4067,12 +4043,12 @@
         composerInput.addEventListener("keydown", (event) => {
           if (event.key !== "Enter") return;
           if (event.isComposing || composerIsComposing || event.keyCode === 229) return;
-          if (matchMedia("(pointer: coarse)").matches) return;
+          // Enter sends on every pointer type (mirrors desktop). There is no Send
+          // button anymore; Shift+Enter inserts a newline.
           if (event.shiftKey) return;
           event.preventDefault();
           commitComposer();
         });
-        composerSendButton.addEventListener("click", () => commitComposer());
         keyBarToggleButton.addEventListener("click", () => setKeyBarVisible(keyBar.hidden));
         keyBarSettingsButton.addEventListener("click", (event) => {
           event.stopPropagation();

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -147,6 +147,50 @@
       .status.error {
         color: var(--danger);
       }
+      .input-mode-toggle {
+        display: inline-flex;
+        flex: 0 0 auto;
+        align-items: stretch;
+        padding: 0;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        overflow: hidden;
+      }
+      .input-mode-seg {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        border: 0;
+        border-radius: 0;
+        padding: 4px 8px;
+        background: transparent;
+        color: var(--muted);
+        font-size: var(--fs-sm);
+        line-height: 1;
+      }
+      .input-mode-seg + .input-mode-seg {
+        border-left: 1px solid var(--border);
+      }
+      .input-mode-seg:hover:not([aria-pressed="true"]) {
+        background: var(--hover-bg);
+      }
+      .input-mode-seg[aria-pressed="true"] {
+        background: var(--accent-20);
+        color: var(--accent);
+      }
+      .input-mode-seg svg {
+        flex: 0 0 auto;
+      }
+      /* Very narrow headers collapse the toggle to icons; the button title still
+         names each mode for assistive tech. */
+      @media (max-width: 360px) {
+        .input-mode-seg .seg-label {
+          display: none;
+        }
+        .input-mode-seg {
+          padding: 4px 7px;
+        }
+      }
       .terminal-shell {
         min-width: 0;
         min-height: 0;
@@ -1178,7 +1222,16 @@
           <span></span>
         </button>
         <div id="status" class="status">Enter the remote token, then connect.</div>
-        <button id="inputModeToggle" type="button" aria-pressed="false" title="Toggle Direct or Composer input">Direct</button>
+        <div id="inputModeToggle" class="input-mode-toggle" role="group" aria-label="Terminal input mode">
+          <button id="inputModeDirect" class="input-mode-seg" type="button" aria-pressed="true" title="Direct input — type straight into the terminal">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><rect x="2.5" y="6" width="19" height="12" rx="2"/><path d="M7 10h.01M11 10h.01M15 10h.01M8.5 14h7" stroke-linecap="round"/></svg>
+            <span class="seg-label">Direct</span>
+          </button>
+          <button id="inputModeComposer" class="input-mode-seg" type="button" aria-pressed="false" title="Composer — draft text, then send to the terminal">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M4 20h4L18.5 9.5a2 2 0 0 0-2.83-2.83L5 17v3z" stroke-linejoin="round"/><path d="M13.5 8.5l2.5 2.5" stroke-linecap="round"/></svg>
+            <span class="seg-label">Composer</span>
+          </button>
+        </div>
         <button id="desktopModeHeader" class="desktop-mode-button" type="button" hidden>PC</button>
       </header>
       <main>
@@ -1314,7 +1367,8 @@
         const clearNotificationsButton = $("clearNotifications");
         const focusTerminalButton = $("focusTerminal");
         const ctrlCButton = $("ctrlC");
-        const inputModeToggleButton = $("inputModeToggle");
+        const inputModeDirectButton = $("inputModeDirect");
+        const inputModeComposerButton = $("inputModeComposer");
         const keyBar = $("keyBar");
         const keyBarToggleButton = $("keyBarToggle");
         const keyBarSettingsButton = $("keyBarSettings");
@@ -1568,11 +1622,8 @@
           const composerMode = mode === "composer";
           const draft = composerDraft();
           terminalComposer.hidden = !composerMode;
-          inputModeToggleButton.textContent = composerMode ? "Composer" : "Direct";
-          inputModeToggleButton.setAttribute("aria-pressed", composerMode ? "true" : "false");
-          inputModeToggleButton.title = composerMode
-            ? "Switch to Direct terminal input"
-            : "Switch to detached Composer input";
+          inputModeDirectButton.setAttribute("aria-pressed", composerMode ? "false" : "true");
+          inputModeComposerButton.setAttribute("aria-pressed", composerMode ? "true" : "false");
           focusTerminalButton.textContent = composerMode ? "Editor" : "Keyboard";
 
           const nextText = draft ? draft.text : "";
@@ -3998,10 +4049,8 @@
         desktopModeDrawerButton.addEventListener("click", () => requestDesktopMode().catch((err) => setStatus(err.message, true)));
         ctrlCButton.addEventListener("click", () => enqueueInput("\x03"));
         focusTerminalButton.addEventListener("click", () => focusCurrentInputSurface());
-        inputModeToggleButton.addEventListener("click", () => {
-          const nextMode = currentInputMode() === "direct" ? "composer" : "direct";
-          setInputMode(nextMode);
-        });
+        inputModeDirectButton.addEventListener("click", () => setInputMode("direct"));
+        inputModeComposerButton.addEventListener("click", () => setInputMode("composer"));
         composerInput.addEventListener("input", () => {
           const draft = composerDraft();
           if (!draft || draft.text === composerInput.value) return;

--- a/ui/e2e/remote-input-composer.spec.ts
+++ b/ui/e2e/remote-input-composer.spec.ts
@@ -472,13 +472,12 @@ test("fine-pointer PC and coarse-pointer mobile can both toggle and persist the 
   await installRemotePage(page, { coarse: false, width: 1280 });
 
   const composer = page.locator("#terminalComposer");
-  const directSeg = page.locator("#inputModeDirect");
-  const composerSeg = page.locator("#inputModeComposer");
+  const toggle = page.locator("#inputModeToggle");
   await expect(composer).toBeHidden();
-  await expect(directSeg).toHaveAttribute("aria-pressed", "true");
-  await composerSeg.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+  await toggle.click();
   await expect(composer).toBeVisible();
-  await expect(composerSeg).toHaveAttribute("aria-pressed", "true");
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem("laymux.remote.inputMode")))
     .toBe("composer");
@@ -493,7 +492,7 @@ test("fine-pointer PC and coarse-pointer mobile can both toggle and persist the 
   // Re-running the static entry simulates a reload: preference survives, drafts do not.
   await page.setContent(await remotePageMarkup());
   await expect(page.locator("#terminalComposer")).toBeVisible();
-  await expect(page.locator("#inputModeComposer")).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator("#inputModeToggle")).toHaveAttribute("aria-pressed", "true");
 });
 
 test("a busy Local input is claimed by retrying the one-shot reservation token", async ({
@@ -521,9 +520,9 @@ test("a busy Local input is claimed by retrying the one-shot reservation token",
 test("coarse pointer defaults to Composer and a saved Direct preference wins", async ({ page }) => {
   await installRemotePage(page, { coarse: true, storedMode: "direct" });
   await expect(page.locator("#terminalComposer")).toBeHidden();
-  await expect(page.locator("#inputModeDirect")).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator("#inputModeToggle")).toHaveAttribute("aria-pressed", "false");
 
-  await page.locator("#inputModeComposer").click();
+  await page.locator("#inputModeToggle").click();
   await expect(page.locator("#terminalComposer")).toBeVisible();
   expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(390);
 });
@@ -542,7 +541,7 @@ test("terminal switches preserve isolated mode and draft state without persisten
   await expect(page.locator("#terminalMeta")).toContainText("Shell 2");
   await expect(editor).toHaveValue("");
   await editor.fill("draft two");
-  await page.locator("#inputModeDirect").click();
+  await page.locator("#inputModeToggle").click();
   await expect(page.locator("#terminalComposer")).toBeHidden();
 
   await selectTerminal(page, "C:\\one");
@@ -551,7 +550,7 @@ test("terminal switches preserve isolated mode and draft state without persisten
 
   await selectTerminal(page, "C:\\two");
   await expect(page.locator("#terminalComposer")).toBeHidden();
-  await page.locator("#inputModeComposer").click();
+  await page.locator("#inputModeToggle").click();
   await expect(editor).toHaveValue("draft two");
   expect(
     await page.evaluate(() => Object.keys(localStorage).filter((key) => key.includes("Draft"))),
@@ -567,7 +566,7 @@ test("a terminal switch isolates the old socket and readiness before delayed hos
     delayTerminal2Snapshot: true,
   });
   await connect(page);
-  await expect(page.locator("#composerSend")).toBeEnabled();
+  await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "true");
 
   await selectTerminal(page, "C:\\two");
   await expect(page.locator("#terminalMeta")).toContainText("Shell 2");
@@ -586,10 +585,10 @@ test("a terminal switch isolates the old socket and readiness before delayed hos
   expect(sockets[0].url).toContain("/terminals/terminal-1/output");
   expect(sockets[1]).toMatchObject({ closed: false });
   expect(sockets[1].url).toContain("/terminals/terminal-2/output");
-  await expect(page.locator("#composerSend")).toBeDisabled();
+  await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "false");
 
   await remote.focuses[0].respond();
-  await expect(page.locator("#composerSend")).toBeDisabled();
+  await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "false");
   await page.evaluate(() => {
     const sockets = (
       window as Window & {
@@ -598,7 +597,7 @@ test("a terminal switch isolates the old socket and readiness before delayed hos
     ).__mockSockets;
     sockets[1].emitSnapshot();
   });
-  await expect(page.locator("#composerSend")).toBeEnabled();
+  await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "true");
 });
 
 test("fine-pointer Composer sends on Enter and keeps Shift+Enter as a newline", async ({
@@ -606,11 +605,11 @@ test("fine-pointer Composer sends on Enter and keeps Shift+Enter as a newline", 
 }) => {
   const remote = await installRemotePage(page, { coarse: false, width: 1280 });
   await connect(page);
-  await page.locator("#inputModeComposer").click();
+  await page.locator("#inputModeToggle").click();
 
   const editor = page.locator("#composerInput");
-  await expect(page.locator("#composerSend")).toBeEnabled();
-  await expect(page.locator("#composerInsert")).toHaveCount(0);
+  await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "true");
+  await expect(page.locator("#composerSend")).toHaveCount(0);
 
   await editor.fill("line");
   await editor.press("Shift+Enter");
@@ -628,15 +627,15 @@ test("fine-pointer Composer sends on Enter and keeps Shift+Enter as a newline", 
   await expect(editor).toHaveValue("");
 });
 
-test("coarse-pointer Composer keeps Enter as a newline and sends only from its button", async ({
-  page,
-}) => {
+test("coarse-pointer Composer also sends on Enter (no Send button)", async ({ page }) => {
   const remote = await installRemotePage(page, { coarse: true });
   await connect(page);
 
   const editor = page.locator("#composerInput");
-  await expect(page.locator("#composerSend")).toBeEnabled();
-  await expect(page.locator("#composerInsert")).toHaveCount(0);
+  await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "true");
+  await expect(page.locator("#composerSend")).toHaveCount(0);
+
+  // Enter during IME composition never sends.
   await editor.fill("한글 조합");
   await editor.dispatchEvent("compositionstart");
   await editor.dispatchEvent("keydown", { key: "Enter", code: "Enter", isComposing: true });
@@ -644,13 +643,14 @@ test("coarse-pointer Composer keeps Enter as a newline and sends only from its b
   expect(remote.inputs).toHaveLength(0);
   await editor.dispatchEvent("compositionend");
 
+  // Shift+Enter inserts a newline; plain Enter sends (mirrors desktop).
   await editor.fill("line");
-  await editor.press("Enter");
+  await editor.press("Shift+Enter");
   await expect(editor).toHaveValue("line\n");
   expect(remote.inputs).toHaveLength(0);
 
   await editor.fill("send me");
-  await page.locator("#composerSend").click();
+  await editor.press("Enter");
   await expect.poll(() => remote.inputs.length).toBe(1);
   expect(remote.inputs[0].body).toEqual({
     leaseId: "lease-1",
@@ -695,8 +695,8 @@ test("legacy unsequenced output remains visible but Composer and direct paste fa
   await connect(page);
 
   await page.locator("#composerInput").fill("preserved draft");
-  await expect(page.locator("#composerSend")).toBeDisabled();
-  await page.locator("#inputModeDirect").click();
+  await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "false");
+  await page.locator("#inputModeToggle").click();
   await dispatchTerminalPaste(page, "must not send");
   expect(remote.inputs).toHaveLength(0);
   await expect(page.locator("#status")).toHaveText("Terminal input is not ready. Reconnecting...");
@@ -721,7 +721,7 @@ test("a malformed output frame stays fail-closed after a delayed snapshot write 
       ),
     )
     .toBe(1);
-  await expect(page.locator("#composerSend")).toBeDisabled();
+  await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "false");
 
   await page.evaluate(() => {
     const socket = (
@@ -738,7 +738,7 @@ test("a malformed output frame stays fail-closed after a delayed snapshot write 
   });
   await page.waitForTimeout(20);
 
-  await expect(page.locator("#composerSend")).toBeDisabled();
+  await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "false");
   expect(
     await page.evaluate(() =>
       (
@@ -755,36 +755,35 @@ test("an in-flight snapshot is sent once and only clears the unchanged revision"
   await connect(page);
 
   const editor = page.locator("#composerInput");
-  const send = page.locator("#composerSend");
+  const composer = page.locator("#terminalComposer");
   await editor.fill("before send");
-  await send.evaluate((button: HTMLButtonElement) => {
-    button.click();
-    button.click();
-  });
+  // Two quick Enters must not double-submit (the in-flight gate blocks the second).
+  await editor.press("Enter");
+  await editor.press("Enter");
   await expect.poll(() => remote.inputs.length).toBe(1);
-  await expect(send).toBeDisabled();
-  await expect(page.locator("#composerInsert")).toHaveCount(0);
+  await expect(composer).toHaveAttribute("data-can-send", "false");
+  await expect(page.locator("#composerSend")).toHaveCount(0);
   await expect(editor).toBeEnabled();
 
   await editor.fill("edited while pending");
   await remote.inputs[0].respond();
-  await expect(send).toBeEnabled();
+  await expect(composer).toHaveAttribute("data-can-send", "true");
   await expect(editor).toHaveValue("edited while pending");
 
-  await send.click();
+  await editor.press("Enter");
   await expect.poll(() => remote.inputs.length).toBe(2);
   await remote.inputs[1].respond();
   await expect(editor).toHaveValue("");
 
   await editor.fill("preserve on failure");
-  await send.click();
+  await editor.press("Enter");
   await expect.poll(() => remote.inputs.length).toBe(3);
   await remote.inputs[2].respond(500);
   await expect(editor).toHaveValue("preserve on failure");
-  await expect(send).toBeEnabled();
+  await expect(composer).toHaveAttribute("data-can-send", "true");
 
   await editor.fill("terminal one pending");
-  await send.click();
+  await editor.press("Enter");
   await expect.poll(() => remote.inputs.length).toBe(4);
   await selectTerminal(page, "C:\\two");
   await editor.fill("terminal two draft");
@@ -801,11 +800,11 @@ test("disconnect releases an in-flight Composer action while preserving its draf
   await connect(page);
 
   const editor = page.locator("#composerInput");
-  const send = page.locator("#composerSend");
+  const composer = page.locator("#terminalComposer");
   await editor.fill("preserve across disconnect");
-  await send.click();
+  await editor.press("Enter");
   await expect.poll(() => remote.inputs.length).toBe(1);
-  await expect(send).toBeDisabled();
+  await expect(composer).toHaveAttribute("data-can-send", "false");
 
   // The mobile connected layout collapses this control outside the viewport;
   // invoke the same button action without coupling this state test to drawer UX.
@@ -816,7 +815,7 @@ test("disconnect releases an in-flight Composer action while preserving its draf
 
   await expect(editor).toHaveValue("preserve across disconnect");
   await expect(editor).toBeEnabled();
-  await expect(send).toBeEnabled();
+  await expect(composer).toHaveAttribute("data-can-send", "true");
 
   // Settle the mocked, already-aborted route so the test leaves no pending
   // Playwright handler behind. The stale response must not clear the draft.
@@ -844,7 +843,7 @@ test("Composer keeps xterm unfocused and hides its inactive application cursor",
     "xterm-helper-textarea",
   );
 
-  await page.locator("#inputModeDirect").click();
+  await page.locator("#inputModeToggle").click();
   expect(
     await page.evaluate(
       () =>

--- a/ui/e2e/remote-input-composer.spec.ts
+++ b/ui/e2e/remote-input-composer.spec.ts
@@ -472,12 +472,13 @@ test("fine-pointer PC and coarse-pointer mobile can both toggle and persist the 
   await installRemotePage(page, { coarse: false, width: 1280 });
 
   const composer = page.locator("#terminalComposer");
-  const toggle = page.locator("#inputModeToggle");
+  const directSeg = page.locator("#inputModeDirect");
+  const composerSeg = page.locator("#inputModeComposer");
   await expect(composer).toBeHidden();
-  await expect(toggle).toHaveText("Direct");
-  await toggle.click();
+  await expect(directSeg).toHaveAttribute("aria-pressed", "true");
+  await composerSeg.click();
   await expect(composer).toBeVisible();
-  await expect(toggle).toHaveText("Composer");
+  await expect(composerSeg).toHaveAttribute("aria-pressed", "true");
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem("laymux.remote.inputMode")))
     .toBe("composer");
@@ -492,7 +493,7 @@ test("fine-pointer PC and coarse-pointer mobile can both toggle and persist the 
   // Re-running the static entry simulates a reload: preference survives, drafts do not.
   await page.setContent(await remotePageMarkup());
   await expect(page.locator("#terminalComposer")).toBeVisible();
-  await expect(page.locator("#inputModeToggle")).toHaveText("Composer");
+  await expect(page.locator("#inputModeComposer")).toHaveAttribute("aria-pressed", "true");
 });
 
 test("a busy Local input is claimed by retrying the one-shot reservation token", async ({
@@ -520,9 +521,9 @@ test("a busy Local input is claimed by retrying the one-shot reservation token",
 test("coarse pointer defaults to Composer and a saved Direct preference wins", async ({ page }) => {
   await installRemotePage(page, { coarse: true, storedMode: "direct" });
   await expect(page.locator("#terminalComposer")).toBeHidden();
-  await expect(page.locator("#inputModeToggle")).toHaveText("Direct");
+  await expect(page.locator("#inputModeDirect")).toHaveAttribute("aria-pressed", "true");
 
-  await page.locator("#inputModeToggle").click();
+  await page.locator("#inputModeComposer").click();
   await expect(page.locator("#terminalComposer")).toBeVisible();
   expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(390);
 });
@@ -541,7 +542,7 @@ test("terminal switches preserve isolated mode and draft state without persisten
   await expect(page.locator("#terminalMeta")).toContainText("Shell 2");
   await expect(editor).toHaveValue("");
   await editor.fill("draft two");
-  await page.locator("#inputModeToggle").click();
+  await page.locator("#inputModeDirect").click();
   await expect(page.locator("#terminalComposer")).toBeHidden();
 
   await selectTerminal(page, "C:\\one");
@@ -550,7 +551,7 @@ test("terminal switches preserve isolated mode and draft state without persisten
 
   await selectTerminal(page, "C:\\two");
   await expect(page.locator("#terminalComposer")).toBeHidden();
-  await page.locator("#inputModeToggle").click();
+  await page.locator("#inputModeComposer").click();
   await expect(editor).toHaveValue("draft two");
   expect(
     await page.evaluate(() => Object.keys(localStorage).filter((key) => key.includes("Draft"))),
@@ -605,7 +606,7 @@ test("fine-pointer Composer sends on Enter and keeps Shift+Enter as a newline", 
 }) => {
   const remote = await installRemotePage(page, { coarse: false, width: 1280 });
   await connect(page);
-  await page.locator("#inputModeToggle").click();
+  await page.locator("#inputModeComposer").click();
 
   const editor = page.locator("#composerInput");
   await expect(page.locator("#composerSend")).toBeEnabled();
@@ -695,7 +696,7 @@ test("legacy unsequenced output remains visible but Composer and direct paste fa
 
   await page.locator("#composerInput").fill("preserved draft");
   await expect(page.locator("#composerSend")).toBeDisabled();
-  await page.locator("#inputModeToggle").click();
+  await page.locator("#inputModeDirect").click();
   await dispatchTerminalPaste(page, "must not send");
   expect(remote.inputs).toHaveLength(0);
   await expect(page.locator("#status")).toHaveText("Terminal input is not ready. Reconnecting...");
@@ -843,7 +844,7 @@ test("Composer keeps xterm unfocused and hides its inactive application cursor",
     "xterm-helper-textarea",
   );
 
-  await page.locator("#inputModeToggle").click();
+  await page.locator("#inputModeDirect").click();
   expect(
     await page.evaluate(
       () =>

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -4,7 +4,7 @@ import { useSettingsStore, type ControlBarMode } from "@/stores/settings-store";
 import { useResolvedKeybinding } from "@/lib/keybinding-registry";
 import { useOverridesStore } from "@/stores/overrides-store";
 import type { ViewInstanceConfig, ViewType } from "@/stores/types";
-import { PaneControlContext } from "./PaneControlContext";
+import { PaneControlContext, type PaneInputModeToggle } from "./PaneControlContext";
 import { useContainerSize } from "@/hooks/useContainerSize";
 import { PaneNumberBadge } from "@/components/ui/PaneNumberBadge";
 
@@ -121,6 +121,60 @@ function Sep() {
   return <div className="ui-sep" />;
 }
 
+// ─── Terminal input-mode toggle (direct ↔ composer) ─────
+// 단일 버튼으로 현재 모드 아이콘을 보여주고 클릭 시 반대 모드로 전환한다.
+// composer 활성 시 accent 로 강조. 단축키(terminal.toggleInputMode)는 별도.
+function InputModeToggleBtn({ toggle }: { toggle: PaneInputModeToggle }) {
+  const composer = toggle.mode === "composer";
+  return (
+    <BarBtn
+      testId="pane-control-input-mode"
+      onClick={toggle.onToggle}
+      active={composer}
+      title={
+        composer
+          ? "Composer input — switch to Direct (Ctrl+Alt+M)"
+          : "Direct input — switch to Composer (Ctrl+Alt+M)"
+      }
+    >
+      {composer ? (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+          <path
+            d="M4 20h4L18.5 9.5a2 2 0 0 0-2.83-2.83L5 17v3z"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M13.5 8.5l2.5 2.5"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          />
+        </svg>
+      ) : (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+          <rect
+            x="2.5"
+            y="6"
+            width="19"
+            height="12"
+            rx="2"
+            stroke="currentColor"
+            strokeWidth="1.8"
+          />
+          <path
+            d="M7 10h.01M11 10h.01M15 10h.01M8.5 14h7"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          />
+        </svg>
+      )}
+    </BarBtn>
+  );
+}
+
 // ─── Propagate CWD once (issue #293 → #324) ─────────────
 // 우측 컨트롤 묶음이 아니라 좌측(pane 번호 배지 우측)에 정렬된다.
 // 단축키(pane.propagateCwdOnce, 기본 Ctrl+Alt+P)는 useKeyboardShortcuts 가 처리한다.
@@ -226,6 +280,7 @@ function BarContent({
   onSetMode,
   cwdSendOn,
   cwdReceiveOn,
+  inputModeToggle,
   expanded = true,
   wrapped = false,
   vertical = false,
@@ -238,6 +293,7 @@ function BarContent({
   onSetMode: (m: ControlBarMode) => void;
   cwdSendOn?: boolean;
   cwdReceiveOn?: boolean;
+  inputModeToggle?: PaneInputModeToggle | null;
   expanded?: boolean;
   wrapped?: boolean;
   vertical?: boolean;
@@ -257,6 +313,12 @@ function BarContent({
     >
       {expanded && (
         <>
+          {inputModeToggle && (
+            <>
+              <InputModeToggleBtn toggle={inputModeToggle} />
+              <Separator />
+            </>
+          )}
           {actions.onChangeView && (
             <ViewSelect
               currentView={currentView}
@@ -493,6 +555,7 @@ function NarrowControlMenu({
   onSetMode,
   cwdSendOn,
   cwdReceiveOn,
+  inputModeToggle,
   position,
   onRequestClose,
   triggerRef,
@@ -503,6 +566,7 @@ function NarrowControlMenu({
   onSetMode: (m: ControlBarMode) => void;
   cwdSendOn?: boolean;
   cwdReceiveOn?: boolean;
+  inputModeToggle?: PaneInputModeToggle | null;
   position: { top: number; right: number };
   onRequestClose: () => void;
   /** ⋯ 트리거 버튼. 트리거 클릭은 외부 클릭으로 보지 않는다(아래 toggle 이 닫기를 처리). */
@@ -554,6 +618,7 @@ function NarrowControlMenu({
         onSetMode={onSetMode}
         cwdSendOn={cwdSendOn}
         cwdReceiveOn={cwdReceiveOn}
+        inputModeToggle={inputModeToggle}
         vertical
         showMinimize={false}
       />
@@ -722,6 +787,7 @@ export function PaneControlBar({
   );
   const [hasViewHeader, setHasViewHeader] = useState(false);
   const [leftBarContent, setLeftBarContentState] = useState<ReactNode>(null);
+  const [inputModeToggle, setInputModeToggleState] = useState<PaneInputModeToggle | null>(null);
   const [narrowMenuOpen, setNarrowMenuOpen] = useState(false);
   const showBar = mode === "pinned" || (mode === "hover" && hovered);
   const isPinned = mode === "pinned";
@@ -826,6 +892,7 @@ export function PaneControlBar({
           onSetMode={setMode}
           cwdSendOn={cwdSendOn}
           cwdReceiveOn={cwdReceiveOn}
+          inputModeToggle={inputModeToggle}
         />
       ),
     [
@@ -838,6 +905,7 @@ export function PaneControlBar({
       toggleNarrowMenu,
       cwdSendOn,
       cwdReceiveOn,
+      inputModeToggle,
     ],
   );
 
@@ -845,6 +913,9 @@ export function PaneControlBar({
   const unregisterHeader = useCallback(() => setHasViewHeader(false), []);
   const setLeftBarContent = useCallback((node: ReactNode) => {
     setLeftBarContentState(node ?? null);
+  }, []);
+  const setInputModeToggle = useCallback((toggle: PaneInputModeToggle | null) => {
+    setInputModeToggleState(toggle);
   }, []);
 
   const ctxValue = useMemo(
@@ -863,6 +934,8 @@ export function PaneControlBar({
       unregisterHeader,
       leftBarContent,
       setLeftBarContent,
+      inputModeToggle,
+      setInputModeToggle,
       paneNumber,
       workspaceId,
       workspaceName,
@@ -880,6 +953,8 @@ export function PaneControlBar({
       unregisterHeader,
       leftBarContent,
       setLeftBarContent,
+      inputModeToggle,
+      setInputModeToggle,
       paneNumber,
       workspaceId,
       workspaceName,
@@ -932,6 +1007,7 @@ export function PaneControlBar({
                 onSetMode={setMode}
                 cwdSendOn={cwdSendOn}
                 cwdReceiveOn={cwdReceiveOn}
+                inputModeToggle={inputModeToggle}
               />
             )}
           </div>
@@ -985,6 +1061,7 @@ export function PaneControlBar({
                   onSetMode={setMode}
                   cwdSendOn={cwdSendOn}
                   cwdReceiveOn={cwdReceiveOn}
+                  inputModeToggle={inputModeToggle}
                 />
               )}
             </div>
@@ -1016,6 +1093,7 @@ export function PaneControlBar({
             onSetMode={setMode}
             cwdSendOn={cwdSendOn}
             cwdReceiveOn={cwdReceiveOn}
+            inputModeToggle={inputModeToggle}
             position={menuPosition}
             onRequestClose={closeNarrowMenu}
             triggerRef={menuBtnRef}

--- a/ui/src/components/layout/PaneControlContext.tsx
+++ b/ui/src/components/layout/PaneControlContext.tsx
@@ -1,6 +1,16 @@
 import { createContext, useContext, type ReactNode } from "react";
 import type { ControlBarMode } from "./PaneControlBar";
 
+/**
+ * 터미널 입력 방식(direct/composer) 툴바 토글 상태. TerminalView 가 자신의 런타임
+ * 모드와 토글 핸들러를 주입하면 PaneControlBar 가 단일 버튼으로 렌더한다(좁은 pane 은
+ * ⋯ 메뉴로 자동 미러). 하단 컴포저 바에는 더 이상 모드 토글을 두지 않는다.
+ */
+export interface PaneInputModeToggle {
+  mode: "direct" | "composer";
+  onToggle: () => void;
+}
+
 export interface PaneControlContextValue {
   /** BarContent 렌더 결과 (split, delete, view selector 등) */
   paneControls: ReactNode;
@@ -33,6 +43,12 @@ export interface PaneControlContextValue {
   leftBarContent: ReactNode;
   /** 좌측 슬롯 콘텐츠 설정/해제. `null` 이면 기본 스페이서로 복귀. */
   setLeftBarContent: (node: ReactNode) => void;
+  /**
+   * 터미널 입력 방식 툴바 토글. TerminalView 가 주입하며 없으면 버튼을 렌더하지 않는다.
+   */
+  inputModeToggle: PaneInputModeToggle | null;
+  /** 입력 방식 토글 설정/해제. `null` 이면 버튼 제거. */
+  setInputModeToggle: (toggle: PaneInputModeToggle | null) => void;
   /**
    * 화면 읽기 순서 기반 pane 번호(issue #256). 컨트롤바 좌측에 배지로 표시한다.
    * 배열 인덱스(`paneIndex`)가 아니라 공간 위치 번호(`paneNumber`)이며, dock 등

--- a/ui/src/components/ui/TerminalInputComposer.test.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.test.tsx
@@ -220,6 +220,26 @@ describe("TerminalInputComposer", () => {
     expect(localStorage.getItem("laymux.desktop.composerHeight")).toBe(String(before + 50));
   });
 
+  it("keeps Shift+Enter as the newline gesture even on an empty draft", () => {
+    const onKeyPassthrough = vi.fn().mockReturnValue(true);
+    const onSend = vi.fn();
+    renderComposer({ text: "", onKeyPassthrough, onSend });
+    const textarea = screen.getByRole("textbox", { name: "Terminal input" });
+
+    const shiftEnter = new KeyboardEvent("keydown", {
+      key: "Enter",
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    textarea.dispatchEvent(shiftEnter);
+
+    // Starting a multiline draft must win over forwarding \r to the terminal.
+    expect(onKeyPassthrough).not.toHaveBeenCalled();
+    expect(onSend).not.toHaveBeenCalled();
+    expect(shiftEnter.defaultPrevented).toBe(false);
+  });
+
   it("at the prompt, edge ↑/↓ recall history; while a program runs they pass through", () => {
     const onHistory = vi.fn().mockReturnValue(true);
     const onKeyPassthrough = vi.fn().mockReturnValue(true);

--- a/ui/src/components/ui/TerminalInputComposer.test.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.test.tsx
@@ -6,9 +6,6 @@ import { TerminalInputComposer, type TerminalInputComposerLabels } from "./Termi
 import type { InputMode } from "@/lib/terminal-input-composer-state";
 
 const labels: TerminalInputComposerLabels = {
-  inputMode: "Input mode",
-  direct: "Direct",
-  composer: "Composer",
   editor: "Terminal input",
   placeholder: "Type before sending",
   send: "Send",
@@ -21,7 +18,6 @@ function renderComposer(
     mode: "composer",
     text: "draft",
     labels,
-    onModeChange: vi.fn(),
     onTextChange: vi.fn(),
     onSend: vi.fn(),
     testId: "composer",
@@ -32,24 +28,17 @@ function renderComposer(
 }
 
 describe("TerminalInputComposer", () => {
-  it("renders an accessible two-mode toggle and reports changes", async () => {
-    const user = userEvent.setup();
-    const onModeChange = vi.fn();
-    renderComposer({ mode: "direct", onModeChange });
+  it("renders nothing but an inert host in Direct mode", () => {
+    renderComposer({ mode: "direct" });
 
-    expect(screen.getByRole("group", { name: "Input mode" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Direct" })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: "Composer" })).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
+    const host = screen.getByTestId("composer");
+    expect(host).toHaveAttribute("data-mode", "direct");
+    expect(host).toHaveAttribute("hidden");
     expect(screen.queryByRole("textbox", { name: "Terminal input" })).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Composer" }));
-    expect(onModeChange).toHaveBeenCalledWith("composer");
+    expect(screen.queryByRole("button", { name: "Send" })).not.toBeInTheDocument();
   });
 
-  it("renders the controlled draft and exposes one Send action", async () => {
+  it("renders the controlled draft and exposes one Send action in Composer mode", async () => {
     const user = userEvent.setup();
     const onTextChange = vi.fn();
     const onSend = vi.fn();
@@ -124,17 +113,26 @@ describe("TerminalInputComposer", () => {
   it("recovers plain Enter after leaving Composer during IME composition", () => {
     const onSend = vi.fn();
 
+    // The mode toggle now lives outside the composer (pane control bar); the test
+    // drives it through a parent-controlled button just like the real toolbar.
     function Harness() {
       const [mode, setMode] = useState<InputMode>("composer");
       return (
-        <TerminalInputComposer
-          mode={mode}
-          text="draft"
-          labels={labels}
-          onModeChange={setMode}
-          onTextChange={vi.fn()}
-          onSend={onSend}
-        />
+        <>
+          <button
+            type="button"
+            onClick={() => setMode((m) => (m === "composer" ? "direct" : "composer"))}
+          >
+            toggle-mode
+          </button>
+          <TerminalInputComposer
+            mode={mode}
+            text="draft"
+            labels={labels}
+            onTextChange={vi.fn()}
+            onSend={onSend}
+          />
+        </>
       );
     }
 
@@ -144,9 +142,9 @@ describe("TerminalInputComposer", () => {
 
     // Removing a focused textarea does not guarantee compositionend/blur in
     // every WebView. Returning to Composer must not inherit that stale gate.
-    fireEvent.click(screen.getByRole("button", { name: "Direct" }));
+    fireEvent.click(screen.getByRole("button", { name: "toggle-mode" }));
     expect(screen.queryByRole("textbox", { name: "Terminal input" })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Composer" }));
+    fireEvent.click(screen.getByRole("button", { name: "toggle-mode" }));
 
     const restoredEditor = screen.getByRole("textbox", { name: "Terminal input" });
     const enter = new KeyboardEvent("keydown", {
@@ -177,49 +175,53 @@ describe("TerminalInputComposer", () => {
     expect(onSend).not.toHaveBeenCalled();
   });
 
-  it("disables every interactive control when externally disabled", () => {
+  it("disables the editor and Send when externally disabled", () => {
     renderComposer({ disabled: true });
 
-    expect(screen.getByRole("button", { name: "Direct" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Composer" })).toBeDisabled();
     expect(screen.getByRole("textbox", { name: "Terminal input" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
   });
 
-  it("keeps mode and draft editing available while commit readiness is disabled", () => {
+  it("keeps draft editing available while commit readiness is disabled", () => {
     renderComposer({ commitDisabled: true });
 
-    expect(screen.getByRole("button", { name: "Direct" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Composer" })).toBeEnabled();
     expect(screen.getByRole("textbox", { name: "Terminal input" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
   });
 
-  it("supports controlled mode and draft state without coupling them", async () => {
+  it("preserves the draft across mode switches without coupling them", async () => {
     const user = userEvent.setup();
 
     function Harness() {
       const [mode, setMode] = useState<InputMode>("direct");
       const [text, setText] = useState("kept");
       return (
-        <TerminalInputComposer
-          mode={mode}
-          text={text}
-          labels={labels}
-          onModeChange={setMode}
-          onTextChange={setText}
-          onSend={vi.fn()}
-          testId="composer"
-        />
+        <>
+          <button
+            type="button"
+            onClick={() => setMode((m) => (m === "composer" ? "direct" : "composer"))}
+          >
+            toggle-mode
+          </button>
+          <TerminalInputComposer
+            mode={mode}
+            text={text}
+            labels={labels}
+            onTextChange={setText}
+            onSend={vi.fn()}
+            testId="composer"
+          />
+        </>
       );
     }
 
     render(<Harness />);
-    await user.click(screen.getByRole("button", { name: "Composer" }));
-    expect(screen.getByRole("textbox", { name: "Terminal input" })).toHaveValue("kept");
-    await user.click(screen.getByRole("button", { name: "Direct" }));
     expect(screen.queryByRole("textbox", { name: "Terminal input" })).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Composer" }));
+    await user.click(screen.getByRole("button", { name: "toggle-mode" }));
+    expect(screen.getByRole("textbox", { name: "Terminal input" })).toHaveValue("kept");
+    await user.click(screen.getByRole("button", { name: "toggle-mode" }));
+    expect(screen.queryByRole("textbox", { name: "Terminal input" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "toggle-mode" }));
     expect(screen.getByRole("textbox", { name: "Terminal input" })).toHaveValue("kept");
   });
 });

--- a/ui/src/components/ui/TerminalInputComposer.test.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.test.tsx
@@ -8,7 +8,7 @@ import type { InputMode } from "@/lib/terminal-input-composer-state";
 const labels: TerminalInputComposerLabels = {
   editor: "Terminal input",
   placeholder: "Type before sending",
-  send: "Send",
+  resize: "Resize input area",
 };
 
 function renderComposer(
@@ -35,10 +35,9 @@ describe("TerminalInputComposer", () => {
     expect(host).toHaveAttribute("data-mode", "direct");
     expect(host).toHaveAttribute("hidden");
     expect(screen.queryByRole("textbox", { name: "Terminal input" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Send" })).not.toBeInTheDocument();
   });
 
-  it("renders the controlled draft and exposes one Send action in Composer mode", async () => {
+  it("renders the controlled draft and submits on plain Enter (no Send button)", async () => {
     const user = userEvent.setup();
     const onTextChange = vi.fn();
     const onSend = vi.fn();
@@ -47,11 +46,13 @@ describe("TerminalInputComposer", () => {
     const textarea = screen.getByRole("textbox", { name: "Terminal input" });
     expect(textarea).toHaveValue("draft");
     expect(textarea).toHaveAttribute("placeholder", "Type before sending");
+    // The editor is the whole surface — no separate action button steals space.
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getByTestId("composer")).toHaveAttribute("data-can-send", "true");
 
     await user.type(textarea, "!");
     expect(onTextChange).toHaveBeenCalled();
-    expect(screen.queryByRole("button", { name: "Insert" })).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Send" }));
+    fireEvent.keyDown(textarea, { key: "Enter" });
     expect(onSend).toHaveBeenCalledTimes(1);
   });
 
@@ -158,7 +159,7 @@ describe("TerminalInputComposer", () => {
     expect(onSend).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps textarea editing enabled but disables Send while in flight", async () => {
+  it("keeps editing enabled but refuses Enter submit while in flight", async () => {
     const user = userEvent.setup();
     const onTextChange = vi.fn();
     const onSend = vi.fn();
@@ -166,8 +167,9 @@ describe("TerminalInputComposer", () => {
 
     const textarea = screen.getByRole("textbox", { name: "Terminal input" });
     expect(textarea).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
-    expect(screen.getByTestId("composer")).toHaveAttribute("aria-busy", "true");
+    const host = screen.getByTestId("composer");
+    expect(host).toHaveAttribute("aria-busy", "true");
+    expect(host).toHaveAttribute("data-can-send", "false");
 
     await user.type(textarea, " more");
     expect(onTextChange).toHaveBeenCalled();
@@ -175,18 +177,47 @@ describe("TerminalInputComposer", () => {
     expect(onSend).not.toHaveBeenCalled();
   });
 
-  it("disables the editor and Send when externally disabled", () => {
-    renderComposer({ disabled: true });
+  it("disables the editor and blocks Enter when externally disabled", () => {
+    const onSend = vi.fn();
+    renderComposer({ disabled: true, onSend });
 
-    expect(screen.getByRole("textbox", { name: "Terminal input" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+    const textarea = screen.getByRole("textbox", { name: "Terminal input" });
+    expect(textarea).toBeDisabled();
+    expect(screen.getByTestId("composer")).toHaveAttribute("data-can-send", "false");
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
   });
 
-  it("keeps draft editing available while commit readiness is disabled", () => {
-    renderComposer({ commitDisabled: true });
+  it("keeps draft editing available but blocks Enter while commit readiness is disabled", () => {
+    const onSend = vi.fn();
+    renderComposer({ commitDisabled: true, onSend });
 
-    expect(screen.getByRole("textbox", { name: "Terminal input" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+    const textarea = screen.getByRole("textbox", { name: "Terminal input" });
+    expect(textarea).toBeEnabled();
+    expect(screen.getByTestId("composer")).toHaveAttribute("data-can-send", "false");
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("resizes by dragging the top edge upward and has no textarea corner grip", () => {
+    localStorage.clear();
+    renderComposer();
+
+    const host = screen.getByTestId("composer");
+    const handle = screen.getByTestId("composer-resize");
+    expect(handle).toHaveAttribute("role", "separator");
+    // No resize-y on the editor — the corner grip is gone.
+    expect(screen.getByRole("textbox", { name: "Terminal input" }).className).not.toMatch(
+      /resize-y/,
+    );
+
+    const before = parseInt(host.style.height, 10);
+    fireEvent.pointerDown(handle, { clientY: 200, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientY: 150, pointerId: 1 }); // drag up 50px
+    expect(parseInt(host.style.height, 10)).toBe(before + 50);
+
+    fireEvent.pointerUp(handle, { clientY: 150, pointerId: 1 });
+    expect(localStorage.getItem("laymux.desktop.composerHeight")).toBe(String(before + 50));
   });
 
   it("preserves the draft across mode switches without coupling them", async () => {

--- a/ui/src/components/ui/TerminalInputComposer.test.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { TerminalInputComposer, type TerminalInputComposerLabels } from "./TerminalInputComposer";
@@ -218,6 +218,35 @@ describe("TerminalInputComposer", () => {
 
     fireEvent.pointerUp(handle, { clientY: 150, pointerId: 1 });
     expect(localStorage.getItem("laymux.desktop.composerHeight")).toBe(String(before + 50));
+  });
+
+  it("at the prompt, edge ↑/↓ recall history; while a program runs they pass through", () => {
+    const onHistory = vi.fn().mockReturnValue(true);
+    const onKeyPassthrough = vi.fn().mockReturnValue(true);
+
+    // Prompt + empty draft: caret is at both edges → ↑/↓ recall history, no passthrough.
+    const prompt = renderComposer({
+      text: "",
+      atShellPrompt: true,
+      onHistory,
+      onKeyPassthrough,
+    });
+    const textarea = screen.getByRole("textbox", { name: "Terminal input" });
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    fireEvent.keyDown(textarea, { key: "ArrowDown" });
+    expect(onHistory).toHaveBeenNthCalledWith(1, "prev");
+    expect(onHistory).toHaveBeenNthCalledWith(2, "next");
+    expect(prompt.onKeyPassthrough).not.toHaveBeenCalled();
+
+    cleanup();
+    onHistory.mockClear();
+    onKeyPassthrough.mockClear();
+
+    // Program running: ↑ is not history — it passes through to the program.
+    renderComposer({ text: "", atShellPrompt: false, onHistory, onKeyPassthrough });
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Terminal input" }), { key: "ArrowUp" });
+    expect(onHistory).not.toHaveBeenCalled();
+    expect(onKeyPassthrough).toHaveBeenCalled();
   });
 
   it("preserves the draft across mode switches without coupling them", async () => {

--- a/ui/src/components/ui/TerminalInputComposer.test.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.test.tsx
@@ -220,6 +220,46 @@ describe("TerminalInputComposer", () => {
     expect(localStorage.getItem("laymux.desktop.composerHeight")).toBe(String(before + 50));
   });
 
+  it("at the prompt, edge ↑/↓ recall Composer history instead of the shell's", () => {
+    const onHistory = vi.fn().mockReturnValue(true);
+    const onSend = vi.fn();
+    // Empty draft: caret is at both start and end.
+    renderComposer({ text: "", atShellPrompt: true, onHistory, onSend });
+    const textarea = screen.getByRole("textbox", { name: "Terminal input" });
+
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    expect(onHistory).toHaveBeenCalledWith("prev");
+    fireEvent.keyDown(textarea, { key: "ArrowDown" });
+    expect(onHistory).toHaveBeenCalledWith("next");
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("while a program runs, forwards every key and IME text to the terminal", () => {
+    const onKeyPassthrough = vi.fn().mockReturnValue(true);
+    const onForwardText = vi.fn();
+    const onTextChange = vi.fn();
+    const onSend = vi.fn();
+    renderComposer({
+      text: "",
+      atShellPrompt: false,
+      onKeyPassthrough,
+      onForwardText,
+      onTextChange,
+      onSend,
+    });
+    const textarea = screen.getByRole("textbox", { name: "Terminal input" });
+
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    fireEvent.keyDown(textarea, { key: "j" });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onKeyPassthrough).toHaveBeenCalledTimes(3);
+    expect(onSend).not.toHaveBeenCalled();
+
+    fireEvent.compositionStart(textarea, { data: "ㅎ" });
+    fireEvent.compositionEnd(textarea, { data: "한" });
+    expect(onForwardText).toHaveBeenCalledWith("한");
+  });
+
   it("preserves the draft across mode switches without coupling them", async () => {
     const user = userEvent.setup();
 

--- a/ui/src/components/ui/TerminalInputComposer.test.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.test.tsx
@@ -220,46 +220,6 @@ describe("TerminalInputComposer", () => {
     expect(localStorage.getItem("laymux.desktop.composerHeight")).toBe(String(before + 50));
   });
 
-  it("at the prompt, edge ↑/↓ recall Composer history instead of the shell's", () => {
-    const onHistory = vi.fn().mockReturnValue(true);
-    const onSend = vi.fn();
-    // Empty draft: caret is at both start and end.
-    renderComposer({ text: "", atShellPrompt: true, onHistory, onSend });
-    const textarea = screen.getByRole("textbox", { name: "Terminal input" });
-
-    fireEvent.keyDown(textarea, { key: "ArrowUp" });
-    expect(onHistory).toHaveBeenCalledWith("prev");
-    fireEvent.keyDown(textarea, { key: "ArrowDown" });
-    expect(onHistory).toHaveBeenCalledWith("next");
-    expect(onSend).not.toHaveBeenCalled();
-  });
-
-  it("while a program runs, forwards every key and IME text to the terminal", () => {
-    const onKeyPassthrough = vi.fn().mockReturnValue(true);
-    const onForwardText = vi.fn();
-    const onTextChange = vi.fn();
-    const onSend = vi.fn();
-    renderComposer({
-      text: "",
-      atShellPrompt: false,
-      onKeyPassthrough,
-      onForwardText,
-      onTextChange,
-      onSend,
-    });
-    const textarea = screen.getByRole("textbox", { name: "Terminal input" });
-
-    fireEvent.keyDown(textarea, { key: "ArrowUp" });
-    fireEvent.keyDown(textarea, { key: "j" });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-    expect(onKeyPassthrough).toHaveBeenCalledTimes(3);
-    expect(onSend).not.toHaveBeenCalled();
-
-    fireEvent.compositionStart(textarea, { data: "ㅎ" });
-    fireEvent.compositionEnd(textarea, { data: "한" });
-    expect(onForwardText).toHaveBeenCalledWith("한");
-  });
-
   it("preserves the draft across mode switches without coupling them", async () => {
     const user = userEvent.setup();
 

--- a/ui/src/components/ui/TerminalInputComposer.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.tsx
@@ -1,10 +1,22 @@
-import { useEffect, useRef, type KeyboardEvent, type Ref } from "react";
-import type { InputMode } from "@/lib/terminal-input-composer-state";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent,
+  type Ref,
+} from "react";
+import {
+  clampComposerHeight,
+  readComposerHeight,
+  writeComposerHeight,
+  type InputMode,
+} from "@/lib/terminal-input-composer-state";
 
 export interface TerminalInputComposerLabels {
   editor: string;
   placeholder: string;
-  send: string;
+  resize: string;
 }
 
 export interface TerminalInputComposerProps {
@@ -31,6 +43,13 @@ function joinClassNames(...parts: Array<string | undefined>): string {
  * itself lives in the pane control bar (see PaneControlBar), so this component
  * only renders when Composer is active and collapses to an inert, zero-footprint
  * host in Direct mode — the terminal keeps all of its vertical space.
+ *
+ * There is no Send button: plain Enter submits, Shift+Enter inserts a newline.
+ * `data-can-send` reflects whether Enter would submit right now (used by tests
+ * and any external affordance in place of a disabled button).
+ *
+ * Height is resized by dragging the top edge upward (not a textarea corner grip),
+ * and the chosen height persists as a desktop UI preference.
  */
 export function TerminalInputComposer({
   mode,
@@ -49,6 +68,40 @@ export function TerminalInputComposer({
   const compositionActiveRef = useRef(false);
   const actionDisabled = disabled || commitDisabled || inFlight;
   const childTestId = (suffix: string) => (testId ? `${testId}-${suffix}` : undefined);
+
+  const [height, setHeightState] = useState(() => readComposerHeight());
+  const heightRef = useRef(height);
+  const setHeight = (px: number) => {
+    const clamped = clampComposerHeight(px);
+    heightRef.current = clamped;
+    setHeightState(clamped);
+  };
+  // Drag the top edge: moving the pointer up (smaller clientY) grows the editor.
+  const dragRef = useRef<{ startY: number; startHeight: number } | null>(null);
+  const onHandlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    dragRef.current = { startY: event.clientY, startHeight: heightRef.current };
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      /* pointer capture unsupported (e.g. jsdom) */
+    }
+  };
+  const onHandlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    setHeight(drag.startHeight + (drag.startY - event.clientY));
+  };
+  const endDrag = (event: PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    dragRef.current = null;
+    try {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    } catch {
+      /* pointer already released */
+    }
+    writeComposerHeight(heightRef.current);
+  };
 
   useEffect(() => {
     if (mode !== "composer") compositionActiveRef.current = false;
@@ -80,18 +133,34 @@ export function TerminalInputComposer({
     <div
       data-testid={testId}
       data-mode={mode}
+      data-can-send={actionDisabled ? "false" : "true"}
       aria-busy={inFlight}
       aria-disabled={disabled || undefined}
-      className={joinClassNames(
-        "terminal-input-composer flex min-w-0 flex-col gap-2 border-t p-2",
-        className,
-      )}
+      className={joinClassNames("terminal-input-composer flex min-w-0 flex-col", className)}
       style={{
-        borderColor: "var(--border)",
+        height: `${height}px`,
         background: "var(--bg-surface)",
         color: "var(--text-primary)",
       }}
     >
+      <div
+        data-testid={childTestId("resize")}
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label={labels.resize}
+        className="terminal-input-composer-resize group flex h-1.5 w-full shrink-0 cursor-row-resize items-center justify-center border-t"
+        style={{ borderColor: "var(--border)", touchAction: "none" }}
+        onPointerDown={onHandlePointerDown}
+        onPointerMove={onHandlePointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+      >
+        <div
+          className="h-0.5 w-8 rounded-full opacity-0 transition-opacity group-hover:opacity-100"
+          style={{ background: "var(--text-secondary)" }}
+        />
+      </div>
+
       <textarea
         ref={textareaRef}
         data-testid={childTestId("textarea")}
@@ -100,13 +169,11 @@ export function TerminalInputComposer({
         placeholder={labels.placeholder}
         disabled={disabled}
         autoFocus={autoFocus && !disabled}
-        rows={3}
         spellCheck={false}
         autoCapitalize="off"
         autoCorrect="off"
-        className="terminal-input-composer-editor min-h-16 w-full min-w-0 resize-y rounded border px-2 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+        className="terminal-input-composer-editor min-h-0 w-full min-w-0 flex-1 resize-none border-0 px-2 py-1.5 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
         style={{
-          borderColor: "var(--border)",
           background: "var(--bg-base)",
           color: "var(--text-primary)",
         }}
@@ -122,23 +189,6 @@ export function TerminalInputComposer({
         }}
         onKeyDown={handleEditorKeyDown}
       />
-
-      <div className="terminal-input-composer-actions flex min-w-0 justify-end gap-2">
-        <button
-          type="button"
-          data-testid={childTestId("send")}
-          disabled={actionDisabled}
-          className="hover-bg-accent rounded border px-3 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
-          style={{
-            borderColor: "var(--accent)",
-            background: "var(--accent-20)",
-            color: "var(--accent)",
-          }}
-          onClick={onSend}
-        >
-          {labels.send}
-        </button>
-      </div>
     </div>
   );
 }

--- a/ui/src/components/ui/TerminalInputComposer.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.tsx
@@ -27,15 +27,28 @@ export interface TerminalInputComposerProps {
   disabled?: boolean;
   commitDisabled?: boolean;
   autoFocus?: boolean;
+  /**
+   * True at a shell command prompt (OSC 133 input phase). The Composer only owns
+   * keys while at the prompt; when a program is running it forwards every key to
+   * the PTY so menus / TUIs / their own history behave natively. Defaults to true
+   * so an unintegrated shell keeps a usable Composer.
+   */
+  atShellPrompt?: boolean;
   textareaRef?: Ref<HTMLTextAreaElement>;
   onTextChange: (text: string) => void;
   onSend: () => void;
   /**
-   * Give the host a chance to forward a keystroke straight to the terminal
-   * (empty-draft nav keys, or any key while a full-screen app runs). Returning
-   * true means the host consumed it and the editor should ignore it.
+   * Forward a keystroke straight to the terminal (used while a program is
+   * running, i.e. not at the prompt). Returning true means it was consumed.
    */
-  onKeyPassthrough?: (event: KeyboardEvent, ctx: { empty: boolean }) => boolean;
+  onKeyPassthrough?: (event: KeyboardEvent) => boolean;
+  /** Forward IME-composed text to the terminal while a program is running. */
+  onForwardText?: (text: string) => void;
+  /**
+   * Navigate the Composer's own sent-history at the prompt, recalling an entry
+   * into the draft. Returning true means an entry replaced the draft.
+   */
+  onHistory?: (direction: "prev" | "next") => boolean;
   className?: string;
   testId?: string;
 }
@@ -65,10 +78,13 @@ export function TerminalInputComposer({
   disabled = false,
   commitDisabled = false,
   autoFocus = false,
+  atShellPrompt = true,
   textareaRef,
   onTextChange,
   onSend,
   onKeyPassthrough,
+  onForwardText,
+  onHistory,
   className,
   testId,
 }: TerminalInputComposerProps) {
@@ -115,21 +131,45 @@ export function TerminalInputComposer({
   }, [mode]);
 
   const handleEditorKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-    // Composition keys always belong to the IME, never to passthrough or Send.
+    // Composition keys always belong to the IME. At the prompt they build the
+    // draft; while a program runs the composed text is forwarded on commit.
     const composing =
       compositionActiveRef.current ||
       event.nativeEvent.isComposing ||
       event.nativeEvent.keyCode === 229;
+    if (composing) return;
 
-    // Let the host forward empty-draft nav keys / full-screen-app keys to the PTY.
-    if (!composing && onKeyPassthrough?.(event.nativeEvent, { empty: text.length === 0 })) {
-      event.preventDefault();
-      event.stopPropagation();
+    if (!atShellPrompt) {
+      // A program owns the screen — forward every key to it (menus, TUIs, and
+      // their own history all behave natively).
+      if (onKeyPassthrough?.(event.nativeEvent)) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
       return;
     }
 
+    // At the prompt the Composer owns editing. ↑/↓ at the draft's edges recall
+    // the Composer's own history instead of the shell's (which would land on the
+    // terminal line, detached from this editor).
+    const ta = event.currentTarget;
+    if (event.key === "ArrowUp" && ta.selectionStart === 0 && ta.selectionEnd === 0) {
+      if (onHistory?.("prev")) {
+        event.preventDefault();
+        return;
+      }
+    } else if (
+      event.key === "ArrowDown" &&
+      ta.selectionStart === ta.value.length &&
+      ta.selectionEnd === ta.value.length
+    ) {
+      if (onHistory?.("next")) {
+        event.preventDefault();
+        return;
+      }
+    }
+
     if (event.key !== "Enter" || event.shiftKey) return;
-    if (composing) return;
 
     // Plain Enter is the Send gesture. While an action is already in flight,
     // consume repeats without turning them into accidental draft newlines.
@@ -191,12 +231,25 @@ export function TerminalInputComposer({
           background: "var(--bg-base)",
           color: "var(--text-primary)",
         }}
-        onChange={(event) => onTextChange(event.currentTarget.value)}
+        onChange={(event) => {
+          // While a program runs the editor is a transparent conduit — never stage
+          // typed text into the draft. Printable keys are forwarded on keydown;
+          // IME-composed text is forwarded on compositionend (below).
+          if (!atShellPrompt) {
+            if (text !== "") onTextChange("");
+            return;
+          }
+          onTextChange(event.currentTarget.value);
+        }}
         onCompositionStart={() => {
           compositionActiveRef.current = true;
         }}
-        onCompositionEnd={() => {
+        onCompositionEnd={(event) => {
           compositionActiveRef.current = false;
+          if (!atShellPrompt && event.data) {
+            onForwardText?.(event.data);
+            if (text !== "") onTextChange("");
+          }
         }}
         onBlur={() => {
           compositionActiveRef.current = false;

--- a/ui/src/components/ui/TerminalInputComposer.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.tsx
@@ -2,9 +2,6 @@ import { useEffect, useRef, type KeyboardEvent, type Ref } from "react";
 import type { InputMode } from "@/lib/terminal-input-composer-state";
 
 export interface TerminalInputComposerLabels {
-  inputMode: string;
-  direct: string;
-  composer: string;
   editor: string;
   placeholder: string;
   send: string;
@@ -19,7 +16,6 @@ export interface TerminalInputComposerProps {
   commitDisabled?: boolean;
   autoFocus?: boolean;
   textareaRef?: Ref<HTMLTextAreaElement>;
-  onModeChange: (mode: InputMode) => void;
   onTextChange: (text: string) => void;
   onSend: () => void;
   className?: string;
@@ -30,40 +26,12 @@ function joinClassNames(...parts: Array<string | undefined>): string {
   return parts.filter(Boolean).join(" ");
 }
 
-function DirectIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      aria-hidden
-    >
-      <rect x="2.5" y="6" width="19" height="12" rx="2" />
-      <path d="M7 10h.01M11 10h.01M15 10h.01M8.5 14h7" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-function ComposerIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      aria-hidden
-    >
-      <path d="M4 20h4L18.5 9.5a2 2 0 0 0-2.83-2.83L5 17v3z" strokeLinejoin="round" />
-      <path d="M13.5 8.5l2.5 2.5" strokeLinecap="round" />
-    </svg>
-  );
-}
-
+/**
+ * Bottom editor surface for the detached "Composer" input mode. The mode toggle
+ * itself lives in the pane control bar (see PaneControlBar), so this component
+ * only renders when Composer is active and collapses to an inert, zero-footprint
+ * host in Direct mode — the terminal keeps all of its vertical space.
+ */
 export function TerminalInputComposer({
   mode,
   text,
@@ -73,7 +41,6 @@ export function TerminalInputComposer({
   commitDisabled = false,
   autoFocus = false,
   textareaRef,
-  onModeChange,
   onTextChange,
   onSend,
   className,
@@ -82,7 +49,6 @@ export function TerminalInputComposer({
   const compositionActiveRef = useRef(false);
   const actionDisabled = disabled || commitDisabled || inFlight;
   const childTestId = (suffix: string) => (testId ? `${testId}-${suffix}` : undefined);
-  const composerMode = mode === "composer";
 
   useEffect(() => {
     if (mode !== "composer") compositionActiveRef.current = false;
@@ -104,6 +70,12 @@ export function TerminalInputComposer({
     if (!actionDisabled) onSend();
   };
 
+  // Direct mode keeps the testid/data-mode in the DOM (state probes, tests) but
+  // paints nothing.
+  if (mode !== "composer") {
+    return <div data-testid={testId} data-mode={mode} hidden />;
+  }
+
   return (
     <div
       data-testid={testId}
@@ -111,10 +83,7 @@ export function TerminalInputComposer({
       aria-busy={inFlight}
       aria-disabled={disabled || undefined}
       className={joinClassNames(
-        // Direct mode collapses to a slim right-aligned strip so it reclaims the
-        // terminal's vertical space; composer mode expands into the full editor.
-        "terminal-input-composer flex min-w-0 border-t",
-        composerMode ? "flex-col gap-2 p-2" : "justify-end px-2 py-1",
+        "terminal-input-composer flex min-w-0 flex-col gap-2 border-t p-2",
         className,
       )}
       style={{
@@ -123,89 +92,53 @@ export function TerminalInputComposer({
         color: "var(--text-primary)",
       }}
     >
-      <div
-        role="group"
-        aria-label={labels.inputMode}
-        className="terminal-input-composer-mode inline-flex min-w-0 items-center overflow-hidden rounded border"
-        style={{ borderColor: "var(--border)" }}
-      >
-        {(["direct", "composer"] as const).map((candidate) => {
-          const selected = mode === candidate;
-          const label = candidate === "direct" ? labels.direct : labels.composer;
-          return (
-            <button
-              key={candidate}
-              type="button"
-              data-testid={childTestId(`mode-${candidate}`)}
-              aria-pressed={selected}
-              disabled={disabled}
-              className="hover-bg flex min-w-0 items-center gap-1 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
-              style={{
-                background: selected ? "var(--accent-20)" : "transparent",
-                color: selected ? "var(--accent)" : "var(--text-secondary)",
-              }}
-              onClick={() => {
-                if (!selected) onModeChange(candidate);
-              }}
-            >
-              {candidate === "direct" ? <DirectIcon /> : <ComposerIcon />}
-              <span className="min-w-0 truncate">{label}</span>
-            </button>
-          );
-        })}
+      <textarea
+        ref={textareaRef}
+        data-testid={childTestId("textarea")}
+        aria-label={labels.editor}
+        value={text}
+        placeholder={labels.placeholder}
+        disabled={disabled}
+        autoFocus={autoFocus && !disabled}
+        rows={3}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        className="terminal-input-composer-editor min-h-16 w-full min-w-0 resize-y rounded border px-2 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+        style={{
+          borderColor: "var(--border)",
+          background: "var(--bg-base)",
+          color: "var(--text-primary)",
+        }}
+        onChange={(event) => onTextChange(event.currentTarget.value)}
+        onCompositionStart={() => {
+          compositionActiveRef.current = true;
+        }}
+        onCompositionEnd={() => {
+          compositionActiveRef.current = false;
+        }}
+        onBlur={() => {
+          compositionActiveRef.current = false;
+        }}
+        onKeyDown={handleEditorKeyDown}
+      />
+
+      <div className="terminal-input-composer-actions flex min-w-0 justify-end gap-2">
+        <button
+          type="button"
+          data-testid={childTestId("send")}
+          disabled={actionDisabled}
+          className="hover-bg-accent rounded border px-3 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+          style={{
+            borderColor: "var(--accent)",
+            background: "var(--accent-20)",
+            color: "var(--accent)",
+          }}
+          onClick={onSend}
+        >
+          {labels.send}
+        </button>
       </div>
-
-      {composerMode && (
-        <>
-          <textarea
-            ref={textareaRef}
-            data-testid={childTestId("textarea")}
-            aria-label={labels.editor}
-            value={text}
-            placeholder={labels.placeholder}
-            disabled={disabled}
-            autoFocus={autoFocus && !disabled}
-            rows={3}
-            spellCheck={false}
-            autoCapitalize="off"
-            autoCorrect="off"
-            className="terminal-input-composer-editor min-h-16 w-full min-w-0 resize-y rounded border px-2 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
-            style={{
-              borderColor: "var(--border)",
-              background: "var(--bg-base)",
-              color: "var(--text-primary)",
-            }}
-            onChange={(event) => onTextChange(event.currentTarget.value)}
-            onCompositionStart={() => {
-              compositionActiveRef.current = true;
-            }}
-            onCompositionEnd={() => {
-              compositionActiveRef.current = false;
-            }}
-            onBlur={() => {
-              compositionActiveRef.current = false;
-            }}
-            onKeyDown={handleEditorKeyDown}
-          />
-
-          <div className="terminal-input-composer-actions flex min-w-0 justify-end gap-2">
-            <button
-              type="button"
-              data-testid={childTestId("send")}
-              disabled={actionDisabled}
-              className="hover-bg-accent rounded border px-3 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
-              style={{
-                borderColor: "var(--accent)",
-                background: "var(--accent-20)",
-                color: "var(--accent)",
-              }}
-              onClick={onSend}
-            >
-              {labels.send}
-            </button>
-          </div>
-        </>
-      )}
     </div>
   );
 }

--- a/ui/src/components/ui/TerminalInputComposer.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.tsx
@@ -2,7 +2,7 @@ import {
   useEffect,
   useRef,
   useState,
-  type KeyboardEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent,
   type Ref,
 } from "react";
@@ -30,6 +30,12 @@ export interface TerminalInputComposerProps {
   textareaRef?: Ref<HTMLTextAreaElement>;
   onTextChange: (text: string) => void;
   onSend: () => void;
+  /**
+   * Give the host a chance to forward a keystroke straight to the terminal
+   * (empty-draft nav keys, or any key while a full-screen app runs). Returning
+   * true means the host consumed it and the editor should ignore it.
+   */
+  onKeyPassthrough?: (event: KeyboardEvent, ctx: { empty: boolean }) => boolean;
   className?: string;
   testId?: string;
 }
@@ -62,6 +68,7 @@ export function TerminalInputComposer({
   textareaRef,
   onTextChange,
   onSend,
+  onKeyPassthrough,
   className,
   testId,
 }: TerminalInputComposerProps) {
@@ -107,15 +114,22 @@ export function TerminalInputComposer({
     if (mode !== "composer") compositionActiveRef.current = false;
   }, [mode]);
 
-  const handleEditorKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key !== "Enter" || event.shiftKey) return;
-    if (
+  const handleEditorKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    // Composition keys always belong to the IME, never to passthrough or Send.
+    const composing =
       compositionActiveRef.current ||
       event.nativeEvent.isComposing ||
-      event.nativeEvent.keyCode === 229
-    ) {
+      event.nativeEvent.keyCode === 229;
+
+    // Let the host forward empty-draft nav keys / full-screen-app keys to the PTY.
+    if (!composing && onKeyPassthrough?.(event.nativeEvent, { empty: text.length === 0 })) {
+      event.preventDefault();
+      event.stopPropagation();
       return;
     }
+
+    if (event.key !== "Enter" || event.shiftKey) return;
+    if (composing) return;
 
     // Plain Enter is the Send gesture. While an action is already in flight,
     // consume repeats without turning them into accidental draft newlines.

--- a/ui/src/components/ui/TerminalInputComposer.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.tsx
@@ -27,28 +27,15 @@ export interface TerminalInputComposerProps {
   disabled?: boolean;
   commitDisabled?: boolean;
   autoFocus?: boolean;
-  /**
-   * True at a shell command prompt (OSC 133 input phase). The Composer only owns
-   * keys while at the prompt; when a program is running it forwards every key to
-   * the PTY so menus / TUIs / their own history behave natively. Defaults to true
-   * so an unintegrated shell keeps a usable Composer.
-   */
-  atShellPrompt?: boolean;
   textareaRef?: Ref<HTMLTextAreaElement>;
   onTextChange: (text: string) => void;
   onSend: () => void;
   /**
-   * Forward a keystroke straight to the terminal (used while a program is
-   * running, i.e. not at the prompt). Returning true means it was consumed.
+   * Give the host a chance to forward a keystroke straight to the terminal
+   * (empty-draft nav keys, or any key while a full-screen app runs). Returning
+   * true means the host consumed it and the editor should ignore it.
    */
-  onKeyPassthrough?: (event: KeyboardEvent) => boolean;
-  /** Forward IME-composed text to the terminal while a program is running. */
-  onForwardText?: (text: string) => void;
-  /**
-   * Navigate the Composer's own sent-history at the prompt, recalling an entry
-   * into the draft. Returning true means an entry replaced the draft.
-   */
-  onHistory?: (direction: "prev" | "next") => boolean;
+  onKeyPassthrough?: (event: KeyboardEvent, ctx: { empty: boolean }) => boolean;
   className?: string;
   testId?: string;
 }
@@ -78,13 +65,10 @@ export function TerminalInputComposer({
   disabled = false,
   commitDisabled = false,
   autoFocus = false,
-  atShellPrompt = true,
   textareaRef,
   onTextChange,
   onSend,
   onKeyPassthrough,
-  onForwardText,
-  onHistory,
   className,
   testId,
 }: TerminalInputComposerProps) {
@@ -131,45 +115,21 @@ export function TerminalInputComposer({
   }, [mode]);
 
   const handleEditorKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-    // Composition keys always belong to the IME. At the prompt they build the
-    // draft; while a program runs the composed text is forwarded on commit.
+    // Composition keys always belong to the IME, never to passthrough or Send.
     const composing =
       compositionActiveRef.current ||
       event.nativeEvent.isComposing ||
       event.nativeEvent.keyCode === 229;
-    if (composing) return;
 
-    if (!atShellPrompt) {
-      // A program owns the screen — forward every key to it (menus, TUIs, and
-      // their own history all behave natively).
-      if (onKeyPassthrough?.(event.nativeEvent)) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
+    // Let the host forward empty-draft nav keys / full-screen-app keys to the PTY.
+    if (!composing && onKeyPassthrough?.(event.nativeEvent, { empty: text.length === 0 })) {
+      event.preventDefault();
+      event.stopPropagation();
       return;
     }
 
-    // At the prompt the Composer owns editing. ↑/↓ at the draft's edges recall
-    // the Composer's own history instead of the shell's (which would land on the
-    // terminal line, detached from this editor).
-    const ta = event.currentTarget;
-    if (event.key === "ArrowUp" && ta.selectionStart === 0 && ta.selectionEnd === 0) {
-      if (onHistory?.("prev")) {
-        event.preventDefault();
-        return;
-      }
-    } else if (
-      event.key === "ArrowDown" &&
-      ta.selectionStart === ta.value.length &&
-      ta.selectionEnd === ta.value.length
-    ) {
-      if (onHistory?.("next")) {
-        event.preventDefault();
-        return;
-      }
-    }
-
     if (event.key !== "Enter" || event.shiftKey) return;
+    if (composing) return;
 
     // Plain Enter is the Send gesture. While an action is already in flight,
     // consume repeats without turning them into accidental draft newlines.
@@ -231,25 +191,12 @@ export function TerminalInputComposer({
           background: "var(--bg-base)",
           color: "var(--text-primary)",
         }}
-        onChange={(event) => {
-          // While a program runs the editor is a transparent conduit — never stage
-          // typed text into the draft. Printable keys are forwarded on keydown;
-          // IME-composed text is forwarded on compositionend (below).
-          if (!atShellPrompt) {
-            if (text !== "") onTextChange("");
-            return;
-          }
-          onTextChange(event.currentTarget.value);
-        }}
+        onChange={(event) => onTextChange(event.currentTarget.value)}
         onCompositionStart={() => {
           compositionActiveRef.current = true;
         }}
-        onCompositionEnd={(event) => {
+        onCompositionEnd={() => {
           compositionActiveRef.current = false;
-          if (!atShellPrompt && event.data) {
-            onForwardText?.(event.data);
-            if (text !== "") onTextChange("");
-          }
         }}
         onBlur={() => {
           compositionActiveRef.current = false;

--- a/ui/src/components/ui/TerminalInputComposer.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.tsx
@@ -30,6 +30,40 @@ function joinClassNames(...parts: Array<string | undefined>): string {
   return parts.filter(Boolean).join(" ");
 }
 
+function DirectIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      aria-hidden
+    >
+      <rect x="2.5" y="6" width="19" height="12" rx="2" />
+      <path d="M7 10h.01M11 10h.01M15 10h.01M8.5 14h7" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ComposerIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      aria-hidden
+    >
+      <path d="M4 20h4L18.5 9.5a2 2 0 0 0-2.83-2.83L5 17v3z" strokeLinejoin="round" />
+      <path d="M13.5 8.5l2.5 2.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 export function TerminalInputComposer({
   mode,
   text,
@@ -48,6 +82,7 @@ export function TerminalInputComposer({
   const compositionActiveRef = useRef(false);
   const actionDisabled = disabled || commitDisabled || inFlight;
   const childTestId = (suffix: string) => (testId ? `${testId}-${suffix}` : undefined);
+  const composerMode = mode === "composer";
 
   useEffect(() => {
     if (mode !== "composer") compositionActiveRef.current = false;
@@ -76,7 +111,10 @@ export function TerminalInputComposer({
       aria-busy={inFlight}
       aria-disabled={disabled || undefined}
       className={joinClassNames(
-        "terminal-input-composer flex min-w-0 flex-col gap-2 border-t p-2",
+        // Direct mode collapses to a slim right-aligned strip so it reclaims the
+        // terminal's vertical space; composer mode expands into the full editor.
+        "terminal-input-composer flex min-w-0 border-t",
+        composerMode ? "flex-col gap-2 p-2" : "justify-end px-2 py-1",
         className,
       )}
       style={{
@@ -88,7 +126,8 @@ export function TerminalInputComposer({
       <div
         role="group"
         aria-label={labels.inputMode}
-        className="terminal-input-composer-mode flex min-w-0 items-center gap-1"
+        className="terminal-input-composer-mode inline-flex min-w-0 items-center overflow-hidden rounded border"
+        style={{ borderColor: "var(--border)" }}
       >
         {(["direct", "composer"] as const).map((candidate) => {
           const selected = mode === candidate;
@@ -100,7 +139,7 @@ export function TerminalInputComposer({
               data-testid={childTestId(`mode-${candidate}`)}
               aria-pressed={selected}
               disabled={disabled}
-              className="hover-bg min-w-0 rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+              className="hover-bg flex min-w-0 items-center gap-1 px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
               style={{
                 background: selected ? "var(--accent-20)" : "transparent",
                 color: selected ? "var(--accent)" : "var(--text-secondary)",
@@ -109,13 +148,14 @@ export function TerminalInputComposer({
                 if (!selected) onModeChange(candidate);
               }}
             >
-              {label}
+              {candidate === "direct" ? <DirectIcon /> : <ComposerIcon />}
+              <span className="min-w-0 truncate">{label}</span>
             </button>
           );
         })}
       </div>
 
-      {mode === "composer" && (
+      {composerMode && (
         <>
           <textarea
             ref={textareaRef}

--- a/ui/src/components/ui/TerminalInputComposer.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.tsx
@@ -133,9 +133,9 @@ export function TerminalInputComposer({
       compositionActiveRef.current ||
       event.nativeEvent.isComposing ||
       event.nativeEvent.keyCode === 229;
-    // Modifier combos are app keybindings (pane focus = Alt+Arrow, …) — leave them
-    // to bubble; never treat them as history or passthrough here.
-    const plainKey = !event.altKey && !event.ctrlKey && !event.metaKey;
+    // History recall only fires on an unmodified arrow: modifier combos are app
+    // keybindings (or selection gestures) — the host's registry check routes them.
+    const plainKey = !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
 
     // At the shell prompt, edge ↑/↓ recall the Composer's own history into the
     // editor (editable), instead of leaking ↑ to the shell where the recalled
@@ -158,8 +158,17 @@ export function TerminalInputComposer({
       }
     }
 
-    // Let the host forward empty-draft nav keys / full-screen-app keys to the PTY.
-    if (!composing && onKeyPassthrough?.(event.nativeEvent, { empty: text.length === 0 })) {
+    // Shift+Enter is always the newline gesture (even on an empty draft, to start
+    // a multiline one) — never offer it for passthrough.
+    const newlineGesture = event.key === "Enter" && event.shiftKey;
+
+    // Let the host forward empty-draft nav/control keys / full-screen-app keys
+    // to the PTY. The host checks laymux keybindings first (rebind-aware).
+    if (
+      !composing &&
+      !newlineGesture &&
+      onKeyPassthrough?.(event.nativeEvent, { empty: text.length === 0 })
+    ) {
       event.preventDefault();
       event.stopPropagation();
       return;

--- a/ui/src/components/ui/TerminalInputComposer.tsx
+++ b/ui/src/components/ui/TerminalInputComposer.tsx
@@ -27,6 +27,12 @@ export interface TerminalInputComposerProps {
   disabled?: boolean;
   commitDisabled?: boolean;
   autoFocus?: boolean;
+  /**
+   * True at a shell command prompt (OSC 133 input phase). Only then do edge ↑/↓
+   * recall Composer history; while a program runs they pass through so its own
+   * history / menu selection work. Defaults true.
+   */
+  atShellPrompt?: boolean;
   textareaRef?: Ref<HTMLTextAreaElement>;
   onTextChange: (text: string) => void;
   onSend: () => void;
@@ -36,6 +42,11 @@ export interface TerminalInputComposerProps {
    * true means the host consumed it and the editor should ignore it.
    */
   onKeyPassthrough?: (event: KeyboardEvent, ctx: { empty: boolean }) => boolean;
+  /**
+   * Recall the Composer's own sent-history into the draft at the prompt (edge
+   * ↑/↓). Returning true means the key was consumed.
+   */
+  onHistory?: (direction: "prev" | "next") => boolean;
   className?: string;
   testId?: string;
 }
@@ -65,10 +76,12 @@ export function TerminalInputComposer({
   disabled = false,
   commitDisabled = false,
   autoFocus = false,
+  atShellPrompt = true,
   textareaRef,
   onTextChange,
   onSend,
   onKeyPassthrough,
+  onHistory,
   className,
   testId,
 }: TerminalInputComposerProps) {
@@ -120,6 +133,30 @@ export function TerminalInputComposer({
       compositionActiveRef.current ||
       event.nativeEvent.isComposing ||
       event.nativeEvent.keyCode === 229;
+    // Modifier combos are app keybindings (pane focus = Alt+Arrow, …) — leave them
+    // to bubble; never treat them as history or passthrough here.
+    const plainKey = !event.altKey && !event.ctrlKey && !event.metaKey;
+
+    // At the shell prompt, edge ↑/↓ recall the Composer's own history into the
+    // editor (editable), instead of leaking ↑ to the shell where the recalled
+    // command would land on the terminal line, detached from this editor.
+    if (atShellPrompt && !composing && plainKey) {
+      const ta = event.currentTarget;
+      if (event.key === "ArrowUp" && ta.selectionStart === 0 && ta.selectionEnd === 0) {
+        onHistory?.("prev");
+        event.preventDefault();
+        return;
+      }
+      if (
+        event.key === "ArrowDown" &&
+        ta.selectionStart === ta.value.length &&
+        ta.selectionEnd === ta.value.length
+      ) {
+        onHistory?.("next");
+        event.preventDefault();
+        return;
+      }
+    }
 
     // Let the host forward empty-draft nav keys / full-screen-app keys to the PTY.
     if (!composing && onKeyPassthrough?.(event.nativeEvent, { empty: text.length === 0 })) {

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -47,6 +47,11 @@ import {
   usesArrowWildcard,
 } from "@/lib/keybinding-registry";
 import { toSupportedCursorShape } from "@/lib/cursor-settings";
+import {
+  readDesktopInputModePreference,
+  writeDesktopInputModePreference,
+  type InputMode,
+} from "@/lib/terminal-input-composer-state";
 import type { PastePathSeparator } from "@/lib/smart-text";
 import { MONOSPACED_FONTS, getSystemMonospaceFonts } from "@/lib/system-fonts";
 import { FocusInput, FocusSelect, inputStyle, inputCls } from "@/components/ui/FormControls";
@@ -1474,10 +1479,35 @@ function TerminalSection() {
   const update = (partial: Partial<typeof terminal>) =>
     setDraftTerminal((prev) => ({ ...prev, ...partial }));
 
+  // Default input mode is a desktop-surface UI preference (localStorage), not part
+  // of the Rust-backed settings.json — so it stays outside the terminal draft.
+  const [defaultInputMode, setDefaultInputMode] = useState<InputMode>(() =>
+    readDesktopInputModePreference(),
+  );
+  const changeDefaultInputMode = (mode: InputMode) => {
+    if (!writeDesktopInputModePreference(mode)) return;
+    setDefaultInputMode(mode);
+  };
+
   return (
     <div>
       <SectionTitle>{t("terminal.title")}</SectionTitle>
       <div style={cardStyle} className="p-4">
+        <SettingRow
+          label={t("terminal.defaultInputMode")}
+          desc={t("terminal.defaultInputModeDesc")}
+        >
+          <FocusSelect
+            data-testid="default-input-mode-select"
+            className={inputCls}
+            value={defaultInputMode}
+            onChange={(e) => changeDefaultInputMode(e.target.value as InputMode)}
+          >
+            <option value="direct">{t("terminal.inputModeDirect")}</option>
+            <option value="composer">{t("terminal.inputModeComposer")}</option>
+          </FocusSelect>
+        </SettingRow>
+
         <ToggleRow
           label={t("terminal.copyOnSelect")}
           desc={t("terminal.copyOnSelectDesc")}

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -6414,7 +6414,7 @@ describe("TerminalView desktop input composer", () => {
     expect(mockWriteToTerminal).not.toHaveBeenCalled();
   });
 
-  it("never swallows Alt/Ctrl+Arrow so pane-navigation shortcuts still bubble", async () => {
+  it("lets combos bound to laymux actions bubble instead of forwarding them", async () => {
     const terminalId = "t-composer-panenav";
     render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
@@ -6423,15 +6423,44 @@ describe("TerminalView desktop input composer", () => {
     const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
     mockWriteToTerminal.mockClear();
 
-    // Empty draft, but modifier combos are app keybindings — must not be forwarded
-    // (and the composer must not stopPropagation them).
+    // Empty draft, but these combos match registry bindings (pane.focus =
+    // Alt+Arrow wildcard, workspace.prev = Ctrl+Alt+Up) — the registry check,
+    // not a hardcoded modifier rule, must keep them bubbling untouched.
     const altLeft = new KeyboardEvent("keydown", { key: "ArrowLeft", altKey: true, bubbles: true });
     const stopSpy = vi.spyOn(altLeft, "stopPropagation");
     textarea.dispatchEvent(altLeft);
     fireEvent.keyDown(textarea, { key: "ArrowUp", ctrlKey: true, altKey: true });
+    // Ctrl+Alt+C = pane.copyIdentifier — bound, so it bubbles too.
+    fireEvent.keyDown(textarea, { key: "c", ctrlKey: true, altKey: true });
 
     expect(mockWriteToTerminal).not.toHaveBeenCalled();
     expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  it("forwards activity-control chords from an empty draft but not paste or drafts", async () => {
+    const terminalId = "t-composer-ctrlc";
+    render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
+    await waitForTerminalInputReady();
+
+    toggleInputMode(terminalId);
+    const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
+    mockWriteToTerminal.mockClear();
+
+    // Empty draft: Ctrl+C interrupts the running activity (SIGINT), Ctrl+D sends EOF.
+    fireEvent.keyDown(textarea, { key: "c", ctrlKey: true });
+    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x03");
+    fireEvent.keyDown(textarea, { key: "d", ctrlKey: true });
+    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x04");
+
+    // Ctrl+V must keep pasting into the draft — never forwarded.
+    mockWriteToTerminal.mockClear();
+    fireEvent.keyDown(textarea, { key: "v", ctrlKey: true });
+    expect(mockWriteToTerminal).not.toHaveBeenCalled();
+
+    // With text staged, Ctrl+C is the editor's copy again — not an interrupt.
+    fireEvent.change(textarea, { target: { value: "draft" } });
+    fireEvent.keyDown(textarea, { key: "c", ctrlKey: true });
+    expect(mockWriteToTerminal).not.toHaveBeenCalled();
   });
 
   it("passes empty-draft nav keys (and honors DECCKM) through while a program runs", async () => {

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -6069,6 +6069,14 @@ describe("TerminalView desktop input composer", () => {
     fireEvent.keyDown(host.parentElement!, { key: "m", ctrlKey: true, altKey: true });
   };
 
+  // Feed raw output so OSC 133 flips the prompt/program phase the Composer routes on.
+  const emitOutput = (terminalId: string, str: string) => {
+    const onOutput = mockOnTerminalOutput.mock.calls.find((call) => call[0] === terminalId)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    act(() => onOutput?.(new TextEncoder().encode(str)));
+  };
+
   it("toggles the desktop composer through the registered keybinding", async () => {
     render(<TerminalView instanceId="t-composer-toggle" profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
@@ -6370,64 +6378,60 @@ describe("TerminalView desktop input composer", () => {
     expect(mockWriteTerminalInput).not.toHaveBeenCalled();
   });
 
-  it("passes empty-draft nav keys and empty Enter through to the PTY", async () => {
-    const terminalId = "t-composer-passthrough";
+  it("recalls Composer history into the draft at the shell prompt (not the shell's)", async () => {
+    const terminalId = "t-composer-history";
     render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
 
     toggleInputMode(terminalId);
-    const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
-    mockWriteToTerminal.mockClear();
-    mockWriteTerminalInput.mockClear();
+    const textarea = screen.getByTestId(
+      `terminal-input-composer-${terminalId}-textarea`,
+    ) as HTMLTextAreaElement;
 
-    fireEvent.keyDown(textarea, { key: "ArrowUp" });
-    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x1b[A");
-
-    // Empty Enter confirms in the terminal (raw CR) — it must not "send" a draft.
+    // Send one entry so the Composer has history, then confirm the draft cleared.
+    fireEvent.change(textarea, { target: { value: "echo hi" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
-    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\r");
-    expect(mockWriteTerminalInput).not.toHaveBeenCalled();
-  });
+    await vi.waitFor(() => expect(textarea.value).toBe(""));
 
-  it("keeps nav keys inside the draft once it has text", async () => {
-    const terminalId = "t-composer-nav-draft";
-    render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
-    await waitForTerminalInputReady();
-
-    toggleInputMode(terminalId);
-    const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
-    fireEvent.change(textarea, { target: { value: "draft" } });
     mockWriteToTerminal.mockClear();
-
+    // Empty draft at the prompt: ↑ recalls into the editor, not the terminal line.
     fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    await vi.waitFor(() => expect(textarea.value).toBe("echo hi"));
     expect(mockWriteToTerminal).not.toHaveBeenCalled();
   });
 
-  it("forwards every key (and honors DECCKM) while a full-screen app owns the screen", async () => {
-    const terminalId = "t-composer-altscreen";
+  it("forwards every key (and honors DECCKM) while a program owns the screen", async () => {
+    const terminalId = "t-composer-program";
     render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
 
     toggleInputMode(terminalId);
     const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
-    const buffer = mockBufferActive as typeof mockBufferActive & { type?: string };
+    // OSC 133;C = a command started running → Composer steps aside to passthrough.
+    emitOutput(terminalId, "\x1b]133;C\x07");
+    mockWriteToTerminal.mockClear();
+
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x1b[A");
+    fireEvent.keyDown(textarea, { key: "j" });
+    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "j");
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\r");
+
     const modes = mockModes as typeof mockModes & { applicationCursorKeysMode?: boolean };
     try {
-      buffer.type = "alternate";
       modes.applicationCursorKeysMode = true;
-      mockWriteToTerminal.mockClear();
-
-      // A printable char is forwarded even with an empty draft in alt-screen.
-      fireEvent.keyDown(textarea, { key: "j" });
-      expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "j");
-
-      // Application cursor mode emits SS3 instead of CSI.
       fireEvent.keyDown(textarea, { key: "ArrowUp" });
       expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x1bOA");
     } finally {
-      delete buffer.type;
       delete modes.applicationCursorKeysMode;
     }
+
+    // Back at the prompt, keys belong to the Composer again.
+    emitOutput(terminalId, "\x1b]133;B\x07");
+    mockWriteToTerminal.mockClear();
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    expect(mockWriteToTerminal).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -6212,8 +6212,8 @@ describe("TerminalView desktop input composer", () => {
     await waitForTerminalInputReady();
 
     toggleInputMode(terminalId);
-    const send = screen.getByTestId(`terminal-input-composer-${terminalId}-send`);
-    await vi.waitFor(() => expect(send).toBeEnabled());
+    const composer = screen.getByTestId(`terminal-input-composer-${terminalId}`);
+    await vi.waitFor(() => expect(composer).toHaveAttribute("data-can-send", "true"));
 
     const registeredOutput = mockOnTerminalOutput.mock.calls.find(
       ([registeredTerminalId]) => registeredTerminalId === terminalId,
@@ -6232,7 +6232,7 @@ describe("TerminalView desktop input composer", () => {
       emitOutput?.({ seqStart: 0, seqEnd: 2, data: [0x61] });
     });
 
-    expect(send).toBeDisabled();
+    expect(composer).toHaveAttribute("data-can-send", "false");
     await vi.waitFor(() => {
       expect(mockAttachTerminalOutput.mock.calls.length).toBeGreaterThan(
         attachCallsBeforeMalformedDelta,
@@ -6266,13 +6266,16 @@ describe("TerminalView desktop input composer", () => {
       "terminal-input-composer-t-composer-send-textarea",
     ) as HTMLTextAreaElement;
     await vi.waitFor(() =>
-      expect(screen.getByTestId("terminal-input-composer-t-composer-send-send")).toBeEnabled(),
+      expect(screen.getByTestId("terminal-input-composer-t-composer-send")).toHaveAttribute(
+        "data-can-send",
+        "true",
+      ),
     );
     fireEvent.change(textarea, { target: { value: "한글\nsecond" } });
     expect(
       screen.queryByTestId("terminal-input-composer-t-composer-send-insert"),
     ).not.toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("terminal-input-composer-t-composer-send-send"));
+    fireEvent.keyDown(textarea, { key: "Enter" });
 
     expect(mockWriteTerminalInput).toHaveBeenCalledWith("t-composer-send", "한글\nsecond", true);
     await vi.waitFor(() => expect(textarea.value).toBe(""));
@@ -6292,11 +6295,11 @@ describe("TerminalView desktop input composer", () => {
     const textarea = screen.getByTestId(
       "terminal-input-composer-t-composer-flight-textarea",
     ) as HTMLTextAreaElement;
-    const send = screen.getByTestId("terminal-input-composer-t-composer-flight-send");
-    await vi.waitFor(() => expect(send).toBeEnabled());
+    const composer = screen.getByTestId("terminal-input-composer-t-composer-flight");
+    await vi.waitFor(() => expect(composer).toHaveAttribute("data-can-send", "true"));
     fireEvent.change(textarea, { target: { value: "first" } });
-    fireEvent.click(send);
-    fireEvent.click(send);
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.keyDown(textarea, { key: "Enter" });
     expect(mockWriteTerminalInput).toHaveBeenCalledTimes(1);
     expect(mockWriteTerminalInput).toHaveBeenCalledWith("t-composer-flight", "first", true);
 
@@ -6321,7 +6324,7 @@ describe("TerminalView desktop input composer", () => {
     toggleInputMode(terminalId);
     const firstTextarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
     fireEvent.change(firstTextarea, { target: { value: "pending across remount" } });
-    fireEvent.click(screen.getByTestId(`terminal-input-composer-${terminalId}-send`));
+    fireEvent.keyDown(firstTextarea, { key: "Enter" });
     first.unmount();
 
     render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
@@ -6329,12 +6332,18 @@ describe("TerminalView desktop input composer", () => {
       `terminal-input-composer-${terminalId}-textarea`,
     );
     expect(replacementTextarea).toHaveValue("pending across remount");
-    expect(screen.getByTestId(`terminal-input-composer-${terminalId}-send`)).toBeDisabled();
+    expect(screen.getByTestId(`terminal-input-composer-${terminalId}`)).toHaveAttribute(
+      "data-can-send",
+      "false",
+    );
 
     await act(async () => resolveInput());
     await vi.waitFor(() => {
       expect(replacementTextarea).toHaveValue("");
-      expect(screen.getByTestId(`terminal-input-composer-${terminalId}-send`)).toBeEnabled();
+      expect(screen.getByTestId(`terminal-input-composer-${terminalId}`)).toHaveAttribute(
+        "data-can-send",
+        "true",
+      );
     });
   });
 
@@ -6354,7 +6363,10 @@ describe("TerminalView desktop input composer", () => {
         screen.getByTestId("terminal-input-composer-t-composer-remote-textarea"),
       ).toBeDisabled();
     });
-    expect(screen.getByTestId("terminal-input-composer-t-composer-remote-send")).toBeDisabled();
+    expect(screen.getByTestId("terminal-input-composer-t-composer-remote")).toHaveAttribute(
+      "data-can-send",
+      "false",
+    );
     expect(mockWriteTerminalInput).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -6458,6 +6458,13 @@ describe("TerminalView desktop input composer", () => {
     } finally {
       delete modes.applicationCursorKeysMode;
     }
+
+    // OSC 133;D = command done → back at the prompt (this is the last OSC at a
+    // PowerShell prompt, where 133;B is never sent). ↑ must now recall, not pass through.
+    emitOutput(terminalId, "\x1b]133;D;0\x07");
+    mockWriteToTerminal.mockClear();
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    expect(mockWriteToTerminal).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -6069,6 +6069,14 @@ describe("TerminalView desktop input composer", () => {
     fireEvent.keyDown(host.parentElement!, { key: "m", ctrlKey: true, altKey: true });
   };
 
+  // Feed raw output so OSC 133 flips the prompt/program phase ↑/↓ routing depends on.
+  const emitOutput = (terminalId: string, str: string) => {
+    const onOutput = mockOnTerminalOutput.mock.calls.find((call) => call[0] === terminalId)?.[1] as
+      | ((data: Uint8Array) => void)
+      | undefined;
+    act(() => onOutput?.(new TextEncoder().encode(str)));
+  };
+
   it("toggles the desktop composer through the registered keybinding", async () => {
     render(<TerminalView instanceId="t-composer-toggle" profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
@@ -6370,23 +6378,26 @@ describe("TerminalView desktop input composer", () => {
     expect(mockWriteTerminalInput).not.toHaveBeenCalled();
   });
 
-  it("passes empty-draft nav keys and empty Enter through to the PTY", async () => {
-    const terminalId = "t-composer-passthrough";
+  it("recalls Composer history into the draft at the shell prompt (not the shell's)", async () => {
+    const terminalId = "t-composer-history";
     render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
 
     toggleInputMode(terminalId);
-    const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
-    mockWriteToTerminal.mockClear();
-    mockWriteTerminalInput.mockClear();
+    const textarea = screen.getByTestId(
+      `terminal-input-composer-${terminalId}-textarea`,
+    ) as HTMLTextAreaElement;
 
-    fireEvent.keyDown(textarea, { key: "ArrowUp" });
-    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x1b[A");
-
-    // Empty Enter confirms in the terminal (raw CR) — it must not "send" a draft.
+    // Send one entry so the Composer has history, then confirm the draft cleared.
+    fireEvent.change(textarea, { target: { value: "echo hi" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
-    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\r");
-    expect(mockWriteTerminalInput).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(textarea.value).toBe(""));
+
+    mockWriteToTerminal.mockClear();
+    // Empty draft at the prompt: ↑ recalls into the editor, not the terminal line.
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    await vi.waitFor(() => expect(textarea.value).toBe("echo hi"));
+    expect(mockWriteToTerminal).not.toHaveBeenCalled();
   });
 
   it("keeps nav keys inside the draft once it has text", async () => {
@@ -6423,29 +6434,28 @@ describe("TerminalView desktop input composer", () => {
     expect(stopSpy).not.toHaveBeenCalled();
   });
 
-  it("forwards every key (and honors DECCKM) while a full-screen app owns the screen", async () => {
-    const terminalId = "t-composer-altscreen";
+  it("passes empty-draft nav keys (and honors DECCKM) through while a program runs", async () => {
+    const terminalId = "t-composer-program";
     render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
 
     toggleInputMode(terminalId);
     const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
-    const buffer = mockBufferActive as typeof mockBufferActive & { type?: string };
+    // OSC 133;C = a command started running → ↑/↓ pass through to it (menu/history).
+    emitOutput(terminalId, "\x1b]133;C\x07");
+    mockWriteToTerminal.mockClear();
+
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x1b[A");
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\r");
+
     const modes = mockModes as typeof mockModes & { applicationCursorKeysMode?: boolean };
     try {
-      buffer.type = "alternate";
       modes.applicationCursorKeysMode = true;
-      mockWriteToTerminal.mockClear();
-
-      // A printable char is forwarded even with an empty draft in alt-screen.
-      fireEvent.keyDown(textarea, { key: "j" });
-      expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "j");
-
-      // Application cursor mode emits SS3 instead of CSI.
       fireEvent.keyDown(textarea, { key: "ArrowUp" });
       expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x1bOA");
     } finally {
-      delete buffer.type;
       delete modes.applicationCursorKeysMode;
     }
   });

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -6069,14 +6069,6 @@ describe("TerminalView desktop input composer", () => {
     fireEvent.keyDown(host.parentElement!, { key: "m", ctrlKey: true, altKey: true });
   };
 
-  // Feed raw output so OSC 133 flips the prompt/program phase the Composer routes on.
-  const emitOutput = (terminalId: string, str: string) => {
-    const onOutput = mockOnTerminalOutput.mock.calls.find((call) => call[0] === terminalId)?.[1] as
-      | ((data: Uint8Array) => void)
-      | undefined;
-    act(() => onOutput?.(new TextEncoder().encode(str)));
-  };
-
   it("toggles the desktop composer through the registered keybinding", async () => {
     render(<TerminalView instanceId="t-composer-toggle" profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
@@ -6378,60 +6370,64 @@ describe("TerminalView desktop input composer", () => {
     expect(mockWriteTerminalInput).not.toHaveBeenCalled();
   });
 
-  it("recalls Composer history into the draft at the shell prompt (not the shell's)", async () => {
-    const terminalId = "t-composer-history";
-    render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
-    await waitForTerminalInputReady();
-
-    toggleInputMode(terminalId);
-    const textarea = screen.getByTestId(
-      `terminal-input-composer-${terminalId}-textarea`,
-    ) as HTMLTextAreaElement;
-
-    // Send one entry so the Composer has history, then confirm the draft cleared.
-    fireEvent.change(textarea, { target: { value: "echo hi" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-    await vi.waitFor(() => expect(textarea.value).toBe(""));
-
-    mockWriteToTerminal.mockClear();
-    // Empty draft at the prompt: ↑ recalls into the editor, not the terminal line.
-    fireEvent.keyDown(textarea, { key: "ArrowUp" });
-    await vi.waitFor(() => expect(textarea.value).toBe("echo hi"));
-    expect(mockWriteToTerminal).not.toHaveBeenCalled();
-  });
-
-  it("forwards every key (and honors DECCKM) while a program owns the screen", async () => {
-    const terminalId = "t-composer-program";
+  it("passes empty-draft nav keys and empty Enter through to the PTY", async () => {
+    const terminalId = "t-composer-passthrough";
     render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
 
     toggleInputMode(terminalId);
     const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
-    // OSC 133;C = a command started running → Composer steps aside to passthrough.
-    emitOutput(terminalId, "\x1b]133;C\x07");
     mockWriteToTerminal.mockClear();
+    mockWriteTerminalInput.mockClear();
 
     fireEvent.keyDown(textarea, { key: "ArrowUp" });
     expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x1b[A");
-    fireEvent.keyDown(textarea, { key: "j" });
-    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "j");
+
+    // Empty Enter confirms in the terminal (raw CR) — it must not "send" a draft.
     fireEvent.keyDown(textarea, { key: "Enter" });
     expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\r");
+    expect(mockWriteTerminalInput).not.toHaveBeenCalled();
+  });
 
+  it("keeps nav keys inside the draft once it has text", async () => {
+    const terminalId = "t-composer-nav-draft";
+    render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
+    await waitForTerminalInputReady();
+
+    toggleInputMode(terminalId);
+    const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
+    fireEvent.change(textarea, { target: { value: "draft" } });
+    mockWriteToTerminal.mockClear();
+
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    expect(mockWriteToTerminal).not.toHaveBeenCalled();
+  });
+
+  it("forwards every key (and honors DECCKM) while a full-screen app owns the screen", async () => {
+    const terminalId = "t-composer-altscreen";
+    render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
+    await waitForTerminalInputReady();
+
+    toggleInputMode(terminalId);
+    const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
+    const buffer = mockBufferActive as typeof mockBufferActive & { type?: string };
     const modes = mockModes as typeof mockModes & { applicationCursorKeysMode?: boolean };
     try {
+      buffer.type = "alternate";
       modes.applicationCursorKeysMode = true;
+      mockWriteToTerminal.mockClear();
+
+      // A printable char is forwarded even with an empty draft in alt-screen.
+      fireEvent.keyDown(textarea, { key: "j" });
+      expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "j");
+
+      // Application cursor mode emits SS3 instead of CSI.
       fireEvent.keyDown(textarea, { key: "ArrowUp" });
       expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x1bOA");
     } finally {
+      delete buffer.type;
       delete modes.applicationCursorKeysMode;
     }
-
-    // Back at the prompt, keys belong to the Composer again.
-    emitOutput(terminalId, "\x1b]133;B\x07");
-    mockWriteToTerminal.mockClear();
-    fireEvent.keyDown(textarea, { key: "ArrowUp" });
-    expect(mockWriteToTerminal).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -6403,6 +6403,26 @@ describe("TerminalView desktop input composer", () => {
     expect(mockWriteToTerminal).not.toHaveBeenCalled();
   });
 
+  it("never swallows Alt/Ctrl+Arrow so pane-navigation shortcuts still bubble", async () => {
+    const terminalId = "t-composer-panenav";
+    render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
+    await waitForTerminalInputReady();
+
+    toggleInputMode(terminalId);
+    const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
+    mockWriteToTerminal.mockClear();
+
+    // Empty draft, but modifier combos are app keybindings — must not be forwarded
+    // (and the composer must not stopPropagation them).
+    const altLeft = new KeyboardEvent("keydown", { key: "ArrowLeft", altKey: true, bubbles: true });
+    const stopSpy = vi.spyOn(altLeft, "stopPropagation");
+    textarea.dispatchEvent(altLeft);
+    fireEvent.keyDown(textarea, { key: "ArrowUp", ctrlKey: true, altKey: true });
+
+    expect(mockWriteToTerminal).not.toHaveBeenCalled();
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
   it("forwards every key (and honors DECCKM) while a full-screen app owns the screen", async () => {
     const terminalId = "t-composer-altscreen";
     render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -6369,6 +6369,66 @@ describe("TerminalView desktop input composer", () => {
     );
     expect(mockWriteTerminalInput).not.toHaveBeenCalled();
   });
+
+  it("passes empty-draft nav keys and empty Enter through to the PTY", async () => {
+    const terminalId = "t-composer-passthrough";
+    render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
+    await waitForTerminalInputReady();
+
+    toggleInputMode(terminalId);
+    const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
+    mockWriteToTerminal.mockClear();
+    mockWriteTerminalInput.mockClear();
+
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x1b[A");
+
+    // Empty Enter confirms in the terminal (raw CR) — it must not "send" a draft.
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\r");
+    expect(mockWriteTerminalInput).not.toHaveBeenCalled();
+  });
+
+  it("keeps nav keys inside the draft once it has text", async () => {
+    const terminalId = "t-composer-nav-draft";
+    render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
+    await waitForTerminalInputReady();
+
+    toggleInputMode(terminalId);
+    const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
+    fireEvent.change(textarea, { target: { value: "draft" } });
+    mockWriteToTerminal.mockClear();
+
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    expect(mockWriteToTerminal).not.toHaveBeenCalled();
+  });
+
+  it("forwards every key (and honors DECCKM) while a full-screen app owns the screen", async () => {
+    const terminalId = "t-composer-altscreen";
+    render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
+    await waitForTerminalInputReady();
+
+    toggleInputMode(terminalId);
+    const textarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
+    const buffer = mockBufferActive as typeof mockBufferActive & { type?: string };
+    const modes = mockModes as typeof mockModes & { applicationCursorKeysMode?: boolean };
+    try {
+      buffer.type = "alternate";
+      modes.applicationCursorKeysMode = true;
+      mockWriteToTerminal.mockClear();
+
+      // A printable char is forwarded even with an empty draft in alt-screen.
+      fireEvent.keyDown(textarea, { key: "j" });
+      expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "j");
+
+      // Application cursor mode emits SS3 instead of CSI.
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      expect(mockWriteToTerminal).toHaveBeenCalledWith(terminalId, "\x1bOA");
+    } finally {
+      delete buffer.type;
+      delete modes.applicationCursorKeysMode;
+    }
+  });
 });
 
 describe("shouldEnableTerminalWebgl", () => {

--- a/ui/src/components/views/TerminalView.test.tsx
+++ b/ui/src/components/views/TerminalView.test.tsx
@@ -6061,6 +6061,14 @@ describe("TerminalView desktop input composer", () => {
     mockWriteTerminalInput.mockResolvedValue(undefined);
   });
 
+  // The input-mode toggle now lives in the pane control bar, which is not mounted
+  // when TerminalView is rendered in isolation. Drive mode switches through the
+  // registered keybinding (Ctrl+Alt+M) instead of clicking an in-composer button.
+  const toggleInputMode = (terminalId: string) => {
+    const host = screen.getByTestId(`terminal-input-composer-${terminalId}`);
+    fireEvent.keyDown(host.parentElement!, { key: "m", ctrlKey: true, altKey: true });
+  };
+
   it("toggles the desktop composer through the registered keybinding", async () => {
     render(<TerminalView instanceId="t-composer-toggle" profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
@@ -6084,7 +6092,7 @@ describe("TerminalView desktop input composer", () => {
     await waitForTerminalInputReady();
 
     const terminal = createdTerminals.at(-1)!;
-    fireEvent.click(screen.getByTestId(`terminal-input-composer-${terminalId}-mode-composer`));
+    toggleInputMode(terminalId);
 
     await vi.waitFor(() => {
       expect(terminal.options.cursorInactiveStyle).toBe("none");
@@ -6093,7 +6101,7 @@ describe("TerminalView desktop input composer", () => {
       );
     });
 
-    fireEvent.click(screen.getByTestId(`terminal-input-composer-${terminalId}-mode-direct`));
+    toggleInputMode(terminalId);
     await vi.waitFor(() => {
       expect(terminal.options.cursorInactiveStyle).toBe("outline");
       expect(screen.getByTestId(`terminal-view-${terminalId}`)).not.toHaveClass(
@@ -6119,7 +6127,7 @@ describe("TerminalView desktop input composer", () => {
     container.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
     await vi.waitFor(() => expect(mockSmartPaste).toHaveBeenCalledWith("", "PowerShell"));
 
-    fireEvent.click(screen.getByTestId(`terminal-input-composer-${terminalId}-mode-composer`));
+    toggleInputMode(terminalId);
     await act(async () => {
       resolvePaste({ pasteType: "text", content: "must stay in the draft boundary" });
       await Promise.resolve();
@@ -6203,7 +6211,7 @@ describe("TerminalView desktop input composer", () => {
     render(<TerminalView instanceId={terminalId} profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
 
-    fireEvent.click(screen.getByTestId(`terminal-input-composer-${terminalId}-mode-composer`));
+    toggleInputMode(terminalId);
     const send = screen.getByTestId(`terminal-input-composer-${terminalId}-send`);
     await vi.waitFor(() => expect(send).toBeEnabled());
 
@@ -6253,7 +6261,7 @@ describe("TerminalView desktop input composer", () => {
     render(<TerminalView instanceId="t-composer-send" profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
 
-    fireEvent.click(screen.getByTestId("terminal-input-composer-t-composer-send-mode-composer"));
+    toggleInputMode("t-composer-send");
     const textarea = screen.getByTestId(
       "terminal-input-composer-t-composer-send-textarea",
     ) as HTMLTextAreaElement;
@@ -6280,7 +6288,7 @@ describe("TerminalView desktop input composer", () => {
     render(<TerminalView instanceId="t-composer-flight" profile="PowerShell" syncGroup="" />);
     await waitForTerminalInputReady();
 
-    fireEvent.click(screen.getByTestId("terminal-input-composer-t-composer-flight-mode-composer"));
+    toggleInputMode("t-composer-flight");
     const textarea = screen.getByTestId(
       "terminal-input-composer-t-composer-flight-textarea",
     ) as HTMLTextAreaElement;
@@ -6310,7 +6318,7 @@ describe("TerminalView desktop input composer", () => {
     );
     await waitForTerminalInputReady();
 
-    fireEvent.click(screen.getByTestId(`terminal-input-composer-${terminalId}-mode-composer`));
+    toggleInputMode(terminalId);
     const firstTextarea = screen.getByTestId(`terminal-input-composer-${terminalId}-textarea`);
     fireEvent.change(firstTextarea, { target: { value: "pending across remount" } });
     fireEvent.click(screen.getByTestId(`terminal-input-composer-${terminalId}-send`));

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -111,6 +111,8 @@ import { ConptyResizeRepaintFilter } from "@/lib/conpty-resize-repaint-filter";
 import { TerminalInputComposer } from "@/components/ui/TerminalInputComposer";
 import {
   beginComposerSubmission,
+  pushComposerHistory,
+  readComposerHistory,
   readRuntimeComposerDraft,
   readRuntimeInputMode,
   settleComposerSubmission,
@@ -122,7 +124,7 @@ import {
   type ComposerDraftState,
   type InputMode,
 } from "@/lib/terminal-input-composer-state";
-import { encodeTerminalKey, isPassthroughNavKey } from "@/lib/terminal-key-encoding";
+import { encodeTerminalKey } from "@/lib/terminal-key-encoding";
 import {
   normalizeTerminalOutputAttachment,
   normalizeTerminalOutputDelta,
@@ -542,6 +544,17 @@ export function TerminalView({
     readRuntimeComposerDraft(instanceId),
   );
   const composerDraftRef = useRef(composerDraft);
+  // OSC 133 input phase, mirrored into React state so the Composer can flip
+  // between "own the keys" (prompt) and "forward to the program" (running).
+  // Defaults true so an unintegrated shell keeps a usable Composer.
+  const [atShellPrompt, setAtShellPrompt] = useState(true);
+  const atShellPromptRef = useRef(true);
+  // Composer sent-history cursor: index into the history list (null = editing the
+  // live draft), plus the draft stashed when history navigation began.
+  const historyNavRef = useRef<{ index: number | null; stash: string }>({
+    index: null,
+    stash: "",
+  });
   const currentInstanceIdRef = useRef(instanceId);
   currentInstanceIdRef.current = instanceId;
 
@@ -568,9 +581,11 @@ export function TerminalView({
     });
     if (!started) return;
     storeComposerDraft(started.draft);
+    historyNavRef.current = { index: null, stash: "" };
     dismissTerminalResponseNotification(instanceId);
     writeTerminalInput(instanceId, started.submission.text, true)
       .then(() => {
+        pushComposerHistory(started.submission.terminalId, started.submission.text);
         storeComposerDraft(
           settleComposerSubmission(readRuntimeComposerDraft(started.submission.terminalId), {
             token: started.submission.token,
@@ -607,28 +622,62 @@ export function TerminalView({
   const localTerminalControlAllowed = () =>
     remoteControlStatusKnownRef.current && !remoteControlActiveRef.current;
 
+  const forwardComposerBytes = (data: string) => {
+    if (!data || !localTerminalControlAllowed()) return;
+    dismissTerminalResponseNotification(instanceId);
+    writeToTerminal(instanceId, data).catch((error) => {
+      console.warn("[TerminalView] composer forward failed:", error);
+    });
+  };
+
   /**
-   * Forward a Composer keystroke to the PTY instead of the draft when either the
-   * draft is empty and the key is a non-text nav key (so shell history / inline
-   * menus work), or a full-screen (alternate-screen) app is running (pass all
-   * keys, like Direct mode). Encoding defers to xterm's reported cursor-key mode.
+   * Forward a Composer keystroke straight to the running program (called only
+   * while NOT at the shell prompt). Encoding defers to xterm's reported cursor-key
+   * mode (DECCKM), so menus / TUIs and their own history behave natively.
    */
-  const passthroughComposerKey = (event: KeyboardEvent, ctx: { empty: boolean }): boolean => {
-    if (!localTerminalControlAllowed()) return false;
+  const passthroughComposerKey = (event: KeyboardEvent): boolean => {
+    if (atShellPromptRef.current || !localTerminalControlAllowed()) return false;
     const term = terminalRef.current;
     if (!term) return false;
-    const altScreen = term.buffer?.active?.type === "alternate";
-    if (!altScreen && !(ctx.empty && isPassthroughNavKey(event))) return false;
     const applicationCursor = Boolean(
       (term as unknown as { modes?: { applicationCursorKeysMode?: boolean } }).modes
         ?.applicationCursorKeysMode,
     );
     const seq = encodeTerminalKey(event, { applicationCursor });
     if (seq == null) return false;
-    dismissTerminalResponseNotification(instanceId);
-    writeToTerminal(instanceId, seq).catch((error) => {
-      console.warn("[TerminalView] composer key passthrough failed:", error);
-    });
+    forwardComposerBytes(seq);
+    return true;
+  };
+
+  /** Forward IME-composed text to the running program (not at the prompt). */
+  const forwardComposerText = (text: string) => {
+    if (atShellPromptRef.current) return;
+    forwardComposerBytes(text);
+  };
+
+  /**
+   * Recall the Composer's own sent-history into the draft (prompt only). Returns
+   * true when an entry (or the stashed live draft) replaced the current draft.
+   */
+  const navigateComposerHistory = (direction: "prev" | "next"): boolean => {
+    const history = readComposerHistory(instanceId);
+    const nav = historyNavRef.current;
+    if (direction === "prev") {
+      if (history.length === 0) return false;
+      if (nav.index === null) {
+        nav.stash = composerDraftRef.current.text;
+        nav.index = history.length;
+      }
+      if (nav.index === 0) return true; // already at the oldest entry
+      nav.index -= 1;
+      storeComposerDraft(updateComposerDraftText(composerDraftRef.current, history[nav.index]));
+      return true;
+    }
+    if (nav.index === null) return false; // not navigating — let ↓ move the caret
+    nav.index += 1;
+    const recalled = nav.index >= history.length ? nav.stash : history[nav.index];
+    if (nav.index >= history.length) nav.index = null;
+    storeComposerDraft(updateComposerDraftText(composerDraftRef.current, recalled));
     return true;
   };
 
@@ -637,6 +686,7 @@ export function TerminalView({
     const nextDraft = readRuntimeComposerDraft(instanceId);
     inputModeRef.current = nextMode;
     composerDraftRef.current = nextDraft;
+    historyNavRef.current = { index: null, stash: "" };
     outputProtocolReadyRef.current = false;
     setInputMode(nextMode);
     setComposerDraft(nextDraft);
@@ -1314,6 +1364,11 @@ export function TerminalView({
     const setInputPhase = (active: boolean) => {
       const shadowCursor = shadowCursorRef.current;
       shadowCursor.isInputPhase = active;
+      // Mirror into the Composer routing signal (ref for handlers, state for render).
+      if (atShellPromptRef.current !== active) {
+        atShellPromptRef.current = active;
+        setAtShellPrompt(active);
+      }
       if (!active) {
         shadowCursor.isRepaintInProgress = false;
       } else {
@@ -3792,11 +3847,16 @@ export function TerminalView({
         commitDisabled={!outputProtocolReady}
         autoFocus={isFocused}
         testId={`terminal-input-composer-${instanceId}`}
-        onTextChange={(text) =>
-          storeComposerDraft(updateComposerDraftText(composerDraftRef.current, text))
-        }
+        atShellPrompt={atShellPrompt}
+        onTextChange={(text) => {
+          // A user edit ends history navigation; recall goes through storeComposerDraft.
+          historyNavRef.current.index = null;
+          storeComposerDraft(updateComposerDraftText(composerDraftRef.current, text));
+        }}
         onSend={submitComposerDraft}
         onKeyPassthrough={passthroughComposerKey}
+        onForwardText={forwardComposerText}
+        onHistory={navigateComposerHistory}
       />
     </div>
   );

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -1358,14 +1358,20 @@ export function TerminalView({
         isAltBufferActive: shadowCursor.isAltBufferActive,
       });
     };
+    // Composer ↑/↓ routing signal. "At prompt" ≙ no command running, which the
+    // shell marks with OSC 133;D (see backend: last OSC D = prompt, C = running).
+    // NOT `isInputPhase` — that needs 133;B, which some shells (PowerShell) skip,
+    // so it stays false at the prompt and history recall would never fire.
+    const markShellPrompt = (atPrompt: boolean) => {
+      if (atShellPromptRef.current !== atPrompt) {
+        atShellPromptRef.current = atPrompt;
+        setAtShellPrompt(atPrompt);
+      }
+    };
+
     const setInputPhase = (active: boolean) => {
       const shadowCursor = shadowCursorRef.current;
       shadowCursor.isInputPhase = active;
-      // Mirror into the Composer's ↑/↓ routing signal (ref for handlers, state for render).
-      if (atShellPromptRef.current !== active) {
-        atShellPromptRef.current = active;
-        setAtShellPrompt(active);
-      }
       if (!active) {
         shadowCursor.isRepaintInProgress = false;
       } else {
@@ -2670,6 +2676,7 @@ export function TerminalView({
         shadowCursorRef.current.hasPromptBoundary = true;
         trace("chunk-prompt-boundary", { code: "A" });
         setInputPhase(false);
+        markShellPrompt(true);
       }
       if (text.includes("\x1b]133;B") || text.includes("\x1b]633;B")) {
         const shadowCursor = shadowCursorRef.current;
@@ -2679,16 +2686,21 @@ export function TerminalView({
         shadowCursor.commandStartX = shadowCursor.cursorX;
         shadowCursor.commandStartLine = shadowCursor.cursorAbsY;
         setInputPhase(true);
+        markShellPrompt(true);
       }
-      if (
-        text.includes("\x1b]133;C") ||
-        text.includes("\x1b]133;D") ||
-        text.includes("\x1b]633;C") ||
-        text.includes("\x1b]633;D")
-      ) {
+      // Split C (command started → running) from D (command done → back at prompt):
+      // isInputPhase collapses both to "not editing", but ↑/↓ routing needs them apart.
+      if (text.includes("\x1b]133;C") || text.includes("\x1b]633;C")) {
         shadowCursorRef.current.hasPromptBoundary = true;
-        trace("chunk-prompt-boundary", { code: "C/D" });
+        trace("chunk-prompt-boundary", { code: "C" });
         setInputPhase(false);
+        markShellPrompt(false);
+      }
+      if (text.includes("\x1b]133;D") || text.includes("\x1b]633;D")) {
+        shadowCursorRef.current.hasPromptBoundary = true;
+        trace("chunk-prompt-boundary", { code: "D" });
+        setInputPhase(false);
+        markShellPrompt(true);
       }
 
       // Detect alt screen buffer switch (vim, nano, htop, less, etc.)

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -122,6 +122,7 @@ import {
   type ComposerDraftState,
   type InputMode,
 } from "@/lib/terminal-input-composer-state";
+import { encodeTerminalKey, isPassthroughNavKey } from "@/lib/terminal-key-encoding";
 import {
   normalizeTerminalOutputAttachment,
   normalizeTerminalOutputDelta,
@@ -605,6 +606,31 @@ export function TerminalView({
   };
   const localTerminalControlAllowed = () =>
     remoteControlStatusKnownRef.current && !remoteControlActiveRef.current;
+
+  /**
+   * Forward a Composer keystroke to the PTY instead of the draft when either the
+   * draft is empty and the key is a non-text nav key (so shell history / inline
+   * menus work), or a full-screen (alternate-screen) app is running (pass all
+   * keys, like Direct mode). Encoding defers to xterm's reported cursor-key mode.
+   */
+  const passthroughComposerKey = (event: KeyboardEvent, ctx: { empty: boolean }): boolean => {
+    if (!localTerminalControlAllowed()) return false;
+    const term = terminalRef.current;
+    if (!term) return false;
+    const altScreen = term.buffer?.active?.type === "alternate";
+    if (!altScreen && !(ctx.empty && isPassthroughNavKey(event))) return false;
+    const applicationCursor = Boolean(
+      (term as unknown as { modes?: { applicationCursorKeysMode?: boolean } }).modes
+        ?.applicationCursorKeysMode,
+    );
+    const seq = encodeTerminalKey(event, { applicationCursor });
+    if (seq == null) return false;
+    dismissTerminalResponseNotification(instanceId);
+    writeToTerminal(instanceId, seq).catch((error) => {
+      console.warn("[TerminalView] composer key passthrough failed:", error);
+    });
+    return true;
+  };
 
   useEffect(() => {
     const nextMode = readRuntimeInputMode(instanceId);
@@ -3770,6 +3796,7 @@ export function TerminalView({
           storeComposerDraft(updateComposerDraftText(composerDraftRef.current, text))
         }
         onSend={submitComposerDraft}
+        onKeyPassthrough={passthroughComposerKey}
       />
     </div>
   );

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -3758,7 +3758,7 @@ export function TerminalView({
         labels={{
           editor: t("terminal.composerEditor"),
           placeholder: t("terminal.composerPlaceholder"),
-          send: t("terminal.composerSend"),
+          resize: t("terminal.composerResize"),
         }}
         textareaRef={composerTextareaRef}
         inFlight={composerDraft.inFlight !== null}

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -124,7 +124,12 @@ import {
   type ComposerDraftState,
   type InputMode,
 } from "@/lib/terminal-input-composer-state";
-import { encodeTerminalKey, isPassthroughNavKey } from "@/lib/terminal-key-encoding";
+import {
+  encodeTerminalKey,
+  isPassthroughControlChord,
+  isPassthroughNavKey,
+} from "@/lib/terminal-key-encoding";
+import { matchesGlobalShortcut } from "@/hooks/useKeyboardShortcuts";
 import {
   normalizeTerminalOutputAttachment,
   normalizeTerminalOutputDelta,
@@ -629,14 +634,19 @@ export function TerminalView({
    */
   const passthroughComposerKey = (event: KeyboardEvent, ctx: { empty: boolean }): boolean => {
     if (!localTerminalControlAllowed()) return false;
-    // Alt/Ctrl/Meta combos belong to app keybindings (pane focus = Alt+Arrow,
-    // Ctrl+Alt+…). Never swallow them here — let them bubble to the document
-    // shortcut handler, otherwise pane navigation dies while the Composer is up.
-    if (event.altKey || event.ctrlKey || event.metaKey) return false;
+    // laymux controls consume first (rebind-aware): any combo bound to a
+    // document-level action (pane focus = Alt+Arrow by default, workspace nav =
+    // Ctrl+Alt+…, or whatever the user rebound them to) is never forwarded — it
+    // bubbles to the document shortcut handler. No hardcoded modifier rules.
+    if (matchesGlobalShortcut(event)) return false;
     const term = terminalRef.current;
     if (!term) return false;
     const altScreen = term.buffer?.active?.type === "alternate";
-    if (!altScreen && !(ctx.empty && isPassthroughNavKey(event))) return false;
+    // Empty draft forwards nav keys (menus, shell history) and activity-control
+    // chords (Ctrl+C/D/Z/L) so a running command stays interruptible.
+    const emptyPassthrough =
+      ctx.empty && (isPassthroughNavKey(event) || isPassthroughControlChord(event));
+    if (!altScreen && !emptyPassthrough) return false;
     const applicationCursor = Boolean(
       (term as unknown as { modes?: { applicationCursorKeysMode?: boolean } }).modes
         ?.applicationCursorKeysMode,

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -111,8 +111,6 @@ import { ConptyResizeRepaintFilter } from "@/lib/conpty-resize-repaint-filter";
 import { TerminalInputComposer } from "@/components/ui/TerminalInputComposer";
 import {
   beginComposerSubmission,
-  pushComposerHistory,
-  readComposerHistory,
   readRuntimeComposerDraft,
   readRuntimeInputMode,
   settleComposerSubmission,
@@ -124,7 +122,7 @@ import {
   type ComposerDraftState,
   type InputMode,
 } from "@/lib/terminal-input-composer-state";
-import { encodeTerminalKey } from "@/lib/terminal-key-encoding";
+import { encodeTerminalKey, isPassthroughNavKey } from "@/lib/terminal-key-encoding";
 import {
   normalizeTerminalOutputAttachment,
   normalizeTerminalOutputDelta,
@@ -544,17 +542,6 @@ export function TerminalView({
     readRuntimeComposerDraft(instanceId),
   );
   const composerDraftRef = useRef(composerDraft);
-  // OSC 133 input phase, mirrored into React state so the Composer can flip
-  // between "own the keys" (prompt) and "forward to the program" (running).
-  // Defaults true so an unintegrated shell keeps a usable Composer.
-  const [atShellPrompt, setAtShellPrompt] = useState(true);
-  const atShellPromptRef = useRef(true);
-  // Composer sent-history cursor: index into the history list (null = editing the
-  // live draft), plus the draft stashed when history navigation began.
-  const historyNavRef = useRef<{ index: number | null; stash: string }>({
-    index: null,
-    stash: "",
-  });
   const currentInstanceIdRef = useRef(instanceId);
   currentInstanceIdRef.current = instanceId;
 
@@ -581,11 +568,9 @@ export function TerminalView({
     });
     if (!started) return;
     storeComposerDraft(started.draft);
-    historyNavRef.current = { index: null, stash: "" };
     dismissTerminalResponseNotification(instanceId);
     writeTerminalInput(instanceId, started.submission.text, true)
       .then(() => {
-        pushComposerHistory(started.submission.terminalId, started.submission.text);
         storeComposerDraft(
           settleComposerSubmission(readRuntimeComposerDraft(started.submission.terminalId), {
             token: started.submission.token,
@@ -622,62 +607,28 @@ export function TerminalView({
   const localTerminalControlAllowed = () =>
     remoteControlStatusKnownRef.current && !remoteControlActiveRef.current;
 
-  const forwardComposerBytes = (data: string) => {
-    if (!data || !localTerminalControlAllowed()) return;
-    dismissTerminalResponseNotification(instanceId);
-    writeToTerminal(instanceId, data).catch((error) => {
-      console.warn("[TerminalView] composer forward failed:", error);
-    });
-  };
-
   /**
-   * Forward a Composer keystroke straight to the running program (called only
-   * while NOT at the shell prompt). Encoding defers to xterm's reported cursor-key
-   * mode (DECCKM), so menus / TUIs and their own history behave natively.
+   * Forward a Composer keystroke to the PTY instead of the draft when either the
+   * draft is empty and the key is a non-text nav key (so shell history / inline
+   * menus work), or a full-screen (alternate-screen) app is running (pass all
+   * keys, like Direct mode). Encoding defers to xterm's reported cursor-key mode.
    */
-  const passthroughComposerKey = (event: KeyboardEvent): boolean => {
-    if (atShellPromptRef.current || !localTerminalControlAllowed()) return false;
+  const passthroughComposerKey = (event: KeyboardEvent, ctx: { empty: boolean }): boolean => {
+    if (!localTerminalControlAllowed()) return false;
     const term = terminalRef.current;
     if (!term) return false;
+    const altScreen = term.buffer?.active?.type === "alternate";
+    if (!altScreen && !(ctx.empty && isPassthroughNavKey(event))) return false;
     const applicationCursor = Boolean(
       (term as unknown as { modes?: { applicationCursorKeysMode?: boolean } }).modes
         ?.applicationCursorKeysMode,
     );
     const seq = encodeTerminalKey(event, { applicationCursor });
     if (seq == null) return false;
-    forwardComposerBytes(seq);
-    return true;
-  };
-
-  /** Forward IME-composed text to the running program (not at the prompt). */
-  const forwardComposerText = (text: string) => {
-    if (atShellPromptRef.current) return;
-    forwardComposerBytes(text);
-  };
-
-  /**
-   * Recall the Composer's own sent-history into the draft (prompt only). Returns
-   * true when an entry (or the stashed live draft) replaced the current draft.
-   */
-  const navigateComposerHistory = (direction: "prev" | "next"): boolean => {
-    const history = readComposerHistory(instanceId);
-    const nav = historyNavRef.current;
-    if (direction === "prev") {
-      if (history.length === 0) return false;
-      if (nav.index === null) {
-        nav.stash = composerDraftRef.current.text;
-        nav.index = history.length;
-      }
-      if (nav.index === 0) return true; // already at the oldest entry
-      nav.index -= 1;
-      storeComposerDraft(updateComposerDraftText(composerDraftRef.current, history[nav.index]));
-      return true;
-    }
-    if (nav.index === null) return false; // not navigating — let ↓ move the caret
-    nav.index += 1;
-    const recalled = nav.index >= history.length ? nav.stash : history[nav.index];
-    if (nav.index >= history.length) nav.index = null;
-    storeComposerDraft(updateComposerDraftText(composerDraftRef.current, recalled));
+    dismissTerminalResponseNotification(instanceId);
+    writeToTerminal(instanceId, seq).catch((error) => {
+      console.warn("[TerminalView] composer key passthrough failed:", error);
+    });
     return true;
   };
 
@@ -686,7 +637,6 @@ export function TerminalView({
     const nextDraft = readRuntimeComposerDraft(instanceId);
     inputModeRef.current = nextMode;
     composerDraftRef.current = nextDraft;
-    historyNavRef.current = { index: null, stash: "" };
     outputProtocolReadyRef.current = false;
     setInputMode(nextMode);
     setComposerDraft(nextDraft);
@@ -1364,11 +1314,6 @@ export function TerminalView({
     const setInputPhase = (active: boolean) => {
       const shadowCursor = shadowCursorRef.current;
       shadowCursor.isInputPhase = active;
-      // Mirror into the Composer routing signal (ref for handlers, state for render).
-      if (atShellPromptRef.current !== active) {
-        atShellPromptRef.current = active;
-        setAtShellPrompt(active);
-      }
       if (!active) {
         shadowCursor.isRepaintInProgress = false;
       } else {
@@ -3847,16 +3792,11 @@ export function TerminalView({
         commitDisabled={!outputProtocolReady}
         autoFocus={isFocused}
         testId={`terminal-input-composer-${instanceId}`}
-        atShellPrompt={atShellPrompt}
-        onTextChange={(text) => {
-          // A user edit ends history navigation; recall goes through storeComposerDraft.
-          historyNavRef.current.index = null;
-          storeComposerDraft(updateComposerDraftText(composerDraftRef.current, text));
-        }}
+        onTextChange={(text) =>
+          storeComposerDraft(updateComposerDraftText(composerDraftRef.current, text))
+        }
         onSend={submitComposerDraft}
         onKeyPassthrough={passthroughComposerKey}
-        onForwardText={forwardComposerText}
-        onHistory={navigateComposerHistory}
       />
     </div>
   );

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -683,6 +683,7 @@ export function TerminalView({
   // 별도의 헤더 바를 만들지 않고 이미 존재하는 pinned 바의 빈 좌측 공간을 재활용한다.
   const paneCtx = usePaneControl();
   const setLeftBarContent = paneCtx?.setLeftBarContent;
+  const setInputModeToggle = paneCtx?.setInputModeToggle;
   const controlBarMode = paneCtx?.mode;
   const rawTitle = useTerminalStore(
     (s) => s.instances.find((i) => i.id === instanceId)?.title?.trim() ?? "",
@@ -704,6 +705,18 @@ export function TerminalView({
     );
     return () => setLeftBarContent(null);
   }, [setLeftBarContent, controlBarMode, instanceId, rawTitle]);
+  // Publish the terminal's input-mode toggle into the pane control bar so mode
+  // switching lives as a single toolbar button (not a bottom bar). onToggle reads
+  // the live mode via ref, so the handler stays correct without re-subscribing.
+  useEffect(() => {
+    if (!setInputModeToggle) return;
+    setInputModeToggle({
+      mode: inputMode,
+      onToggle: () => changeInputMode(inputModeRef.current === "direct" ? "composer" : "direct"),
+    });
+    return () => setInputModeToggle(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setInputModeToggle, inputMode]);
   const syncOutputActiveRef = useRef(false);
   const compositionPreviewRef = useRef<CompositionPreviewState>({
     active: false,
@@ -3743,9 +3756,6 @@ export function TerminalView({
         mode={inputMode}
         text={composerDraft.text}
         labels={{
-          inputMode: t("terminal.inputMode"),
-          direct: t("terminal.directInput"),
-          composer: t("terminal.composerInput"),
           editor: t("terminal.composerEditor"),
           placeholder: t("terminal.composerPlaceholder"),
           send: t("terminal.composerSend"),
@@ -3756,7 +3766,6 @@ export function TerminalView({
         commitDisabled={!outputProtocolReady}
         autoFocus={isFocused}
         testId={`terminal-input-composer-${instanceId}`}
-        onModeChange={changeInputMode}
         onTextChange={(text) =>
           storeComposerDraft(updateComposerDraftText(composerDraftRef.current, text))
         }

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -111,6 +111,8 @@ import { ConptyResizeRepaintFilter } from "@/lib/conpty-resize-repaint-filter";
 import { TerminalInputComposer } from "@/components/ui/TerminalInputComposer";
 import {
   beginComposerSubmission,
+  pushComposerHistory,
+  readComposerHistory,
   readRuntimeComposerDraft,
   readRuntimeInputMode,
   settleComposerSubmission,
@@ -542,6 +544,16 @@ export function TerminalView({
     readRuntimeComposerDraft(instanceId),
   );
   const composerDraftRef = useRef(composerDraft);
+  // OSC 133 input phase mirrored into state: true at a shell prompt (↑/↓ recall
+  // Composer history), false while a program runs (↑/↓ pass through to it).
+  const [atShellPrompt, setAtShellPrompt] = useState(true);
+  const atShellPromptRef = useRef(true);
+  // Composer sent-history cursor (null = editing the live draft) + the draft
+  // stashed when history navigation began.
+  const historyNavRef = useRef<{ index: number | null; stash: string }>({
+    index: null,
+    stash: "",
+  });
   const currentInstanceIdRef = useRef(instanceId);
   currentInstanceIdRef.current = instanceId;
 
@@ -568,9 +580,11 @@ export function TerminalView({
     });
     if (!started) return;
     storeComposerDraft(started.draft);
+    historyNavRef.current = { index: null, stash: "" };
     dismissTerminalResponseNotification(instanceId);
     writeTerminalInput(instanceId, started.submission.text, true)
       .then(() => {
+        pushComposerHistory(started.submission.terminalId, started.submission.text);
         storeComposerDraft(
           settleComposerSubmission(readRuntimeComposerDraft(started.submission.terminalId), {
             token: started.submission.token,
@@ -636,10 +650,39 @@ export function TerminalView({
     return true;
   };
 
+  /**
+   * Recall the Composer's own sent-history into the draft (shell prompt only, via
+   * ↑/↓ at the draft edges). Keeping it in the editor — rather than passing ↑ to
+   * the shell — avoids the recalled command landing on the terminal line detached
+   * from the editor. Always returns true so the caller consumes the key.
+   */
+  const navigateComposerHistory = (direction: "prev" | "next"): boolean => {
+    const history = readComposerHistory(instanceId);
+    const nav = historyNavRef.current;
+    if (direction === "prev") {
+      if (history.length === 0) return true;
+      if (nav.index === null) {
+        nav.stash = composerDraftRef.current.text;
+        nav.index = history.length;
+      }
+      if (nav.index === 0) return true; // already at the oldest entry
+      nav.index -= 1;
+      storeComposerDraft(updateComposerDraftText(composerDraftRef.current, history[nav.index]));
+      return true;
+    }
+    if (nav.index === null) return true; // not navigating — nothing newer to show
+    nav.index += 1;
+    const recalled = nav.index >= history.length ? nav.stash : history[nav.index];
+    if (nav.index >= history.length) nav.index = null;
+    storeComposerDraft(updateComposerDraftText(composerDraftRef.current, recalled));
+    return true;
+  };
+
   useEffect(() => {
     const nextMode = readRuntimeInputMode(instanceId);
     const nextDraft = readRuntimeComposerDraft(instanceId);
     inputModeRef.current = nextMode;
+    historyNavRef.current = { index: null, stash: "" };
     composerDraftRef.current = nextDraft;
     outputProtocolReadyRef.current = false;
     setInputMode(nextMode);
@@ -1318,6 +1361,11 @@ export function TerminalView({
     const setInputPhase = (active: boolean) => {
       const shadowCursor = shadowCursorRef.current;
       shadowCursor.isInputPhase = active;
+      // Mirror into the Composer's ↑/↓ routing signal (ref for handlers, state for render).
+      if (atShellPromptRef.current !== active) {
+        atShellPromptRef.current = active;
+        setAtShellPrompt(active);
+      }
       if (!active) {
         shadowCursor.isRepaintInProgress = false;
       } else {
@@ -3796,11 +3844,15 @@ export function TerminalView({
         commitDisabled={!outputProtocolReady}
         autoFocus={isFocused}
         testId={`terminal-input-composer-${instanceId}`}
-        onTextChange={(text) =>
-          storeComposerDraft(updateComposerDraftText(composerDraftRef.current, text))
-        }
+        atShellPrompt={atShellPrompt}
+        onTextChange={(text) => {
+          // A user edit ends history navigation (recall goes through storeComposerDraft).
+          historyNavRef.current.index = null;
+          storeComposerDraft(updateComposerDraftText(composerDraftRef.current, text));
+        }}
         onSend={submitComposerDraft}
         onKeyPassthrough={passthroughComposerKey}
+        onHistory={navigateComposerHistory}
       />
     </div>
   );

--- a/ui/src/components/views/TerminalView.tsx
+++ b/ui/src/components/views/TerminalView.tsx
@@ -615,6 +615,10 @@ export function TerminalView({
    */
   const passthroughComposerKey = (event: KeyboardEvent, ctx: { empty: boolean }): boolean => {
     if (!localTerminalControlAllowed()) return false;
+    // Alt/Ctrl/Meta combos belong to app keybindings (pane focus = Alt+Arrow,
+    // Ctrl+Alt+…). Never swallow them here — let them bubble to the document
+    // shortcut handler, otherwise pane navigation dies while the Composer is up.
+    if (event.altKey || event.ctrlKey || event.metaKey) return false;
     const term = terminalRef.current;
     if (!term) return false;
     const altScreen = term.buffer?.active?.type === "alternate";

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -442,6 +442,18 @@ const SHORTCUT_HANDLERS: Record<string, (e: KeyboardEvent) => void> = {
 
 const SHORTCUT_ACTION_IDS = Object.keys(SHORTCUT_HANDLERS);
 
+/**
+ * True when the event's combo is bound (default or user-rebound) to any
+ * document-level laymux action this hook dispatches (pane/workspace navigation,
+ * notifications, UI toggles). Focused surfaces that forward raw keys to a PTY
+ * (e.g. the terminal Composer) must check this FIRST and let matching events
+ * bubble — laymux controls consume before passthrough, and rebinding moves
+ * this check together with the dispatcher automatically.
+ */
+export function matchesGlobalShortcut(e: KeyboardEvent): boolean {
+  return SHORTCUT_ACTION_IDS.some((actionId) => matchesKeybinding(e, actionId));
+}
+
 export function useKeyboardShortcuts() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -8,9 +8,6 @@
     "terminal": {
       "pasteConfirm": "The text to paste is {{bytes}} bytes. Do you want to continue?",
       "scrollToBottom": "Scroll to bottom",
-      "inputMode": "Terminal input mode",
-      "directInput": "Direct",
-      "composerInput": "Composer",
       "composerEditor": "Terminal input draft",
       "composerPlaceholder": "Type text to send",
       "composerSend": "Send"
@@ -256,6 +253,10 @@
     },
     "terminal": {
       "title": "Terminal",
+      "defaultInputMode": "Default Input Mode",
+      "defaultInputModeDesc": "Input mode a new terminal starts in. Switch anytime with Ctrl+Alt+M or the pane toolbar button.",
+      "inputModeDirect": "Direct",
+      "inputModeComposer": "Composer",
       "copyOnSelect": "Copy on Select",
       "copyOnSelectDesc": "Automatically copy to clipboard when selecting text in the terminal",
       "scrollbarStyle": "Scrollbar Style",

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -9,8 +9,8 @@
       "pasteConfirm": "The text to paste is {{bytes}} bytes. Do you want to continue?",
       "scrollToBottom": "Scroll to bottom",
       "composerEditor": "Terminal input draft",
-      "composerPlaceholder": "Type text to send",
-      "composerSend": "Send"
+      "composerPlaceholder": "Type, then Enter to send · Shift+Enter for a newline",
+      "composerResize": "Resize input area (drag the top edge)"
     },
     "remoteControl": {
       "title": "Remote control active",

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -9,8 +9,8 @@
       "pasteConfirm": "붙여넣을 텍스트가 {{bytes}}바이트입니다. 계속하시겠습니까?",
       "scrollToBottom": "맨 아래로 이동",
       "composerEditor": "터미널 입력 초안",
-      "composerPlaceholder": "전송할 내용을 입력하세요",
-      "composerSend": "전송"
+      "composerPlaceholder": "입력 후 Enter 전송 · Shift+Enter 줄바꿈",
+      "composerResize": "입력 영역 크기 조절 (위 경계 드래그)"
     },
     "remoteControl": {
       "title": "원격 제어 중",

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -8,9 +8,6 @@
     "terminal": {
       "pasteConfirm": "붙여넣을 텍스트가 {{bytes}}바이트입니다. 계속하시겠습니까?",
       "scrollToBottom": "맨 아래로 이동",
-      "inputMode": "터미널 입력 방식",
-      "directInput": "직접 입력",
-      "composerInput": "입력칸",
       "composerEditor": "터미널 입력 초안",
       "composerPlaceholder": "전송할 내용을 입력하세요",
       "composerSend": "전송"
@@ -256,6 +253,10 @@
     },
     "terminal": {
       "title": "터미널",
+      "defaultInputMode": "기본 입력 방식",
+      "defaultInputModeDesc": "새 터미널이 시작할 때의 입력 방식. Ctrl+Alt+M 또는 pane 툴바 버튼으로 언제든 전환.",
+      "inputModeDirect": "직접",
+      "inputModeComposer": "입력칸",
       "copyOnSelect": "선택 시 복사",
       "copyOnSelectDesc": "터미널에서 텍스트 선택 시 자동으로 클립보드에 복사",
       "scrollbarStyle": "스크롤바 방식",

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -6,6 +6,7 @@
   --bg-overlay: #313244;
   --text-primary: #cdd6f4;
   --text-secondary: #a6adc8;
+  --text-muted: #6c7086;
   --accent: #89b4fa;
   --accent-50: rgba(137, 180, 250, 0.5);
   --accent-20: rgba(137, 180, 250, 0.2);

--- a/ui/src/lib/terminal-input-composer-state.test.ts
+++ b/ui/src/lib/terminal-input-composer-state.test.ts
@@ -9,7 +9,9 @@ import {
   clampComposerHeight,
   clearRuntimeComposerState,
   createComposerDraftState,
+  pushComposerHistory,
   readComposerHeight,
+  readComposerHistory,
   readDesktopInputModePreference,
   readRuntimeComposerDraft,
   readRuntimeInputMode,
@@ -21,6 +23,29 @@ import {
   writeRuntimeComposerDraft,
   writeRuntimeInputMode,
 } from "./terminal-input-composer-state";
+
+describe("composer sent-history", () => {
+  beforeEach(() => {
+    clearRuntimeComposerState();
+  });
+
+  it("appends entries, skipping blanks and consecutive duplicates", () => {
+    pushComposerHistory("t1", "one");
+    pushComposerHistory("t1", "one"); // duplicate — ignored
+    pushComposerHistory("t1", ""); // blank — ignored
+    pushComposerHistory("t1", "two");
+    expect(readComposerHistory("t1")).toEqual(["one", "two"]);
+  });
+
+  it("isolates history per terminal and clears it with runtime state", () => {
+    pushComposerHistory("a", "cmd-a");
+    pushComposerHistory("b", "cmd-b");
+    expect(readComposerHistory("a")).toEqual(["cmd-a"]);
+    clearRuntimeComposerState("a");
+    expect(readComposerHistory("a")).toEqual([]);
+    expect(readComposerHistory("b")).toEqual(["cmd-b"]);
+  });
+});
 
 describe("desktop composer height preference", () => {
   beforeEach(() => {

--- a/ui/src/lib/terminal-input-composer-state.test.ts
+++ b/ui/src/lib/terminal-input-composer-state.test.ts
@@ -9,7 +9,9 @@ import {
   clampComposerHeight,
   clearRuntimeComposerState,
   createComposerDraftState,
+  pushComposerHistory,
   readComposerHeight,
+  readComposerHistory,
   readDesktopInputModePreference,
   readRuntimeComposerDraft,
   readRuntimeInputMode,
@@ -21,6 +23,31 @@ import {
   writeRuntimeComposerDraft,
   writeRuntimeInputMode,
 } from "./terminal-input-composer-state";
+
+describe("composer sent-history", () => {
+  beforeEach(() => {
+    clearRuntimeComposerState();
+  });
+
+  it("appends entries, skipping blanks and consecutive duplicates", () => {
+    pushComposerHistory("t1", "one");
+    pushComposerHistory("t1", "one"); // duplicate — ignored
+    pushComposerHistory("t1", ""); // blank — ignored
+    pushComposerHistory("t1", "two");
+    expect(readComposerHistory("t1")).toEqual(["one", "two"]);
+  });
+
+  it("keeps history isolated per terminal and clears with runtime state", () => {
+    pushComposerHistory("a", "cmd-a");
+    pushComposerHistory("b", "cmd-b");
+    expect(readComposerHistory("a")).toEqual(["cmd-a"]);
+    expect(readComposerHistory("b")).toEqual(["cmd-b"]);
+
+    clearRuntimeComposerState("a");
+    expect(readComposerHistory("a")).toEqual([]);
+    expect(readComposerHistory("b")).toEqual(["cmd-b"]);
+  });
+});
 
 describe("desktop composer height preference", () => {
   beforeEach(() => {

--- a/ui/src/lib/terminal-input-composer-state.test.ts
+++ b/ui/src/lib/terminal-input-composer-state.test.ts
@@ -9,9 +9,7 @@ import {
   clampComposerHeight,
   clearRuntimeComposerState,
   createComposerDraftState,
-  pushComposerHistory,
   readComposerHeight,
-  readComposerHistory,
   readDesktopInputModePreference,
   readRuntimeComposerDraft,
   readRuntimeInputMode,
@@ -23,31 +21,6 @@ import {
   writeRuntimeComposerDraft,
   writeRuntimeInputMode,
 } from "./terminal-input-composer-state";
-
-describe("composer sent-history", () => {
-  beforeEach(() => {
-    clearRuntimeComposerState();
-  });
-
-  it("appends entries, skipping blanks and consecutive duplicates", () => {
-    pushComposerHistory("t1", "one");
-    pushComposerHistory("t1", "one"); // duplicate — ignored
-    pushComposerHistory("t1", ""); // blank — ignored
-    pushComposerHistory("t1", "two");
-    expect(readComposerHistory("t1")).toEqual(["one", "two"]);
-  });
-
-  it("keeps history isolated per terminal and clears with runtime state", () => {
-    pushComposerHistory("a", "cmd-a");
-    pushComposerHistory("b", "cmd-b");
-    expect(readComposerHistory("a")).toEqual(["cmd-a"]);
-    expect(readComposerHistory("b")).toEqual(["cmd-b"]);
-
-    clearRuntimeComposerState("a");
-    expect(readComposerHistory("a")).toEqual([]);
-    expect(readComposerHistory("b")).toEqual(["cmd-b"]);
-  });
-});
 
 describe("desktop composer height preference", () => {
   beforeEach(() => {

--- a/ui/src/lib/terminal-input-composer-state.test.ts
+++ b/ui/src/lib/terminal-input-composer-state.test.ts
@@ -1,19 +1,48 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  DEFAULT_COMPOSER_HEIGHT,
+  DESKTOP_COMPOSER_HEIGHT_STORAGE_KEY,
   DESKTOP_INPUT_MODE_STORAGE_KEY,
+  MAX_COMPOSER_HEIGHT,
+  MIN_COMPOSER_HEIGHT,
   beginComposerSubmission,
+  clampComposerHeight,
   clearRuntimeComposerState,
   createComposerDraftState,
+  readComposerHeight,
   readDesktopInputModePreference,
   readRuntimeComposerDraft,
   readRuntimeInputMode,
   settleComposerSubmission,
   subscribeRuntimeComposerDraft,
   updateComposerDraftText,
+  writeComposerHeight,
   writeDesktopInputModePreference,
   writeRuntimeComposerDraft,
   writeRuntimeInputMode,
 } from "./terminal-input-composer-state";
+
+describe("desktop composer height preference", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults when unset and clamps to the draggable bounds", () => {
+    expect(readComposerHeight()).toBe(DEFAULT_COMPOSER_HEIGHT);
+    expect(clampComposerHeight(0)).toBe(MIN_COMPOSER_HEIGHT);
+    expect(clampComposerHeight(99999)).toBe(MAX_COMPOSER_HEIGHT);
+    expect(clampComposerHeight(Number.NaN)).toBe(DEFAULT_COMPOSER_HEIGHT);
+  });
+
+  it("round-trips a clamped height through storage", () => {
+    expect(writeComposerHeight(140)).toBe(true);
+    expect(localStorage.getItem(DESKTOP_COMPOSER_HEIGHT_STORAGE_KEY)).toBe("140");
+    expect(readComposerHeight()).toBe(140);
+
+    writeComposerHeight(10_000);
+    expect(readComposerHeight()).toBe(MAX_COMPOSER_HEIGHT);
+  });
+});
 
 describe("desktop terminal input-mode preference", () => {
   beforeEach(() => {

--- a/ui/src/lib/terminal-input-composer-state.ts
+++ b/ui/src/lib/terminal-input-composer-state.ts
@@ -88,28 +88,6 @@ export function writeComposerHeight(px: number, storage?: InputModeStorage | nul
   }
 }
 
-const MAX_COMPOSER_HISTORY = 200;
-const runtimeHistory = new Map<string, string[]>();
-
-/** Runtime-only per-terminal history of texts sent from the Composer. */
-export function readComposerHistory(terminalId: string): string[] {
-  return runtimeHistory.get(terminalId) ?? [];
-}
-
-/**
- * Appends a sent draft to the terminal's Composer history. Blank entries and
- * consecutive duplicates are ignored; the list is capped so it cannot grow
- * without bound.
- */
-export function pushComposerHistory(terminalId: string, text: string): void {
-  if (!text) return;
-  const list = runtimeHistory.get(terminalId) ?? [];
-  if (list[list.length - 1] === text) return;
-  list.push(text);
-  if (list.length > MAX_COMPOSER_HISTORY) list.splice(0, list.length - MAX_COMPOSER_HISTORY);
-  runtimeHistory.set(terminalId, list);
-}
-
 export type ComposerSubmissionToken = string;
 
 export interface ComposerSubmissionSnapshot {
@@ -212,7 +190,6 @@ export function clearRuntimeComposerState(terminalId?: string): void {
     const subscribedTerminalIds = [...runtimeDraftListeners.keys()];
     runtimeDrafts.clear();
     runtimeModes.clear();
-    runtimeHistory.clear();
     for (const subscribedTerminalId of subscribedTerminalIds) {
       notifyRuntimeComposerDraft(subscribedTerminalId, createComposerDraftState());
     }
@@ -220,7 +197,6 @@ export function clearRuntimeComposerState(terminalId?: string): void {
   }
   runtimeDrafts.delete(terminalId);
   runtimeModes.delete(terminalId);
-  runtimeHistory.delete(terminalId);
   notifyRuntimeComposerDraft(terminalId, createComposerDraftState());
 }
 

--- a/ui/src/lib/terminal-input-composer-state.ts
+++ b/ui/src/lib/terminal-input-composer-state.ts
@@ -88,6 +88,28 @@ export function writeComposerHeight(px: number, storage?: InputModeStorage | nul
   }
 }
 
+const MAX_COMPOSER_HISTORY = 200;
+const runtimeHistory = new Map<string, string[]>();
+
+/** Runtime-only per-terminal history of texts sent from the Composer. */
+export function readComposerHistory(terminalId: string): string[] {
+  return runtimeHistory.get(terminalId) ?? [];
+}
+
+/**
+ * Appends a sent draft to the terminal's Composer history. Blank entries and
+ * consecutive duplicates are ignored; the list is capped so it cannot grow
+ * without bound.
+ */
+export function pushComposerHistory(terminalId: string, text: string): void {
+  if (!text) return;
+  const list = runtimeHistory.get(terminalId) ?? [];
+  if (list[list.length - 1] === text) return;
+  list.push(text);
+  if (list.length > MAX_COMPOSER_HISTORY) list.splice(0, list.length - MAX_COMPOSER_HISTORY);
+  runtimeHistory.set(terminalId, list);
+}
+
 export type ComposerSubmissionToken = string;
 
 export interface ComposerSubmissionSnapshot {
@@ -190,6 +212,7 @@ export function clearRuntimeComposerState(terminalId?: string): void {
     const subscribedTerminalIds = [...runtimeDraftListeners.keys()];
     runtimeDrafts.clear();
     runtimeModes.clear();
+    runtimeHistory.clear();
     for (const subscribedTerminalId of subscribedTerminalIds) {
       notifyRuntimeComposerDraft(subscribedTerminalId, createComposerDraftState());
     }
@@ -197,6 +220,7 @@ export function clearRuntimeComposerState(terminalId?: string): void {
   }
   runtimeDrafts.delete(terminalId);
   runtimeModes.delete(terminalId);
+  runtimeHistory.delete(terminalId);
   notifyRuntimeComposerDraft(terminalId, createComposerDraftState());
 }
 

--- a/ui/src/lib/terminal-input-composer-state.ts
+++ b/ui/src/lib/terminal-input-composer-state.ts
@@ -51,6 +51,43 @@ export function writeDesktopInputModePreference(
   }
 }
 
+export const DESKTOP_COMPOSER_HEIGHT_STORAGE_KEY = "laymux.desktop.composerHeight";
+export const DEFAULT_COMPOSER_HEIGHT = 96;
+export const MIN_COMPOSER_HEIGHT = 56;
+export const MAX_COMPOSER_HEIGHT = 480;
+
+/** Keeps a composer height within the draggable bounds; rounds to a whole pixel. */
+export function clampComposerHeight(px: number): number {
+  if (!Number.isFinite(px)) return DEFAULT_COMPOSER_HEIGHT;
+  return Math.round(Math.min(MAX_COMPOSER_HEIGHT, Math.max(MIN_COMPOSER_HEIGHT, px)));
+}
+
+/**
+ * Reads the desktop composer editor height (px). Like the input-mode default it
+ * is a UI-only surface preference, so it lives in localStorage, not settings.json.
+ */
+export function readComposerHeight(storage?: InputModeStorage | null): number {
+  try {
+    const stored = resolveBrowserStorage(storage)?.getItem(DESKTOP_COMPOSER_HEIGHT_STORAGE_KEY);
+    const parsed = stored == null ? NaN : Number(stored);
+    return Number.isFinite(parsed) ? clampComposerHeight(parsed) : DEFAULT_COMPOSER_HEIGHT;
+  } catch {
+    return DEFAULT_COMPOSER_HEIGHT;
+  }
+}
+
+/** Returns false when browser storage is unavailable. Clamps before persisting. */
+export function writeComposerHeight(px: number, storage?: InputModeStorage | null): boolean {
+  try {
+    const target = resolveBrowserStorage(storage);
+    if (!target) return false;
+    target.setItem(DESKTOP_COMPOSER_HEIGHT_STORAGE_KEY, String(clampComposerHeight(px)));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export type ComposerSubmissionToken = string;
 
 export interface ComposerSubmissionSnapshot {

--- a/ui/src/lib/terminal-key-encoding.test.ts
+++ b/ui/src/lib/terminal-key-encoding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { encodeTerminalKey } from "./terminal-key-encoding";
+import { encodeTerminalKey, isPassthroughNavKey } from "./terminal-key-encoding";
 
 type Key = Parameters<typeof encodeTerminalKey>[0];
 const ev = (over: Partial<Key> & Pick<Key, "key">): Key => ({
@@ -8,6 +8,20 @@ const ev = (over: Partial<Key> & Pick<Key, "key">): Key => ({
   metaKey: false,
   shiftKey: false,
   ...over,
+});
+
+describe("isPassthroughNavKey", () => {
+  it("flags non-character navigation keys", () => {
+    for (const key of ["ArrowUp", "ArrowDown", "Home", "End", "PageUp", "Escape", "Tab", "Enter"]) {
+      expect(isPassthroughNavKey({ key })).toBe(true);
+    }
+  });
+
+  it("excludes printable characters and modifiers", () => {
+    for (const key of ["a", " ", "1", "Shift", "Control"]) {
+      expect(isPassthroughNavKey({ key })).toBe(false);
+    }
+  });
 });
 
 describe("encodeTerminalKey", () => {

--- a/ui/src/lib/terminal-key-encoding.test.ts
+++ b/ui/src/lib/terminal-key-encoding.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { encodeTerminalKey, isPassthroughNavKey } from "./terminal-key-encoding";
+import {
+  encodeTerminalKey,
+  isPassthroughControlChord,
+  isPassthroughNavKey,
+} from "./terminal-key-encoding";
 
 type Key = Parameters<typeof encodeTerminalKey>[0];
 const ev = (over: Partial<Key> & Pick<Key, "key">): Key => ({
@@ -53,5 +57,34 @@ describe("encodeTerminalKey", () => {
     expect(encodeTerminalKey(ev({ key: "Shift" }))).toBeNull();
     expect(encodeTerminalKey(ev({ key: "Control", ctrlKey: true }))).toBeNull();
     expect(encodeTerminalKey(ev({ key: "Meta", metaKey: true }))).toBeNull();
+  });
+
+  it("encodes modified navigation keys with the xterm CSI 1;mod form", () => {
+    expect(encodeTerminalKey(ev({ key: "ArrowLeft", ctrlKey: true }))).toBe("\x1b[1;5D");
+    expect(encodeTerminalKey(ev({ key: "ArrowUp", altKey: true }))).toBe("\x1b[1;3A");
+    expect(encodeTerminalKey(ev({ key: "ArrowUp", ctrlKey: true, altKey: true }))).toBe(
+      "\x1b[1;7A",
+    );
+    expect(encodeTerminalKey(ev({ key: "Home", shiftKey: true }))).toBe("\x1b[1;2H");
+    expect(encodeTerminalKey(ev({ key: "Delete", ctrlKey: true }))).toBe("\x1b[3;5~");
+    // Modifiers force the CSI form even in application-cursor mode (xterm rule).
+    expect(
+      encodeTerminalKey(ev({ key: "ArrowUp", ctrlKey: true }), { applicationCursor: true }),
+    ).toBe("\x1b[1;5A");
+  });
+});
+
+describe("isPassthroughControlChord", () => {
+  it("accepts the activity-control chords Ctrl+C/D/Z/L", () => {
+    for (const key of ["c", "d", "z", "l"]) {
+      expect(isPassthroughControlChord(ev({ key, ctrlKey: true }))).toBe(true);
+    }
+  });
+
+  it("rejects everything else (paste, extra modifiers, plain keys)", () => {
+    expect(isPassthroughControlChord(ev({ key: "v", ctrlKey: true }))).toBe(false); // paste stays in the draft
+    expect(isPassthroughControlChord(ev({ key: "c", ctrlKey: true, shiftKey: true }))).toBe(false);
+    expect(isPassthroughControlChord(ev({ key: "c", ctrlKey: true, altKey: true }))).toBe(false);
+    expect(isPassthroughControlChord(ev({ key: "c" }))).toBe(false);
   });
 });

--- a/ui/src/lib/terminal-key-encoding.test.ts
+++ b/ui/src/lib/terminal-key-encoding.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { encodeTerminalKey, isPassthroughNavKey } from "./terminal-key-encoding";
+
+type Key = Parameters<typeof encodeTerminalKey>[0];
+const ev = (over: Partial<Key> & Pick<Key, "key">): Key => ({
+  ctrlKey: false,
+  altKey: false,
+  metaKey: false,
+  shiftKey: false,
+  ...over,
+});
+
+describe("isPassthroughNavKey", () => {
+  it("flags non-character navigation keys", () => {
+    for (const key of ["ArrowUp", "ArrowDown", "Home", "End", "PageUp", "Escape", "Tab", "Enter"]) {
+      expect(isPassthroughNavKey({ key })).toBe(true);
+    }
+  });
+
+  it("excludes printable characters and modifiers", () => {
+    for (const key of ["a", " ", "1", "Shift", "Control"]) {
+      expect(isPassthroughNavKey({ key })).toBe(false);
+    }
+  });
+});
+
+describe("encodeTerminalKey", () => {
+  it("encodes arrows per DECCKM (application cursor) mode", () => {
+    expect(encodeTerminalKey(ev({ key: "ArrowUp" }))).toBe("\x1b[A");
+    expect(encodeTerminalKey(ev({ key: "ArrowUp" }), { applicationCursor: true })).toBe("\x1bOA");
+    expect(encodeTerminalKey(ev({ key: "ArrowLeft" }))).toBe("\x1b[D");
+    expect(encodeTerminalKey(ev({ key: "End" }), { applicationCursor: true })).toBe("\x1bOF");
+  });
+
+  it("encodes the common control/navigation keys", () => {
+    expect(encodeTerminalKey(ev({ key: "Escape" }))).toBe("\x1b");
+    expect(encodeTerminalKey(ev({ key: "Enter" }))).toBe("\r");
+    expect(encodeTerminalKey(ev({ key: "Tab" }))).toBe("\t");
+    expect(encodeTerminalKey(ev({ key: "Tab", shiftKey: true }))).toBe("\x1b[Z");
+    expect(encodeTerminalKey(ev({ key: "Backspace" }))).toBe("\x7f");
+    expect(encodeTerminalKey(ev({ key: "PageUp" }))).toBe("\x1b[5~");
+    expect(encodeTerminalKey(ev({ key: "Delete" }))).toBe("\x1b[3~");
+  });
+
+  it("encodes printable characters and Ctrl/Alt combos for full-screen passthrough", () => {
+    expect(encodeTerminalKey(ev({ key: "j" }))).toBe("j");
+    expect(encodeTerminalKey(ev({ key: "c", ctrlKey: true }))).toBe("\x03");
+    expect(encodeTerminalKey(ev({ key: "a", ctrlKey: true }))).toBe("\x01");
+    expect(encodeTerminalKey(ev({ key: "b", altKey: true }))).toBe("\x1bb");
+  });
+
+  it("ignores modifier-only keys", () => {
+    expect(encodeTerminalKey(ev({ key: "Shift" }))).toBeNull();
+    expect(encodeTerminalKey(ev({ key: "Control", ctrlKey: true }))).toBeNull();
+    expect(encodeTerminalKey(ev({ key: "Meta", metaKey: true }))).toBeNull();
+  });
+});

--- a/ui/src/lib/terminal-key-encoding.test.ts
+++ b/ui/src/lib/terminal-key-encoding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { encodeTerminalKey, isPassthroughNavKey } from "./terminal-key-encoding";
+import { encodeTerminalKey } from "./terminal-key-encoding";
 
 type Key = Parameters<typeof encodeTerminalKey>[0];
 const ev = (over: Partial<Key> & Pick<Key, "key">): Key => ({
@@ -8,20 +8,6 @@ const ev = (over: Partial<Key> & Pick<Key, "key">): Key => ({
   metaKey: false,
   shiftKey: false,
   ...over,
-});
-
-describe("isPassthroughNavKey", () => {
-  it("flags non-character navigation keys", () => {
-    for (const key of ["ArrowUp", "ArrowDown", "Home", "End", "PageUp", "Escape", "Tab", "Enter"]) {
-      expect(isPassthroughNavKey({ key })).toBe(true);
-    }
-  });
-
-  it("excludes printable characters and modifiers", () => {
-    for (const key of ["a", " ", "1", "Shift", "Control"]) {
-      expect(isPassthroughNavKey({ key })).toBe(false);
-    }
-  });
 });
 
 describe("encodeTerminalKey", () => {

--- a/ui/src/lib/terminal-key-encoding.ts
+++ b/ui/src/lib/terminal-key-encoding.ts
@@ -50,6 +50,28 @@ export function isPassthroughNavKey(event: Pick<KeyboardEvent, "key">): boolean 
   return PASSTHROUGH_NAV_KEYS.has(event.key);
 }
 
+/**
+ * Control chords an empty Composer forwards so a running activity stays
+ * controllable: Ctrl+C (SIGINT), Ctrl+D (EOF), Ctrl+Z (SIGTSTP), Ctrl+L
+ * (repaint). Deliberately NOT every Ctrl+letter — e.g. Ctrl+V must keep
+ * pasting into the draft. Callers must check laymux keybindings first
+ * (`matchesGlobalShortcut`), so a user who rebinds one of these to a laymux
+ * action keeps the laymux behavior.
+ */
+const PASSTHROUGH_CTRL_KEYS = new Set(["c", "d", "z", "l"]);
+
+export function isPassthroughControlChord(
+  event: Pick<KeyboardEvent, "key" | "ctrlKey" | "altKey" | "metaKey" | "shiftKey">,
+): boolean {
+  return (
+    event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey &&
+    !event.shiftKey &&
+    PASSTHROUGH_CTRL_KEYS.has(event.key.toLowerCase())
+  );
+}
+
 /** Returns the PTY byte sequence for the event, or null when it should not be forwarded. */
 export function encodeTerminalKey(
   event: Pick<KeyboardEvent, "key" | "ctrlKey" | "altKey" | "metaKey" | "shiftKey">,
@@ -58,30 +80,45 @@ export function encodeTerminalKey(
   const { key } = event;
   if (MODIFIER_ONLY_KEYS.has(key)) return null;
 
-  const cursor = (normal: string, application: string) =>
-    options.applicationCursor ? application : normal;
+  // xterm modifier parameter: 1 + Shift(1) + Alt(2) + Ctrl(4) + Meta(8).
+  // Modified navigation keys always use the CSI `1;<mod>` form regardless of
+  // DECCKM (per xterm); unmodified ones honor application-cursor mode.
+  const modifierCode =
+    1 +
+    (event.shiftKey ? 1 : 0) +
+    (event.altKey ? 2 : 0) +
+    (event.ctrlKey ? 4 : 0) +
+    (event.metaKey ? 8 : 0);
+  const cursor = (letter: string, normal: string, application: string) =>
+    modifierCode > 1
+      ? `\x1b[1;${modifierCode}${letter}`
+      : options.applicationCursor
+        ? application
+        : normal;
+  const tilde = (code: number) =>
+    modifierCode > 1 ? `\x1b[${code};${modifierCode}~` : `\x1b[${code}~`;
 
   switch (key) {
     case "ArrowUp":
-      return cursor("\x1b[A", "\x1bOA");
+      return cursor("A", "\x1b[A", "\x1bOA");
     case "ArrowDown":
-      return cursor("\x1b[B", "\x1bOB");
+      return cursor("B", "\x1b[B", "\x1bOB");
     case "ArrowRight":
-      return cursor("\x1b[C", "\x1bOC");
+      return cursor("C", "\x1b[C", "\x1bOC");
     case "ArrowLeft":
-      return cursor("\x1b[D", "\x1bOD");
+      return cursor("D", "\x1b[D", "\x1bOD");
     case "Home":
-      return cursor("\x1b[H", "\x1bOH");
+      return cursor("H", "\x1b[H", "\x1bOH");
     case "End":
-      return cursor("\x1b[F", "\x1bOF");
+      return cursor("F", "\x1b[F", "\x1bOF");
     case "PageUp":
-      return "\x1b[5~";
+      return tilde(5);
     case "PageDown":
-      return "\x1b[6~";
+      return tilde(6);
     case "Insert":
-      return "\x1b[2~";
+      return tilde(2);
     case "Delete":
-      return "\x1b[3~";
+      return tilde(3);
     case "Escape":
       return "\x1b";
     case "Tab":

--- a/ui/src/lib/terminal-key-encoding.ts
+++ b/ui/src/lib/terminal-key-encoding.ts
@@ -1,0 +1,110 @@
+/**
+ * Encodes a browser KeyboardEvent into the byte sequence a PTY expects, so the
+ * detached Composer can pass non-text keys (arrows, Esc, Tab, Enter, …) straight
+ * to the terminal when its draft is empty, and pass everything through while a
+ * full-screen (alternate-screen) app is running.
+ *
+ * Arrow/Home/End honor the terminal's DECCKM (application cursor keys) mode — the
+ * caller reads it from xterm (`terminal.modes.applicationCursorKeysMode`) so we
+ * defer to xterm's own state instead of guessing.
+ */
+
+export interface EncodeTerminalKeyOptions {
+  /** xterm `terminal.modes.applicationCursorKeysMode` — flips CSI (`\x1b[`) to SS3 (`\x1bO`). */
+  applicationCursor?: boolean;
+}
+
+/** Keys that carry no character and are safe to forward at an empty prompt. */
+const PASSTHROUGH_NAV_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+  "Escape",
+  "Tab",
+  "Enter",
+]);
+
+const MODIFIER_ONLY_KEYS = new Set([
+  "Shift",
+  "Control",
+  "Alt",
+  "Meta",
+  "CapsLock",
+  "NumLock",
+  "ScrollLock",
+  "Dead",
+  "Unidentified",
+]);
+
+/**
+ * True for non-character navigation/control keys the empty Composer forwards to
+ * the terminal (so shell history / inline menus work). Printable characters are
+ * excluded — those keep editing the draft.
+ */
+export function isPassthroughNavKey(event: Pick<KeyboardEvent, "key">): boolean {
+  return PASSTHROUGH_NAV_KEYS.has(event.key);
+}
+
+/** Returns the PTY byte sequence for the event, or null when it should not be forwarded. */
+export function encodeTerminalKey(
+  event: Pick<KeyboardEvent, "key" | "ctrlKey" | "altKey" | "metaKey" | "shiftKey">,
+  options: EncodeTerminalKeyOptions = {},
+): string | null {
+  const { key } = event;
+  if (MODIFIER_ONLY_KEYS.has(key)) return null;
+
+  const cursor = (normal: string, application: string) =>
+    options.applicationCursor ? application : normal;
+
+  switch (key) {
+    case "ArrowUp":
+      return cursor("\x1b[A", "\x1bOA");
+    case "ArrowDown":
+      return cursor("\x1b[B", "\x1bOB");
+    case "ArrowRight":
+      return cursor("\x1b[C", "\x1bOC");
+    case "ArrowLeft":
+      return cursor("\x1b[D", "\x1bOD");
+    case "Home":
+      return cursor("\x1b[H", "\x1bOH");
+    case "End":
+      return cursor("\x1b[F", "\x1bOF");
+    case "PageUp":
+      return "\x1b[5~";
+    case "PageDown":
+      return "\x1b[6~";
+    case "Insert":
+      return "\x1b[2~";
+    case "Delete":
+      return "\x1b[3~";
+    case "Escape":
+      return "\x1b";
+    case "Tab":
+      return event.shiftKey ? "\x1b[Z" : "\t";
+    case "Enter":
+      return "\r";
+    case "Backspace":
+      return "\x7f";
+  }
+
+  // Ctrl+letter → C0 control code (Ctrl+A = 0x01 … Ctrl+Z = 0x1a).
+  if (event.ctrlKey && !event.altKey && !event.metaKey && key.length === 1) {
+    const lower = key.toLowerCase();
+    if (lower >= "a" && lower <= "z") {
+      return String.fromCharCode(lower.charCodeAt(0) - 96);
+    }
+    return null;
+  }
+
+  // Plain printable character (Alt prefixes it with ESC, as terminals expect).
+  if (!event.ctrlKey && !event.metaKey && key.length === 1) {
+    return event.altKey ? `\x1b${key}` : key;
+  }
+
+  return null;
+}

--- a/ui/src/lib/terminal-key-encoding.ts
+++ b/ui/src/lib/terminal-key-encoding.ts
@@ -14,6 +14,21 @@ export interface EncodeTerminalKeyOptions {
   applicationCursor?: boolean;
 }
 
+/** Keys that carry no character and are safe to forward at an empty prompt. */
+const PASSTHROUGH_NAV_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+  "Escape",
+  "Tab",
+  "Enter",
+]);
+
 const MODIFIER_ONLY_KEYS = new Set([
   "Shift",
   "Control",
@@ -25,6 +40,15 @@ const MODIFIER_ONLY_KEYS = new Set([
   "Dead",
   "Unidentified",
 ]);
+
+/**
+ * True for non-character navigation/control keys the empty Composer forwards to
+ * the terminal (so shell history / inline menus work). Printable characters are
+ * excluded — those keep editing the draft.
+ */
+export function isPassthroughNavKey(event: Pick<KeyboardEvent, "key">): boolean {
+  return PASSTHROUGH_NAV_KEYS.has(event.key);
+}
 
 /** Returns the PTY byte sequence for the event, or null when it should not be forwarded. */
 export function encodeTerminalKey(

--- a/ui/src/lib/terminal-key-encoding.ts
+++ b/ui/src/lib/terminal-key-encoding.ts
@@ -14,21 +14,6 @@ export interface EncodeTerminalKeyOptions {
   applicationCursor?: boolean;
 }
 
-/** Keys that carry no character and are safe to forward at an empty prompt. */
-const PASSTHROUGH_NAV_KEYS = new Set([
-  "ArrowUp",
-  "ArrowDown",
-  "ArrowLeft",
-  "ArrowRight",
-  "Home",
-  "End",
-  "PageUp",
-  "PageDown",
-  "Escape",
-  "Tab",
-  "Enter",
-]);
-
 const MODIFIER_ONLY_KEYS = new Set([
   "Shift",
   "Control",
@@ -40,15 +25,6 @@ const MODIFIER_ONLY_KEYS = new Set([
   "Dead",
   "Unidentified",
 ]);
-
-/**
- * True for non-character navigation/control keys the empty Composer forwards to
- * the terminal (so shell history / inline menus work). Printable characters are
- * excluded — those keep editing the draft.
- */
-export function isPassthroughNavKey(event: Pick<KeyboardEvent, "key">): boolean {
-  return PASSTHROUGH_NAV_KEYS.has(event.key);
-}
 
 /** Returns the PTY byte sequence for the event, or null when it should not be forwarded. */
 export function encodeTerminalKey(


### PR DESCRIPTION
## 배경

터미널 입력 컴포저(#462)의 모드 전환 UX 전면 개선 + 컴포저 키 라우팅 정립. 컴포저의 제출/초안 계약(ADR-0029/0034)은 불변.

## PC (데스크톱)

- **모드 전환 = pane 컨트롤 바의 단일 토글 버튼** (⌨ 직접 / ✎ 입력칸 아이콘, composer 시 accent). 좁은 pane 은 ⋯ 오버플로 메뉴로 미러. `Ctrl+Alt+M` 유지. 하단 상시 모드바 제거
- **컴포저 슬림화**: Send 버튼 제거(Enter 전송 · Shift+Enter 줄바꿈, placeholder 힌트), 부모 padding·textarea 테두리 제거(flush), 우하단 그립 대신 **상단 경계 드래그로 리사이즈**(높이 localStorage 유지)
- Settings > Terminal 에 **기본 입력 방식** 셀렉터 (localStorage 기반, settings.json/ADR 무관)

## 컴포저 키 라우팅

- **셸 프롬프트(OSC 133 C/D 로 판정)**: draft 가장자리 ↑/↓ = **컴포저 자체 전송 히스토리**를 에디터로 리콜(터미널 줄에 안 새고 편집 가능). 전송 시 히스토리 push (per-terminal, dedupe, cap)
- **프로그램 실행중**: 빈 draft 의 nav 키(화살표·Esc·Tab·Enter 등)를 PTY 로 passthrough → 메뉴 선택이동/앱 히스토리가 네이티브로 동작. DECCKM(application cursor) 반영, 수정자 nav 는 xterm CSI `1;mod` 형식
- **재바인딩 대응 우선순위**: 콤보가 문서 레벨 laymux 액션(pane.focus, workspace.* 등)에 매칭되면 절대 forward 안 함 → 버블. `matchesGlobalShortcut()` 이 디스패처와 같은 테이블에서 파생 — 하드코딩 키값 없음
- **빈 draft 활동 제어**: `Ctrl+C/D/Z/L`(SIGINT/EOF/SIGTSTP/repaint) passthrough. Ctrl+V 는 제외(draft 붙여넣기), 텍스트 있으면 Ctrl+C=복사

## 리모트

- PC 와 정렬: **단일 토글 버튼**(2세그먼트 아님, ≤360px 아이콘-only), **Send 버튼 제거**(모든 포인터에서 Enter 전송 · Shift+Enter 줄바꿈), flush 에디터
- 준비 상태는 `data-can-send` 로 노출

## 검증

- tsc / eslint / prettier 통과
- vitest: 컴포저·PaneControlBar·TerminalView·SettingsView·key-encoding·state 스위트 통과 (306+)
- playwright remote e2e: 20/20
- 시각: PC dev 앱 + 리모트 페이지(단일 토글/flush/협폭) 확인, 사용자 라이브 검증 완료

## 이력 메모

중간에 시도한 step-aside 라우팅(option A)은 사용자 검증에서 반려되어 같은 브랜치에서 revert 됨 (`c23d39d` → `39f7f03`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)