### PR TITLE
fix(remote): footer Send 4등분 + Keyboard 버튼을 포커스 토글로 통일

### DIFF
--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -923,6 +923,11 @@
           text-overflow: ellipsis;
           white-space: nowrap;
         }
+        /* Send joins the equal split — its base flex: 0 0 auto outranks the
+           rule above and would collapse against width: 0, clipping the icon. */
+        footer .composer-send {
+          flex: 1 1 0;
+        }
         .terminal-composer {
           grid-template-columns: minmax(0, 1fr);
           grid-template-rows: minmax(64px, auto);
@@ -1668,6 +1673,25 @@
           }
         }
 
+        function inputSurfaceFocused() {
+          if (currentInputMode() === "direct") {
+            return Boolean(terminal?.textarea) && document.activeElement === terminal.textarea;
+          }
+          return document.activeElement === composerInput;
+        }
+
+        // The Keyboard button toggles the soft keyboard: blur the focused
+        // input surface to dismiss it, focus it to raise it.
+        function toggleInputSurfaceFocus() {
+          if (!leaseId || !activeTerminalId) return;
+          if (inputSurfaceFocused()) {
+            if (currentInputMode() === "direct") terminal?.blur?.();
+            else composerInput.blur();
+          } else {
+            focusCurrentInputSurface();
+          }
+        }
+
         function renderInputSurface(options = {}) {
           const mode = currentInputMode();
           const composerMode = mode === "composer";
@@ -1679,7 +1703,6 @@
             : "Switch to Composer input";
           inputModeIcon.innerHTML = INPUT_MODE_ICONS[composerMode ? "composer" : "direct"];
           inputModeLabel.textContent = composerMode ? "Composer" : "Direct";
-          focusTerminalButton.textContent = composerMode ? "Editor" : "Keyboard";
 
           const nextText = draft ? draft.text : "";
           if (composerInput.value !== nextText) composerInput.value = nextText;
@@ -4146,7 +4169,14 @@
         desktopModeHeaderButton.addEventListener("click", () => requestDesktopMode().catch((err) => setStatus(err.message, true)));
         desktopModeDrawerButton.addEventListener("click", () => requestDesktopMode().catch((err) => setStatus(err.message, true)));
         ctrlCButton.addEventListener("click", () => enqueueInput("\x03"));
-        focusTerminalButton.addEventListener("click", () => focusCurrentInputSurface());
+        // Same trick as installSoftKey: without this, mobile browsers move
+        // focus to the button on pointerdown, closing the keyboard before the
+        // click handler can read the surface's real focus state.
+        focusTerminalButton.addEventListener("pointerdown", (event) => {
+          if (!event.isPrimary || event.button !== 0) return;
+          event.preventDefault();
+        });
+        focusTerminalButton.addEventListener("click", () => toggleInputSurfaceFocus());
         inputModeToggleButton.addEventListener("click", () => {
           setInputMode(currentInputMode() === "composer" ? "direct" : "composer");
         });

--- a/ui/e2e/remote-input-composer.spec.ts
+++ b/ui/e2e/remote-input-composer.spec.ts
@@ -851,8 +851,17 @@ test("Composer keeps xterm unfocused and hides its inactive application cursor",
           .options.cursorInactiveStyle,
     ),
   ).toBe("outline");
+  // The mode switch itself focuses the direct surface; the Keyboard button
+  // toggles that focus (dismiss when focused, raise when blurred).
+  await expect
+    .poll(() => page.evaluate(() => document.activeElement?.className ?? ""))
+    .toContain("xterm-helper-textarea");
   await page.locator("#focusTerminal").click();
-  expect(await page.evaluate(() => document.activeElement?.className)).toContain(
+  expect(await page.evaluate(() => document.activeElement?.className ?? "")).not.toContain(
+    "xterm-helper-textarea",
+  );
+  await page.locator("#focusTerminal").click();
+  expect(await page.evaluate(() => document.activeElement?.className ?? "")).toContain(
     "xterm-helper-textarea",
   );
 });

--- a/ui/e2e/remote-page-layout.spec.ts
+++ b/ui/e2e/remote-page-layout.spec.ts
@@ -30,7 +30,7 @@ test.describe("remote mobile layout", () => {
     await expect(page.locator("#keyBar")).toBeHidden();
     await expect(terminalMeta).toBeHidden();
     expect((await footer.boundingBox())?.height).toBeLessThan(50);
-    const footerButtons = await footer.locator("button").evaluateAll((buttons) =>
+    const footerButtons = await footer.locator("button:not([hidden])").evaluateAll((buttons) =>
       buttons.map((button) => ({
         width: button.getBoundingClientRect().width,
         minWidth: getComputedStyle(button).minWidth,
@@ -47,7 +47,7 @@ test.describe("remote mobile layout", () => {
       clientWidth: element.clientWidth,
       scrollWidth: element.scrollWidth,
       buttonWidths: Array.from(
-        element.querySelectorAll("button"),
+        element.querySelectorAll("button:not([hidden])"),
         (button) => button.getBoundingClientRect().width,
       ),
     }));
@@ -265,8 +265,9 @@ test.describe("remote mobile layout", () => {
     await page.goto("http://remote.test/remote/#token=test-token");
     await page.locator("#connect").click();
     await expect(page.locator("#focusTerminal")).toBeEnabled();
-    await page.locator("#focusTerminal").tap();
 
+    // Connecting focuses the direct input surface on its own; the Keyboard
+    // button is a focus toggle now, so tapping it here would dismiss it.
     const helperTextarea = page.locator(".xterm-helper-textarea");
     await expect(helperTextarea).toBeFocused();
 


### PR DESCRIPTION
## 변경 내용

### 1. 모바일 footer Send 버튼 화살표 클리핑 수정 + 4등분
- 원인: `@media (max-width: 520px)`의 `footer button { width: 0; overflow: hidden; }`이 Send 버튼에도 적용되는데, base `.composer-send { flex: 0 0 auto }`가 특이도로 이겨서 flex-basis가 `width: 0`을 읽어 버튼 내용폭이 0으로 붕괴 → 화살표 SVG 통째로 클리핑.
- 수정: media query 안에 `footer .composer-send { flex: 1 1 0 }` 추가로 base flex를 뒤집어 Ctrl+C / Keyboard / Keys / Send 4개 버튼이 균등 분할.

### 2. Keyboard 버튼 통일 + 포커스 토글화
- Composer 모드에서 "Editor"로 바뀌던 라벨을 모드 무관 **"Keyboard"** 로 통일.
- 동작을 토글로 변경: 현재 입력 surface(Direct=xterm, Composer=textarea)가 포커스 상태면 blur(소프트 키보드 내림), 아니면 focus(올림). 기존에는 focus만 있어서 키보드를 내릴 방법이 없었음.
- `installSoftKey`와 동일한 `pointerdown` `preventDefault` 관용구로 버튼 탭이 포커스를 먼저 뺏어 상태 판정이 틀어지는 것 방지.

### 3. e2e 스펙 갱신
- `remote-input-composer.spec.ts` 826, `remote-page-layout.spec.ts` 192: "누르면 포커스" 옛 계약 → 토글 계약으로 갱신.
- `remote-page-layout.spec.ts` "footer compact": hidden Send 버튼을 필터하지 않아 **main에서도 깨져 있던 스펙**(#466에서 Send 버튼 추가 시 미갱신) 함께 수정.

## 검증
- `remote-page-layout.spec.ts`: 7/7 통과 (main 기준 1건 기존 실패 → 0건)
- `remote-input-composer.spec.ts`: 7/13 통과 — 실패 6건은 clean main과 동일한 기존 실패(`data-can-send` readiness, 이 PR과 무관, stash 재실행으로 확인)
- dev 인스턴스(19281)에서 모바일 레이아웃 수동 확인 완료 (사용자 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nqVr1pPqE26tSyKLH5SPz