### PR TITLE
feat(remote): 원격 attach 스냅샷 상한 설정 + 뷰포트 live tail 고정

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -54,6 +54,7 @@ Remote Access 모달의 복사 URL 호스트는 `get_remote_host_candidates` Tau
     "authToken": "",                   // enabled=true일 때 필수
     "heartbeatTimeoutSeconds": 45,      // 기본 45초, 최소 30초로 clamp
     "autoMobileModeMinWidth": 720,      // 앱 창 폭이 이 값 이하이면 Remote Access 모달 자동 표시. 0 = 비활성
+    "snapshotMaxKib": 16,               // 원격 attach 시 재생하는 최근 출력 스냅샷 상한(KiB). 1~1024로 clamp, 절단 시 개행 경계로 정렬
     "preferredHost": "",               // 복사 URL 기본 호스트. 빈 값 = 자동
     "customHosts": [],                  // 감지 후보 외에 URL host select 에 표시할 수동 호스트
     "cloudEnabled": false,              // 클라우드 연결 영속 설정. pairing 전 기본값 false

--- a/src-tauri/src/cloud/tunnel.rs
+++ b/src-tauri/src/cloud/tunnel.rs
@@ -68,7 +68,6 @@ const SOCKET_PENDING_BYTES_LIMIT: usize = 16 * 1024 * 1024;
 const HTTP_REQUEST_BYTES_LIMIT: usize = 16 * 1024 * 1024;
 const HTTP_RESPONSE_BYTES_LIMIT: usize = 16 * 1024 * 1024;
 const BACKPRESSURE_TIMEOUT: Duration = Duration::from_secs(5);
-const OUTPUT_INITIAL_BYTES: usize = 64 * 1024;
 const LEASE_CHECK_MS: u64 = 500;
 const STREAM_DATA_CHUNK_BYTES: usize = 64 * 1024;
 const MAX_BACKOFF_SECONDS: u64 = 30;
@@ -1507,10 +1506,11 @@ fn terminal_output_subscription(
     app_state: &AppState,
     terminal_id: &str,
 ) -> Result<TerminalOutputSubscribedAttachment, AppError> {
+    let settings = remote_server::effective_remote_settings(app_state).map_err(AppError::Other)?;
     terminal_output::attach_and_subscribe_terminal_output(
         &app_state.terminal_protocol_states,
         terminal_id,
-        OUTPUT_INITIAL_BYTES,
+        remote_server::effective_snapshot_max_bytes(&settings),
     )
     .map_err(|error| {
         if error == format!("Session '{terminal_id}' not found") {

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -116,6 +116,17 @@ pub const REMOTE_CLAIM_RESERVATION_TTL_MS: u64 = 2_000;
 /// Desktop attach returns the retained output ring (currently capped at 1 MiB).
 pub const TERMINAL_ATTACH_SNAPSHOT_MAX_BYTES: usize = 1024 * 1024;
 
+/// Default cap (KiB) for the recent-output snapshot replayed to a remote
+/// client on terminal attach. Small on purpose: a remote connect or workspace
+/// switch should open at the live tail instead of replaying long history.
+pub const DEFAULT_REMOTE_SNAPSHOT_MAX_KIB: u32 = 16;
+
+/// Effective bounds for `remote.snapshotMaxKib`. The upper bound matches the
+/// retained output ring (1 MiB); the lower bound keeps at least one screen of
+/// context so a TUI attach is not visibly empty.
+pub const MIN_REMOTE_SNAPSHOT_MAX_KIB: u32 = 1;
+pub const MAX_REMOTE_SNAPSHOT_MAX_KIB: u32 = 1024;
+
 /// Number of bytes to scan from the end of a terminal output buffer when
 /// detecting activity state or Claude Code presence. 16KB covers terminal
 /// title sequences even when OSC 133 markers have scrolled out.

--- a/src-tauri/src/output_buffer.rs
+++ b/src-tauri/src/output_buffer.rs
@@ -118,9 +118,20 @@ impl TerminalOutputBuffer {
     }
 
     /// Return an exact, sequenced tail snapshot.
+    ///
+    /// When `max_bytes` truncates retained history, the cut almost always lands
+    /// mid-line (or mid escape sequence). Dropping through the first `\n` keeps
+    /// the replayed tail starting on a clean line boundary; a tail with no
+    /// newline at all is kept as-is rather than returned empty.
     pub fn snapshot(&self, max_bytes: usize) -> TerminalOutputSlice {
         let inner = self.lock_inner();
-        let data = recent_bytes_from(&inner, max_bytes);
+        let truncated = max_bytes < inner.buffer.len();
+        let mut data = recent_bytes_from(&inner, max_bytes);
+        if truncated {
+            if let Some(newline) = data.iter().position(|&byte| byte == b'\n') {
+                data.drain(..=newline);
+            }
+        }
         let seq_end = inner.write_seq;
         TerminalOutputSlice {
             seq_start: seq_end.saturating_sub(data.len() as u64),
@@ -369,6 +380,40 @@ mod tests {
         assert_eq!(snapshot.seq_end, 8);
         assert_eq!(snapshot.data, b"fgh");
         assert_eq!(buf.start_seq(), 3);
+    }
+
+    #[test]
+    fn truncated_snapshot_drops_the_partial_first_line() {
+        let mut buf = TerminalOutputBuffer::new(1024);
+        buf.push(b"line1\nline2\nline3");
+
+        let snapshot = buf.snapshot(10); // cuts inside "line2"
+
+        assert_eq!(snapshot.data, b"line3");
+        assert_eq!(snapshot.seq_end, 17);
+        assert_eq!(snapshot.seq_start, 17 - 5);
+    }
+
+    #[test]
+    fn untruncated_snapshot_keeps_a_leading_partial_line() {
+        let mut buf = TerminalOutputBuffer::new(1024);
+        buf.push(b"line1\nline2");
+
+        let snapshot = buf.snapshot(1024);
+
+        assert_eq!(snapshot.data, b"line1\nline2");
+        assert_eq!(snapshot.seq_start, 0);
+    }
+
+    #[test]
+    fn truncated_snapshot_without_a_newline_is_kept_as_is() {
+        let mut buf = TerminalOutputBuffer::new(1024);
+        buf.push(b"one very long line without breaks");
+
+        let snapshot = buf.snapshot(10);
+
+        assert_eq!(snapshot.data, b"out breaks");
+        assert_eq!(snapshot.seq_start, snapshot.seq_end - 10);
     }
 
     #[test]

--- a/src-tauri/src/remote_server/access.rs
+++ b/src-tauri/src/remote_server/access.rs
@@ -102,6 +102,16 @@ pub(crate) fn effective_remote_settings(app_state: &AppState) -> Result<RemoteSe
     Ok(settings)
 }
 
+/// Attach snapshot byte budget for remote clients. Clamps hand-edited
+/// settings.json values into the supported range instead of trusting them.
+pub(crate) fn effective_snapshot_max_bytes(settings: &RemoteSettings) -> usize {
+    settings.snapshot_max_kib.clamp(
+        crate::constants::MIN_REMOTE_SNAPSHOT_MAX_KIB,
+        crate::constants::MAX_REMOTE_SNAPSHOT_MAX_KIB,
+    ) as usize
+        * 1024
+}
+
 pub(crate) fn update_persistent_remote_settings(
     app_state: &AppState,
     app_handle: &AppHandle,

--- a/src-tauri/src/remote_server/mod.rs
+++ b/src-tauri/src/remote_server/mod.rs
@@ -16,8 +16,8 @@ use axum::Json;
 #[cfg(test)]
 pub(crate) use access::update_persistent_remote_settings_for_test;
 pub(crate) use access::{
-    effective_remote_settings, update_persistent_cloud_settings_snapshot,
-    update_persistent_remote_settings,
+    effective_remote_settings, effective_snapshot_max_bytes,
+    update_persistent_cloud_settings_snapshot, update_persistent_remote_settings,
 };
 pub use access::{
     get_remote_access_status, set_remote_runtime_access, RemoteAccessRuntimeState,

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -3378,6 +3378,9 @@
                 ) {
                   return;
                 }
+                // A replayed snapshot must land at the live tail, not wherever
+                // the fit/reflow race left the viewport.
+                term.scrollToBottom();
                 composerReady = true;
                 updateComposerControls();
                 focusCurrentInputSurface();

--- a/src-tauri/src/remote_server/routes.rs
+++ b/src-tauri/src/remote_server/routes.rs
@@ -37,7 +37,6 @@ use super::terminal_info::remote_terminal_infos;
 use super::{internal_error, json_error};
 
 pub(super) const REMOTE_LEASE_HEADER: &str = "x-laymux-remote-lease";
-const OUTPUT_INITIAL_BYTES: usize = 64 * 1024;
 const LEASE_CHECK_MS: u64 = 500;
 
 #[derive(Debug, Deserialize)]
@@ -585,9 +584,17 @@ async fn remote_terminal_output_ws(
         Err(err) => return internal_error(err),
     };
     let timeout_seconds = effective_heartbeat_timeout_seconds(&settings);
+    let snapshot_max_bytes = super::effective_snapshot_max_bytes(&settings);
 
     ws.on_upgrade(move |socket| {
-        stream_terminal_output(socket, server.app_state, id, lease_id, timeout_seconds)
+        stream_terminal_output(
+            socket,
+            server.app_state,
+            id,
+            lease_id,
+            timeout_seconds,
+            snapshot_max_bytes,
+        )
     })
 }
 
@@ -597,11 +604,12 @@ async fn stream_terminal_output(
     id: String,
     lease_id: String,
     timeout_seconds: u64,
+    snapshot_max_bytes: usize,
 ) {
     let subscribed = match terminal_output::attach_and_subscribe_terminal_output(
         &app_state.terminal_protocol_states,
         &id,
-        OUTPUT_INITIAL_BYTES,
+        snapshot_max_bytes,
     ) {
         Ok(subscribed) => subscribed,
         Err(err) => {

--- a/src-tauri/src/settings/models.rs
+++ b/src-tauri/src/settings/models.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::constants::DEFAULT_REMOTE_HEARTBEAT_TIMEOUT_SECONDS;
+use crate::constants::{DEFAULT_REMOTE_HEARTBEAT_TIMEOUT_SECONDS, DEFAULT_REMOTE_SNAPSHOT_MAX_KIB};
 
 /// Color scheme definition (Windows Terminal compatible).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
@@ -1034,6 +1034,9 @@ pub struct RemoteSettings {
     /// App window width at or below which the Remote Access modal opens automatically. 0 disables.
     #[serde(default = "default_remote_auto_mobile_mode_min_width")]
     pub auto_mobile_mode_min_width: u32,
+    /// Max KiB of recent output replayed to a remote client on terminal attach.
+    #[serde(default = "default_remote_snapshot_max_kib")]
+    pub snapshot_max_kib: u32,
     /// Preferred host for copyable remote URLs. Empty = auto-select the first candidate.
     #[serde(default)]
     pub preferred_host: String,
@@ -1076,6 +1079,10 @@ fn default_remote_auto_mobile_mode_min_width() -> u32 {
     720
 }
 
+fn default_remote_snapshot_max_kib() -> u32 {
+    DEFAULT_REMOTE_SNAPSHOT_MAX_KIB
+}
+
 fn default_cloud_auto_reconnect() -> bool {
     true
 }
@@ -1113,6 +1120,7 @@ impl Default for RemoteSettings {
             auth_token: String::new(),
             heartbeat_timeout_seconds: default_remote_heartbeat_timeout_seconds(),
             auto_mobile_mode_min_width: default_remote_auto_mobile_mode_min_width(),
+            snapshot_max_kib: default_remote_snapshot_max_kib(),
             preferred_host: String::new(),
             custom_hosts: Vec::new(),
             cloud_enabled: false,

--- a/src-tauri/src/settings/schema.rs
+++ b/src-tauri/src/settings/schema.rs
@@ -160,6 +160,12 @@ const ENTRIES: &[MetadataEntry] = &[
         apply_mode: ApplyMode::Restart,
     },
     MetadataEntry {
+        path: "/remote/snapshotMaxKib",
+        description: "원격 접속·터미널 전환 시 재생하는 최근 출력 스냅샷 상한(KiB, 1~1024)입니다. 다음 attach부터 적용됩니다.",
+        sensitive: false,
+        apply_mode: ApplyMode::NextUse,
+    },
+    MetadataEntry {
         path: "/remote/authToken",
         description: "Direct Remote browser가 사용하는 bearer token입니다. 응답에는 원문을 노출하지 않으며 ***REDACTED***를 다시 보내면 기존 값을 유지합니다.",
         sensitive: true,

--- a/src-tauri/src/settings/semantic_validation.rs
+++ b/src-tauri/src/settings/semantic_validation.rs
@@ -322,6 +322,21 @@ fn validate_remote(settings: &Settings, issues: &mut Vec<SettingsIssue>) {
             "heartbeatTimeoutSeconds는 30 이상이어야 합니다.".into(),
         );
     }
+    if !(crate::constants::MIN_REMOTE_SNAPSHOT_MAX_KIB
+        ..=crate::constants::MAX_REMOTE_SNAPSHOT_MAX_KIB)
+        .contains(&remote.snapshot_max_kib)
+    {
+        issue(
+            issues,
+            "out_of_range",
+            "/remote/snapshotMaxKib",
+            format!(
+                "snapshotMaxKib는 {}~{} 범위여야 합니다.",
+                crate::constants::MIN_REMOTE_SNAPSHOT_MAX_KIB,
+                crate::constants::MAX_REMOTE_SNAPSHOT_MAX_KIB
+            ),
+        );
+    }
     for (index, entry) in remote.allowed_ips.iter().enumerate() {
         if !is_valid_ip_or_cidr(entry) {
             issue(

--- a/src-tauri/tests/settings_mcp_contract_test.rs
+++ b/src-tauri/tests/settings_mcp_contract_test.rs
@@ -217,6 +217,35 @@ fn changing_a_preexisting_invalid_value_to_another_invalid_value_is_rejected() {
 }
 
 #[test]
+fn remote_snapshot_max_kib_outside_range_is_rejected() {
+    let too_small = prepare_settings_update(
+        &Settings::default(),
+        &json!({ "remote": { "snapshotMaxKib": 0 } }),
+    );
+    assert!(!too_small.valid);
+    assert!(too_small
+        .errors
+        .iter()
+        .any(|issue| issue.path == "/remote/snapshotMaxKib"));
+
+    let too_large = prepare_settings_update(
+        &Settings::default(),
+        &json!({ "remote": { "snapshotMaxKib": 2048 } }),
+    );
+    assert!(!too_large.valid);
+    assert!(too_large
+        .errors
+        .iter()
+        .any(|issue| issue.path == "/remote/snapshotMaxKib"));
+
+    let in_range = prepare_settings_update(
+        &Settings::default(),
+        &json!({ "remote": { "snapshotMaxKib": 64 } }),
+    );
+    assert!(in_range.valid, "errors: {:?}", in_range.errors);
+}
+
+#[test]
 fn duplicate_profiles_and_bad_extension_viewer_reference_are_rejected() {
     let duplicate = prepare_settings_update(
         &Settings::default(),

--- a/ui/e2e/remote-snapshot.spec.ts
+++ b/ui/e2e/remote-snapshot.spec.ts
@@ -1,0 +1,177 @@
+import { expect, test, type Page } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+
+const remoteRoot = fileURLToPath(new URL("../../src-tauri/src/remote_server/", import.meta.url));
+
+const navigation = {
+  activeWorkspace: {
+    id: "ws-1",
+    name: "Main",
+    panes: [
+      {
+        id: "pane-1",
+        location: "workspace",
+        workspaceId: "ws-1",
+        paneIndex: 0,
+        paneNumber: 1,
+        viewType: "terminal",
+        terminalId: "terminal-1",
+        terminalLive: true,
+        title: "Shell",
+        profile: "PowerShell",
+        cwd: "C:\\work",
+        branch: "main",
+        activity: { type: "shell" },
+        outputActive: false,
+        commandRunning: false,
+        isFocused: true,
+        unreadCount: 0,
+        hidden: false,
+        collapsed: false,
+        x: 0,
+        y: 0,
+        w: 1,
+        h: 1,
+      },
+    ],
+  },
+  workspaces: [
+    {
+      id: "ws-1",
+      name: "Main",
+      isActive: true,
+      hidden: false,
+      collapsed: false,
+      paneCount: 1,
+      terminalPaneCount: 1,
+      liveTerminalCount: 1,
+      unreadCount: 0,
+      panes: [],
+    },
+  ],
+  docks: [],
+  terminals: [
+    {
+      id: "terminal-1",
+      title: "Shell",
+      profile: "PowerShell",
+      cwd: "C:\\work",
+      appearance: {},
+    },
+  ],
+  workspaceSelector: { display: {}, pathEllipsis: "start" },
+  notifications: [],
+  unreadNotificationCount: 0,
+};
+
+function snapshotFrames(lineCount: number): { header: string; payload: Buffer } {
+  const text = Array.from(
+    { length: lineCount },
+    (_, index) => `line-${String(index + 1).padStart(4, "0")}\r\n`,
+  ).join("");
+  const payload = Buffer.from(text, "utf8");
+  const header = JSON.stringify({
+    type: "terminal.output",
+    version: 1,
+    phase: "snapshot",
+    seqStart: 0,
+    seqEnd: payload.byteLength,
+    byteLength: payload.byteLength,
+    state: {
+      version: 1,
+      snapshotStartSeq: 0,
+      snapshotSeq: payload.byteLength,
+      protocolRevision: 0,
+      modes: { bracketedPaste: false },
+    },
+  });
+  return { header, payload };
+}
+
+async function installRemoteMocks(page: Page, lineCount: number) {
+  await page.route("http://remote.test/remote/", (route) =>
+    route.fulfill({
+      path: `${remoteRoot}page.html`,
+      contentType: "text/html; charset=utf-8",
+    }),
+  );
+  await page.route("http://remote.test/remote/vendor/xterm.js", (route) =>
+    route.fulfill({
+      path: `${remoteRoot}assets/xterm.js`,
+      contentType: "application/javascript; charset=utf-8",
+    }),
+  );
+  await page.route("http://remote.test/remote/vendor/addon-fit.js", (route) =>
+    route.fulfill({
+      path: `${remoteRoot}assets/addon-fit.js`,
+      contentType: "application/javascript; charset=utf-8",
+    }),
+  );
+  await page.route("http://remote.test/remote/vendor/xterm.css", (route) =>
+    route.fulfill({
+      path: `${remoteRoot}assets/xterm.css`,
+      contentType: "text/css; charset=utf-8",
+    }),
+  );
+  await page.route("http://remote.test/remote/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/remote/v1/session/claim") {
+      await route.fulfill({
+        json: { active: true, leaseId: "lease-1", heartbeatTimeoutSeconds: 45 },
+      });
+      return;
+    }
+    if (url.pathname === "/remote/v1/session/heartbeat") {
+      await route.fulfill({ json: { active: true, leaseId: "lease-1" } });
+      return;
+    }
+    if (url.pathname === "/remote/v1/navigation") {
+      await route.fulfill({ json: navigation });
+      return;
+    }
+    await route.fulfill({ json: {} });
+  });
+
+  await page.routeWebSocket(/\/remote\/v1\/terminals\/terminal-1\/output/, (socket) => {
+    const { header, payload } = snapshotFrames(lineCount);
+    socket.send(header);
+    socket.send(payload);
+  });
+}
+
+type TermWindow = typeof window & {
+  Terminal: { prototype: { reset: () => void } };
+  __remoteTerm?: {
+    buffer: { active: { viewportY: number; baseY: number } };
+  };
+};
+
+test("a v1 snapshot replay lands the viewport at the live tail", async ({ page }) => {
+  await installRemoteMocks(page, 300);
+  await page.goto("http://remote.test/remote/#token=test-token");
+  await page.evaluate(() => {
+    const target = window as TermWindow;
+    const originalReset = target.Terminal.prototype.reset;
+    target.Terminal.prototype.reset = function resetCapturingInstance() {
+      (window as TermWindow).__remoteTerm = this as never;
+      return originalReset.call(this);
+    };
+  });
+
+  await page.locator("#connect").click();
+  await expect(page.locator("#status")).toHaveText("Connected to terminal-1");
+
+  // 300 lines must overflow the viewport into scrollback, and the viewport
+  // must end pinned to the live tail, not mid-history.
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const term = (window as TermWindow).__remoteTerm;
+        if (!term) return "terminal not created yet";
+        const { viewportY, baseY } = term.buffer.active;
+        if (baseY <= 0) return "no scrollback yet";
+        return viewportY === baseY ? "at-bottom" : `viewport ${viewportY} of base ${baseY}`;
+      }),
+    )
+    .toBe("at-bottom");
+});

--- a/ui/src/components/views/SettingsView.tsx
+++ b/ui/src/components/views/SettingsView.tsx
@@ -64,7 +64,10 @@ import {
   LOOPBACK_ALLOWED_IPS,
   normalizeAutoMobileWidth,
   normalizeCustomHosts,
+  normalizeSnapshotMaxKib,
   parseAllowedIps,
+  SNAPSHOT_MAX_KIB_MAX,
+  SNAPSHOT_MAX_KIB_MIN,
   TAILSCALE_ALLOWED_IPS,
 } from "@/lib/remote-hosts";
 import { useRemoteHostOptions } from "@/hooks/useRemoteHostOptions";
@@ -1712,6 +1715,7 @@ function toRemoteSettings(draft: RemoteSectionDraft): RemoteSettings {
     customHosts,
     allowedIps: allowedIps.length > 0 ? allowedIps : LOOPBACK_ALLOWED_IPS,
     autoMobileModeMinWidth: normalizeAutoMobileWidth(remote.autoMobileModeMinWidth),
+    snapshotMaxKib: normalizeSnapshotMaxKib(remote.snapshotMaxKib),
   };
 }
 
@@ -1984,6 +1988,27 @@ function RemoteSection() {
             />
             <span className="text-[11px]" style={{ color: "var(--text-secondary)" }}>
               px
+            </span>
+          </div>
+        </SettingRow>
+
+        <SettingRow label={t("remote.snapshotMaxKib")} desc={t("remote.snapshotMaxKibDesc")}>
+          <div className="flex items-center gap-2">
+            <FocusInput
+              data-testid="remote-settings-snapshot-max-kib-input"
+              type="number"
+              min={SNAPSHOT_MAX_KIB_MIN}
+              max={SNAPSHOT_MAX_KIB_MAX}
+              step={1}
+              className={inputCls}
+              inputStyle={{ width: 110 }}
+              value={remote.snapshotMaxKib}
+              onChange={(event) =>
+                update({ snapshotMaxKib: normalizeSnapshotMaxKib(event.target.value) })
+              }
+            />
+            <span className="text-[11px]" style={{ color: "var(--text-secondary)" }}>
+              KiB
             </span>
           </div>
         </SettingRow>

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -309,6 +309,8 @@
       "resetLoopback": "Reset Local",
       "autoMobileMinWidth": "Auto Mobile Width",
       "autoMobileMinWidthDesc": "0 disables. At or below this app window width, Remote Access opens automatically.",
+      "snapshotMaxKib": "Initial Output Snapshot",
+      "snapshotMaxKibDesc": "Max recent output (KiB) replayed when a remote client attaches or switches terminals. Smaller opens faster with shorter scrollback.",
       "customHosts": "Custom Hosts",
       "customHostsDesc": "Host names or IPs to offer in the Remote Access copy URL selector.",
       "customHostPlaceholder": "devbox.tailnet.ts.net",

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -309,6 +309,8 @@
       "resetLoopback": "로컬로 초기화",
       "autoMobileMinWidth": "자동 모바일 폭",
       "autoMobileMinWidthDesc": "0이면 비활성화. 앱 창 폭이 이 값 이하가 되면 Remote Access가 자동으로 열립니다.",
+      "snapshotMaxKib": "초기 출력 스냅샷",
+      "snapshotMaxKibDesc": "원격 접속·터미널 전환 시 재생할 최근 출력 상한(KiB)입니다. 작을수록 빠르게 열리고 스크롤백이 짧아집니다.",
       "customHosts": "수동 호스트",
       "customHostsDesc": "Remote Access 복사 URL 선택기에 표시할 호스트 이름 또는 IP입니다.",
       "customHostPlaceholder": "devbox.tailnet.ts.net",

--- a/ui/src/lib/remote-hosts.ts
+++ b/ui/src/lib/remote-hosts.ts
@@ -48,6 +48,17 @@ export function normalizeAutoMobileWidth(value: string | number): number {
   return Math.max(0, Math.floor(parsed));
 }
 
+/** Mirrors the Rust-side range for remote.snapshotMaxKib (1..=1024 KiB). */
+export const SNAPSHOT_MAX_KIB_MIN = 1;
+export const SNAPSHOT_MAX_KIB_MAX = 1024;
+export const SNAPSHOT_MAX_KIB_DEFAULT = 16;
+
+export function normalizeSnapshotMaxKib(value: string | number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return SNAPSHOT_MAX_KIB_DEFAULT;
+  return Math.min(SNAPSHOT_MAX_KIB_MAX, Math.max(SNAPSHOT_MAX_KIB_MIN, Math.floor(parsed)));
+}
+
 export function normalizeCustomHosts(hosts: string[]): string[] {
   const seen = new Set<string>();
   return hosts

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -402,6 +402,7 @@ export interface RemoteSettings {
   authToken: string;
   heartbeatTimeoutSeconds: number;
   autoMobileModeMinWidth: number;
+  snapshotMaxKib: number;
   preferredHost: string;
   customHosts: string[];
   cloudEnabled: boolean;

--- a/ui/src/stores/settings-store.test.ts
+++ b/ui/src/stores/settings-store.test.ts
@@ -892,6 +892,7 @@ describe("settings-store", () => {
     });
     expect(useSettingsStore.getState().remote.autoMobileModeMinWidth).toBe(720);
     expect(useSettingsStore.getState().remote.heartbeatTimeoutSeconds).toBe(45);
+    expect(useSettingsStore.getState().remote.snapshotMaxKib).toBe(16);
     expect(useSettingsStore.getState().remote.preferredHost).toBe("");
     expect(useSettingsStore.getState().remote.customHosts).toEqual([]);
   });

--- a/ui/src/stores/settings-store.ts
+++ b/ui/src/stores/settings-store.ts
@@ -491,6 +491,7 @@ const DEFAULT_REMOTE: RemoteSettings = {
   authToken: "",
   heartbeatTimeoutSeconds: 45,
   autoMobileModeMinWidth: 720,
+  snapshotMaxKib: 16,
   preferredHost: "",
   customHosts: [],
   cloudEnabled: false,


### PR DESCRIPTION
## 문제

리모트 새 접속·워크스페이스 전환 시마다 터미널 출력 꼬리 **64 KiB 고정** 스냅샷이 재생되어:

- 대화 히스토리가 통째로 넘어와 렌더가 느리고
- 뷰포트가 히스토리 중간에 떨어져 스크롤을 한참 내려야 함

## 변경

1. **`settings.remote.snapshotMaxKib`** 신설 — 기본 16, 1~1024 clamp. LAN(`remote_server/routes.rs`)과 클라우드 터널(`cloud/tunnel.rs`) 양쪽의 하드코딩 `OUTPUT_INITIAL_BYTES = 64 KiB` 상수를 제거하고 이 설정을 사용.
2. **개행 경계 절단** — `TerminalOutputBuffer::snapshot()`이 절단 발생 시 첫 `\n`까지 버려 재생 첫 줄이 깨지지 않게 함. 데스크톱 attach(1 MiB = 링 전체)는 절단이 일어나지 않아 무영향.
3. **스냅샷 재생 후 `scrollToBottom()`** — 원격 페이지가 fit/reflow 경합과 무관하게 항상 live tail에서 시작.
4. 설정 UI(Settings → 원격), i18n(ko/en), `describe_settings` 메타데이터, semantic validation, living doc(`api-contracts.md`) 동기화.

## 테스트

- Rust unit: 절단 시 개행 경계 정렬 3케이스 (`output_buffer.rs`)
- Rust contract: `snapshotMaxKib` 범위 밖 patch 거부 (`settings_mcp_contract_test.rs`)
- Playwright e2e: V1 스냅샷 300줄 재생 후 뷰포트가 live tail에 고정되는지 (`ui/e2e/remote-snapshot.spec.ts`)
- 전체: cargo test 통과, vitest 113 파일 2587 통과, tsc/eslint/prettier 클린

## ADR

ADR 불필요: V1 output 프로토콜(스냅샷+delta, seq 계약)과 인증·게이트 정책 불변. 기존 attach 계약의 `max_snapshot_bytes` 파라미터를 설정으로 노출한 additive 필드 1개로, 모듈 책임 경계가 바뀌지 않음. living doc은 같은 PR에서 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BGk6wKzJFCE8REq4YY9rx