### PR TITLE
fix(remote): use paper plane for send button

### DIFF
--- a/src-tauri/src/remote_server/page.html
+++ b/src-tauri/src/remote_server/page.html
@@ -1523,7 +1523,7 @@
         <button id="keyBarToggle" class="key-toggle" type="button" aria-pressed="false" aria-controls="keyBar" title="Toggle special-key toolbar">Keys</button>
         <div id="terminalMeta" class="status-hint grow">No terminal selected.</div>
         <button id="composerSend" class="composer-send" type="button" hidden aria-label="Send input" title="Send">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 5l6.5 6.5-1.42 1.42L13 8.83V19h-2V8.83l-4.08 4.09L5.5 11.5z"/></svg>
+          <svg data-icon="paper-plane" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M13.47 20.21 19.91 4.09 3.8 10.53l3.75 3.77 9.14-6.99-6.99 9.14 3.77 3.76Z"/></svg>
         </button>
       </footer>
     </div>

--- a/src-tauri/src/remote_server/page.rs
+++ b/src-tauri/src/remote_server/page.rs
@@ -381,6 +381,13 @@ mod tests {
         // A dedicated Send button is the touch-device send affordance.
         assert!(html.contains("id=\"composerSend\""));
         assert!(html.contains("class=\"composer-send\""));
+        assert!(html.contains(
+            "data-icon=\"paper-plane\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"currentColor\""
+        ));
+        assert!(html.contains(
+            "M13.47 20.21 19.91 4.09 3.8 10.53l3.75 3.77 9.14-6.99-6.99 9.14 3.77 3.76Z"
+        ));
+        assert!(!html.contains("M12 5l6.5 6.5-1.42 1.42L13 8.83V19h-2V8.83l-4.08 4.09L5.5 11.5z"));
         assert!(html.contains("laymux.remote.inputMode"));
         assert!(html.contains("matchMedia(\"(pointer: coarse)\")"));
 


### PR DESCRIPTION
## 변경 사항

- 리모트 모바일 composer의 전송 버튼 아이콘을 위쪽 화살표에서 채운 대각선 종이비행기로 교체했습니다.
- 종이비행기 SVG와 기존 업 화살표 제거를 정적 계약 테스트로 고정했습니다.

## 배경

기존 수직 화살표는 방향키가 많은 리모트 UI에서 전송보다 위로 이동 또는 업로드로 읽혔습니다. 모바일 composer에서 버튼만 실제 제출 동작을 수행하므로, 메시지 전송 의미가 즉시 드러나는 종이비행기 아이콘으로 바꿨습니다.

## 영향

표현만 바뀝니다. composer 입력, lease, Remote API 및 PTY 전송 동작에는 변화가 없습니다.

## 검증

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p laymux remote_server::page::tests` — 18 passed
- `npx playwright test e2e/remote-input-composer.spec.ts --grep "mobile-layout Composer keeps Enter as a newline and submits with the Send button"` — 1 passed
- 모바일 뷰포트 실제 렌더링 확인

ADR 불필요: 리모트 composer의 동작·외부 계약·상태 소유권을 바꾸지 않는 단일 SVG 아이콘 교체입니다.