### PR TITLE
fix: restore compact workspace row height

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -189,6 +189,13 @@
     opacity: 0;
     pointer-events: none;
     transition: opacity var(--transition-fast);
+    /* Inline row buttons must not inflate the row: drop the 24px box that
+       .hidden-item-action-btn gives the shelf and fall back to the old
+       row-eye-btn feel (icon-sized + negative margin for a hover hit area). */
+    width: auto;
+    height: auto;
+    padding: 2px;
+    margin: -2px;
   }
   .workspace-item-animated:hover .workspace-quick-hide,
   .workspace-item-animated:focus-within .workspace-quick-hide,


### PR DESCRIPTION
## 문제
업데이트 후 WorkspaceSelector 의 워크스페이스/pane 행 height 가 갑자기 커짐.

## 원인
PR #460 (hidden items shelf) 이 shelf 용 `.hidden-item-action-btn`(고정 **24px×24px** 박스)을 인라인 eye 버튼 `.workspace-quick-hide` / `.pane-quick-hide` 에 그대로 재사용. 옛 `.row-eye-btn`(고정 크기 없음 + `margin:-2px` → 행 높이 안 키움)과 달리 24px 박스가 각 행 높이를 강제로 키움.

## 수정
`ui/src/index.css` — 인라인 quick-hide 버튼에만 24px 박스 override:
- `width/height: auto; padding: 2px; margin: -2px` → 옛 `.row-eye-btn` 느낌 복원
- shelf 자체 액션 버튼은 24px 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)