### PR TITLE
fix(remote): 컴포저 send가 본문과 제출 CR을 분리 write 하도록 (#490)

### DIFF
--- a/src-tauri/src/automation_server/mcp.rs
+++ b/src-tauri/src/automation_server/mcp.rs
@@ -695,7 +695,9 @@ impl McpHandler {
     /// 전달을 더 크게 묶어 ~200ms 미만에서는 두 write가 codex의 burst 창 안에
     /// 합쳐졌다(제출 실패). 양 환경 모두 안전하도록 여유 마진을 둔다. 셸/
     /// PowerShell/Claude Code 에는 무해하다(추가 지연만 발생).
-    const ENTER_CR_DELAY_MS: u64 = 300;
+    ///
+    /// 컴포저 send 경로(`write_terminal_input_inner`, #490)도 같은 값을 공유한다.
+    const ENTER_CR_DELAY_MS: u64 = crate::constants::ENTER_SUBMIT_CR_DELAY_MS;
 
     /// Upper bound for `capture_ms` — the caller blocks for at most this long
     /// waiting to snapshot the target's post-write output.

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -959,7 +959,7 @@ pub fn write_to_terminal_inner(
         .ok_or_else(|| format!("Session '{id}' not found"))?;
 
     let deadline = permit.deadline();
-    let pending = permit.enqueue_pty_job(|| handle.enqueue_write(data, deadline))?;
+    let pending = permit.enqueue_pty_job(|| handle.enqueue_write(data, false, deadline))?;
     let result = handle.await_enqueued_control_job(pending, deadline, || permit.is_current());
     finish_human_control_io(permit, &handle, result)
 }
@@ -988,13 +988,22 @@ pub fn write_terminal_input_inner(
         let protocol = protocol_gate.lock_or_err()?;
         protocol.bracketed_paste()
     };
-    // Encode only the body here; the submit CR is written as a separate,
-    // delayed PTY write below. Fusing text and CR into one write makes a TUI
-    // (Codex/Claude Code) or shell (PowerShell/PSReadLine, WSL) fold the CR into
-    // the bracketed paste of the body, so the line is typed but never submitted
-    // until a second lone CR arrives (#490; matches the MCP path's #314 split).
+    // Strip a trailing newline before a submit so the body never carries its own
+    // line break into the separate submit CR (which would land an extra empty
+    // Enter). Internal newlines are preserved for multi-line input. Matches the
+    // MCP path (#314).
+    let body_text = if submit {
+        text.trim_end_matches(|c| c == '\n' || c == '\r')
+    } else {
+        text
+    };
+    // Encode only the body. The submit CR is appended by the PTY worker after a
+    // short gap, within this same FIFO job, so a TUI (Codex/Claude Code) or
+    // shell (PowerShell/PSReadLine, WSL) registers a distinct Enter instead of
+    // folding the CR into the body's bracketed paste — and no other write on
+    // this terminal can slip between the body and its CR (#490).
     let body = encode_terminal_input(
-        text,
+        body_text,
         false,
         bracketed_paste,
         TERMINAL_STRUCTURED_INPUT_MAX_BYTES,
@@ -1012,26 +1021,7 @@ pub fn write_terminal_input_inner(
         .cloned()
         .ok_or_else(|| format!("Session '{id}' not found"))?;
     let deadline = permit.deadline();
-
-    if !body.is_empty() {
-        permit.ensure_current()?;
-        let pending = permit.enqueue_pty_job(|| handle.enqueue_write(&body, deadline))?;
-        let result = handle.await_enqueued_control_job(pending, deadline, || permit.is_current());
-        if result.is_err() {
-            return finish_human_control_io(permit, &handle, result);
-        }
-    }
-
-    if !submit {
-        return finish_human_control_io(permit, &handle, Ok(()));
-    }
-
-    // Only gap the CR when a body preceded it; a lone Enter needs no delay.
-    if !body.is_empty() {
-        std::thread::sleep(std::time::Duration::from_millis(ENTER_SUBMIT_CR_DELAY_MS));
-    }
-    permit.ensure_current()?;
-    let pending = permit.enqueue_pty_job(|| handle.enqueue_write(b"\r", deadline))?;
+    let pending = permit.enqueue_pty_job(|| handle.enqueue_write(&body, submit, deadline))?;
     let result = handle.await_enqueued_control_job(pending, deadline, || permit.is_current());
     finish_human_control_io(permit, &handle, result)
 }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -988,15 +988,20 @@ pub fn write_terminal_input_inner(
         let protocol = protocol_gate.lock_or_err()?;
         protocol.bracketed_paste()
     };
-    let encoded = encode_terminal_input(
+    // Encode only the body here; the submit CR is written as a separate,
+    // delayed PTY write below. Fusing text and CR into one write makes a TUI
+    // (Codex/Claude Code) or shell (PowerShell/PSReadLine, WSL) fold the CR into
+    // the bracketed paste of the body, so the line is typed but never submitted
+    // until a second lone CR arrives (#490; matches the MCP path's #314 split).
+    let body = encode_terminal_input(
         text,
-        submit,
+        false,
         bracketed_paste,
         TERMINAL_STRUCTURED_INPUT_MAX_BYTES,
     )
     .map_err(|err| err.to_string())?;
     permit.ensure_current()?;
-    if encoded.is_empty() {
+    if body.is_empty() && !submit {
         return permit.finish();
     }
 
@@ -1007,7 +1012,26 @@ pub fn write_terminal_input_inner(
         .cloned()
         .ok_or_else(|| format!("Session '{id}' not found"))?;
     let deadline = permit.deadline();
-    let pending = permit.enqueue_pty_job(|| handle.enqueue_write(&encoded, deadline))?;
+
+    if !body.is_empty() {
+        permit.ensure_current()?;
+        let pending = permit.enqueue_pty_job(|| handle.enqueue_write(&body, deadline))?;
+        let result = handle.await_enqueued_control_job(pending, deadline, || permit.is_current());
+        if result.is_err() {
+            return finish_human_control_io(permit, &handle, result);
+        }
+    }
+
+    if !submit {
+        return finish_human_control_io(permit, &handle, Ok(()));
+    }
+
+    // Only gap the CR when a body preceded it; a lone Enter needs no delay.
+    if !body.is_empty() {
+        std::thread::sleep(std::time::Duration::from_millis(ENTER_SUBMIT_CR_DELAY_MS));
+    }
+    permit.ensure_current()?;
+    let pending = permit.enqueue_pty_job(|| handle.enqueue_write(b"\r", deadline))?;
     let result = handle.await_enqueued_control_job(pending, deadline, || permit.is_current());
     finish_human_control_io(permit, &handle, result)
 }
@@ -1696,12 +1720,16 @@ mod tests {
         );
 
         let worker_state = Arc::clone(&state);
+        // submit=false so the body is a single blocking write; a submit would
+        // add a second, delayed CR write (#490) that the one-shot BlockingTest-
+        // Writer release channel can't serve. The no-table-lock-during-I/O
+        // invariant is identical for both writes.
         let worker = thread::spawn(move || {
             write_terminal_input_inner(
                 &worker_state,
                 "t1",
                 "blocking input",
-                true,
+                false,
                 HumanControlOrigin::Local,
             )
         });
@@ -1718,6 +1746,60 @@ mod tests {
 
         release_tx.send(()).unwrap();
         worker.join().unwrap().unwrap();
+    }
+
+    /// #490: a submit must reach the PTY as the body followed by a *separate*
+    /// CR write, not one fused `text\r` buffer. Fusing them makes a TUI/shell
+    /// fold the CR into a bracketed paste of the body, typing the line without
+    /// submitting it. A per-write recorder proves the two are distinct writes.
+    #[test]
+    fn structured_submit_writes_body_and_cr_as_separate_pty_writes() {
+        #[derive(Clone)]
+        struct ChunkRecordingWriter(Arc<Mutex<Vec<Vec<u8>>>>);
+        impl Write for ChunkRecordingWriter {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().push(bytes.to_vec());
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let write_chunks = |text: &str, submit: bool| -> Vec<Vec<u8>> {
+            let state = AppState::new();
+            state
+                .terminals
+                .lock_or_err()
+                .unwrap()
+                .insert("t1".into(), test_session());
+            state
+                .terminal_protocol_states
+                .lock_or_err()
+                .unwrap()
+                .insert("t1".into(), terminal_output::new_protocol_gate());
+            let chunks = Arc::new(Mutex::new(Vec::new()));
+            state.pty_handles.lock_or_err().unwrap().insert(
+                "t1".into(),
+                pty::PtyHandle::from_test_writer(Box::new(ChunkRecordingWriter(Arc::clone(
+                    &chunks,
+                )))),
+            );
+            write_terminal_input_inner(&state, "t1", text, submit, HumanControlOrigin::Local)
+                .unwrap();
+            let recorded = chunks.lock().unwrap().clone();
+            recorded
+        };
+
+        // Body + submit → two distinct writes, CR last and by itself.
+        assert_eq!(
+            write_chunks("hi", true),
+            vec![b"hi".to_vec(), b"\r".to_vec()]
+        );
+        // Lone submit → a single CR write (no empty body write ahead of it).
+        assert_eq!(write_chunks("", true), vec![b"\r".to_vec()]);
+        // No submit → body only, never a trailing CR.
+        assert_eq!(write_chunks("hi", false), vec![b"hi".to_vec()]);
     }
 
     #[test]

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -91,6 +91,13 @@ pub const PTY_CONTROL_QUEUE_CAPACITY: usize = 64;
 pub const PTY_CONTROL_JOB_TIMEOUT_MS: u64 = 15_000;
 /// Poll cadence used while waiting for owner cancellation or worker completion.
 pub const PTY_CONTROL_WAIT_POLL_MS: u64 = 10;
+/// Delay inserted between the input body and the submit carriage return so a
+/// TUI (Codex/Claude Code) or shell (PowerShell/PSReadLine, WSL) registers the
+/// CR as a distinct Enter keypress instead of folding it into a bracketed paste
+/// of the body. Sending them fused makes the line get typed but never submitted
+/// until a second lone CR arrives (#490; the MCP write path already splits this
+/// way per #314). Harmless where unneeded — only adds latency.
+pub const ENTER_SUBMIT_CR_DELAY_MS: u64 = 300;
 /// Grace after cancellation before the PTY is faulted and terminated.
 pub const PTY_CONTROL_CANCEL_GRACE_MS: u64 = 250;
 /// Final bounded wait for the platform worker to acknowledge PTY termination.

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -187,20 +187,25 @@ impl PtyHandle {
         deadline: Instant,
         is_current_owner: impl FnMut() -> bool,
     ) -> Result<(), String> {
-        let pending = self.enqueue_write(data, deadline)?;
+        let pending = self.enqueue_write(data, false, deadline)?;
         self.await_enqueued_control_job(pending, deadline, is_current_owner)
     }
 
     /// Place a write on this terminal's FIFO without waiting for it. Human
     /// controller callers use this narrow operation while holding their owner
     /// gate, making FIFO submission atomic with an ownership transition.
+    ///
+    /// When `submit` is set, the worker appends a submit CR after the body,
+    /// gapped so a TUI/shell registers a distinct Enter, all inside this one
+    /// FIFO job so the body and CR stay atomic against other writes (#490).
     pub(crate) fn enqueue_write(
         &self,
         data: &[u8],
+        submit: bool,
         deadline: Instant,
     ) -> Result<PendingControlJob, String> {
         self.ensure_input_healthy()?;
-        self.control.submit_write(data, deadline)
+        self.control.submit_write(data, submit, deadline)
     }
 
     /// Get the child process ID.

--- a/src-tauri/src/pty_control.rs
+++ b/src-tauri/src/pty_control.rs
@@ -9,11 +9,13 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use portable_pty::{MasterPty, PtySize};
 
-use crate::constants::PTY_CONTROL_QUEUE_CAPACITY;
+use crate::constants::{
+    ENTER_SUBMIT_CR_DELAY_MS, PTY_CONTROL_QUEUE_CAPACITY, PTY_CONTROL_WAIT_POLL_MS,
+};
 use crate::lock_ext::MutexExt;
 use crate::pty::chunked_write_to_guarded;
 
@@ -23,6 +25,9 @@ enum ControlJob {
     Write {
         id: u64,
         data: Vec<u8>,
+        /// Append a submit CR after the body, gapped by [`ENTER_SUBMIT_CR_DELAY_MS`],
+        /// within this same job so the pair stays atomic on the FIFO (#490).
+        submit: bool,
         cancelled: Arc<AtomicBool>,
         deadline: Instant,
         result: mpsc::Sender<ControlResult>,
@@ -109,6 +114,7 @@ impl PtyControlWorker {
     pub(crate) fn submit_write(
         &self,
         data: &[u8],
+        submit: bool,
         deadline: Instant,
     ) -> Result<PendingControlJob, String> {
         let id = self.next_id();
@@ -117,6 +123,7 @@ impl PtyControlWorker {
         self.submit(ControlJob::Write {
             id,
             data: data.to_vec(),
+            submit,
             cancelled: Arc::clone(&cancelled),
             deadline,
             result: result_tx,
@@ -253,12 +260,33 @@ fn execute_job(
     match job {
         ControlJob::Write {
             data,
+            submit,
             cancelled,
             deadline,
             ..
-        } => chunked_write_to_guarded(writer, &data, || {
-            !cancelled.load(Ordering::Acquire) && Instant::now() < deadline
-        }),
+        } => {
+            if !data.is_empty() {
+                chunked_write_to_guarded(writer, &data, || {
+                    !cancelled.load(Ordering::Acquire) && Instant::now() < deadline
+                })?;
+            }
+            if submit {
+                // Emit the submit CR as its own write, gapped from the body, so
+                // a TUI (Codex/Claude Code) or shell (PowerShell/PSReadLine,
+                // WSL) registers a real Enter instead of folding the CR into the
+                // body's bracketed paste (#490). Running the gap here on the
+                // FIFO worker keeps body+CR atomic — no other write on this
+                // terminal can slip between them. A lone Enter (empty body)
+                // needs no gap.
+                if !data.is_empty() {
+                    wait_before_submit_cr(&cancelled, deadline)?;
+                }
+                chunked_write_to_guarded(writer, b"\r", || {
+                    !cancelled.load(Ordering::Acquire) && Instant::now() < deadline
+                })?;
+            }
+            Ok(())
+        }
         ControlJob::Resize {
             cols,
             rows,
@@ -283,6 +311,21 @@ fn execute_job(
             ensure_job_current(&cancelled, deadline)
         }
     }
+}
+
+/// Bounded, cancellation-aware pause before the submit CR. Splitting the CR
+/// from the body lets a TUI/shell see a distinct Enter (#490); running it on the
+/// FIFO worker keeps the pair atomic against other writes on this terminal.
+/// Polled in small steps so an owner-epoch change or deadline aborts the CR
+/// (leaving the body typed) instead of waiting out the full gap.
+fn wait_before_submit_cr(cancelled: &AtomicBool, deadline: Instant) -> ControlResult {
+    let poll = Duration::from_millis(PTY_CONTROL_WAIT_POLL_MS);
+    let until = Instant::now() + Duration::from_millis(ENTER_SUBMIT_CR_DELAY_MS);
+    while Instant::now() < until {
+        ensure_job_current(cancelled, deadline)?;
+        thread::sleep(poll.min(until.saturating_duration_since(Instant::now())));
+    }
+    ensure_job_current(cancelled, deadline)
 }
 
 fn ensure_job_current(cancelled: &AtomicBool, deadline: Instant) -> Result<(), String> {

--- a/src-tauri/src/pty_control.rs
+++ b/src-tauri/src/pty_control.rs
@@ -276,8 +276,11 @@ fn execute_job(
                 // WSL) registers a real Enter instead of folding the CR into the
                 // body's bracketed paste (#490). Running the gap here on the
                 // FIFO worker keeps body+CR atomic — no other write on this
-                // terminal can slip between them. A lone Enter (empty body)
-                // needs no gap.
+                // terminal can slip between them. Accepted tradeoff: same-owner
+                // input queued behind a submit waits out this gap (~300ms); that
+                // is the cost of atomicity, and a cross-owner transition still
+                // aborts the gap within one poll (see `wait_before_submit_cr`).
+                // A lone Enter (empty body) needs no gap.
                 if !data.is_empty() {
                     wait_before_submit_cr(&cancelled, deadline)?;
                 }

--- a/src-tauri/src/pty_control/tests.rs
+++ b/src-tauri/src/pty_control/tests.rs
@@ -18,6 +18,23 @@ impl Write for RecordingWriter {
     }
 }
 
+/// Records each `write()` call as its own chunk, so tests can tell a split
+/// body+CR (two writes) apart from a fused `body\r` (one write).
+struct ChunkWriter {
+    chunks: Arc<StdMutex<Vec<Vec<u8>>>>,
+}
+
+impl Write for ChunkWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.chunks.lock().expect("chunk writer").push(buf.to_vec());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 struct GatedWriter {
     started: Option<mpsc::Sender<()>>,
     gate: Arc<(StdMutex<bool>, Condvar)>,
@@ -72,40 +89,53 @@ fn control_worker_preserves_fifo_job_order() {
     worker.close();
 }
 
-/// #490: a submit job carries its own gapped CR, and because it is one atomic
-/// FIFO job, a write queued behind it lands AFTER the CR — never between the
-/// body and the CR. This is the property that the earlier app-level split
-/// (two separate jobs) could not guarantee.
+/// #490: a submit job writes the body and the CR as TWO distinct writes (not a
+/// fused `body\r`), gapped by the delay, and because it is one atomic FIFO job a
+/// write queued behind it lands AFTER the CR — never between the body and the
+/// CR. This is the property the earlier app-level split (two jobs) could not
+/// guarantee. Per-`write()` chunk recording is what distinguishes split from
+/// fused; a concatenating writer would pass even on a fused regression.
 #[test]
-fn submit_write_appends_gapped_cr_atomically_before_next_job() {
-    let bytes = Arc::new(StdMutex::new(Vec::new()));
+fn submit_write_appends_gapped_cr_as_separate_write_before_next_job() {
+    let chunks = Arc::new(StdMutex::new(Vec::new()));
     let worker = PtyControlWorker::spawn(
-        Box::new(RecordingWriter {
-            bytes: Arc::clone(&bytes),
+        Box::new(ChunkWriter {
+            chunks: Arc::clone(&chunks),
         }),
         no_master(),
     )
     .expect("spawn worker");
     let deadline = Instant::now() + Duration::from_secs(5);
 
+    let started = Instant::now();
     let submit = worker
         .submit_write(b"cmd", true, deadline)
         .expect("submit job");
     let raw = worker.submit_write(b"x", false, deadline).expect("raw job");
-
     assert_eq!(submit.result.recv().expect("submit result"), Ok(()));
     assert_eq!(raw.result.recv().expect("raw result"), Ok(()));
-    assert_eq!(&*bytes.lock().expect("recorded bytes"), b"cmd\rx");
+
+    // Body, CR, then the following raw write — three separate writes, in order.
+    assert_eq!(
+        &*chunks.lock().expect("chunks"),
+        &[b"cmd".to_vec(), b"\r".to_vec(), b"x".to_vec()]
+    );
+    // The gap actually elapsed — guards against the CR being fused or un-delayed.
+    assert!(
+        started.elapsed()
+            >= Duration::from_millis(ENTER_SUBMIT_CR_DELAY_MS)
+                .saturating_sub(Duration::from_millis(50))
+    );
     worker.close();
 }
 
 /// A lone Enter (submit with an empty body) emits just the CR, with no gap.
 #[test]
 fn submit_write_with_empty_body_emits_only_cr() {
-    let bytes = Arc::new(StdMutex::new(Vec::new()));
+    let chunks = Arc::new(StdMutex::new(Vec::new()));
     let worker = PtyControlWorker::spawn(
-        Box::new(RecordingWriter {
-            bytes: Arc::clone(&bytes),
+        Box::new(ChunkWriter {
+            chunks: Arc::clone(&chunks),
         }),
         no_master(),
     )
@@ -116,7 +146,7 @@ fn submit_write_with_empty_body_emits_only_cr() {
         .submit_write(b"", true, deadline)
         .expect("lone enter job");
     assert_eq!(lone.result.recv().expect("lone result"), Ok(()));
-    assert_eq!(&*bytes.lock().expect("recorded bytes"), b"\r");
+    assert_eq!(&*chunks.lock().expect("chunks"), &[b"\r".to_vec()]);
     worker.close();
 }
 

--- a/src-tauri/src/pty_control/tests.rs
+++ b/src-tauri/src/pty_control/tests.rs
@@ -59,14 +59,64 @@ fn control_worker_preserves_fifo_job_order() {
     .expect("spawn worker");
     let deadline = Instant::now() + Duration::from_secs(1);
 
-    let first = worker.submit_write(b"first", deadline).expect("first job");
+    let first = worker
+        .submit_write(b"first", false, deadline)
+        .expect("first job");
     let second = worker
-        .submit_write(b"-second", deadline)
+        .submit_write(b"-second", false, deadline)
         .expect("second job");
 
     assert_eq!(first.result.recv().expect("first result"), Ok(()));
     assert_eq!(second.result.recv().expect("second result"), Ok(()));
     assert_eq!(&*bytes.lock().expect("recorded bytes"), b"first-second");
+    worker.close();
+}
+
+/// #490: a submit job carries its own gapped CR, and because it is one atomic
+/// FIFO job, a write queued behind it lands AFTER the CR — never between the
+/// body and the CR. This is the property that the earlier app-level split
+/// (two separate jobs) could not guarantee.
+#[test]
+fn submit_write_appends_gapped_cr_atomically_before_next_job() {
+    let bytes = Arc::new(StdMutex::new(Vec::new()));
+    let worker = PtyControlWorker::spawn(
+        Box::new(RecordingWriter {
+            bytes: Arc::clone(&bytes),
+        }),
+        no_master(),
+    )
+    .expect("spawn worker");
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    let submit = worker
+        .submit_write(b"cmd", true, deadline)
+        .expect("submit job");
+    let raw = worker.submit_write(b"x", false, deadline).expect("raw job");
+
+    assert_eq!(submit.result.recv().expect("submit result"), Ok(()));
+    assert_eq!(raw.result.recv().expect("raw result"), Ok(()));
+    assert_eq!(&*bytes.lock().expect("recorded bytes"), b"cmd\rx");
+    worker.close();
+}
+
+/// A lone Enter (submit with an empty body) emits just the CR, with no gap.
+#[test]
+fn submit_write_with_empty_body_emits_only_cr() {
+    let bytes = Arc::new(StdMutex::new(Vec::new()));
+    let worker = PtyControlWorker::spawn(
+        Box::new(RecordingWriter {
+            bytes: Arc::clone(&bytes),
+        }),
+        no_master(),
+    )
+    .expect("spawn worker");
+    let deadline = Instant::now() + Duration::from_secs(1);
+
+    let lone = worker
+        .submit_write(b"", true, deadline)
+        .expect("lone enter job");
+    assert_eq!(lone.result.recv().expect("lone result"), Ok(()));
+    assert_eq!(&*bytes.lock().expect("recorded bytes"), b"\r");
     worker.close();
 }
 
@@ -86,7 +136,7 @@ fn cancelling_active_job_never_starts_its_later_chunk() {
     .expect("spawn worker");
     let payload = vec![b'x'; crate::constants::PTY_WRITE_CHUNK_SIZE + 7];
     let pending = worker
-        .submit_write(&payload, Instant::now() + Duration::from_secs(1))
+        .submit_write(&payload, false, Instant::now() + Duration::from_secs(1))
         .expect("write job");
     started_rx
         .recv_timeout(Duration::from_secs(1))
@@ -126,12 +176,14 @@ fn queued_cancelled_job_is_rejected_without_writing() {
     )
     .expect("spawn worker");
     let deadline = Instant::now() + Duration::from_secs(1);
-    let first = worker.submit_write(b"first", deadline).expect("first job");
+    let first = worker
+        .submit_write(b"first", false, deadline)
+        .expect("first job");
     started_rx
         .recv_timeout(Duration::from_secs(1))
         .expect("first write started");
     let second = worker
-        .submit_write(b"second", deadline)
+        .submit_write(b"second", false, deadline)
         .expect("second job");
     second.cancelled.store(true, Ordering::Release);
     assert!(!worker.cancel_job(second.id));


### PR DESCRIPTION
## 이슈
#490 — 리모트 PowerShell(및 Codex·Claude TUI)에서 send 를 눌러도 입력만 타이핑되고 제출되지 않음. 빈 입력으로 한 번 더 send 해야 Enter 가 먹음.

## 근본 원인
컴포저 send 경로(`write_terminal_input_inner`)가 `text` + `\r` 를 **한 번의 PTY write 로 융합**해 보냈다. TUI/셸(PowerShell·PSReadLine·WSL·Codex·Claude)은 텍스트에 바로 붙은 CR 을 bracketed paste 의 일부로 읽어, 줄은 입력되지만 제출되지 않는다. 두 번째 lone CR 이 와야 제출된다.

MCP write 경로는 이미 본문과 CR 을 300ms 간격으로 **분리**해 보내고 있었으나(#314), 컴포저 경로는 그 처리를 받지 못했다.

## 수정
- **`write_terminal_input_inner`**: 본문만 인코딩→write, `ENTER_SUBMIT_CR_DELAY_MS` 만큼 sleep, 이후 별도 `\r` write. lone submit 은 지연 없이 단일 CR. sleep 중 어떤 락도 보유하지 않는다. 이 경로 하나가 리모트 `/input`(`remote_terminal_input`) 과 데스크톱 컴포저(tauri command) 를 모두 처리 → PowerShell/WSL/셸/Codex/Claude 일괄 대응.
- **`constants.rs`**: 공용 상수 `ENTER_SUBMIT_CR_DELAY_MS = 300` 신설.
- **`mcp.rs`**: 기존 로컬 `ENTER_CR_DELAY_MS` 를 공용 상수 별칭으로 단일화(단일 소스).

## 테스트
- 기존 `structured_write_holds_no_app_state_table_lock_during_pty_io` 를 단일 write(`submit=false`)로 조정 — 한 번뿐인 `BlockingTestWriter` release 로는 두 write 를 서빙 못 함. 락 미보유 불변식은 두 write 모두 동일하므로 검증력 유지.
- 신규 `structured_submit_writes_body_and_cr_as_separate_pty_writes`: body+CR **분리 write**, lone submit=단일 CR, no-submit=본문만 을 고정(융합 회귀 방지).
- 터미널 모듈 27건 통과. `cargo check`/`clippy`/`fmt` 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)