### PR TITLE
fix(ui): add small top padding to workspace list

### DIFF
--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -1347,7 +1347,10 @@ export function WorkspaceSelectorView() {
       </div>
 
       {/* Workspace list */}
-      <div data-testid="workspace-list" className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div
+        data-testid="workspace-list"
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto pt-1"
+      >
         {selectorWorkspaces.map((ws, idx) => {
           const isActive = ws.id === activeWorkspaceId;
           // Compute summary from frontend stores (event-driven, no polling).


### PR DESCRIPTION
## 문제
워크스페이스 항목에 세로 패딩이 없어서 첫 행이 정렬 헤더에 딱 붙음. 상단 여백이 지나치게 작음.

## 수정
`workspace-list` 컨테이너에 `pt-1`(4px) 추가. 상단 여백만 확보하고 항목 밀도는 그대로 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)