### PR TITLE
feat: layout-based composer send model (mobile Send button, desktop Enter)

### DIFF
--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -1285,7 +1285,7 @@
                 autocomplete="off"
                 autocapitalize="off"
                 spellcheck="false"
-                placeholder="Enter for a newline · tap Send to submit"
+                placeholder="Enter to send · Shift+Enter for a newline"
               ></textarea>
             </section>
           </div>

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -1262,6 +1262,7 @@
                 autocomplete="off"
                 autocapitalize="off"
                 spellcheck="false"
+                enterkeyhint="send"
                 placeholder="Type, then Enter to send · Shift+Enter for a newline"
               ></textarea>
             </section>
@@ -4040,14 +4041,36 @@
         composerInput.addEventListener("compositionend", () => {
           composerIsComposing = false;
         });
-        composerInput.addEventListener("keydown", (event) => {
-          if (event.key !== "Enter") return;
-          if (event.isComposing || composerIsComposing || event.keyCode === 229) return;
-          // Enter sends on every pointer type (mirrors desktop). There is no Send
-          // button anymore; Shift+Enter inserts a newline.
-          if (event.shiftKey) return;
+        // Enter sends. Mobile soft keyboards (Android GBoard, etc.) fire an
+        // unreliable Enter keydown — keyCode 229 or key "Unidentified" — so the
+        // send decision cannot rely on keydown alone. Two paths cover every
+        // keyboard:
+        //   1. keydown, when it reports a trustworthy Enter (desktop / hardware
+        //      keyboards): send immediately and preventDefault, which also
+        //      suppresses the follow-up beforeinput.
+        //   2. beforeinput "insertLineBreak": the reliable mobile path. Fires
+        //      after IME commit with a clean isComposing, so the soft return
+        //      key sends even when the keydown was masked by keyCode 229.
+        // Shift+Enter always stays a native newline; IME candidate confirmation
+        // (isComposing) never submits.
+        let composerShiftEnter = false;
+        function submitComposerFromEnter(event) {
+          if (event.isComposing || composerIsComposing) return;
+          if (composerShiftEnter) return;
           event.preventDefault();
           commitComposer();
+        }
+        composerInput.addEventListener("keydown", (event) => {
+          if (event.key !== "Enter") return;
+          composerShiftEnter = event.shiftKey === true;
+          // keyCode 229 marks an IME-masked Enter on mobile — defer to
+          // beforeinput rather than trusting this keydown.
+          if (event.keyCode === 229) return;
+          submitComposerFromEnter(event);
+        });
+        composerInput.addEventListener("beforeinput", (event) => {
+          if (event.inputType !== "insertLineBreak" && event.inputType !== "insertParagraph") return;
+          submitComposerFromEnter(event);
         });
         keyBarToggleButton.addEventListener("click", () => setKeyBarVisible(keyBar.hidden));
         keyBarSettingsButton.addEventListener("click", (event) => {

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -128,6 +128,28 @@
         cursor: default;
         opacity: 0.55;
       }
+      /* Mobile-only Send affordance (desktop sends with Enter). Filled accent
+         circle with an up-arrow, mirroring chat-app composers. */
+      .composer-send {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        padding: 0;
+        border: 0;
+        border-radius: 999px;
+        background: var(--accent);
+        color: #11111b;
+      }
+      .composer-send[hidden] {
+        display: none;
+      }
+      .composer-send:disabled {
+        cursor: default;
+        opacity: 0.4;
+      }
       main {
         position: relative;
         display: grid;
@@ -908,6 +930,7 @@
         }
         .composer-input {
           min-height: 64px;
+          padding: 7px 0 0;
         }
       }
       @supports (height: 100dvh) {
@@ -1262,8 +1285,7 @@
                 autocomplete="off"
                 autocapitalize="off"
                 spellcheck="false"
-                enterkeyhint="send"
-                placeholder="Type, then Enter to send · Shift+Enter for a newline"
+                placeholder="Enter for a newline · tap Send to submit"
               ></textarea>
             </section>
           </div>
@@ -1289,6 +1311,9 @@
         <button id="focusTerminal" disabled>Keyboard</button>
         <button id="keyBarToggle" class="key-toggle" type="button" aria-pressed="false" aria-controls="keyBar" title="Toggle special-key toolbar">Keys</button>
         <div id="terminalMeta" class="status-hint grow">No terminal selected.</div>
+        <button id="composerSend" class="composer-send" type="button" hidden aria-label="Send input" title="Send">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 5l6.5 6.5-1.42 1.42L13 8.83V19h-2V8.83l-4.08 4.09L5.5 11.5z"/></svg>
+        </button>
       </footer>
     </div>
     <script src="/remote/vendor/xterm.js"></script>
@@ -1330,6 +1355,9 @@
         const clearNotificationsButton = $("clearNotifications");
         const focusTerminalButton = $("focusTerminal");
         const ctrlCButton = $("ctrlC");
+        const composerSendButton = $("composerSend");
+        const coarsePointer =
+          typeof matchMedia === "function" && matchMedia("(pointer: coarse)").matches;
         const inputModeToggleButton = $("inputModeToggle");
         const inputModeIcon = $("inputModeIcon");
         const inputModeLabel = $("inputModeLabel");
@@ -1435,6 +1463,17 @@
         document.querySelector(".app").classList.toggle("local-app", localAppMode);
         desktopModeHeaderButton.hidden = !localAppMode;
         desktopModeDrawerButton.hidden = !localAppMode;
+        // Layout naming (canonical):
+        //   desktop layout — Enter sends, Shift+Enter newline, no Send button.
+        //   mobile layout  — Enter is a newline, the Send button sends.
+        // Rule: mobile layout when the pointer is coarse (touch device) OR when
+        // the page is the PC app's embedded mobile view (localApp=1) — if it
+        // looks like mobile, it behaves like mobile. Ctrl/Cmd+Enter sends in
+        // BOTH layouts. A default; a settings override can come later.
+        const mobileLayout = coarsePointer || localAppMode;
+        composerInput.placeholder = mobileLayout
+          ? "Enter for a newline · Send (or Ctrl+Enter) to submit"
+          : "Enter to send · Shift+Enter for a newline";
 
         const defaultAppearance = Object.freeze({
           fontFamily: "'Cascadia Mono', 'Cascadia Mono', 'Consolas', monospace",
@@ -1573,11 +1612,14 @@
           const draft = composerDraft();
           const composerMode = currentInputMode() === "composer";
           const canEdit = Boolean(leaseId && activeTerminalId && composerMode);
-          // No Send button anymore; Enter submits. `data-can-send` exposes the same
-          // readiness the button's disabled state used to (for tests / a11y).
+          // `data-can-send` mirrors the Send button's readiness for tests / a11y.
           const canCommit = Boolean(canEdit && composerReady && draft && !draft.inFlight);
           composerInput.disabled = !canEdit;
           terminalComposer.dataset.canSend = canCommit ? "true" : "false";
+          // Send button belongs to the mobile layout in composer mode; the
+          // desktop layout relies on Enter. Disabled until a commit is possible.
+          composerSendButton.hidden = !(mobileLayout && composerMode);
+          composerSendButton.disabled = !canCommit;
         }
 
         function focusCurrentInputSurface() {
@@ -4041,36 +4083,29 @@
         composerInput.addEventListener("compositionend", () => {
           composerIsComposing = false;
         });
-        // Enter sends. Mobile soft keyboards (Android GBoard, etc.) fire an
-        // unreliable Enter keydown — keyCode 229 or key "Unidentified" — so the
-        // send decision cannot rely on keydown alone. Two paths cover every
-        // keyboard:
-        //   1. keydown, when it reports a trustworthy Enter (desktop / hardware
-        //      keyboards): send immediately and preventDefault, which also
-        //      suppresses the follow-up beforeinput.
-        //   2. beforeinput "insertLineBreak": the reliable mobile path. Fires
-        //      after IME commit with a clean isComposing, so the soft return
-        //      key sends even when the keydown was masked by keyCode 229.
-        // Shift+Enter always stays a native newline; IME candidate confirmation
-        // (isComposing) never submits.
-        let composerShiftEnter = false;
-        function submitComposerFromEnter(event) {
-          if (event.isComposing || composerIsComposing) return;
-          if (composerShiftEnter) return;
+        // Enter behavior follows the layout (see `mobileLayout`):
+        //   - mobile layout: Enter inserts a newline. Sending is the dedicated
+        //     Send button, so the unreliable soft-keyboard Enter (keyCode 229,
+        //     IME/isComposing races) is never on the send path.
+        //   - desktop layout: Enter sends, Shift+Enter is a newline. IME
+        //     candidate confirmation (isComposing / keyCode 229) never submits.
+        //   - Ctrl/Cmd+Enter sends in BOTH layouts — the keyboard send gesture
+        //     for the PC app's mobile view, immune to IME masking.
+        composerInput.addEventListener("keydown", (event) => {
+          if (event.key !== "Enter" || event.shiftKey) return;
+          if (event.ctrlKey || event.metaKey) {
+            event.preventDefault();
+            commitComposer();
+            return;
+          }
+          if (mobileLayout) return;
+          if (event.isComposing || composerIsComposing || event.keyCode === 229) return;
           event.preventDefault();
           commitComposer();
-        }
-        composerInput.addEventListener("keydown", (event) => {
-          if (event.key !== "Enter") return;
-          composerShiftEnter = event.shiftKey === true;
-          // keyCode 229 marks an IME-masked Enter on mobile — defer to
-          // beforeinput rather than trusting this keydown.
-          if (event.keyCode === 229) return;
-          submitComposerFromEnter(event);
         });
-        composerInput.addEventListener("beforeinput", (event) => {
-          if (event.inputType !== "insertLineBreak" && event.inputType !== "insertParagraph") return;
-          submitComposerFromEnter(event);
+        composerSendButton.addEventListener("click", () => {
+          commitComposer();
+          focusCurrentInputSurface();
         });
         keyBarToggleButton.addEventListener("click", () => setKeyBarVisible(keyBar.hidden));
         keyBarSettingsButton.addEventListener("click", (event) => {

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -254,7 +254,8 @@ mod tests {
         assert!(html.contains("id=\"terminalComposer\""));
         assert!(html.contains("id=\"composerInput\""));
         assert!(!html.contains("id=\"composerInsert\""));
-        assert!(html.contains("id=\"composerSend\""));
+        // No standalone Send button — Enter is the only send gesture.
+        assert!(!html.contains("id=\"composerSend\""));
         assert!(html.contains("laymux.remote.inputMode"));
         assert!(html.contains("matchMedia(\"(pointer: coarse)\")"));
 
@@ -275,14 +276,18 @@ mod tests {
         assert!(html.contains("draft.revision === submission.revision"));
         assert!(html.contains("draft.text === submission.text"));
 
-        // IME confirmation Enter never submits. Fine-pointer clients send on
-        // ordinary Enter, while Shift+Enter and coarse-pointer Enter remain
-        // native textarea newlines.
+        // Enter sends via two paths so mobile soft keyboards (keyCode 229 /
+        // "Unidentified" Enter) still submit: a trustworthy keydown Enter, or
+        // the beforeinput line-break that fires cleanly after IME commit.
+        // Shift+Enter stays a native newline; IME confirmation never submits.
         assert!(html.contains("composerInput.addEventListener(\"compositionstart\""));
         assert!(html.contains("composerInput.addEventListener(\"compositionend\""));
-        assert!(html.contains("event.isComposing || composerIsComposing || event.keyCode === 229"));
+        assert!(html.contains("composerInput.addEventListener(\"beforeinput\""));
+        assert!(html.contains("event.inputType !== \"insertLineBreak\""));
+        assert!(html.contains("if (event.isComposing || composerIsComposing) return;"));
+        assert!(html.contains("composerShiftEnter = event.shiftKey === true"));
+        assert!(html.contains("if (event.keyCode === 229) return;"));
         assert!(html.contains("matchMedia(\"(pointer: coarse)\").matches"));
-        assert!(html.contains("if (event.shiftKey) return;"));
 
         // Composer actions stay closed until a valid V1 snapshot header/state +
         // binary frame pair has established the active output attachment.

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use axum::extract::{ConnectInfo, Request, State};
+use axum::http::header;
 use axum::response::{Html, IntoResponse, Redirect, Response};
 
 use crate::automation_server::ServerState;
@@ -53,7 +54,14 @@ pub(crate) async fn remote_page(
         return response;
     }
 
-    Html(remote_page_html()).into_response()
+    // The page is compiled in via include_str!, so there is no mtime/ETag for
+    // revalidation — without this, browsers heuristically cache it and users
+    // need a hard refresh after every update.
+    (
+        [(header::CACHE_CONTROL, "no-store")],
+        Html(remote_page_html()),
+    )
+        .into_response()
 }
 
 fn remote_page_html() -> &'static str {
@@ -254,8 +262,9 @@ mod tests {
         assert!(html.contains("id=\"terminalComposer\""));
         assert!(html.contains("id=\"composerInput\""));
         assert!(!html.contains("id=\"composerInsert\""));
-        // No standalone Send button — Enter is the only send gesture.
-        assert!(!html.contains("id=\"composerSend\""));
+        // A dedicated Send button is the touch-device send affordance.
+        assert!(html.contains("id=\"composerSend\""));
+        assert!(html.contains("class=\"composer-send\""));
         assert!(html.contains("laymux.remote.inputMode"));
         assert!(html.contains("matchMedia(\"(pointer: coarse)\")"));
 
@@ -276,17 +285,23 @@ mod tests {
         assert!(html.contains("draft.revision === submission.revision"));
         assert!(html.contains("draft.text === submission.text"));
 
-        // Enter sends via two paths so mobile soft keyboards (keyCode 229 /
-        // "Unidentified" Enter) still submit: a trustworthy keydown Enter, or
-        // the beforeinput line-break that fires cleanly after IME commit.
-        // Shift+Enter stays a native newline; IME confirmation never submits.
+        // Enter follows the layout: the mobile layout (coarse pointer OR the PC
+        // app's embedded mobile view, localApp=1) inserts a newline and sends
+        // via the button, keeping the fragile soft-keyboard Enter off the send
+        // path; the desktop layout sends on Enter with Shift+Enter as newline.
+        // Ctrl/Cmd+Enter sends in both layouts, and IME confirmation
+        // (isComposing / keyCode 229) never sends.
         assert!(html.contains("composerInput.addEventListener(\"compositionstart\""));
         assert!(html.contains("composerInput.addEventListener(\"compositionend\""));
-        assert!(html.contains("composerInput.addEventListener(\"beforeinput\""));
-        assert!(html.contains("event.inputType !== \"insertLineBreak\""));
-        assert!(html.contains("if (event.isComposing || composerIsComposing) return;"));
-        assert!(html.contains("composerShiftEnter = event.shiftKey === true"));
-        assert!(html.contains("if (event.keyCode === 229) return;"));
+        assert!(html.contains("const mobileLayout = coarsePointer || localAppMode"));
+        assert!(html.contains("if (event.key !== \"Enter\" || event.shiftKey) return;"));
+        assert!(html.contains("if (event.ctrlKey || event.metaKey) {"));
+        assert!(html.contains("if (mobileLayout) return;"));
+        assert!(html.contains(
+            "if (event.isComposing || composerIsComposing || event.keyCode === 229) return;"
+        ));
+        assert!(html.contains("composerSendButton.addEventListener(\"click\""));
+        assert!(html.contains("composerSendButton.hidden = !(mobileLayout && composerMode)"));
         assert!(html.contains("matchMedia(\"(pointer: coarse)\").matches"));
 
         // Composer actions stay closed until a valid V1 snapshot header/state +


### PR DESCRIPTION
## 문제

모바일(app.laymux.com)에서 컴포저 Enter 전송 불가. 조사 결과 두 개의 독립 버그:

1. **키 감지 불안정**: Android 소프트키보드는 조합 없이도 Enter를 `keyCode 229`(IME sentinel)로 보고 → keydown 기반 전송은 구조적으로 불안정.
2. **터널 프로토콜 버그(진짜 원인)**: 릴레이가 v1 출력 헤더를 재구성하지 않아 `composerReady`가 영원히 false → 터널 경유 시 모든 전송 죽음. **별도 수정: kochul2000/laymux-server#25** (본 PR과 셋트).

## 설계 결정 — 레이아웃 규칙

```
mobileLayout = (pointer: coarse) || localApp=1
```

| 레이아웃 | Enter | 전송 |
|---|---|---|
| **데스크톱** (fine-pointer 웹) | 전송 (Shift+Enter=개행) | Enter, Ctrl/Cmd+Enter |
| **모바일** (터치 기기, PC 앱 모바일 뷰) | 개행 | Send 버튼(↑ filled), Ctrl/Cmd+Enter |

- "모양이 모바일이면 거동도 모바일": PC 앱의 임베드 모바일 뷰(localApp=1)도 모바일 거동 → 폰 없이 데스크톱에서 모바일 UX 검증 가능.
- 모바일 전송을 Send 버튼으로 옮겨 keyCode 229/IME 레이스를 전송 경로에서 완전 제거 (Claude/GPT 앱과 동일 패턴).
- Ctrl/Cmd+Enter는 양쪽 공통 키보드 전송 제스처.

## 변경

- `page.html`: `mobileLayout` 플래그, footer 우측 원형 filled ↑ Send 버튼(`composerMode`에서만 노출, `canCommit` 전까지 disabled), 레이아웃별 Enter keydown 처리, Ctrl/Cmd+Enter 공통 전송, 레이아웃별 placeholder, 모바일 textarea 좌우/하단 패딩 제거
- `page.rs`: 페이지 응답 `Cache-Control: no-store` (include_str 페이지의 휴리스틱 캐시 → 매번 하드 리프레시 강요 문제 해소), 테스트를 새 계약으로 갱신 + main에서 이미 깨져있던 `composerSend` assert 수정

## 테스트

`cargo test --lib remote_server::page` — 14/14 통과.

실기기: 안드로이드에서 Send 버튼 노출 확인. 전송 활성화(composerReady)는 릴레이 수정(laymux-server#25) 배포 후 E2E 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EeQXwuT7rv9cwbAvBpNq6