### PR TITLE
test(grid): view-memo 단언을 workspace pane으로 스코프

### DIFF
--- a/ui/e2e/grid-edit.spec.ts
+++ b/ui/e2e/grid-edit.spec.ts
@@ -97,7 +97,8 @@ test.describe("View Switcher", () => {
   test("changing view type in dropdown switches the view", async ({ appPage: page }) => {
     await hoverPane(page, 0);
     await page.getByTestId("pane-control-view-select").selectOption("MemoView");
-    await expect(page.getByTestId("view-memo")).toBeVisible();
+    // The right dock also hosts a MemoView, so scope the assertion to the pane.
+    await expect(page.getByTestId("workspace-pane-0").getByTestId("view-memo")).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## 문제

`grid-edit.spec.ts > changing view type in dropdown switches the view` 가 main에서 실패 (PR #476 검증 중 발견, main에서 재현 확인).

strict mode violation: 기본 레이아웃의 right dock에도 MemoView가 존재해 `getByTestId(view-memo)` 가 workspace pane + dock 2개에 매칭. dock 기능 도입 이전에 작성된 셀렉터.

## 변경 (테스트 전용 1줄)

단언을 `workspace-pane-0` 스코프로 한정 — 드롭다운 전환 결과인 pane의 MemoView만 검증.

## 테스트

- grid-edit.spec.ts 12/12 통과
- 전체 e2e 103 passed / 0 failed (suite 전체 그린)

## ADR

ADR 불필요: 모호한 테스트 셀렉터 수정, 새 결정 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9T75HC6xXXZ6d1KHtMeay