### PR TITLE
fix(ui): 숨김 보관함을 칩 바로 아래·workspace 전용으로, pane 숨김은 pane 토글로 (ADR-0035)

### DIFF
--- a/docs/adr/0035-workspace-only-shelf-per-pane-hide-toggle.md
+++ b/docs/adr/0035-workspace-only-shelf-per-pane-hide-toggle.md
@@ -1,0 +1,38 @@
+# 0035. 숨김 보관함은 workspace 전용 상단 배치, Pane 숨김은 pane 자체 토글 (0033 정정)
+
+- Status: Accepted
+- Date: 2026-07-18
+- Source: 사용자 요구 (보관함 위치·Pane 항목 혼재 불만) · ADR-0033 · ADR-0005
+
+## Context
+
+ADR-0033 은 전역 hideMode 를 제거하면서 숨김 복원 경로를 selector 하단의 bottom shelf 하나로 통합했고, 그 보관함에 hidden workspace 와 hidden Pane 을 함께 나열했다. 실제 사용에서 두 가지 문제가 드러났다.
+
+1. **위치 불일치** — 보관함을 여는 count chip 은 workspace 목록 헤더(상단)에 있는데 보관함 자체는 selector 최하단에 열린다. 버튼과 결과 UI 가 화면 반대편에 나타나 조작 흐름이 끊긴다.
+2. **계층 혼재** — workspace 복원과 Pane 복원은 성격이 다른 작업인데 한 보관함에 섞여 있다. Pane 은 grid 에서 항상 접근 가능하므로(숨김은 selector 요약 행 표시 여부일 뿐) 별도 복원 목록이 필요 없고, 오히려 보관함을 길고 복잡하게 만든다.
+
+범위: 이 결정은 표시 모델과 UI 컨트롤 표면만 바꾼다. `hiddenWorkspaceIds`/`hiddenPaneIds` raw state 분리, localStorage key, `deriveHiddenItems` 단일 계산 모듈, Automation REST/MCP 계약(`set_hidden_items_open`, workspace/Pane hidden toggle), active workspace fallback 불변식(ADR-0033)은 그대로 유지한다.
+
+## Decision
+
+- **보관함은 hidden workspace 전용이다.** hidden Pane 은 보관함에 나열하지 않으며, count chip 도 유효 hidden workspace 수만 센다. chip 은 hidden workspace 가 있을 때만 표시된다.
+- **보관함은 그것을 여는 chip 바로 아래(workspace 목록 위)에 열린다.** 트리거와 결과 UI 를 같은 위치에 둔다.
+- **Pane 숨김의 컨트롤 표면은 pane 자신이다.** workspace grid 의 각 pane 컨트롤바에 목록 숨김 eye 토글을 두고, 숨김/복원 모두 이 토글로 수행한다. selector 의 pane 요약 행에는 숨김 버튼을 두지 않는다(행 자체는 계속 필터된다). dock pane 은 selector 에 나오지 않으므로 토글을 노출하지 않는다.
+- **"모두 표시"는 hidden workspace set 만 비운다.** 개별 숨김 Pane flag 는 pane 토글 소관이므로 건드리지 않는다. ADR-0033 의 "'모두 표시'만 두 hidden set 을 함께 비운다" 조항을 이 조항으로 대체한다.
+- **보관함 자동 닫힘은 hidden workspace 기준이다.** 유효 hidden workspace 가 0 이 되면 hidden Pane 존재 여부와 무관하게 닫힌다.
+
+## Alternatives Considered
+
+- **보관함을 chip 앵커 popover 로 띄우기** — 위치 문제는 해결하지만 스크린샷 검증(html2canvas)과 포커스 관리가 복잡해지고, 기존 shelf 스타일·접근성 구조를 재사용할 수 없다. 인라인 배치로 충분하다.
+- **hidden Pane 행을 selector 목록에 dimmed 로 남겨 행에서 토글** — 목록 정리라는 숨김의 목적을 훼손한다(숨겨도 행이 남음). 기각.
+- **보관함에 Pane 섹션 유지 + 위치만 이동** — 사용자가 명시적으로 Pane 항목 노출 자체를 원치 않았고, Pane 복원 경로는 grid 토글로 대체 가능하다. 기각.
+- **restoreAll 이 Pane flag 도 비우기(0033 유지)** — 보관함에 보이지 않는 상태를 보관함 버튼이 지우면 사용자가 예측할 수 없는 부작용이 된다. 표시 범위와 조작 범위를 일치시키는 쪽을 택했다.
+
+## Consequences
+
+- 숨김 UX 가 계층별로 일관된다: workspace 는 목록 행에서 숨기고 상단 보관함에서 복원, Pane 은 pane 컨트롤바 토글 하나로 숨김/복원.
+- 개별 숨김 Pane 은 보관함·chip 에 더 이상 나타나지 않으므로, 사용자가 pane 토글의 존재를 모르면 복원 경로를 찾기 어려울 수 있다. 토글은 컨트롤바 기본 노출(hover/pinned)로 완화한다.
+- "모두 표시" 의미가 좁아진다(workspace 만). 기존에 Pane 까지 복원되길 기대한 사용자는 pane 토글을 개별 조작해야 한다.
+- 숨김 상태에서 pane 이 evict(터미널 자동 종료, issue #269)된 경우에도 복원은 pane 토글로만 가능하다 — 토글이 eviction 해제를 함께 수행해야 한다(기존 `setPaneHidden` set semantics 유지).
+- Automation/Remote 계약과 raw state 는 불변이므로 외부 클라이언트 마이그레이션은 없다. ADR-0033 의 나머지 결정(즉시 숨김, set semantics, stale ID 파생 계산, active fallback)은 계속 유효하다.
+- 재검토 조건: pane 수가 많은 워크스페이스에서 개별 Pane 복원 경로(grid hover 필요)가 실제로 불편하다는 피드백이 쌓이면 Pane 복원 보조 UI 를 다시 검토한다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,6 +52,7 @@ ADR 이 필요한 대표 기준:
 | [0032](0032-llm-settings-introspection-and-safe-mutation.md) | LLM 설정 계약 — 자기설명·엄격 검증·민감값 보호 | Accepted |
 | [0033](0033-hidden-items-shelf-set-contract.md) | 숨긴 항목 보관함 — raw 숨김 상태와 결정론적 set 계약 | Accepted |
 | [0034](0034-single-send-terminal-composer.md) | Terminal composer는 Send 단일 action을 제공한다 | Accepted |
+| [0035](0035-workspace-only-shelf-per-pane-hide-toggle.md) | 숨김 보관함은 workspace 전용 상단 배치, Pane 숨김은 pane 자체 토글 (0033 정정) | Accepted |
 
 ## 새 ADR 추가
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -322,6 +322,10 @@ human-control permit은 등록 시점의 owner epoch·absolute deadline·operati
 ┌───────────────────────────────┐
 │  + New Workspace              │
 ├───────────────────────────────┤
+│ WORKSPACES     [Hidden 2] [≡] │  ← 섹션 헤더: 유효 hidden workspace chip + 정렬 토글
+│  (chip 클릭 시 바로 아래에    │
+│   workspace 전용 보관함 전개) │
+├───────────────────────────────┤
 │ 🔵 프로젝트A              [2] │  ← 이름 + 읽지 않은 배지 + 알림 링
 │    feature/login · ~/dev/proj │  ← 브랜치(초록) · CWD(회색) 한 줄
 │    :3000  :8080               │  ← 리스닝 포트(시안, 활성 WS만)
@@ -329,20 +333,19 @@ human-control permit은 등록 시점의 owner epoch·absolute deadline·operati
 │    "빌드 완료"                │  ← 최신 알림(레벨별 색상)
 ├───────────────────────────────┤
 │    main · ~/dev/api           │  ← 비활성: 이름+브랜치+CWD만
-├───────────────────────────────┤
-│ Hidden 2                      │  ← 유효 숨김 개수 chip
-│  (열면 workspace/pane 보관함) │
 └───────────────────────────────┘
 ```
 
 ### 숨김 상태 파생과 복원
 
 - `uiStore.hiddenWorkspaceIds`와 `hiddenPaneIds`는 localStorage에 저장하는 독립 raw state다. UI는 이 set을 직접 세어 표시하지 않고 `lib/hidden-items.ts`의 `deriveHiddenItems`가 현재 workspace 구조와 함께 계산한 visible 목록, 유효 숨김 개수, stale ID, shelf grouping을 사용한다([ADR-0005](../adr/0005-display-state-raw-separation-compute.md), [ADR-0033](../adr/0033-hidden-items-shelf-set-contract.md)).
-- 평상시 workspace/pane 행의 quick-hide 버튼은 항상 DOM에 존재하고 hover 또는 `:focus-within`에서 시각화된다. 숨김은 즉시 반영하며 최근 action은 5초 Undo snackbar로 되돌릴 수 있다.
-- hidden workspace 아래의 hidden pane은 해당 workspace 그룹 안에서만 표시하고 top-level pane 목록에는 중복하지 않는다. workspace만 복원하면 그 아래 pane의 raw hidden flag는 유지하며, “모두 표시”만 두 set을 함께 비운다.
-- 보관함의 기본 복원은 목록만 다시 표시한다. 별도 open/focus action은 workspace를 활성화하거나 pane의 원본 index를 포커스한다. pane 번호는 화면 정렬용이고 포커스에는 원본 `paneIndex`를 사용한다.
+- **보관함(shelf)은 hidden workspace 전용이며, 그것을 여는 count chip 바로 아래(목록 위)에 인라인으로 열린다**([ADR-0035](../adr/0035-workspace-only-shelf-per-pane-hide-toggle.md)). chip 카운트도 유효 hidden workspace 수만 세고, hidden pane 은 chip·보관함 어디에도 나타나지 않는다.
+- workspace 행의 quick-hide 버튼은 항상 DOM에 존재하고 hover 또는 `:focus-within`에서 시각화된다. 숨김은 즉시 반영하며 최근 action은 5초 Undo snackbar로 되돌릴 수 있다.
+- **Pane 숨김은 workspace grid 의 각 pane 컨트롤바 eye 토글로만 제어한다**(숨김·복원 모두). selector 의 pane 요약 행에는 숨김 버튼이 없고, 숨겨진 pane 행은 목록에서 필터된다. dock pane 은 selector 에 나오지 않으므로 토글을 노출하지 않는다.
+- 보관함의 기본 복원(행 클릭)은 workspace 를 다시 표시하고 활성화하며, eye 버튼은 표시만 한다. "모두 표시"는 hidden workspace set 만 비우고 개별 숨김 pane flag 는 유지한다.
+- workspace 를 복원해도 그 아래 pane 의 raw hidden flag 는 유지된다(복원은 pane 토글 소관).
 - active workspace를 숨길 때는 현재 정렬 순서에서 다음 visible workspace를 먼저 활성화한다. 마지막 visible workspace는 숨길 수 없다. `useHiddenItemsCoordinator`는 Automation·세션 교체·구조 삭제처럼 selector 밖에서 raw state가 바뀌는 경우에도 이 불변식과 stale ID 정리를 즉시 적용한다.
-- 명시적 `setPaneHidden`/`setWorkspaceHidden` 복원은 같은 store 전환에서 관련 `evictedPaneIds`를 지운다. 마지막 숨김 항목이 사라지면 보관함도 닫힌다.
+- 명시적 `setPaneHidden`/`setWorkspaceHidden` 복원은 같은 store 전환에서 관련 `evictedPaneIds`를 지운다. 유효 hidden workspace 가 0 이 되면(hidden pane 존재 여부와 무관하게) 보관함도 닫힌다.
 
 ### Pane 위치 미니맵
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -69,7 +69,7 @@ Pane 이 많은 워크스페이스를 활성화하면 모든 `TerminalView` 가 
 
 #### 숨김 터미널 자동 종료 (issue #269)
 
-WorkspaceSelectorView의 평상시 목록에서 quick-hide한 워크스페이스/Pane이 일정 시간 이상 계속 숨겨져 있으면 해당 터미널(PTY)을 자동 종료하여 메모리/CPU를 절약한다. 숨긴 항목은 selector 하단의 유효 개수 chip과 보관함에서 복원한다([ADR-0033](../adr/0033-hidden-items-shelf-set-contract.md)).
+WorkspaceSelectorView의 평상시 목록에서 quick-hide한 워크스페이스, 또는 pane 컨트롤바 토글로 숨긴 Pane이 일정 시간 이상 계속 숨겨져 있으면 해당 터미널(PTY)을 자동 종료하여 메모리/CPU를 절약한다. 숨긴 workspace는 목록 헤더의 유효 개수 chip 아래 보관함에서, 숨긴 Pane은 해당 pane 컨트롤바 토글로 복원한다([ADR-0033](../adr/0033-hidden-items-shelf-set-contract.md), [ADR-0035](../adr/0035-workspace-only-shelf-per-pane-hide-toggle.md)).
 
 - **설정**: `workspaceSelector.hiddenAutoCloseSeconds`(초, `0` = 비활성화). Rust `WorkspaceSelectorSettings`와 프론트 settings-store 양쪽에 존재하며 `settings.json`에 영구 저장된다.
 - **판정/타이머**: `lib/hidden-auto-close.ts`의 순수 함수(`computeHiddenPaneIds`, `advanceHiddenTimers`)가 "현재 숨김인 Pane"과 "타임아웃 경과 여부"를 계산한다. **활성 워크스페이스의 Pane은 절대 종료 대상이 아니다.**

--- a/ui/e2e/workspace-selector.spec.ts
+++ b/ui/e2e/workspace-selector.spec.ts
@@ -104,67 +104,81 @@ test.describe("WorkspaceSelectorView - Listening Ports", () => {
   });
 });
 
-test.describe("WorkspaceSelectorView - Hidden Items Shelf", () => {
-  test("hides, restores with both action modes, and restores all", async ({ appPage: page }) => {
-    // Create an active three-pane workspace while keeping the default workspace
-    // available as the workspace-level hide target.
+test.describe("WorkspaceSelectorView - Hidden Workspaces Shelf (ADR-0035)", () => {
+  test("hides a workspace, opens the shelf under the chip, restores, and restores all", async ({
+    appPage: page,
+  }) => {
+    // Keep a second workspace so the default one can be hidden.
     await page.getByTestId("layout-create-dev-split").click();
     const workspaceItems = page.locator("[data-testid^='workspace-item-']");
     await expect(workspaceItems).toHaveCount(2);
-    const splitWorkspaceTestId = await workspaceItems.nth(1).getAttribute("data-testid");
-    expect(splitWorkspaceTestId).toBeTruthy();
     const defaultWorkspace = page.getByTestId("workspace-item-ws-default");
-    const splitWorkspace = page.getByTestId(splitWorkspaceTestId!);
-    await expect(splitWorkspace).toHaveAttribute("data-active", "true");
 
     await defaultWorkspace.hover();
     await defaultWorkspace.locator("[data-testid^='workspace-hide-']").click();
 
-    const splitPaneRows = splitWorkspace.locator("[data-testid^='pane-row-']");
-    await expect(splitPaneRows).toHaveCount(3);
-    const secondPaneRow = splitPaneRows.nth(1);
-    await secondPaneRow.hover();
-    await secondPaneRow.locator("[data-testid^='pane-hide-']").click();
-    await expect(splitPaneRows).toHaveCount(2);
-
     const chip = page.getByTestId("hidden-items-chip");
-    await expect(chip).toContainText("2");
+    await expect(chip).toContainText("1");
     await expect(chip).toHaveAttribute("aria-expanded", "false");
     await chip.click();
     await expect(chip).toHaveAttribute("aria-expanded", "true");
 
     const shelf = page.getByTestId("hidden-items-shelf");
     await expect(shelf).toBeVisible();
-    await expect(shelf.locator(".hidden-shelf-row")).toHaveCount(2);
+    await expect(shelf.locator(".hidden-shelf-row")).toHaveCount(1);
 
-    // Show-only restores the workspace without changing the active workspace.
+    // The shelf opens right under the header chip — above the workspace list.
+    const shelfBox = await shelf.boundingBox();
+    const listBox = await page.getByTestId("workspace-list").boundingBox();
+    expect(shelfBox!.y).toBeLessThan(listBox!.y);
+
+    // Show-only restores the workspace without changing the active workspace,
+    // and the last restore closes the shelf and removes the chip.
     await shelf.locator("[data-testid^='hidden-workspace-show-only-']").click();
     await expect(defaultWorkspace).toBeVisible();
     await expect(defaultWorkspace).toHaveAttribute("data-active", "false");
-    await expect(splitWorkspace).toHaveAttribute("data-active", "true");
-    await expect(chip).toContainText("1");
-
-    // Primary pane action restores and focuses the original pane index.
-    await shelf.locator("[data-testid^='hidden-pane-primary-']").click();
     await expect(page.getByTestId("hidden-items-chip")).toHaveCount(0);
     await expect(page.getByTestId("hidden-items-shelf")).toHaveCount(0);
-    await expect(splitPaneRows).toHaveCount(3);
-    await expect(
-      page.getByTestId("workspace-pane-1").getByTestId("pane-focus-indicator"),
-    ).toBeVisible();
 
-    // A second hide cycle exercises the atomic restore-all path.
+    // A second hide cycle exercises the restore-all path.
     await defaultWorkspace.hover();
     await defaultWorkspace.locator("[data-testid^='workspace-hide-']").click();
-    const thirdPaneRow = splitPaneRows.nth(2);
-    await thirdPaneRow.hover();
-    await thirdPaneRow.locator("[data-testid^='pane-hide-']").click();
     await page.getByTestId("hidden-items-chip").click();
     await page.getByTestId("hidden-items-restore-all").click();
 
     await expect(page.getByTestId("hidden-items-chip")).toHaveCount(0);
     await expect(page.getByTestId("hidden-items-shelf")).toHaveCount(0);
     await expect(workspaceItems).toHaveCount(2);
+  });
+
+  test("pane hiding is controlled by the pane control bar toggle, not the shelf", async ({
+    appPage: page,
+  }) => {
+    await page.getByTestId("layout-create-dev-split").click();
+    const workspaceItems = page.locator("[data-testid^='workspace-item-']");
+    await expect(workspaceItems).toHaveCount(2);
+    const splitWorkspaceTestId = await workspaceItems.nth(1).getAttribute("data-testid");
+    expect(splitWorkspaceTestId).toBeTruthy();
+    const splitWorkspace = page.getByTestId(splitWorkspaceTestId!);
+    const splitPaneRows = splitWorkspace.locator("[data-testid^='pane-row-']");
+    await expect(splitPaneRows).toHaveCount(3);
+
+    // The selector rows no longer carry a pane hide button.
+    const firstRow = splitPaneRows.nth(0);
+    await firstRow.hover();
+    await expect(firstRow.locator("[data-testid^='pane-hide-']")).toHaveCount(0);
+
+    // Hide via the pane's own control bar toggle.
+    const pane = page.getByTestId("workspace-pane-0");
+    await pane.hover();
+    await pane.getByTestId("pane-control-hide").click();
+    await expect(splitPaneRows).toHaveCount(2);
+    // Hidden panes never surface the chip or the shelf.
+    await expect(page.getByTestId("hidden-items-chip")).toHaveCount(0);
+
+    // Toggling again restores the summary row.
+    await pane.hover();
+    await pane.getByTestId("pane-control-hide").click();
     await expect(splitPaneRows).toHaveCount(3);
   });
 });

--- a/ui/src/components/layout/PaneControlBar.test.tsx
+++ b/ui/src/components/layout/PaneControlBar.test.tsx
@@ -20,6 +20,7 @@ import { PaneControlBar } from "./PaneControlBar";
 import { PaneControlContext } from "./PaneControlContext";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useOverridesStore } from "@/stores/overrides-store";
+import { useUiStore } from "@/stores/ui-store";
 
 describe("PaneControlBar", () => {
   const defaultView = { type: "TerminalView" as const, profile: "PowerShell" };
@@ -1049,5 +1050,54 @@ describe("PaneControlBar", () => {
       </PaneControlBar>,
     );
     expect(screen.queryByTestId("pane-control-bar-left-solid")).not.toBeInTheDocument();
+  });
+
+  // -- workspace-list hide toggle (ADR-0035) --
+  // pane 숨김은 보관함이 아니라 각 pane 컨트롤바의 이 토글로만 제어한다.
+  describe("workspace-list hide toggle (ADR-0035)", () => {
+    beforeEach(() => {
+      useUiStore.setState(useUiStore.getInitialState());
+    });
+
+    it("toggles the pane's hidden raw state and reflects it on the button", async () => {
+      const user = userEvent.setup();
+      render(
+        <PaneControlBar
+          paneId="pane-x"
+          currentView={terminalView}
+          actions={defaultActions}
+          hovered={true}
+          showListHideToggle
+        >
+          <div>content</div>
+        </PaneControlBar>,
+      );
+      const button = screen.getByTestId("pane-control-hide");
+      expect(button).toHaveAttribute("title", "Hide from workspace list");
+
+      await user.click(button);
+      expect(useUiStore.getState().hiddenPaneIds.has("pane-x")).toBe(true);
+      expect(screen.getByTestId("pane-control-hide")).toHaveAttribute(
+        "title",
+        "Show in workspace list",
+      );
+
+      await user.click(screen.getByTestId("pane-control-hide"));
+      expect(useUiStore.getState().hiddenPaneIds.has("pane-x")).toBe(false);
+    });
+
+    it("does not render the toggle when showListHideToggle is off (e.g. dock panes)", () => {
+      render(
+        <PaneControlBar
+          paneId="pane-x"
+          currentView={terminalView}
+          actions={defaultActions}
+          hovered={true}
+        >
+          <div>content</div>
+        </PaneControlBar>,
+      );
+      expect(screen.queryByTestId("pane-control-hide")).not.toBeInTheDocument();
+    });
   });
 });

--- a/ui/src/components/layout/PaneControlBar.tsx
+++ b/ui/src/components/layout/PaneControlBar.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { useSettingsStore, type ControlBarMode } from "@/stores/settings-store";
 import { useResolvedKeybinding } from "@/lib/keybinding-registry";
 import { useOverridesStore } from "@/stores/overrides-store";
+import { useUiStore } from "@/stores/ui-store";
 import type { ViewInstanceConfig, ViewType } from "@/stores/types";
 import { PaneControlContext, type PaneInputModeToggle } from "./PaneControlContext";
 import { useContainerSize } from "@/hooks/useContainerSize";
@@ -67,6 +68,12 @@ interface PaneControlBarProps {
   onPaneDragStart?: (e: React.DragEvent) => void;
   /** 드래그 종료 핸들러. */
   onPaneDragEnd?: () => void;
+  /**
+   * workspace selector 목록 숨김 토글 노출 여부 (ADR-0035). pane 숨김은 보관함이
+   * 아니라 각 pane 의 이 토글로만 제어한다. dock pane 은 selector 에 나오지 않으므로
+   * PaneGrid 가 location === "workspace" 일 때만 켠다.
+   */
+  showListHideToggle?: boolean;
   children: React.ReactNode;
 }
 
@@ -281,6 +288,8 @@ function BarContent({
   cwdSendOn,
   cwdReceiveOn,
   inputModeToggle,
+  paneHidden,
+  onToggleHidden,
   expanded = true,
   wrapped = false,
   vertical = false,
@@ -294,6 +303,10 @@ function BarContent({
   cwdSendOn?: boolean;
   cwdReceiveOn?: boolean;
   inputModeToggle?: PaneInputModeToggle | null;
+  /** workspace selector 목록 숨김 여부(토글 표시 상태). */
+  paneHidden?: boolean;
+  /** 있으면 목록 숨김 토글 버튼을 렌더한다 (ADR-0035). */
+  onToggleHidden?: () => void;
   expanded?: boolean;
   wrapped?: boolean;
   vertical?: boolean;
@@ -458,6 +471,42 @@ function BarContent({
               </svg>
             </BarBtn>
           )}
+          {onToggleHidden && (
+            <BarBtn
+              testId="pane-control-hide"
+              onClick={onToggleHidden}
+              title={paneHidden ? "Show in workspace list" : "Hide from workspace list"}
+              active={paneHidden}
+            >
+              {paneHidden ? (
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                  <path
+                    d="M1.5 7s2.4-3.8 5.5-3.8S12.5 7 12.5 7s-2.4 3.8-5.5 3.8S1.5 7 1.5 7Z"
+                    stroke="currentColor"
+                    strokeWidth="1.2"
+                    strokeLinejoin="round"
+                  />
+                  <circle cx="7" cy="7" r="1.7" stroke="currentColor" strokeWidth="1.2" />
+                  <path
+                    d="M2.5 11.5l9-9"
+                    stroke="currentColor"
+                    strokeWidth="1.2"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              ) : (
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                  <path
+                    d="M1.5 7s2.4-3.8 5.5-3.8S12.5 7 12.5 7s-2.4 3.8-5.5 3.8S1.5 7 1.5 7Z"
+                    stroke="currentColor"
+                    strokeWidth="1.2"
+                    strokeLinejoin="round"
+                  />
+                  <circle cx="7" cy="7" r="1.7" stroke="currentColor" strokeWidth="1.2" />
+                </svg>
+              )}
+            </BarBtn>
+          )}
           {actions.onClear && (
             <BarBtn testId="pane-control-clear" onClick={actions.onClear} title="Clear view" danger>
               <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
@@ -556,6 +605,8 @@ function NarrowControlMenu({
   cwdSendOn,
   cwdReceiveOn,
   inputModeToggle,
+  paneHidden,
+  onToggleHidden,
   position,
   onRequestClose,
   triggerRef,
@@ -567,6 +618,8 @@ function NarrowControlMenu({
   cwdSendOn?: boolean;
   cwdReceiveOn?: boolean;
   inputModeToggle?: PaneInputModeToggle | null;
+  paneHidden?: boolean;
+  onToggleHidden?: () => void;
   position: { top: number; right: number };
   onRequestClose: () => void;
   /** ⋯ 트리거 버튼. 트리거 클릭은 외부 클릭으로 보지 않는다(아래 toggle 이 닫기를 처리). */
@@ -619,6 +672,8 @@ function NarrowControlMenu({
         cwdSendOn={cwdSendOn}
         cwdReceiveOn={cwdReceiveOn}
         inputModeToggle={inputModeToggle}
+        paneHidden={paneHidden}
+        onToggleHidden={onToggleHidden}
         vertical
         showMinimize={false}
       />
@@ -765,9 +820,21 @@ export function PaneControlBar({
   dndEnabled,
   onPaneDragStart,
   onPaneDragEnd,
+  showListHideToggle,
   children,
 }: PaneControlBarProps) {
   const rootRef = useRef<HTMLDivElement>(null);
+  // workspace selector 목록 숨김 상태(raw)를 구독해 토글 버튼 상태로 쓴다 (ADR-0035).
+  const paneHidden = useUiStore((s) =>
+    showListHideToggle && paneId ? s.hiddenPaneIds.has(paneId) : false,
+  );
+  const onToggleHidden = useMemo(
+    () =>
+      showListHideToggle && paneId
+        ? () => useUiStore.getState().togglePaneHidden(paneId)
+        : undefined,
+    [showListHideToggle, paneId],
+  );
   const { w: paneWidth } = useContainerSize(rootRef);
   const persistedMode = useOverridesStore((s) =>
     paneId ? s.paneOverrides[paneId]?.controlBarMode : undefined,
@@ -893,6 +960,8 @@ export function PaneControlBar({
           cwdSendOn={cwdSendOn}
           cwdReceiveOn={cwdReceiveOn}
           inputModeToggle={inputModeToggle}
+          paneHidden={paneHidden}
+          onToggleHidden={onToggleHidden}
         />
       ),
     [
@@ -906,6 +975,8 @@ export function PaneControlBar({
       cwdSendOn,
       cwdReceiveOn,
       inputModeToggle,
+      paneHidden,
+      onToggleHidden,
     ],
   );
 
@@ -1008,6 +1079,8 @@ export function PaneControlBar({
                 cwdSendOn={cwdSendOn}
                 cwdReceiveOn={cwdReceiveOn}
                 inputModeToggle={inputModeToggle}
+                paneHidden={paneHidden}
+                onToggleHidden={onToggleHidden}
               />
             )}
           </div>
@@ -1062,6 +1135,8 @@ export function PaneControlBar({
                   cwdSendOn={cwdSendOn}
                   cwdReceiveOn={cwdReceiveOn}
                   inputModeToggle={inputModeToggle}
+                  paneHidden={paneHidden}
+                  onToggleHidden={onToggleHidden}
                 />
               )}
             </div>
@@ -1094,6 +1169,8 @@ export function PaneControlBar({
             cwdSendOn={cwdSendOn}
             cwdReceiveOn={cwdReceiveOn}
             inputModeToggle={inputModeToggle}
+            paneHidden={paneHidden}
+            onToggleHidden={onToggleHidden}
             position={menuPosition}
             onRequestClose={closeNarrowMenu}
             triggerRef={menuBtnRef}

--- a/ui/src/components/layout/PaneGrid.tsx
+++ b/ui/src/components/layout/PaneGrid.tsx
@@ -245,6 +245,7 @@ export function PaneGrid({
               dndEnabled={dndEnabled}
               onPaneDragStart={(e) => handleDragStart(e, pane.id)}
               onPaneDragEnd={handleDragEnd}
+              showListHideToggle={location === "workspace"}
               actions={{
                 onChangeView: onSetPaneView
                   ? (config) => onSetPaneView(pane.id, config)

--- a/ui/src/components/views/WorkspaceSelectorView.test.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.test.tsx
@@ -1912,7 +1912,7 @@ describe("WorkspaceSelectorView", () => {
       expect(screen.queryByTestId("hide-mode-toggle")).not.toBeInTheDocument();
     });
 
-    it("offers immediate workspace and pane hide actions in the normal list", () => {
+    it("offers immediate workspace hide actions but no per-row pane hide button", () => {
       render(<WorkspaceSelectorView />);
       fireEvent.mouseEnter(screen.getByTestId("workspace-item-ws-1"));
       expect(screen.getByTestId("workspace-hide-ws-1")).toHaveAttribute(
@@ -1926,11 +1926,10 @@ describe("WorkspaceSelectorView", () => {
         "Hide from list",
       );
 
+      // Pane hiding is controlled from each pane's control bar (ADR-0035),
+      // not from the selector rows.
       fireEvent.mouseEnter(screen.getByTestId("pane-row-pane-a"));
-      expect(screen.getByTestId("pane-hide-pane-a")).toHaveAttribute(
-        "aria-label",
-        "Hide from list",
-      );
+      expect(screen.queryByTestId("pane-hide-pane-a")).not.toBeInTheDocument();
     });
 
     it("renders only visible workspace and pane rows after hiding", () => {
@@ -1944,7 +1943,7 @@ describe("WorkspaceSelectorView", () => {
       expect(screen.getByTestId("pane-row-pane-b")).toBeInTheDocument();
     });
 
-    it("shows a valid hidden count chip with disclosure semantics and ignores stale IDs", () => {
+    it("counts only valid hidden workspaces in the chip and ignores panes and stale IDs", () => {
       useUiStore.setState({
         hiddenWorkspaceIds: new Set(["ws-2", "ws-stale"]),
         hiddenPaneIds: new Set(["pane-a", "pane-stale"]),
@@ -1952,12 +1951,18 @@ describe("WorkspaceSelectorView", () => {
       render(<WorkspaceSelectorView />);
 
       const chip = screen.getByTestId("hidden-items-chip");
-      expect(chip).toHaveTextContent("Hidden 2");
+      expect(chip).toHaveTextContent("Hidden 1");
       expect(chip).toHaveAttribute("aria-expanded", "false");
       expect(chip).toHaveAttribute("aria-controls", "hidden-items-shelf");
     });
 
-    it("groups hidden workspaces and panes without duplicating a child pane", () => {
+    it("hides the chip when only panes are hidden", () => {
+      useUiStore.getState().setPaneHidden("pane-a", true);
+      render(<WorkspaceSelectorView />);
+      expect(screen.queryByTestId("hidden-items-chip")).not.toBeInTheDocument();
+    });
+
+    it("lists hidden workspaces only — never hidden panes", () => {
       useUiStore.getState().setWorkspaceHidden("ws-2", true);
       useUiStore.getState().setPaneHidden("p2", true);
       useUiStore.getState().setPaneHidden("pane-a", true);
@@ -1965,12 +1970,26 @@ describe("WorkspaceSelectorView", () => {
       render(<WorkspaceSelectorView />);
 
       expect(screen.getByTestId("hidden-items-shelf")).toBeInTheDocument();
-      expect(screen.getByTestId("hidden-workspace-ws-2")).toHaveTextContent(
-        "1 individually hidden pane",
+      expect(screen.getByTestId("hidden-workspace-ws-2")).toBeInTheDocument();
+      expect(screen.getByTestId("hidden-workspace-ws-2")).not.toHaveTextContent(
+        "individually hidden",
       );
       expect(screen.queryByTestId("hidden-pane-p2")).not.toBeInTheDocument();
-      expect(screen.getByTestId("hidden-pane-pane-a")).toHaveTextContent("Project A");
-      expect(screen.getByTestId("hidden-items-chip")).toHaveTextContent("Hidden 3");
+      expect(screen.queryByTestId("hidden-pane-pane-a")).not.toBeInTheDocument();
+      expect(screen.getByTestId("hidden-items-chip")).toHaveTextContent("Hidden 1");
+    });
+
+    it("opens the shelf directly under the header chip, above the workspace list", () => {
+      useUiStore.getState().setWorkspaceHidden("ws-2", true);
+      useUiStore.getState().setHiddenShelfOpen(true);
+      render(<WorkspaceSelectorView />);
+
+      const chip = screen.getByTestId("hidden-items-chip");
+      const shelf = screen.getByTestId("hidden-items-shelf");
+      const list = screen.getByTestId("workspace-list");
+      // chip < shelf < workspace list in document order.
+      expect(chip.compareDocumentPosition(shelf) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      expect(shelf.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
 
     it("restores a workspace without changing the active workspace via the eye button", () => {
@@ -1995,7 +2014,6 @@ describe("WorkspaceSelectorView", () => {
 
     it("provides distinct tooltips for primary and show-only restore actions", () => {
       useUiStore.getState().setWorkspaceHidden("ws-2", true);
-      useUiStore.getState().setPaneHidden("pane-a", true);
       useUiStore.getState().setHiddenShelfOpen(true);
       render(<WorkspaceSelectorView />);
 
@@ -2007,35 +2025,13 @@ describe("WorkspaceSelectorView", () => {
         "title",
         "Show only",
       );
-      expect(screen.getByTestId("hidden-pane-primary-pane-a")).toHaveAttribute(
-        "title",
-        "Show again and focus",
-      );
-      expect(screen.getByTestId("hidden-pane-show-only-pane-a")).toHaveAttribute(
-        "title",
-        "Show only",
-      );
     });
 
-    it("distinguishes show-only from show-and-focus for panes", () => {
+    it("does not open the shelf for hidden panes alone", () => {
       useUiStore.getState().setPaneHidden("p2", true);
       useUiStore.getState().setHiddenShelfOpen(true);
-      const { rerender } = render(<WorkspaceSelectorView />);
-
-      fireEvent.click(screen.getByTestId("hidden-pane-show-only-p2"));
-      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("ws-1");
-      expect(useGridStore.getState().focusedPaneIndex).toBe(0);
-
-      act(() => {
-        useUiStore.getState().setPaneHidden("p2", true);
-        useUiStore.getState().setHiddenShelfOpen(true);
-        useDockStore.getState().setFocusedDock("left");
-      });
-      rerender(<WorkspaceSelectorView />);
-      fireEvent.click(screen.getByTestId("hidden-pane-primary-p2"));
-      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("ws-2");
-      expect(useGridStore.getState().focusedPaneIndex).toBe(0);
-      expect(useDockStore.getState().focusedDock).toBeNull();
+      render(<WorkspaceSelectorView />);
+      expect(screen.queryByTestId("hidden-items-shelf")).not.toBeInTheDocument();
     });
 
     it("moves to the next visible workspace before hiding the active one", () => {
@@ -2059,27 +2055,28 @@ describe("WorkspaceSelectorView", () => {
       expect(button).toHaveAttribute("title", "The last workspace cannot be hidden");
     });
 
-    it("shows an undo snackbar and restores with an idempotent set action", () => {
+    it("shows an undo snackbar for workspace hide and restores with a set action", () => {
       render(<WorkspaceSelectorView />);
-      fireEvent.mouseEnter(screen.getByTestId("pane-row-pane-a"));
-      fireEvent.click(screen.getByTestId("pane-hide-pane-a"));
+      fireEvent.mouseEnter(screen.getByTestId("workspace-item-ws-2"));
+      fireEvent.click(screen.getByTestId("workspace-hide-ws-2"));
 
       expect(screen.getByRole("status")).toHaveTextContent("hidden from the list");
-      useUiStore.getState().setPaneHidden("pane-a", true);
       fireEvent.click(screen.getByTestId("undo-snackbar-action"));
-      expect(useUiStore.getState().hiddenPaneIds.has("pane-a")).toBe(false);
+      expect(useUiStore.getState().hiddenWorkspaceIds.has("ws-2")).toBe(false);
     });
 
-    it("restore all atomically clears state and closes the shelf", () => {
+    it("restore all clears hidden workspaces and their evictions, leaving hidden panes alone", () => {
       useUiStore.getState().setWorkspaceHidden("ws-2", true);
       useUiStore.getState().setPaneHidden("pane-a", true);
-      useUiStore.getState().setEvictedPaneIds(new Set(["pane-a"]));
+      useUiStore.getState().setEvictedPaneIds(new Set(["p2"]));
       useUiStore.getState().setHiddenShelfOpen(true);
       render(<WorkspaceSelectorView />);
 
       fireEvent.click(screen.getByTestId("hidden-items-restore-all"));
       expect(useUiStore.getState().hiddenWorkspaceIds.size).toBe(0);
-      expect(useUiStore.getState().hiddenPaneIds.size).toBe(0);
+      // Individually-hidden panes stay hidden — they are controlled per pane.
+      expect(useUiStore.getState().hiddenPaneIds.has("pane-a")).toBe(true);
+      // ws-2's evicted pane is cleared by the workspace restore.
       expect(useUiStore.getState().evictedPaneIds.size).toBe(0);
       expect(screen.queryByTestId("hidden-items-shelf")).not.toBeInTheDocument();
     });

--- a/ui/src/components/views/WorkspaceSelectorView.tsx
+++ b/ui/src/components/views/WorkspaceSelectorView.tsx
@@ -2,7 +2,6 @@ import { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import { useGridStore } from "@/stores/grid-store";
-import { useDockStore } from "@/stores/dock-store";
 import { useNotificationStore } from "@/stores/notification-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { sortWorkspaces } from "@/lib/workspace-sort";
@@ -133,9 +132,7 @@ interface DragContext {
   onDragEnd: () => void;
 }
 
-type HiddenUndoItem =
-  | { kind: "workspace"; id: string; name: string; paneIds: string[]; nonce: number }
-  | { kind: "pane"; id: string; name: string; nonce: number };
+type HiddenUndoItem = { id: string; name: string; paneIds: string[]; nonce: number };
 
 /** Eye icon (visible state) — 11x11 */
 function EyeIcon({ size = 11 }: { size?: number }) {
@@ -172,7 +169,6 @@ function WorkspaceItem({
   onClose,
   onDuplicate,
   onRename,
-  onHidePane,
   onHideWorkspace,
 }: {
   ws: { id: string; name: string };
@@ -195,7 +191,6 @@ function WorkspaceItem({
   onClose: () => void;
   onDuplicate: () => void;
   onRename: () => void;
-  onHidePane: (paneId: string) => void;
   onHideWorkspace: () => void;
 }) {
   const { t } = useTranslation("workspace");
@@ -614,19 +609,6 @@ function WorkspaceItem({
                             />
                           )}
                         </div>
-                        <button
-                          type="button"
-                          data-testid={`pane-hide-${pane.id}`}
-                          className="hidden-item-action-btn pane-quick-hide hover-bg cursor-pointer"
-                          aria-label={t("hiddenItems.hideFromList")}
-                          title={t("hiddenItems.hidePaneDescription")}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onHidePane(pane.id);
-                          }}
-                        >
-                          <EyeIcon size={12} />
-                        </button>
                       </div>
                     );
                   }
@@ -671,19 +653,6 @@ function WorkspaceItem({
                           </span>
                         </div>
                       </div>
-                      <button
-                        type="button"
-                        data-testid={`pane-hide-${pane.id}`}
-                        className="hidden-item-action-btn pane-quick-hide hover-bg cursor-pointer"
-                        aria-label={t("hiddenItems.hideFromList")}
-                        title={t("hiddenItems.hidePaneDescription")}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onHidePane(pane.id);
-                        }}
-                      >
-                        <EyeIcon size={12} />
-                      </button>
                     </div>
                   );
                 });
@@ -1036,9 +1005,7 @@ export function WorkspaceSelectorView() {
   const hiddenWorkspaceIds = useUiStore((s) => s.hiddenWorkspaceIds);
   const hiddenShelfOpen = useUiStore((s) => s.hiddenShelfOpen);
   const setHiddenShelfOpen = useUiStore((s) => s.setHiddenShelfOpen);
-  const setPaneHidden = useUiStore((s) => s.setPaneHidden);
   const setWorkspaceHidden = useUiStore((s) => s.setWorkspaceHidden);
-  const restoreAllHidden = useUiStore((s) => s.restoreAllHidden);
 
   const pathEllipsis = useSettingsStore((s) => s.workspaceSelector.pathEllipsis);
   const workspaceSortOrder = useSettingsStore((s) => s.workspaceSelector.sortOrder);
@@ -1075,20 +1042,6 @@ export function WorkspaceSelectorView() {
         !hiddenItems.validHiddenWorkspaceIds.has(workspace.id),
     );
   }, [activeWorkspaceId, hiddenItems, sortedWorkspaces]);
-  const paneDetailsById = useMemo(() => {
-    const details = new Map<string, { label?: string; cwd?: string }>();
-    for (const workspace of workspaces) {
-      for (const pane of workspace.panes) {
-        const instance = terminalInstances.find((item) => item.id === `terminal-${pane.id}`);
-        details.set(pane.id, {
-          label: instance?.label ?? (pane.view.profile as string | undefined),
-          cwd: instance?.cwd ?? (pane.view.lastCwd as string | undefined),
-        });
-      }
-    }
-    return details;
-  }, [terminalInstances, workspaces]);
-
   // Drag and drop handlers (ID-based to avoid index mismatch with sorted lists)
   const dragIdRef = useRef<string | null>(null);
   const dropPositionRef = useRef<"top" | "bottom">("top");
@@ -1223,29 +1176,11 @@ export function WorkspaceSelectorView() {
     if (result.blocked) return;
     undoNonceRef.current += 1;
     setUndoItem({
-      kind: "workspace",
       id: workspace.id,
       name: workspace.name,
       paneIds: workspace.panes.map((pane) => pane.id),
       nonce: undoNonceRef.current,
     });
-  };
-
-  const handleHidePane = (paneId: string) => {
-    for (const workspace of workspaces) {
-      const pane = workspace.panes.find((candidate) => candidate.id === paneId);
-      if (!pane) continue;
-      const paneNumber = computePaneNumbers(workspace.panes).get(pane.id) ?? 1;
-      setPaneHidden(pane.id, true);
-      undoNonceRef.current += 1;
-      setUndoItem({
-        kind: "pane",
-        id: pane.id,
-        name: `${workspace.name} · #${paneNumber}`,
-        nonce: undoNonceRef.current,
-      });
-      return;
-    }
   };
 
   const handleCloseHiddenShelf = () => {
@@ -1289,7 +1224,7 @@ export function WorkspaceSelectorView() {
       >
         <SectionLabel>{t("workspaces")}</SectionLabel>
         <span className="flex items-center gap-1">
-          {hiddenItems.count > 0 && (
+          {hiddenItems.hiddenWorkspaces.length > 0 && (
             <button
               ref={hiddenChipRef}
               type="button"
@@ -1304,7 +1239,7 @@ export function WorkspaceSelectorView() {
                 border: "1px solid transparent",
               }}
             >
-              {t("hiddenItems.chip", { count: hiddenItems.count })}
+              {t("hiddenItems.chip", { count: hiddenItems.hiddenWorkspaces.length })}
             </button>
           )}
           <button
@@ -1345,6 +1280,36 @@ export function WorkspaceSelectorView() {
           </button>
         </span>
       </div>
+
+      {/* Hidden-workspace restore shelf — opens directly under the chip that
+          toggles it (top of the list), not at the bottom of the selector. */}
+      {hiddenShelfOpen && hiddenItems.hiddenWorkspaces.length > 0 && (
+        <HiddenItemsShelf
+          items={hiddenItems}
+          onClose={handleCloseHiddenShelf}
+          onFocusAfterEmpty={() => sortOrderToggleRef.current?.focus()}
+          onRestoreAll={() => {
+            // Workspace-only shelf: restore every hidden workspace, leave
+            // individually-hidden panes to their per-pane toggles.
+            for (const item of hiddenItems.hiddenWorkspaces) {
+              setWorkspaceHidden(
+                item.workspace.id,
+                false,
+                item.workspace.panes.map((pane) => pane.id),
+              );
+            }
+            setUndoItem(null);
+          }}
+          onRestoreWorkspace={(item, open) => {
+            setWorkspaceHidden(
+              item.workspace.id,
+              false,
+              item.workspace.panes.map((pane) => pane.id),
+            );
+            if (open) handleSelectWorkspace(item.workspace.id);
+          }}
+        />
+      )}
 
       {/* Workspace list */}
       <div
@@ -1443,7 +1408,6 @@ export function WorkspaceSelectorView() {
                 // prompt does not work on Windows/WebView2.
                 useRenameWorkspaceStore.getState().openRename(ws.id, ws.name);
               }}
-              onHidePane={handleHidePane}
               onHideWorkspace={() => handleHideWorkspace(ws.id)}
             />
           );
@@ -1483,35 +1447,6 @@ export function WorkspaceSelectorView() {
         )}
       </div>
 
-      {hiddenShelfOpen && hiddenItems.count > 0 && (
-        <HiddenItemsShelf
-          items={hiddenItems}
-          paneDetailsById={paneDetailsById}
-          onClose={handleCloseHiddenShelf}
-          onFocusAfterEmpty={() => sortOrderToggleRef.current?.focus()}
-          onRestoreAll={() => {
-            restoreAllHidden();
-            setUndoItem(null);
-          }}
-          onRestoreWorkspace={(item, open) => {
-            setWorkspaceHidden(
-              item.workspace.id,
-              false,
-              item.workspace.panes.map((pane) => pane.id),
-            );
-            if (open) handleSelectWorkspace(item.workspace.id);
-          }}
-          onRestorePane={(item, focus) => {
-            setPaneHidden(item.pane.id, false);
-            if (focus) {
-              handleSelectWorkspace(item.workspace.id);
-              useGridStore.getState().setFocusedPane(item.paneIndex);
-              useDockStore.getState().setFocusedDock(null);
-            }
-          }}
-        />
-      )}
-
       {/* #6: Notifications section header — matches Workspaces section style */}
       <div
         data-testid="toggle-notification-panel"
@@ -1540,11 +1475,7 @@ export function WorkspaceSelectorView() {
           actionLabel={t("hiddenItems.undo")}
           onDismiss={dismissUndo}
           onAction={() => {
-            if (undoItem.kind === "workspace") {
-              setWorkspaceHidden(undoItem.id, false, undoItem.paneIds);
-            } else {
-              setPaneHidden(undoItem.id, false);
-            }
+            setWorkspaceHidden(undoItem.id, false, undoItem.paneIds);
             setUndoItem(null);
           }}
         />

--- a/ui/src/components/views/workspace-selector/HiddenItemsShelf.tsx
+++ b/ui/src/components/views/workspace-selector/HiddenItemsShelf.tsx
@@ -1,20 +1,13 @@
 import { useLayoutEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import type { DerivedHiddenItems, HiddenPaneItem, HiddenWorkspaceItem } from "@/lib/hidden-items";
-
-export interface HiddenPaneDetails {
-  label?: string;
-  cwd?: string;
-}
+import type { DerivedHiddenItems, HiddenWorkspaceItem } from "@/lib/hidden-items";
 
 interface HiddenItemsShelfProps {
   items: DerivedHiddenItems;
-  paneDetailsById: Map<string, HiddenPaneDetails>;
   onClose: () => void;
   onFocusAfterEmpty: () => void;
   onRestoreAll: () => void;
   onRestoreWorkspace: (item: HiddenWorkspaceItem, open: boolean) => void;
-  onRestorePane: (item: HiddenPaneItem, focus: boolean) => void;
 }
 
 function EyeIcon() {
@@ -31,22 +24,21 @@ function EyeIcon() {
   );
 }
 
+/**
+ * Workspace-only restore shelf. Hidden panes are intentionally NOT listed here —
+ * each pane carries its own hide toggle in the pane control bar (ADR-0035).
+ */
 export function HiddenItemsShelf({
   items,
-  paneDetailsById,
   onClose,
   onFocusAfterEmpty,
   onRestoreAll,
   onRestoreWorkspace,
-  onRestorePane,
 }: HiddenItemsShelfProps) {
   const { t } = useTranslation("workspace");
   const headerRef = useRef<HTMLDivElement>(null);
   const pendingFocusIndexRef = useRef<number | null>(null);
-  const rowKeys = [
-    ...items.hiddenWorkspaces.map((item) => `workspace:${item.workspace.id}`),
-    ...items.hiddenPanes.map((item) => `pane:${item.pane.id}`),
-  ];
+  const rowKeys = items.hiddenWorkspaces.map((item) => `workspace:${item.workspace.id}`);
 
   useLayoutEffect(() => {
     const pendingIndex = pendingFocusIndexRef.current;
@@ -57,10 +49,10 @@ export function HiddenItemsShelf({
     );
     if (pendingIndex < rowButtons.length) rowButtons[pendingIndex]?.focus();
     else headerRef.current?.focus();
-  }, [items.count]);
+  }, [items.hiddenWorkspaces.length]);
 
   const prepareFocusAfterRemoval = (key: string) => {
-    if (items.count === 1) {
+    if (items.hiddenWorkspaces.length === 1) {
       onFocusAfterEmpty();
       return;
     }
@@ -76,7 +68,7 @@ export function HiddenItemsShelf({
     >
       <div ref={headerRef} tabIndex={-1} className="flex shrink-0 items-center gap-1 px-2 py-1.5">
         <span className="min-w-0 flex-1 truncate text-[11px] font-semibold">
-          {t("hiddenItems.titleCount", { count: items.count })}
+          {t("hiddenItems.titleCount", { count: items.hiddenWorkspaces.length })}
         </span>
         <button
           type="button"
@@ -102,123 +94,48 @@ export function HiddenItemsShelf({
       </div>
 
       <div className="empty-view-scroll min-h-0 overflow-y-auto px-1 pb-1">
-        {items.hiddenWorkspaces.length > 0 && (
-          <div>
-            <div className="hidden-shelf-section-label">{t("hiddenItems.workspaces")}</div>
-            {items.hiddenWorkspaces.map((item) => {
-              const key = `workspace:${item.workspace.id}`;
-              return (
-                <div
-                  key={key}
-                  data-testid={`hidden-workspace-${item.workspace.id}`}
-                  className="hidden-shelf-row"
-                >
-                  <button
-                    type="button"
-                    data-hidden-row-primary="true"
-                    data-testid={`hidden-workspace-primary-${item.workspace.id}`}
-                    className="hidden-shelf-primary hover-bg"
-                    aria-label={t("hiddenItems.showAndOpenLabel", {
-                      name: item.workspace.name,
-                    })}
-                    title={t("hiddenItems.showAndOpen")}
-                    onClick={() => {
-                      prepareFocusAfterRemoval(key);
-                      onRestoreWorkspace(item, true);
-                    }}
-                  >
-                    <span className="truncate">{item.workspace.name}</span>
-                    {item.hiddenPanes.length > 0 && (
-                      <span
-                        className="truncate text-[9px]"
-                        style={{ color: "var(--text-secondary)" }}
-                      >
-                        {t("hiddenItems.nestedPaneCount", { count: item.hiddenPanes.length })}
-                      </span>
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    data-testid={`hidden-workspace-show-only-${item.workspace.id}`}
-                    className="hidden-shelf-icon-button hover-bg"
-                    aria-label={t("hiddenItems.showOnlyWorkspaceLabel", {
-                      name: item.workspace.name,
-                    })}
-                    title={t("hiddenItems.showOnly")}
-                    onClick={() => {
-                      prepareFocusAfterRemoval(key);
-                      onRestoreWorkspace(item, false);
-                    }}
-                  >
-                    <EyeIcon />
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-        )}
-
-        {items.hiddenPanes.length > 0 && (
-          <div>
-            <div className="hidden-shelf-section-label">{t("hiddenItems.panes")}</div>
-            {items.hiddenPanes.map((item) => {
-              const key = `pane:${item.pane.id}`;
-              const details = paneDetailsById.get(item.pane.id);
-              const label = details?.label ?? String(item.pane.view.profile ?? item.pane.view.type);
-              return (
-                <div
-                  key={key}
-                  data-testid={`hidden-pane-${item.pane.id}`}
-                  className="hidden-shelf-row"
-                >
-                  <button
-                    type="button"
-                    data-hidden-row-primary="true"
-                    data-testid={`hidden-pane-primary-${item.pane.id}`}
-                    className="hidden-shelf-primary hover-bg"
-                    aria-label={t("hiddenItems.showAndFocusLabel", {
-                      workspace: item.workspace.name,
-                      pane: item.paneNumber,
-                    })}
-                    title={t("hiddenItems.showAndFocus")}
-                    onClick={() => {
-                      prepareFocusAfterRemoval(key);
-                      onRestorePane(item, true);
-                    }}
-                  >
-                    <span className="truncate">
-                      {item.workspace.name} · #{item.paneNumber} · {label}
-                    </span>
-                    {details?.cwd && (
-                      <span
-                        className="truncate text-[9px]"
-                        style={{ color: "var(--text-secondary)" }}
-                      >
-                        {details.cwd}
-                      </span>
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    data-testid={`hidden-pane-show-only-${item.pane.id}`}
-                    className="hidden-shelf-icon-button hover-bg"
-                    aria-label={t("hiddenItems.showOnlyPaneLabel", {
-                      workspace: item.workspace.name,
-                      pane: item.paneNumber,
-                    })}
-                    title={t("hiddenItems.showOnly")}
-                    onClick={() => {
-                      prepareFocusAfterRemoval(key);
-                      onRestorePane(item, false);
-                    }}
-                  >
-                    <EyeIcon />
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-        )}
+        {items.hiddenWorkspaces.map((item) => {
+          const key = `workspace:${item.workspace.id}`;
+          return (
+            <div
+              key={key}
+              data-testid={`hidden-workspace-${item.workspace.id}`}
+              className="hidden-shelf-row"
+            >
+              <button
+                type="button"
+                data-hidden-row-primary="true"
+                data-testid={`hidden-workspace-primary-${item.workspace.id}`}
+                className="hidden-shelf-primary hover-bg"
+                aria-label={t("hiddenItems.showAndOpenLabel", {
+                  name: item.workspace.name,
+                })}
+                title={t("hiddenItems.showAndOpen")}
+                onClick={() => {
+                  prepareFocusAfterRemoval(key);
+                  onRestoreWorkspace(item, true);
+                }}
+              >
+                <span className="truncate">{item.workspace.name}</span>
+              </button>
+              <button
+                type="button"
+                data-testid={`hidden-workspace-show-only-${item.workspace.id}`}
+                className="hidden-shelf-icon-button hover-bg"
+                aria-label={t("hiddenItems.showOnlyWorkspaceLabel", {
+                  name: item.workspace.name,
+                })}
+                title={t("hiddenItems.showOnly")}
+                onClick={() => {
+                  prepareFocusAfterRemoval(key);
+                  onRestoreWorkspace(item, false);
+                }}
+              >
+                <EyeIcon />
+              </button>
+            </div>
+          );
+        })}
       </div>
     </section>
   );

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -483,29 +483,20 @@
       "notificationTitle": "Sort: Notification (most recent first)"
     },
     "hiddenItems": {
-      "title": "Hidden items",
-      "titleCount": "Hidden items {{count}}",
+      "title": "Hidden workspaces",
+      "titleCount": "Hidden workspaces {{count}}",
       "chip": "Hidden {{count}}",
       "hideFromList": "Hide from list",
-      "hidePaneDescription": "Hide this pane summary from the workspace list",
-      "showAgain": "Show again",
       "showOnly": "Show only",
       "showAndOpen": "Show again and open",
-      "showAndFocus": "Show again and focus",
       "restoreAll": "Show all",
       "undo": "Undo",
-      "close": "Close hidden items",
-      "workspaces": "Workspaces",
-      "panes": "Panes",
-      "nestedPaneCount_one": "{{count}} individually hidden pane",
-      "nestedPaneCount_other": "{{count}} individually hidden panes",
+      "close": "Close hidden workspaces",
       "hiddenMessage": "{{name}} was hidden from the list",
       "lastWorkspace": "The last workspace cannot be hidden",
       "hideAndMove": "Hide and move to the next workspace",
       "showAndOpenLabel": "Show {{name}} again and open it",
-      "showOnlyWorkspaceLabel": "Show {{name}} again without opening it",
-      "showAndFocusLabel": "Show {{workspace}} pane {{pane}} again and focus it",
-      "showOnlyPaneLabel": "Show {{workspace}} pane {{pane}} again without focusing it"
+      "showOnlyWorkspaceLabel": "Show {{name}} again without opening it"
     },
     "layout": {
       "options": "Layout options",

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -483,29 +483,20 @@
       "notificationTitle": "정렬: 알림순 (최근 항목 우선)"
     },
     "hiddenItems": {
-      "title": "숨긴 항목",
-      "titleCount": "숨긴 항목 {{count}}",
+      "title": "숨긴 워크스페이스",
+      "titleCount": "숨긴 워크스페이스 {{count}}",
       "chip": "숨김 {{count}}",
       "hideFromList": "목록에서 숨기기",
-      "hidePaneDescription": "이 Pane 요약 행을 워크스페이스 목록에서 숨기기",
-      "showAgain": "다시 표시",
       "showOnly": "표시만",
       "showAndOpen": "다시 표시하고 열기",
-      "showAndFocus": "다시 표시하고 포커스",
       "restoreAll": "모두 표시",
       "undo": "되돌리기",
-      "close": "숨긴 항목 닫기",
-      "workspaces": "워크스페이스",
-      "panes": "Pane",
-      "nestedPaneCount_one": "개별 숨김 Pane {{count}}",
-      "nestedPaneCount_other": "개별 숨김 Pane {{count}}",
+      "close": "숨긴 워크스페이스 닫기",
       "hiddenMessage": "{{name}}을(를) 목록에서 숨겼습니다",
       "lastWorkspace": "마지막 workspace는 숨길 수 없습니다",
       "hideAndMove": "숨기고 다음 workspace로 이동",
       "showAndOpenLabel": "{{name}}을(를) 다시 표시하고 열기",
-      "showOnlyWorkspaceLabel": "{{name}}을(를) 다시 표시만 하기",
-      "showAndFocusLabel": "{{workspace}}의 {{pane}}번 Pane을 다시 표시하고 포커스",
-      "showOnlyPaneLabel": "{{workspace}}의 {{pane}}번 Pane을 다시 표시만 하기"
+      "showOnlyWorkspaceLabel": "{{name}}을(를) 다시 표시만 하기"
     },
     "layout": {
       "options": "레이아웃 옵션",

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -184,8 +184,7 @@
   .hidden-item-action-btn:disabled {
     cursor: not-allowed;
   }
-  .workspace-quick-hide,
-  .pane-quick-hide {
+  .workspace-quick-hide {
     opacity: 0;
     pointer-events: none;
     transition: opacity var(--transition-fast);
@@ -198,9 +197,7 @@
     margin: -2px;
   }
   .workspace-item-animated:hover .workspace-quick-hide,
-  .workspace-item-animated:focus-within .workspace-quick-hide,
-  .workspace-pane-row:hover .pane-quick-hide,
-  .workspace-pane-row:focus-within .pane-quick-hide {
+  .workspace-item-animated:focus-within .workspace-quick-hide {
     opacity: 1;
     pointer-events: auto;
   }
@@ -221,15 +218,6 @@
     border-top: 1px solid var(--border);
     border-bottom: 1px solid var(--border);
     background: var(--bg-surface);
-  }
-  .hidden-shelf-section-label {
-    padding: 5px 5px 2px;
-    color: var(--text-secondary);
-    font-size: var(--fs-2xs);
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    opacity: 0.7;
   }
   .hidden-shelf-row {
     display: flex;
@@ -682,7 +670,6 @@
     animation: none;
   }
   .workspace-quick-hide,
-  .pane-quick-hide,
   .workspace-item-animated,
   .workspace-pane-row {
     transition: none;

--- a/ui/src/stores/ui-store.test.ts
+++ b/ui/src/stores/ui-store.test.ts
@@ -138,11 +138,13 @@ describe("ui-store", () => {
     expect(JSON.parse(localStorage.getItem("laymux-hidden-panes") ?? "null")).toEqual([]);
   });
 
-  it("closes the shelf when the last pane is restored", () => {
+  it("keeps the workspace-only shelf open across pane hidden transitions", () => {
+    // The shelf lists hidden workspaces only; pane hide/restore must not close it.
+    useUiStore.getState().setWorkspaceHidden("ws-1", true);
     useUiStore.getState().setPaneHidden("pane-1", true);
     useUiStore.getState().setHiddenShelfOpen(true);
     useUiStore.getState().setPaneHidden("pane-1", false);
-    expect(useUiStore.getState().hiddenShelfOpen).toBe(false);
+    expect(useUiStore.getState().hiddenShelfOpen).toBe(true);
   });
 
   // -- hidden workspace ids --
@@ -193,6 +195,16 @@ describe("ui-store", () => {
     expect(useUiStore.getState().hiddenShelfOpen).toBe(false);
   });
 
+  it("closes the shelf on last workspace restore even when panes stay hidden", () => {
+    // Hidden panes are not shown in the shelf, so they must not keep it open.
+    useUiStore.getState().setWorkspaceHidden("ws-1", true);
+    useUiStore.getState().setPaneHidden("pane-1", true);
+    useUiStore.getState().setHiddenShelfOpen(true);
+    useUiStore.getState().setWorkspaceHidden("ws-1", false);
+    expect(useUiStore.getState().hiddenShelfOpen).toBe(false);
+    expect(useUiStore.getState().hiddenPaneIds.has("pane-1")).toBe(true);
+  });
+
   it("restoreAllHidden clears both hidden sets and evictions atomically", () => {
     useUiStore.getState().setWorkspaceHidden("ws-1", true);
     useUiStore.getState().setPaneHidden("pane-1", true);
@@ -224,6 +236,17 @@ describe("ui-store", () => {
     expect(JSON.parse(localStorage.getItem("laymux-hidden-panes") ?? "null")).toEqual([
       "pane-valid",
     ]);
+  });
+
+  it("pruneHiddenIds closes the shelf when no valid hidden workspace remains", () => {
+    useUiStore.getState().setWorkspaceHidden("ws-stale", true);
+    useUiStore.getState().setPaneHidden("pane-valid", true);
+    useUiStore.getState().setHiddenShelfOpen(true);
+
+    useUiStore.getState().pruneHiddenIds(new Set(["ws-valid"]), new Set(["pane-valid"]));
+
+    expect(useUiStore.getState().hiddenShelfOpen).toBe(false);
+    expect(useUiStore.getState().hiddenPaneIds.has("pane-valid")).toBe(true);
   });
 
   // -- evicted (auto-closed) pane ids (issue #269) --

--- a/ui/src/stores/ui-store.ts
+++ b/ui/src/stores/ui-store.ts
@@ -134,14 +134,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
     set((state) => {
       const currentlyHidden = state.hiddenPaneIds.has(paneId);
       const needsEvictionClear = !hidden && state.evictedPaneIds.has(paneId);
-      const remainingHiddenPaneCount =
-        currentlyHidden && !hidden ? state.hiddenPaneIds.size - 1 : state.hiddenPaneIds.size;
-      const shouldCloseShelf =
-        !hidden &&
-        remainingHiddenPaneCount === 0 &&
-        state.hiddenWorkspaceIds.size === 0 &&
-        state.hiddenShelfOpen;
-      if (currentlyHidden === hidden && !needsEvictionClear && !shouldCloseShelf) return state;
+      if (currentlyHidden === hidden && !needsEvictionClear) return state;
 
       let next = state.hiddenPaneIds;
       if (currentlyHidden !== hidden) {
@@ -158,7 +151,6 @@ export const useUiStore = create<UiState>()((set, get) => ({
         nextEvicted.delete(paneId);
         patch.evictedPaneIds = nextEvicted;
       }
-      if (shouldCloseShelf) patch.hiddenShelfOpen = false;
       return patch;
     }),
   setWorkspaceHidden: (workspaceId, hidden, paneIds = []) =>
@@ -171,11 +163,9 @@ export const useUiStore = create<UiState>()((set, get) => ({
         currentlyHidden && !hidden
           ? state.hiddenWorkspaceIds.size - 1
           : state.hiddenWorkspaceIds.size;
+      // The shelf lists hidden workspaces only, so hidden panes never keep it open.
       const shouldCloseShelf =
-        !hidden &&
-        remainingHiddenWorkspaceCount === 0 &&
-        state.hiddenPaneIds.size === 0 &&
-        state.hiddenShelfOpen;
+        !hidden && remainingHiddenWorkspaceCount === 0 && state.hiddenShelfOpen;
       if (currentlyHidden === hidden && !needsEvictionClear && !shouldCloseShelf) return state;
 
       let next = state.hiddenWorkspaceIds;
@@ -225,7 +215,8 @@ export const useUiStore = create<UiState>()((set, get) => ({
       const workspacesChanged = !setsEqual(state.hiddenWorkspaceIds, nextWorkspaces);
       const panesChanged = !setsEqual(state.hiddenPaneIds, nextPanes);
       const evictedChanged = !setsEqual(state.evictedPaneIds, nextEvicted);
-      const shouldCloseShelf = nextWorkspaces.size + nextPanes.size === 0 && state.hiddenShelfOpen;
+      // Workspace-only shelf: close as soon as no valid hidden workspace remains.
+      const shouldCloseShelf = nextWorkspaces.size === 0 && state.hiddenShelfOpen;
       if (!workspacesChanged && !panesChanged && !evictedChanged && !shouldCloseShelf) return state;
       if (workspacesChanged) saveHiddenIds(HIDDEN_WORKSPACES_KEY, nextWorkspaces);
       if (panesChanged) saveHiddenIds(HIDDEN_PANES_KEY, nextPanes);


### PR DESCRIPTION
## 문제

- 숨김 칩 버튼은 workspace 목록 헤더(상단)에 있는데, 누르면 보관함이 selector **최하단**에서 열림
- 보관함에 hidden workspace 와 hidden pane 이 섞여 있어 복잡함

## 변경

- **보관함 위치**: 칩 바로 아래(목록 위)에 인라인으로 열림
- **보관함은 workspace 전용**: pane 항목·중첩 pane 카운트 제거, 칩 카운트도 유효 hidden workspace 수만 표시. hidden pane 만 있으면 칩 자체가 안 보임
- **"모두 표시"**: hidden workspace set 만 비움 (개별 pane flag 유지)
- **pane 숨김 컨트롤 이동**: selector pane row 의 eye 버튼 제거 → workspace grid 의 각 pane 컨트롤바에 eye **토글** 추가(숨김/복원 모두, narrow 메뉴 포함). dock pane 은 미노출
- **보관함 자동 닫힘**: 유효 hidden workspace 0 기준 (pane 무관)

raw state(`hiddenWorkspaceIds`/`hiddenPaneIds`), localStorage key, `deriveHiddenItems`, Automation REST/MCP 계약은 모두 불변.

ADR: [0035](docs/adr/0035-workspace-only-shelf-per-pane-hide-toggle.md) (ADR-0033 정정) · living doc(data-flow.md §9, overview.md) 동기화 포함

## 검증

- unit: 113 files / 2587 tests 통과 (ui-store·WorkspaceSelectorView·PaneControlBar 스펙 신규/갱신)
- e2e(playwright): workspace-selector.spec 재작성 — shelf 가 목록 위에서 열리는지 boundingBox 로 검증, pane 토글 왕복 검증. 13/13 통과
- dev 인스턴스(19281) 스크린샷으로 shelf 위치·workspace 전용 표시·pane row 숨김/칩 불변 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9ABQfEbP97oDoNSPgZni9