### PR TITLE
fix(ui): keep workspace notification badge flush-right at rest

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -185,6 +185,10 @@
     cursor: not-allowed;
   }
   .workspace-quick-hide {
+    /* At rest the button is invisible; take it out of flow so it does not
+       reserve width to the right of the count badge (keeps the badge flush
+       right). It rejoins the flow on hover/focus below. */
+    position: absolute;
     opacity: 0;
     pointer-events: none;
     transition: opacity var(--transition-fast);
@@ -198,6 +202,7 @@
   }
   .workspace-item-animated:hover .workspace-quick-hide,
   .workspace-item-animated:focus-within .workspace-quick-hide {
+    position: static;
     opacity: 1;
     pointer-events: auto;
   }


### PR DESCRIPTION
## 문제
최근 hidden items shelf 리워크에서 workspace 행 우측에 항상 마운트되는 `.workspace-quick-hide`(눈 아이콘) 버튼이 추가됐다. 이 버튼은 안 보일 때 `opacity: 0`으로만 숨겨져 여전히 레이아웃 흐름을 차지 → notification count 뱃지 오른쪽에 아이콘 폭만큼 공간을 예약해 뱃지가 한 칸 왼쪽으로 밀렸다.

## 수정
- rest 상태에서 버튼을 `position: absolute`로 흐름에서 제거 → 폭 예약 없음, 뱃지 flush-right 복원
- hover/focus 시 `position: static`으로 흐름에 복귀 → 기존처럼 표시

마이너스 마진 우회 없음. opacity 페이드·키보드 포커스 동작 유지. CSS 2줄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)