### PR TITLE
fix(remote): Keyboard 토글이 컴포저 에디터 영역도 함께 접고 펼침

### DIFF
--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -1684,7 +1684,12 @@
           const composerMode = currentInputMode() === "composer";
           const canEdit = Boolean(leaseId && activeTerminalId && composerMode);
           // `data-can-send` mirrors the Send button's readiness for tests / a11y.
-          const canCommit = Boolean(canEdit && composerReady && draft && !draft.inFlight);
+          // A collapsed editor never commits: its draft is invisible, so Send
+          // stays disabled (not hidden — the footer buttons must not shift
+          // under the finger that just tapped Keyboard).
+          const canCommit = Boolean(
+            canEdit && composerReady && draft && !draft.inFlight && !composerCollapsed,
+          );
           composerInput.disabled = !canEdit;
           terminalComposer.dataset.canSend = canCommit ? "true" : "false";
           // Send button belongs to the mobile layout in composer mode; the
@@ -1697,7 +1702,9 @@
           if (!leaseId || !activeTerminalId) return;
           if (currentInputMode() === "direct") {
             terminal?.focus?.();
-          } else if (!composerInput.disabled) {
+          } else if (!composerCollapsed && !composerInput.disabled) {
+            // A collapsed editor must not regain focus behind the user's back
+            // (reconnect, attach-ready) — only the Keyboard button restores it.
             composerInput.focus({ preventScroll: true });
           }
         }

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -1458,6 +1458,9 @@
         let preferredInputMode = loadPreferredInputMode();
         let composerIsComposing = false;
         let composerReady = false;
+        // Keyboard-button collapse state: in composer mode the editor pane
+        // hides and restores together with the soft keyboard.
+        let composerCollapsed = false;
         let notificationPanelOpen = false;
         let dockPanelOpen = false;
         let touchGesture = null;
@@ -1707,12 +1710,23 @@
         }
 
         // The Keyboard button toggles the soft keyboard: blur the focused
-        // input surface to dismiss it, focus it to raise it.
+        // input surface to dismiss it, focus it to raise it. In composer mode
+        // the editor pane collapses with the keyboard so the terminal gets the
+        // space back, and restores when the keyboard is raised again.
         function toggleInputSurfaceFocus() {
           if (!leaseId || !activeTerminalId) return;
-          if (inputSurfaceFocused()) {
-            if (currentInputMode() === "direct") terminal?.blur?.();
-            else composerInput.blur();
+          if (currentInputMode() === "direct") {
+            if (inputSurfaceFocused()) terminal?.blur?.();
+            else focusCurrentInputSurface();
+            return;
+          }
+          if (composerCollapsed) {
+            composerCollapsed = false;
+            renderInputSurface({ focus: true });
+          } else if (inputSurfaceFocused()) {
+            composerCollapsed = true;
+            composerInput.blur();
+            renderInputSurface();
           } else {
             focusCurrentInputSurface();
           }
@@ -1722,7 +1736,7 @@
           const mode = currentInputMode();
           const composerMode = mode === "composer";
           const draft = composerDraft();
-          terminalComposer.hidden = !composerMode;
+          terminalComposer.hidden = !composerMode || composerCollapsed;
           inputModeToggleButton.setAttribute("aria-pressed", composerMode ? "true" : "false");
           inputModeToggleButton.title = composerMode
             ? "Switch to Direct input"
@@ -1752,6 +1766,9 @@
         function setInputMode(mode, options = {}) {
           if (mode !== "direct" && mode !== "composer") return;
           preferredInputMode = mode;
+          // An explicit mode switch always reveals its input surface; a stale
+          // collapse would leave composer mode with no visible editor.
+          composerCollapsed = false;
           if (activeTerminalId) inputModeByTerminalId.set(activeTerminalId, mode);
           if (options.persist !== false) savePreferredInputMode(mode);
           renderInputSurface({ focus: options.focus !== false });

--- a/ui/e2e/remote-input-composer.spec.ts
+++ b/ui/e2e/remote-input-composer.spec.ts
@@ -951,12 +951,42 @@ test("Keyboard button collapses and restores the Composer editor with the soft k
   await keyboardButton.click();
   await expect(composer).toBeHidden();
   await expect(editor).not.toBeFocused();
+  // The hidden draft must not be sendable; the button stays (footer layout
+  // is stable) but disabled.
+  await expect(page.locator("#composerSend")).toBeVisible();
+  await expect(page.locator("#composerSend")).toBeDisabled();
 
   // The second toggle restores the editor pane and raises the keyboard.
   await keyboardButton.click();
   await expect(composer).toBeVisible();
   await expect(editor).toBeFocused();
   await expect(editor).toHaveValue("draft survives collapse");
+  await expect(page.locator("#composerSend")).toBeEnabled();
+});
+
+test("reconnect keeps a collapsed Composer editor collapsed and unfocused", async ({ page }) => {
+  await installRemotePage(page, { coarse: true });
+  await connect(page);
+
+  await expect(page.locator("#composerInput")).toBeFocused();
+  await page.locator("#focusTerminal").click();
+  await expect(page.locator("#terminalComposer")).toBeHidden();
+
+  // The mobile connected layout collapses this control outside the viewport;
+  // invoke the same button action without coupling this state test to drawer UX.
+  await page.locator("#release").evaluate((button: HTMLButtonElement) => button.click());
+  await expect(page.locator("#connect")).toBeEnabled();
+  await page.locator("#connect").evaluate((button: HTMLButtonElement) => button.click());
+  await expect(page.locator("#status")).toHaveText("Connected to terminal-1");
+
+  // Attach-ready auto-focus must not resurrect the editor or raise the
+  // keyboard behind the user's back — only the Keyboard button does.
+  await expect(page.locator("#terminalComposer")).toBeHidden();
+  await expect(page.locator("#composerInput")).not.toBeFocused();
+
+  await page.locator("#focusTerminal").click();
+  await expect(page.locator("#terminalComposer")).toBeVisible();
+  await expect(page.locator("#composerInput")).toBeFocused();
 });
 
 test("explicit mode switches reset a collapsed Composer editor", async ({ page }) => {

--- a/ui/e2e/remote-input-composer.spec.ts
+++ b/ui/e2e/remote-input-composer.spec.ts
@@ -931,3 +931,46 @@ test("Composer keeps xterm unfocused and hides its inactive application cursor",
     "xterm-helper-textarea",
   );
 });
+
+test("Keyboard button collapses and restores the Composer editor with the soft keyboard", async ({
+  page,
+}) => {
+  await installRemotePage(page, { coarse: true });
+  await connect(page);
+
+  const composer = page.locator("#terminalComposer");
+  const editor = page.locator("#composerInput");
+  const keyboardButton = page.locator("#focusTerminal");
+
+  // Connect focuses the composer editor; the first toggle dismisses the
+  // keyboard and collapses the editor pane with it.
+  await expect(editor).toBeFocused();
+  await expect(composer).toBeVisible();
+  await editor.fill("draft survives collapse");
+
+  await keyboardButton.click();
+  await expect(composer).toBeHidden();
+  await expect(editor).not.toBeFocused();
+
+  // The second toggle restores the editor pane and raises the keyboard.
+  await keyboardButton.click();
+  await expect(composer).toBeVisible();
+  await expect(editor).toBeFocused();
+  await expect(editor).toHaveValue("draft survives collapse");
+});
+
+test("explicit mode switches reset a collapsed Composer editor", async ({ page }) => {
+  await installRemotePage(page, { coarse: true });
+  await connect(page);
+
+  await expect(page.locator("#composerInput")).toBeFocused();
+  await page.locator("#focusTerminal").click();
+  await expect(page.locator("#terminalComposer")).toBeHidden();
+
+  // Direct and back to Composer: the mode switch must reveal the editor
+  // instead of leaving composer mode with no visible input surface.
+  await page.locator("#inputModeToggle").click();
+  await page.locator("#inputModeToggle").click();
+  await expect(page.locator("#terminalComposer")).toBeVisible();
+  await expect(page.locator("#composerInput")).toBeFocused();
+});


### PR DESCRIPTION
## 문제

리모트 컴포저 모드에서 푸터 Keyboard 버튼이 소프트 키보드만 내리고 에디터 영역(`#terminalComposer`)은 그대로 남아, 좁은 모바일 화면에서 터미널 공간을 계속 차지했다.

## 변경

- `composerCollapsed` 상태 추가: Keyboard 버튼 전용 접힘 토글. 키보드 내림 = 에디터도 접힘(터미널이 공간 회수), 다시 누르면 에디터 복원 + 포커스(키보드 상승). 드래프트는 접힘 동안 보존.
- 다른 원인의 blur(출력 탭, 앱 전환)는 에디터를 접지 않음 — 버튼만 접는다.
- `focusCurrentInputSurface` 가드: 리커넥트/attach-ready 자동 포커스가 접힌 에디터를 되살리거나 키보드를 몰래 올리지 않음.
- `canCommit` 에 `!composerCollapsed` 게이트: 보이지 않는 드래프트 전송 차단. Send 는 숨기지 않고 비활성 — 푸터 4버튼 레이아웃이 토글 순간 이동하지 않게 유지.
- 명시적 모드 전환(`setInputMode`)은 접힘 리셋 — 컴포저 모드에 보이는 입력 surface 없는 상태 방지.
- direct 모드 동작(포커스 토글)은 기존 그대로.

설계 노트: 터미널 전환 시 접힘 유지는 의도됨 — 키보드를 내린 열람 의도는 터미널과 무관하게 지속.

## 테스트

- e2e 3건 추가: 접기/복원+드래프트 보존+Send 비활성, 모드 전환 리셋, 리커넥트 후 접힘 유지
- 전체 e2e 106건 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016b5Jb4MbomU2CyhRQekR7R