### PR TITLE
test(remote): composer e2e 6건 수리 - mock scrollToBottom + ADR-0036 정합

### DIFF
--- a/ui/e2e/remote-input-composer.spec.ts
+++ b/ui/e2e/remote-input-composer.spec.ts
@@ -231,6 +231,7 @@ async function installBrowserMocks(
           this.textarea?.blur();
         }
         scrollLines(_amount: number) {}
+        scrollToBottom() {}
         emitData(data: string) {
           this.dataListener?.(data);
         }
@@ -609,7 +610,8 @@ test("fine-pointer Composer sends on Enter and keeps Shift+Enter as a newline", 
 
   const editor = page.locator("#composerInput");
   await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "true");
-  await expect(page.locator("#composerSend")).toHaveCount(0);
+  // Desktop layout has no visible Send button — Enter is the send gesture.
+  await expect(page.locator("#composerSend")).toBeHidden();
 
   await editor.fill("line");
   await editor.press("Shift+Enter");
@@ -627,15 +629,18 @@ test("fine-pointer Composer sends on Enter and keeps Shift+Enter as a newline", 
   await expect(editor).toHaveValue("");
 });
 
-test("coarse-pointer Composer also sends on Enter (no Send button)", async ({ page }) => {
+test("mobile-layout Composer keeps Enter as a newline and submits with the Send button", async ({
+  page,
+}) => {
   const remote = await installRemotePage(page, { coarse: true });
   await connect(page);
 
   const editor = page.locator("#composerInput");
   await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "true");
-  await expect(page.locator("#composerSend")).toHaveCount(0);
+  // Mobile layout submits with the dedicated Send button only (ADR-0036).
+  await expect(page.locator("#composerSend")).toBeVisible();
 
-  // Enter during IME composition never sends.
+  // Enter — composing or not — never sends on the mobile layout.
   await editor.fill("한글 조합");
   await editor.dispatchEvent("compositionstart");
   await editor.dispatchEvent("keydown", { key: "Enter", code: "Enter", isComposing: true });
@@ -643,14 +648,13 @@ test("coarse-pointer Composer also sends on Enter (no Send button)", async ({ pa
   expect(remote.inputs).toHaveLength(0);
   await editor.dispatchEvent("compositionend");
 
-  // Shift+Enter inserts a newline; plain Enter sends (mirrors desktop).
   await editor.fill("line");
-  await editor.press("Shift+Enter");
+  await editor.press("Enter");
   await expect(editor).toHaveValue("line\n");
   expect(remote.inputs).toHaveLength(0);
 
   await editor.fill("send me");
-  await editor.press("Enter");
+  await page.locator("#composerSend").click();
   await expect.poll(() => remote.inputs.length).toBe(1);
   expect(remote.inputs[0].body).toEqual({
     leaseId: "lease-1",
@@ -756,13 +760,15 @@ test("an in-flight snapshot is sent once and only clears the unchanged revision"
 
   const editor = page.locator("#composerInput");
   const composer = page.locator("#terminalComposer");
+  const send = page.locator("#composerSend");
   await editor.fill("before send");
-  // Two quick Enters must not double-submit (the in-flight gate blocks the second).
-  await editor.press("Enter");
-  await editor.press("Enter");
+  // Two quick sends must not double-submit: the first flips the in-flight
+  // gate, which disables Send, and a forced second click is still gated.
+  await send.click();
+  await send.click({ force: true }).catch(() => {});
   await expect.poll(() => remote.inputs.length).toBe(1);
   await expect(composer).toHaveAttribute("data-can-send", "false");
-  await expect(page.locator("#composerSend")).toHaveCount(0);
+  await expect(send).toBeDisabled();
   await expect(editor).toBeEnabled();
 
   await editor.fill("edited while pending");
@@ -770,20 +776,20 @@ test("an in-flight snapshot is sent once and only clears the unchanged revision"
   await expect(composer).toHaveAttribute("data-can-send", "true");
   await expect(editor).toHaveValue("edited while pending");
 
-  await editor.press("Enter");
+  await send.click();
   await expect.poll(() => remote.inputs.length).toBe(2);
   await remote.inputs[1].respond();
   await expect(editor).toHaveValue("");
 
   await editor.fill("preserve on failure");
-  await editor.press("Enter");
+  await send.click();
   await expect.poll(() => remote.inputs.length).toBe(3);
   await remote.inputs[2].respond(500);
   await expect(editor).toHaveValue("preserve on failure");
   await expect(composer).toHaveAttribute("data-can-send", "true");
 
   await editor.fill("terminal one pending");
-  await editor.press("Enter");
+  await send.click();
   await expect.poll(() => remote.inputs.length).toBe(4);
   await selectTerminal(page, "C:\\two");
   await editor.fill("terminal two draft");
@@ -802,7 +808,7 @@ test("disconnect releases an in-flight Composer action while preserving its draf
   const editor = page.locator("#composerInput");
   const composer = page.locator("#terminalComposer");
   await editor.fill("preserve across disconnect");
-  await editor.press("Enter");
+  await page.locator("#composerSend").click();
   await expect.poll(() => remote.inputs.length).toBe(1);
   await expect(composer).toHaveAttribute("data-can-send", "false");
 

--- a/ui/e2e/remote-input-composer.spec.ts
+++ b/ui/e2e/remote-input-composer.spec.ts
@@ -343,6 +343,7 @@ async function installRemotePage(
   page: Page,
   options: {
     coarse: boolean;
+    localApp?: boolean;
     storedMode?: "direct" | "composer";
     holdInputs?: boolean;
     holdTerminalFocus?: boolean;
@@ -360,8 +361,13 @@ async function installRemotePage(
   let remainingClaimBusyResponses = options.claimBusyResponses ?? 0;
   await page.setViewportSize({ width: options.width ?? 390, height: 844 });
   await installBrowserMocks(page, options);
-  await page.route("http://remote.test/", (route) =>
-    route.fulfill({ contentType: "text/html", body: "<!doctype html><title>remote test</title>" }),
+  await page.route(
+    (url) => url.origin === "http://remote.test" && url.pathname === "/",
+    (route) =>
+      route.fulfill({
+        contentType: "text/html",
+        body: "<!doctype html><title>remote test</title>",
+      }),
   );
   await page.route("**/remote/v1/**", async (route) => {
     const url = new URL(route.request().url());
@@ -439,7 +445,9 @@ async function installRemotePage(
     await route.fulfill({ json: { ok: true } });
   });
 
-  await page.goto("http://remote.test/");
+  // setContent keeps the URL, so the page script still reads localApp=1
+  // from location.search at init (ADR-0036 layout classification).
+  await page.goto(options.localApp ? "http://remote.test/?localApp=1" : "http://remote.test/");
   await page.setContent(await remotePageMarkup());
   return state;
 }
@@ -613,6 +621,22 @@ test("fine-pointer Composer sends on Enter and keeps Shift+Enter as a newline", 
   // Desktop layout has no visible Send button — Enter is the send gesture.
   await expect(page.locator("#composerSend")).toBeHidden();
 
+  // The desktop keydown guards: Enter mid-composition (isComposing) and the
+  // soft-keyboard keyCode 229 variant never submit.
+  await editor.fill("한글 조합");
+  await editor.dispatchEvent("compositionstart");
+  await editor.dispatchEvent("keydown", { key: "Enter", code: "Enter", isComposing: true });
+  await page.waitForTimeout(20);
+  expect(remote.inputs).toHaveLength(0);
+  await editor.dispatchEvent("compositionend");
+  await editor.evaluate((element) => {
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+    Object.defineProperty(event, "keyCode", { get: () => 229 });
+    element.dispatchEvent(event);
+  });
+  await page.waitForTimeout(20);
+  expect(remote.inputs).toHaveLength(0);
+
   await editor.fill("line");
   await editor.press("Shift+Enter");
   await expect(editor).toHaveValue("line\n");
@@ -674,6 +698,38 @@ test("mobile-layout Composer keeps Enter as a newline and submits with the Send 
   await expect.poll(() => remote.writes.length).toBe(2);
   expect(remote.writes[1].data).toBe("\x1b");
   await expect(editor).toHaveValue("untouched draft");
+});
+
+test("PC-app embedded mobile view (localApp=1) keeps the mobile send gesture on a fine pointer", async ({
+  page,
+}) => {
+  const remote = await installRemotePage(page, {
+    coarse: false,
+    localApp: true,
+    storedMode: "composer",
+  });
+  await connect(page);
+
+  const editor = page.locator("#composerInput");
+  await expect(page.locator("#terminalComposer")).toHaveAttribute("data-can-send", "true");
+  // mobileLayout = coarse pointer || localApp=1 (ADR-0036): the embedded
+  // mobile view behaves mobile even though it is driven by a mouse/keyboard.
+  await expect(page.locator("#composerSend")).toBeVisible();
+
+  await editor.fill("line");
+  await editor.press("Enter");
+  await expect(editor).toHaveValue("line\n");
+  expect(remote.inputs).toHaveLength(0);
+
+  await editor.fill("send me");
+  await page.locator("#composerSend").click();
+  await expect.poll(() => remote.inputs.length).toBe(1);
+  expect(remote.inputs[0].body).toEqual({
+    leaseId: "lease-1",
+    text: "send me",
+    submit: true,
+  });
+  await expect(editor).toHaveValue("");
 });
 
 test("Direct paste uses structured input only after a V1 snapshot establishes readiness", async ({
@@ -762,10 +818,14 @@ test("an in-flight snapshot is sent once and only clears the unchanged revision"
   const composer = page.locator("#terminalComposer");
   const send = page.locator("#composerSend");
   await editor.fill("before send");
-  // Two quick sends must not double-submit: the first flips the in-flight
-  // gate, which disables Send, and a forced second click is still gated.
+  // Two quick sends must not double-submit. A disabled button swallows real
+  // clicks, so drive the second submit through a synthetic click that still
+  // reaches the handler — only the draft.inFlight gate can block it.
   await send.click();
-  await send.click({ force: true }).catch(() => {});
+  await send.evaluate((button) =>
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true })),
+  );
+  await page.waitForTimeout(20);
   await expect.poll(() => remote.inputs.length).toBe(1);
   await expect(composer).toHaveAttribute("data-can-send", "false");
   await expect(send).toBeDisabled();


### PR DESCRIPTION
## 문제

`ui/e2e/remote-input-composer.spec.ts` 13개 중 6개가 main에서 실패 (PR #475 검증 중 발견).

## 원인 2건

1. **#472 회귀**: 스냅샷 적용 후 `term.scrollToBottom()`(page.html:3436)을 호출하는데, 이 스펙의 `MockTerminal`에 해당 메서드가 없어 `.then()` 안에서 TypeError → `composerReady`가 영영 설정되지 않음 → `data-can-send="true"` 대기 실패. 6건 전부의 공통 실패 지점.
2. **ADR-0036 미반영 스테일 단언**: 스펙이 pointer 기준 구계약(b592833, "coarse도 Enter 전송, Send 버튼 없음")을 단언하는데, [ADR-0036](docs/adr/0036-remote-composer-layout-rule.md) + #473 이후 실제 계약은 layout 기준이다 — mobile layout은 Enter=줄바꿈·footer Send 버튼만 제출, desktop layout은 Enter 전송·Send 버튼 hidden(요소는 존재하므로 `toHaveCount(0)`은 애초 불성립).

## 변경 (테스트 전용)

- `MockTerminal`에 `scrollToBottom() {}` 추가 — 실제 xterm 인터페이스와 정렬
- fine-pointer 테스트: `#composerSend` `toHaveCount(0)` → `toBeHidden()`
- coarse 테스트를 ADR-0036 계약으로 재작성: Enter(조합 여부 무관)는 전송 안 함 + 줄바꿈, Send 버튼 visible·클릭 제출
- in-flight/disconnect 테스트의 제출 경로를 Enter → Send 버튼 클릭으로 교체, in-flight 중 Send disabled 단언 추가

## 테스트

- `remote-input-composer.spec.ts` 13/13 통과
- 전체 e2e: 101 passed, 1 failed — `grid-edit.spec.ts › changing view type in dropdown switches the view`는 main에서도 동일 실패(stash 검증)로 본 PR 무관, 별도 추적 필요

## ADR

ADR 불필요: 새 결정 없음 — 기존 ADR-0036 계약에 테스트를 정합시키고 #472 회귀에 대한 mock 인터페이스 누락을 보완하는 테스트 전용 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9T75HC6xXXZ6d1KHtMeay
