### PR TITLE
feat(remote): RDP 진입 시 Remote Access 패널 자동 오픈

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,7 @@ tokio-tungstenite = { version = "0.28", default-features = false, features = ["c
 
 [target.'cfg(windows)'.dependencies]
 clipboard-win = "5"
-windows-sys = { version = "0.59", features = ["Win32_System_Diagnostics_ToolHelp", "Win32_Foundation", "Win32_System_IO", "Win32_System_Threading"] }
+windows-sys = { version = "0.59", features = ["Win32_System_Diagnostics_ToolHelp", "Win32_Foundation", "Win32_System_IO", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -56,6 +56,15 @@ pub fn set_remote_runtime_access(
     Ok(status)
 }
 
+/// Whether the laymux process is currently attached to an OS remote-desktop
+/// (RDP / Terminal Services) session. The UI pulls this on mount to auto-open
+/// the Remote Access panel when launched inside a remote session; live
+/// transitions arrive via the `remote-session-changed` event.
+#[tauri::command]
+pub fn get_remote_session_active() -> bool {
+    crate::remote_session::is_remote_session()
+}
+
 #[tauri::command]
 pub fn reclaim_remote_control(
     state: State<Arc<AppState>>,

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -16,7 +16,17 @@ pub const EVENT_TERMINAL_TITLE_CHANGED: &str = "terminal-title-changed";
 pub const EVENT_CLAUDE_MESSAGE_CHANGED: &str = "claude-message-changed";
 pub const EVENT_TERMINAL_OUTPUT_ACTIVITY: &str = "terminal-output-activity";
 pub const EVENT_REMOTE_CONTROL_CHANGED: &str = "remote-control-changed";
+/// Fired when the OS remote-desktop (RDP / Terminal Services) session state of
+/// the laymux process flips. Payload is a bool: `true` while the window is being
+/// viewed over a remote session. The UI uses it to auto-open the Remote Access
+/// panel when the window is entered from a phone RDP client (see
+/// `useAutoRemoteAccessPrompt`).
+pub const EVENT_REMOTE_SESSION_CHANGED: &str = "remote-session-changed";
 pub const EVENT_TERMINAL_OUTPUT_V2_PREFIX: &str = "terminal-output-v2-";
+
+/// Poll interval for the OS remote-session watcher. RDP connect/disconnect is a
+/// rare, human-scale event, so a slow poll keeps the cost negligible.
+pub const REMOTE_SESSION_POLL: Duration = Duration::from_secs(2);
 
 // ── Environment variable names ─────────────────────────────────────
 
@@ -241,6 +251,7 @@ mod tests {
             EVENT_CLAUDE_MESSAGE_CHANGED,
             EVENT_TERMINAL_OUTPUT_ACTIVITY,
             EVENT_REMOTE_CONTROL_CHANGED,
+            EVENT_REMOTE_SESSION_CHANGED,
             EVENT_WORKSPACE_STATE_CHANGED,
             EVENT_TERMINALS_LIST_CHANGED,
         ];

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ pub mod pty;
 mod pty_control;
 pub mod pty_trace;
 pub mod remote_server;
+pub mod remote_session;
 pub mod settings;
 pub mod state;
 pub mod terminal;
@@ -124,6 +125,18 @@ pub fn run() {
                 }
             });
 
+            // Watch for OS remote-desktop (RDP) session transitions and push
+            // them to the UI so it can auto-open the Remote Access panel when
+            // the window is entered from a phone. Windows-only; other platforms
+            // have no equivalent session concept.
+            #[cfg(target_os = "windows")]
+            {
+                let rdp_app = app.handle().clone();
+                std::thread::spawn(move || {
+                    remote_session::watch_remote_session(rdp_app);
+                });
+            }
+
             // Set window icon (for taskbar in dev mode)
             if let Some(window) = app.get_webview_window("main") {
                 if let Ok(icon) = Image::from_bytes(include_bytes!("../icons/icon.png")) {
@@ -188,6 +201,7 @@ pub fn run() {
             commands::get_remote_access_status,
             commands::set_remote_runtime_access,
             commands::get_remote_control_status,
+            commands::get_remote_session_active,
             commands::get_remote_host_candidates,
             commands::reclaim_remote_control,
             commands::get_cloud_status,

--- a/src-tauri/src/remote_session.rs
+++ b/src-tauri/src/remote_session.rs
@@ -1,0 +1,68 @@
+//! OS-level remote-desktop session detection.
+//!
+//! The intended scenario: laymux is already running on the desktop, and the
+//! user opens Windows Remote Desktop from their phone to reach that window.
+//! When the window is entered over a remote session we want the Remote Access
+//! panel open so the phone can quickly switch to the mobile web UI.
+//!
+//! The window-width heuristic in `useAutoRemoteAccessPrompt` is an unreliable
+//! proxy for this — phone RDP clients usually negotiate a resolution wider than
+//! the threshold, and a non-maximized window never fires a `resize` on connect.
+//! This module reads the real Terminal Services state instead and pushes a
+//! transition event to the UI.
+
+#[cfg(target_os = "windows")]
+pub fn is_remote_session() -> bool {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_REMOTESESSION};
+    // SAFETY: `GetSystemMetrics` is a pure query with no preconditions.
+    // A non-zero return means the calling process is attached to a Terminal
+    // Services (RDP) client session rather than the physical console.
+    unsafe { GetSystemMetrics(SM_REMOTESESSION) != 0 }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn is_remote_session() -> bool {
+    false
+}
+
+/// Poll the OS remote-session state forever, emitting
+/// [`crate::constants::EVENT_REMOTE_SESSION_CHANGED`] on every transition so the
+/// UI can react to RDP connect/disconnect. The initial state is *not* emitted —
+/// the frontend pulls it once on mount via `get_remote_session_active` to avoid
+/// racing the webview's listener registration.
+#[cfg(target_os = "windows")]
+pub fn watch_remote_session(app: tauri::AppHandle) {
+    use crate::constants::{EVENT_REMOTE_SESSION_CHANGED, REMOTE_SESSION_POLL};
+    use tauri::Emitter;
+
+    let mut last = is_remote_session();
+    loop {
+        std::thread::sleep(REMOTE_SESSION_POLL);
+        let now = is_remote_session();
+        if now != last {
+            last = now;
+            if let Err(err) = app.emit(EVENT_REMOTE_SESSION_CHANGED, now) {
+                tracing::warn!(error = %err, "Failed to emit remote-session-changed");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn non_windows_is_never_remote() {
+        assert!(!is_remote_session());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn query_does_not_panic() {
+        // We can't force an RDP session in a unit test, but the query itself
+        // must be callable and return a stable bool.
+        let _ = is_remote_session();
+    }
+}

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -110,6 +110,8 @@ vi.mock("@/lib/tauri-api", () => {
       heartbeatTimeoutSeconds: 15,
     }),
     onRemoteControlChanged: vi.fn().mockResolvedValue(unlisten),
+    getRemoteSessionActive: vi.fn().mockResolvedValue(false),
+    onRemoteSessionChanged: vi.fn().mockResolvedValue(unlisten),
     reclaimRemoteControl: vi.fn().mockResolvedValue({
       active: false,
       leaseId: null,

--- a/ui/src/hooks/useAutoRemoteAccessPrompt.test.tsx
+++ b/ui/src/hooks/useAutoRemoteAccessPrompt.test.tsx
@@ -1,9 +1,15 @@
-import { render } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoRemoteAccessPrompt } from "./useAutoRemoteAccessPrompt";
+import { getRemoteSessionActive, onRemoteSessionChanged } from "@/lib/tauri-api";
 import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useUiStore } from "@/stores/ui-store";
+
+vi.mock("@/lib/tauri-api", () => ({
+  getRemoteSessionActive: vi.fn().mockResolvedValue(false),
+  onRemoteSessionChanged: vi.fn().mockResolvedValue(vi.fn()),
+}));
 
 function Probe({ enabled = true }: { enabled?: boolean }) {
   useAutoRemoteAccessPrompt(enabled);
@@ -23,6 +29,8 @@ describe("useAutoRemoteAccessPrompt", () => {
     useUiStore.setState(useUiStore.getInitialState());
     useLocalMobileModeStore.setState(useLocalMobileModeStore.getInitialState());
     setInnerWidth(1200);
+    vi.mocked(getRemoteSessionActive).mockResolvedValue(false);
+    vi.mocked(onRemoteSessionChanged).mockResolvedValue(vi.fn());
   });
 
   it("opens the Remote Access modal when the app window is narrow", () => {
@@ -63,6 +71,55 @@ describe("useAutoRemoteAccessPrompt", () => {
 
     render(<Probe />);
 
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+  });
+
+  it("opens the modal when launched inside an OS remote session, even on a wide window", async () => {
+    // Threshold disabled + wide window: the width heuristic must NOT fire, so a
+    // pass here proves the RDP-session path is what opens the modal.
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 0 });
+    setInnerWidth(1920);
+    vi.mocked(getRemoteSessionActive).mockResolvedValue(true);
+
+    render(<Probe />);
+
+    await waitFor(() => {
+      expect(useUiStore.getState().remoteAccessModalOpen).toBe(true);
+    });
+  });
+
+  it("opens the modal when a remote session connects after mount", async () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 0 });
+    setInnerWidth(1920);
+    let fire: ((active: boolean) => void) | undefined;
+    vi.mocked(onRemoteSessionChanged).mockImplementation((cb) => {
+      fire = cb;
+      return Promise.resolve(vi.fn());
+    });
+
+    render(<Probe />);
+
+    await waitFor(() => expect(fire).toBeDefined());
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+
+    fire?.(true);
+
+    await waitFor(() => {
+      expect(useUiStore.getState().remoteAccessModalOpen).toBe(true);
+    });
+  });
+
+  it("does not open the modal on remote session while local mobile mode is active", async () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 0 });
+    useLocalMobileModeStore.getState().enter("http://127.0.0.1:19281/remote/?localApp=1");
+    setInnerWidth(1920);
+    vi.mocked(getRemoteSessionActive).mockResolvedValue(true);
+
+    render(<Probe />);
+
+    // Give the resolved promise a chance to run.
+    await Promise.resolve();
+    await Promise.resolve();
     expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
   });
 });

--- a/ui/src/hooks/useAutoRemoteAccessPrompt.ts
+++ b/ui/src/hooks/useAutoRemoteAccessPrompt.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { getRemoteSessionActive, onRemoteSessionChanged } from "@/lib/tauri-api";
 import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useUiStore } from "@/stores/ui-store";
@@ -8,6 +9,11 @@ export function useAutoRemoteAccessPrompt(enabled = true) {
   const localMobileModeActive = useLocalMobileModeStore((state) => state.active);
   const promptedRef = useRef(false);
 
+  // Narrow-window heuristic: open the panel when the app is rendered into a
+  // small viewport (e.g. a browser opened at phone size). Fires on mount and on
+  // resize. This does NOT reliably cover a phone RDP session — those connect at
+  // full resolution and a non-maximized window never resizes — which the OS
+  // remote-session effect below handles.
   useEffect(() => {
     if (!enabled) {
       promptedRef.current = false;
@@ -34,4 +40,48 @@ export function useAutoRemoteAccessPrompt(enabled = true) {
     window.addEventListener("resize", check);
     return () => window.removeEventListener("resize", check);
   }, [enabled, localMobileModeActive, threshold]);
+
+  // OS remote-desktop (RDP) trigger: open the panel when the window is entered
+  // over a remote session, independent of window width. Covers the intended
+  // scenario — reaching an already-running laymux window via Windows Remote
+  // Desktop from a phone. The initial state is pulled once; live connect events
+  // arrive via the backend event. Backend is Windows-only (elsewhere the query
+  // resolves `false` and the event never fires).
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
+    const open = () => {
+      // Local mobile mode already gives the phone a tailored UI — don't stack
+      // the modal on top of it.
+      if (useLocalMobileModeStore.getState().active) return;
+      useUiStore.getState().openRemoteAccessModal();
+    };
+
+    getRemoteSessionActive()
+      .then((active) => {
+        if (!cancelled && active) open();
+      })
+      .catch(() => {
+        /* not in Tauri / not on Windows — ignore */
+      });
+
+    onRemoteSessionChanged((active) => {
+      if (active) open();
+    })
+      .then((cleanup) => {
+        if (cancelled) cleanup();
+        else unlisten = cleanup;
+      })
+      .catch(() => {
+        /* listener registration unavailable — ignore */
+      });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [enabled]);
 }

--- a/ui/src/lib/tauri-api.ts
+++ b/ui/src/lib/tauri-api.ts
@@ -183,6 +183,18 @@ export async function reclaimRemoteControl(): Promise<RemoteControlStatus> {
   return invoke("reclaim_remote_control");
 }
 
+/** Whether the window is currently viewed over an OS remote-desktop (RDP) session. */
+export async function getRemoteSessionActive(): Promise<boolean> {
+  return invoke("get_remote_session_active");
+}
+
+/** Listen for OS remote-desktop (RDP) session connect/disconnect transitions. */
+export function onRemoteSessionChanged(callback: (active: boolean) => void): Promise<UnlistenFn> {
+  return listen<boolean>("remote-session-changed", (event) => {
+    callback(event.payload);
+  });
+}
+
 export interface TerminalStateInfo {
   activity: TerminalActivityInfo;
 }


### PR DESCRIPTION
## 문제

폰에서 Windows 원격 데스크톱으로 실행 중인 laymux 창에 진입하면 Remote Access 패널이 자동으로 열리게 만든 기능이 동작하지 않았다.

기존 트리거(`useAutoRemoteAccessPrompt`)는 **창 너비 휴리스틱** 하나뿐:
```
window.innerWidth <= autoMobileModeMinWidth  (기본 ~640-720)
```
발동 시점도 **마운트 + `resize`** 뿐이라 폰-RDP 시나리오를 못 잡음:

1. **신호가 틀림** — 폰 RDP 클라이언트는 고해상도로 협상 → `innerWidth`가 임계값보다 커서 발동 안 함.
2. **resize 없음** — 이미 실행 중인 창에 진입. 비최대화 창은 RDP 진입 시 resize 이벤트가 없어 `check()` 재실행 자체가 안 됨.
3. 너비 ≠ "RDP 진입". 창 최대화 + RDP 해상도 < 임계값 둘 다 맞을 때만 우연히 일치.

## 수정

OS 원격 세션을 직접 감지 (`GetSystemMetrics(SM_REMOTESESSION)`), 너비와 무관.

- `remote_session.rs` (신규): `is_remote_session()` (Windows API, 그 외 false) + `watch_remote_session()` — 2초 폴링, console↔remote 전환 시 `remote-session-changed` emit.
- `lib.rs`: 워처 스레드 spawn (cfg windows) + `get_remote_session_active` 커맨드 등록.
- `misc.rs` / `constants.rs`: 커맨드 + 이벤트 상수 + poll 간격.
- `useAutoRemoteAccessPrompt.ts`: 신규 effect — 마운트 시 세션 상태 pull + 전환 리스닝, `active=true`면 패널 오픈(로컬 모바일 모드 켜져 있으면 skip).
- 기존 너비 휴리스틱은 fallback으로 유지.

## 테스트

- 프론트 vitest 32개 통과 (추가: 넓은 창에서도 RDP 세션이면 오픈, 마운트 후 연결 시 오픈, 모바일 모드 가드).
- Rust `remote_session` / `constants` 테스트 통과. 수정 파일 clippy 클린.

## ⚠️ 실기기 검증 필요

샌드박스에서 RDP 불가. `SM_REMOTESESSION`은 MS 공식 신호이고 일반 폰-RDP-진입에선 nonzero로 뒤집히지만, "이미 로그인된 콘솔 세션에 내 계정으로 RDP" 엣지는 Windows 구성마다 다를 수 있음. laymux 실행 → 폰 RDP 진입 → 패널 자동 오픈 확인 요망. 안 되면 다음 수순 = `WM_WTSSESSION_CHANGE` + `WTSRegisterSessionNotification`(이벤트 기반).

🤖 Generated with [Claude Code](https://claude.com/claude-code)