### PR TITLE
fix(remote): mobile composer padding/margin + square Send button

### DIFF
--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -128,18 +128,16 @@
         cursor: default;
         opacity: 0.55;
       }
-      /* Mobile-only Send affordance (desktop sends with Enter). Filled accent
-         circle with an up-arrow, mirroring chat-app composers. */
+      /* Mobile-only Send affordance (desktop sends with Enter). Square button
+         matching the sibling footer keys, but filled with the accent. */
       .composer-send {
         flex: 0 0 auto;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: 40px;
-        height: 40px;
-        padding: 0;
-        border: 0;
-        border-radius: 999px;
+        padding: 5px 9px;
+        border: 1px solid var(--accent);
+        border-radius: var(--radius-md);
         background: var(--accent);
         color: #11111b;
       }
@@ -230,6 +228,7 @@
         min-height: 72px;
         max-height: 40vh;
         resize: vertical;
+        margin: 0;
         border: 0;
         border-radius: 0;
         padding: 7px 8px;
@@ -930,7 +929,8 @@
         }
         .composer-input {
           min-height: 64px;
-          padding: 7px 0 0;
+          margin: 0;
+          padding: 6px 8px;
         }
       }
       @supports (height: 100dvh) {


### PR DESCRIPTION
@
## What

Mobile remote composer CSS tweaks (`page.html` only, no behavior change):

1. **padding** — mobile `.composer-input` had `7px 0 0`, leaving text flush against the sides/bottom. Restored a small even padding `6px 8px`.
2. **margin** — added explicit `margin: 0` on `.composer-input`.
3. **Send button** — dropped the 40×40 circle (`border-radius: 999px`), now matches the sibling footer keys (`radius-md`, `5px 9px`) while keeping the accent fill.

CSS only. Nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@