### PR TITLE
fix(remote): 재연결·셸 진입 시 xterm 프로토콜 응답이 PTY로 새는 stray 입력(엔터) 차단 (#480)

### DIFF
--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -1510,6 +1510,13 @@
         let terminalSelectionRevision = 0;
         let terminalOutputWriteChain = Promise.resolve();
         let terminalOutputGeneration = 0;
+        // The remote xterm is a display mirror; the desktop pane is the
+        // authoritative terminal that answers protocol queries. While we replay
+        // captured output into xterm its parser auto-answers any query
+        // sequences (DSR/DA/DECRQM, ...) embedded in that output via onData.
+        // This counter is raised around such replay writes so those replies are
+        // swallowed instead of forwarded to the PTY (issue #480).
+        let terminalReplayDepth = 0;
         const inputModeByTerminalId = new Map();
         const composerDraftByTerminalId = new Map();
         let preferredInputMode = loadPreferredInputMode();
@@ -2478,7 +2485,14 @@
           terminalHost.addEventListener("paste", handleDirectTerminalPaste, true);
           installSelectionHandles(terminal);
           installTouchSelectionBridge(terminal);
-          terminal.onData((data) => enqueueInput(data));
+          terminal.onData((data) => {
+            // Swallow xterm's own protocol replies emitted while replaying
+            // captured output (issue #480); forward only genuine user input.
+            // A running program's queries are answered by the desktop pane, so
+            // the mirror must never echo replies back into the PTY.
+            if (terminalReplayDepth > 0) return;
+            enqueueInput(data);
+          });
           terminal.onResize(({ cols, rows }) => queueResize(cols, rows));
           terminal.onSelectionChange(() => {
             updateTerminalControls();
@@ -3495,7 +3509,11 @@
             outputSocket.close();
           };
 
-          const queueTerminalWrite = (payload) => {
+          // `guardInput` marks replay writes (snapshot + synthetic mode) whose
+          // onData replies must be swallowed rather than forwarded to the PTY.
+          // Live deltas stay unguarded so real keystrokes typed during heavy
+          // output are never dropped by a lingering replay window (issue #480).
+          const queueTerminalWrite = (payload, guardInput = false) => {
             terminalOutputWriteChain = terminalOutputWriteChain.then(
               () =>
                 new Promise((resolve) => {
@@ -3507,7 +3525,9 @@
                     resolve();
                     return;
                   }
+                  if (guardInput) terminalReplayDepth += 1;
                   term.write(payload, () => {
+                    if (guardInput) terminalReplayDepth -= 1;
                     scheduleTerminalRefresh();
                     resolve();
                   });
@@ -3523,7 +3543,14 @@
                 outputGeneration === terminalOutputGeneration &&
                 socket === outputSocket
               ) {
-                term.reset();
+                // reset() only runs at attach/reconnect, never mid-stream, so
+                // guarding it can't drop live keystrokes.
+                terminalReplayDepth += 1;
+                try {
+                  term.reset();
+                } finally {
+                  terminalReplayDepth -= 1;
+                }
                 scheduleTerminalRefresh();
               }
             });
@@ -3621,8 +3648,8 @@
               const syntheticMode = header.state.modes.bracketedPaste
                 ? "\x1b[?2004h"
                 : "\x1b[?2004l";
-              queueTerminalWrite(payload);
-              queueTerminalWrite(syntheticMode).then(() => {
+              queueTerminalWrite(payload, true);
+              queueTerminalWrite(syntheticMode, true).then(() => {
                 if (
                   outputProtocolFailed ||
                   outputGeneration !== terminalOutputGeneration ||

--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -1510,12 +1510,11 @@
         let terminalSelectionRevision = 0;
         let terminalOutputWriteChain = Promise.resolve();
         let terminalOutputGeneration = 0;
-        // The remote xterm is a display mirror; the desktop pane is the
-        // authoritative terminal that answers protocol queries. While we replay
-        // captured output into xterm its parser auto-answers any query
-        // sequences (DSR/DA/DECRQM, ...) embedded in that output via onData.
-        // This counter is raised around such replay writes so those replies are
-        // swallowed instead of forwarded to the PTY (issue #480).
+        // Raised around replay writes (snapshot / reset / synthetic mode) so
+        // any onData xterm emits while parsing them is swallowed rather than
+        // forwarded to the PTY. Known query replies are already suppressed at
+        // the parser (suppressMirrorQueryReplies); this is the catch-all that
+        // covers the reconnect flood for sequences we did not enumerate (#480).
         let terminalReplayDepth = 0;
         const inputModeByTerminalId = new Map();
         const composerDraftByTerminalId = new Map();
@@ -2458,6 +2457,37 @@
           element.addEventListener("pointercancel", finishTouchSelection, pointerOptions);
         }
 
+        // CSI query sequences whose only effect is to make the terminal emit a
+        // reply. The remote xterm is a display mirror; the desktop pane is the
+        // authoritative responder, so the mirror must answer none of these
+        // (issue #480). Keyed the way xterm's parser matches — prefix (private
+        // marker), intermediates, final byte. Pure queries carry no display
+        // side effect, so a handler that returns true only drops the reply.
+        // DECSCUSR (CSI SP q) is intentionally left alone; only XTVERSION
+        // (CSI > q) is suppressed.
+        const MIRROR_SUPPRESSED_CSI = [
+          { final: "n" }, // DSR / cursor position report (ANSI)
+          { prefix: "?", final: "n" }, // DSR (DEC private)
+          { final: "c" }, // Primary Device Attributes
+          { prefix: ">", final: "c" }, // Secondary Device Attributes
+          { prefix: "=", final: "c" }, // Tertiary Device Attributes
+          { intermediates: "$", final: "p" }, // DECRQM (ANSI)
+          { prefix: "?", intermediates: "$", final: "p" }, // DECRQM (DEC private)
+          { prefix: ">", final: "q" }, // XTVERSION
+        ];
+
+        // A running program's queries are answered once, by the desktop pane.
+        // Without this the mirror answers them a second time — every prompt
+        // render emits DSR, and reconnect replays the whole scrollback at once —
+        // and those replies land on the shell prompt as stray input (issue #480).
+        function suppressMirrorQueryReplies(term) {
+          const parser = term.parser;
+          if (!parser || typeof parser.registerCsiHandler !== "function") return;
+          for (const id of MIRROR_SUPPRESSED_CSI) {
+            parser.registerCsiHandler(id, () => true);
+          }
+        }
+
         function ensureTerminal(appearance = {}) {
           if (terminal) return terminal;
           const TerminalCtor = window.Terminal;
@@ -2469,6 +2499,7 @@
           fitAddon = new FitAddonCtor();
           terminal.loadAddon(fitAddon);
           terminal.open(terminalSizer);
+          suppressMirrorQueryReplies(terminal);
           terminalHost.addEventListener(
             "focusin",
             (event) => {
@@ -2486,10 +2517,12 @@
           installSelectionHandles(terminal);
           installTouchSelectionBridge(terminal);
           terminal.onData((data) => {
-            // Swallow xterm's own protocol replies emitted while replaying
-            // captured output (issue #480); forward only genuine user input.
-            // A running program's queries are answered by the desktop pane, so
-            // the mirror must never echo replies back into the PTY.
+            // Known query replies are already suppressed at the parser
+            // (suppressMirrorQueryReplies). This is the catch-all for the
+            // reconnect flood (issue #480): a whole-scrollback replay can make
+            // xterm emit replies to any sequence we did not enumerate, so drop
+            // all onData while a replay write is in flight and forward only
+            // genuine user input.
             if (terminalReplayDepth > 0) return;
             enqueueInput(data);
           });
@@ -3526,11 +3559,18 @@
                     return;
                   }
                   if (guardInput) terminalReplayDepth += 1;
-                  term.write(payload, () => {
+                  try {
+                    term.write(payload, () => {
+                      if (guardInput) terminalReplayDepth -= 1;
+                      scheduleTerminalRefresh();
+                      resolve();
+                    });
+                  } catch (_err) {
+                    // A synchronous throw means the callback never fires; undo
+                    // the guard and unblock the chain so input is not wedged.
                     if (guardInput) terminalReplayDepth -= 1;
-                    scheduleTerminalRefresh();
                     resolve();
-                  });
+                  }
                 })
             );
             return terminalOutputWriteChain;

--- a/ui/e2e/remote-input-composer.spec.ts
+++ b/ui/e2e/remote-input-composer.spec.ts
@@ -824,6 +824,57 @@ test("a malformed output frame stays fail-closed after a delayed snapshot write 
   ).toEqual([]);
 });
 
+test("snapshot replay swallows xterm protocol replies but resumes real keystrokes (#480)", async ({
+  page,
+}) => {
+  // The remote xterm is a display mirror; the desktop pane answers protocol
+  // queries. Replaying captured output makes xterm auto-answer any queries in
+  // that output via onData. On reconnect the whole snapshot is replayed, so
+  // every reply would otherwise flood the PTY as stray input (a phantom Enter).
+  const remote = await installRemotePage(page, {
+    coarse: false,
+    delayFirstTerminalWrite: true,
+    deferSocketCloseEvent: true,
+  });
+  await connect(page);
+
+  // Hold the snapshot write mid-flight so the replay guard stays active.
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as Window & { __mockTerminal: { written: unknown[] } }).__mockTerminal.written
+            .length,
+      ),
+    )
+    .toBe(1);
+
+  // xterm's reply to a query embedded in the replayed snapshot (here a DSR
+  // "ESC[0n") must never reach the PTY while the replay is in flight.
+  await page.evaluate(() =>
+    (
+      window as Window & { __mockTerminal: { emitData: (data: string) => void } }
+    ).__mockTerminal.emitData("\x1b[0n"),
+  );
+  await page.waitForTimeout(20);
+  expect(remote.writes).toHaveLength(0);
+
+  // Once the replay completes the mirror forwards genuine keystrokes again.
+  await page.evaluate(() =>
+    (
+      window as Window & { __mockTerminal: { releaseDelayedWrite: () => void } }
+    ).__mockTerminal.releaseDelayedWrite(),
+  );
+  await page.waitForTimeout(20);
+  await page.evaluate(() =>
+    (
+      window as Window & { __mockTerminal: { emitData: (data: string) => void } }
+    ).__mockTerminal.emitData("ls"),
+  );
+  await expect.poll(() => remote.writes.length).toBe(1);
+  expect(remote.writes[0]).toEqual({ leaseId: "lease-1", data: "ls" });
+});
+
 test("an in-flight snapshot is sent once and only clears the unchanged revision", async ({
   page,
 }) => {

--- a/ui/e2e/remote-input-composer.spec.ts
+++ b/ui/e2e/remote-input-composer.spec.ts
@@ -167,6 +167,16 @@ async function installBrowserMocks(
         };
         selection = "";
         written: Array<string | Uint8Array> = [];
+        parser = {
+          csiHandlers: [] as Array<{ prefix?: string; intermediates?: string; final: string }>,
+          registerCsiHandler(
+            id: { prefix?: string; intermediates?: string; final: string },
+            _handler: () => boolean,
+          ) {
+            this.csiHandlers.push(id);
+            return { dispose() {} };
+          },
+        };
         private dataListener: ((data: string) => void) | null = null;
         private resizeListener: ((size: { cols: number; rows: number }) => void) | null = null;
         private delayNextWrite = Boolean(delayFirstTerminalWrite);
@@ -250,6 +260,21 @@ async function installBrowserMocks(
         scrollToBottom() {}
         emitData(data: string) {
           this.dataListener?.(data);
+        }
+        // Simulate xterm parsing a CSI query out of streamed output: it emits
+        // the reply via onData unless a registered handler claims the sequence.
+        emitCsiQueryReply(
+          id: { prefix?: string; intermediates?: string; final: string },
+          reply: string,
+        ) {
+          const suppressed = this.parser.csiHandlers.some(
+            (handler) =>
+              (handler.prefix ?? "") === (id.prefix ?? "") &&
+              (handler.intermediates ?? "") === (id.intermediates ?? "") &&
+              handler.final === id.final,
+          );
+          if (suppressed) return;
+          this.dataListener?.(reply);
         }
         emitResize() {
           this.resizeListener?.({ cols: this.cols, rows: this.rows });
@@ -873,6 +898,43 @@ test("snapshot replay swallows xterm protocol replies but resumes real keystroke
   );
   await expect.poll(() => remote.writes.length).toBe(1);
   expect(remote.writes[0]).toEqual({ leaseId: "lease-1", data: "ls" });
+});
+
+test("the mirror never answers terminal protocol queries, even in steady state (#480)", async ({
+  page,
+}) => {
+  // The desktop pane already answers protocol queries; the mirror must answer
+  // none of them. Prompt frameworks emit DSR on every render, arriving as live
+  // deltas long after any replay window — so parser-level suppression, not just
+  // the replay guard, has to swallow the reply.
+  const remote = await installRemotePage(page, { coarse: false });
+  await connect(page);
+
+  // Steady state: no replay is in flight, yet a DSR the running program emits
+  // must still produce no cursor-position reply back to the PTY.
+  await page.evaluate(() =>
+    (
+      window as Window & {
+        __mockTerminal: {
+          emitCsiQueryReply: (
+            id: { prefix?: string; intermediates?: string; final: string },
+            reply: string,
+          ) => void;
+        };
+      }
+    ).__mockTerminal.emitCsiQueryReply({ final: "n" }, "\x1b[24;1R"),
+  );
+  await page.waitForTimeout(20);
+  expect(remote.writes).toHaveLength(0);
+
+  // Genuine keystrokes are untouched by the suppression.
+  await page.evaluate(() =>
+    (
+      window as Window & { __mockTerminal: { emitData: (data: string) => void } }
+    ).__mockTerminal.emitData("echo hi"),
+  );
+  await expect.poll(() => remote.writes.length).toBe(1);
+  expect(remote.writes[0]).toEqual({ leaseId: "lease-1", data: "echo hi" });
 });
 
 test("an in-flight snapshot is sent once and only clears the unchanged revision", async ({


### PR DESCRIPTION
## 이슈
#480 — 네트워크 재연결 시, 그리고 셸 진입 시 원치 않는 엔터(stray 입력)가 터미널로 전송됨.

## 근본 원인
원격 브라우저의 xterm 은 데스크톱 pane 을 비추는 **display mirror** 다. 프로토콜 쿼리(DSR `ESC[6n`, DA, DECRQM, XTVERSION 등)의 응답 주체는 데스크톱 터미널인데, 캡처된 출력을 원격 xterm 에 재생하면 xterm 파서가 그 출력에 섞인 쿼리에 **자동응답**하고, 그 응답이 `terminal.onData` 를 통해 그대로 PTY 로 전송됐다.

- **재연결**: 전체 스냅샷이 한 번에 재생 → 스크롤백에 쌓인 모든 쿼리가 동시에 재응답 → 프롬프트에 stray 입력 폭탄 = "엔터 나감".
- **셸 진입/정상 상태**: 프롬프트 프레임워크가 매 렌더마다 DSR 방출 → 미러가 중복 응답.

## 수정
1. **원천 억제** — 미러 xterm 파서에 DSR/DA(1·2·3차)/DECRQM/XTVERSION 억제 핸들러 등록. 재생·라이브 무관하게 어떤 쿼리에도 응답하지 않는다. 순수 쿼리라 표시 부작용 없음.
2. **재생 catch-all** — `terminalReplayDepth` 로 재생 쓰기(스냅샷·reset·synthetic mode) 중 onData 를 삼켜, 미열거 시퀀스로 인한 재연결 플러드까지 방어. 라이브 델타는 무가드로 두어 대량 출력 중 실제 키 드롭 방지.
3. **누수 방지** — `term.write` 를 try/catch 로 감싸 동기 throw 시 guard 되돌림.

서브에이전트 리뷰 1회 반영(원천 억제 채택, try/catch 보강).

## 테스트
- e2e 2건 추가: 재생 중 응답 삼킴 + 완료 후 키 복원, steady-state 파서 억제 + 실제 키 통과.
- `remote-input-composer` `remote-snapshot` 스펙 21건 통과.

> 주의: `reconnect keeps a collapsed Composer editor collapsed and unfocused` 1건은 **이 PR 이전부터 origin/main(a199443)에서 실패**하던 선재 red 로, #474 친근한 제목 도입으로 인한 stale 기대값("Connected to terminal-1" vs "Main · Pane 1")이며 본 변경과 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)