### PR TITLE
fix(remote): auto-open Remote Access only for phone RDP sessions

### DIFF
--- a/docs/architecture/api-contracts.md
+++ b/docs/architecture/api-contracts.md
@@ -53,7 +53,7 @@ Remote Access 모달의 복사 URL 호스트는 `get_remote_host_candidates` Tau
     "allowedIps": ["127.0.0.1/32", "::1/128"],
     "authToken": "",                   // enabled=true일 때 필수
     "heartbeatTimeoutSeconds": 45,      // 기본 45초, 최소 30초로 clamp
-    "autoMobileModeMinWidth": 720,      // 앱 창 폭이 이 값 이하이면 Remote Access 모달 자동 표시. 0 = 비활성
+    "autoMobileModeMinWidth": 720,      // 앱 창 폭이 이 값 이하이거나, 휴대폰(세로 화면+짧은 변이 이 값 이하)에서 RDP 접속 시 Remote Access 모달 자동 표시. 0 = 비활성
     "snapshotMaxKib": 16,               // 원격 attach 시 재생하는 최근 출력 스냅샷 상한(KiB). 1~1024로 clamp, 절단 시 개행 경계로 정렬
     "preferredHost": "",               // 복사 URL 기본 호스트. 빈 값 = 자동
     "customHosts": [],                  // 감지 후보 외에 URL host select 에 표시할 수동 호스트

--- a/src-tauri/src/remote_session.rs
+++ b/src-tauri/src/remote_session.rs
@@ -1,15 +1,18 @@
 //! OS-level remote-desktop session detection.
 //!
 //! The intended scenario: laymux is already running on the desktop, and the
-//! user opens Windows Remote Desktop from their phone to reach that window.
-//! When the window is entered over a remote session we want the Remote Access
-//! panel open so the phone can quickly switch to the mobile web UI.
+//! user opens Windows Remote Desktop *from their phone* to reach that window.
+//! When the window is entered over a remote session driven by a phone we want
+//! the Remote Access panel open so the phone can quickly switch to the mobile
+//! web UI. A desktop-to-desktop RDP session must not pop the panel.
 //!
-//! The window-width heuristic in `useAutoRemoteAccessPrompt` is an unreliable
-//! proxy for this — phone RDP clients usually negotiate a resolution wider than
-//! the threshold, and a non-maximized window never fires a `resize` on connect.
-//! This module reads the real Terminal Services state instead and pushes a
-//! transition event to the UI.
+//! This module only answers the coarse "is this an RDP session?" question via
+//! Terminal Services and pushes a transition event to the UI. RDP exposes no
+//! device-type flag, so the phone-vs-desktop decision lives in the frontend
+//! (`useAutoRemoteAccessPrompt` / `isPhoneLikeRemoteScreen`), which inspects the
+//! session's display geometry — a phone client is portrait and narrow on its
+//! short edge. The laymux window's own width is not used for this: a
+//! non-maximized window never fires a `resize` on connect.
 
 #[cfg(target_os = "windows")]
 pub fn is_remote_session() -> bool {

--- a/ui/src/hooks/useAutoRemoteAccessPrompt.test.tsx
+++ b/ui/src/hooks/useAutoRemoteAccessPrompt.test.tsx
@@ -1,6 +1,6 @@
 import { render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoRemoteAccessPrompt } from "./useAutoRemoteAccessPrompt";
+import { isPhoneLikeRemoteScreen, useAutoRemoteAccessPrompt } from "./useAutoRemoteAccessPrompt";
 import { getRemoteSessionActive, onRemoteSessionChanged } from "@/lib/tauri-api";
 import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -23,12 +23,22 @@ function setInnerWidth(width: number) {
   });
 }
 
+function setScreen(width: number, height: number) {
+  Object.defineProperty(window, "screen", {
+    value: { width, height },
+    configurable: true,
+  });
+}
+
 describe("useAutoRemoteAccessPrompt", () => {
   beforeEach(() => {
     useSettingsStore.setState(useSettingsStore.getInitialState());
     useUiStore.setState(useUiStore.getInitialState());
     useLocalMobileModeStore.setState(useLocalMobileModeStore.getInitialState());
     setInnerWidth(1200);
+    // Default to a desktop-sized remote screen so the RDP path stays closed
+    // unless a test opts into phone geometry.
+    setScreen(1920, 1080);
     vi.mocked(getRemoteSessionActive).mockResolvedValue(false);
     vi.mocked(onRemoteSessionChanged).mockResolvedValue(vi.fn());
   });
@@ -74,11 +84,12 @@ describe("useAutoRemoteAccessPrompt", () => {
     expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
   });
 
-  it("opens the modal when launched inside an OS remote session, even on a wide window", async () => {
-    // Threshold disabled + wide window: the width heuristic must NOT fire, so a
-    // pass here proves the RDP-session path is what opens the modal.
-    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 0 });
+  it("opens the modal on an RDP session driven by a phone-sized screen", async () => {
+    // Wide laymux window + a phone-shaped remote display: the narrow-window
+    // heuristic must NOT fire, so a pass here proves the phone-RDP path opened it.
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 720 });
     setInnerWidth(1920);
+    setScreen(390, 844);
     vi.mocked(getRemoteSessionActive).mockResolvedValue(true);
 
     render(<Probe />);
@@ -88,9 +99,36 @@ describe("useAutoRemoteAccessPrompt", () => {
     });
   });
 
-  it("opens the modal when a remote session connects after mount", async () => {
-    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 0 });
+  it("does NOT open the modal on a desktop-sized RDP session", async () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 720 });
     setInnerWidth(1920);
+    setScreen(1920, 1080);
+    vi.mocked(getRemoteSessionActive).mockResolvedValue(true);
+
+    render(<Probe />);
+
+    // Let the resolved promise run.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+  });
+
+  it("does NOT open the modal on a portrait but large (rotated-monitor) RDP session", async () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 720 });
+    setScreen(1080, 1920);
+    vi.mocked(getRemoteSessionActive).mockResolvedValue(true);
+
+    render(<Probe />);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+  });
+
+  it("opens the modal when a phone RDP session connects after mount", async () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 720 });
+    setInnerWidth(1920);
+    setScreen(390, 844);
     let fire: ((active: boolean) => void) | undefined;
     vi.mocked(onRemoteSessionChanged).mockImplementation((cb) => {
       fire = cb;
@@ -109,10 +147,10 @@ describe("useAutoRemoteAccessPrompt", () => {
     });
   });
 
-  it("does not open the modal on remote session while local mobile mode is active", async () => {
-    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 0 });
+  it("does not open the modal on a phone RDP session while local mobile mode is active", async () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 720 });
     useLocalMobileModeStore.getState().enter("http://127.0.0.1:19281/remote/?localApp=1");
-    setInnerWidth(1920);
+    setScreen(390, 844);
     vi.mocked(getRemoteSessionActive).mockResolvedValue(true);
 
     render(<Probe />);
@@ -121,5 +159,42 @@ describe("useAutoRemoteAccessPrompt", () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+  });
+
+  it("does not open the modal on a phone RDP session when the threshold is disabled", async () => {
+    useSettingsStore.getState().setRemote({ autoMobileModeMinWidth: 0 });
+    setScreen(390, 844);
+    vi.mocked(getRemoteSessionActive).mockResolvedValue(true);
+
+    render(<Probe />);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(useUiStore.getState().remoteAccessModalOpen).toBe(false);
+  });
+});
+
+describe("isPhoneLikeRemoteScreen", () => {
+  const cases: Array<[string, number, number, number, boolean]> = [
+    ["portrait phone", 390, 844, 720, true],
+    ["portrait phone at the threshold edge", 720, 1280, 720, true],
+    ["landscape desktop", 1920, 1080, 720, false],
+    ["small 720p desktop (landscape)", 1280, 720, 720, false],
+    ["portrait rotated monitor (wide short edge)", 1080, 1920, 720, false],
+    ["landscape phone (not portrait)", 844, 390, 720, false],
+  ];
+
+  it.each(cases)("%s -> %s", (_label, width, height, threshold, expected) => {
+    Object.defineProperty(window, "screen", { value: { width, height }, configurable: true });
+    expect(isPhoneLikeRemoteScreen(threshold)).toBe(expected);
+  });
+
+  it("returns false when the threshold is disabled or non-finite", () => {
+    Object.defineProperty(window, "screen", {
+      value: { width: 390, height: 844 },
+      configurable: true,
+    });
+    expect(isPhoneLikeRemoteScreen(0)).toBe(false);
+    expect(isPhoneLikeRemoteScreen(Number.NaN)).toBe(false);
   });
 });

--- a/ui/src/hooks/useAutoRemoteAccessPrompt.ts
+++ b/ui/src/hooks/useAutoRemoteAccessPrompt.ts
@@ -4,6 +4,28 @@ import { useLocalMobileModeStore } from "@/stores/local-mobile-mode-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useUiStore } from "@/stores/ui-store";
 
+/**
+ * Heuristic for "the current OS remote-desktop session is driven by a phone".
+ *
+ * RDP exposes no device-type flag, so we infer it from the session's display
+ * geometry. `window.screen` mirrors the negotiated RDP desktop size, which for
+ * a phone client is the phone's own screen: portrait *and* narrow on its short
+ * edge. A desktop-to-desktop session is landscape and/or large, so it is
+ * excluded — the two conditions together also reject a portrait-rotated monitor
+ * (portrait but wide short edge) and a small landscape display (narrow but not
+ * portrait). Falls back to `window.innerWidth/innerHeight` where `window.screen`
+ * is unavailable. Returns false when the threshold is disabled (<= 0) or
+ * non-finite, matching the "auto mobile mode off" setting.
+ */
+export function isPhoneLikeRemoteScreen(threshold: number): boolean {
+  if (!Number.isFinite(threshold) || threshold <= 0) return false;
+  const width = window.screen?.width ?? window.innerWidth;
+  const height = window.screen?.height ?? window.innerHeight;
+  const portrait = height > width;
+  const shortEdge = Math.min(width, height);
+  return portrait && shortEdge <= threshold;
+}
+
 export function useAutoRemoteAccessPrompt(enabled = true) {
   const threshold = useSettingsStore((state) => state.remote.autoMobileModeMinWidth);
   const localMobileModeActive = useLocalMobileModeStore((state) => state.active);
@@ -42,11 +64,13 @@ export function useAutoRemoteAccessPrompt(enabled = true) {
   }, [enabled, localMobileModeActive, threshold]);
 
   // OS remote-desktop (RDP) trigger: open the panel when the window is entered
-  // over a remote session, independent of window width. Covers the intended
-  // scenario — reaching an already-running laymux window via Windows Remote
-  // Desktop from a phone. The initial state is pulled once; live connect events
-  // arrive via the backend event. Backend is Windows-only (elsewhere the query
-  // resolves `false` and the event never fires).
+  // over a remote session *from a phone-sized client*, independent of the laymux
+  // window's own width. Covers the intended scenario — reaching an already-
+  // running laymux window via Windows Remote Desktop from a phone — while a
+  // desktop-to-desktop RDP session must NOT pop the panel. The initial state is
+  // pulled once; live connect events arrive via the backend event. Backend is
+  // Windows-only (elsewhere the query resolves `false` and the event never
+  // fires).
   useEffect(() => {
     if (!enabled) return;
 
@@ -57,6 +81,11 @@ export function useAutoRemoteAccessPrompt(enabled = true) {
       // Local mobile mode already gives the phone a tailored UI — don't stack
       // the modal on top of it.
       if (useLocalMobileModeStore.getState().active) return;
+      // Only a phone-shaped remote screen should auto-open the panel; a desktop
+      // RDP session stays untouched. Read the threshold fresh so live setting
+      // edits apply without re-registering the OS listener.
+      const currentThreshold = useSettingsStore.getState().remote.autoMobileModeMinWidth;
+      if (!isPhoneLikeRemoteScreen(currentThreshold)) return;
       useUiStore.getState().openRemoteAccessModal();
     };
 

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -308,7 +308,7 @@
       "addTailscale": "Add Tailscale",
       "resetLoopback": "Reset Local",
       "autoMobileMinWidth": "Auto Mobile Width",
-      "autoMobileMinWidthDesc": "0 disables. At or below this app window width, Remote Access opens automatically.",
+      "autoMobileMinWidthDesc": "0 disables. Remote Access opens automatically when the app window is at or below this width, or when a phone (portrait screen with its short edge at or below this value) connects over RDP.",
       "snapshotMaxKib": "Initial Output Snapshot",
       "snapshotMaxKibDesc": "Max recent output (KiB) replayed when a remote client attaches or switches terminals. Smaller opens faster with shorter scrollback.",
       "customHosts": "Custom Hosts",

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -308,7 +308,7 @@
       "addTailscale": "Tailscale 추가",
       "resetLoopback": "로컬로 초기화",
       "autoMobileMinWidth": "자동 모바일 폭",
-      "autoMobileMinWidthDesc": "0이면 비활성화. 앱 창 폭이 이 값 이하가 되면 Remote Access가 자동으로 열립니다.",
+      "autoMobileMinWidthDesc": "0이면 비활성화. 앱 창 폭이 이 값 이하이거나, 휴대폰(세로 화면 + 짧은 변이 이 값 이하)에서 RDP로 접속하면 Remote Access가 자동으로 열립니다.",
       "snapshotMaxKib": "초기 출력 스냅샷",
       "snapshotMaxKibDesc": "원격 접속·터미널 전환 시 재생할 최근 출력 상한(KiB)입니다. 작을수록 빠르게 열리고 스크롤백이 짧아집니다.",
       "customHosts": "수동 호스트",


### PR DESCRIPTION
## 문제

RDP 접속이면 화면 크기와 무관하게 **무조건** Remote Access 패널이 떴다. `useAutoRemoteAccessPrompt` 의 OS remote-session 트리거가 `GetSystemMetrics(SM_REMOTESESSION)` 이 참이기만 하면 `openRemoteAccessModal()` 을 호출했기 때문. 데스크톱→데스크톱 RDP 에서도 패널이 떠서 방해가 됐다. 의도한 시나리오는 **휴대폰으로** 이미 떠 있는 laymux 창에 접속한 경우뿐이다.

## 원인

RDP/Win32 에는 "클라이언트가 폰인가" 를 알려주는 **정확한 플래그가 없다**. `SM_REMOTESESSION` 은 RDP 여부(예/아니오)만 반환하고, WTS API 로도 클라이언트 이름·해상도까진 얻지만 기기 종류는 얻지 못한다.

## 수정

폰 여부를 세션의 **화면 기하**로 추정한다. RDP 세션에서는 `window.screen` 이 협상된 원격 데스크톱 해상도(= 클라이언트 화면)를 반영하므로, 폰이면 **세로(portrait) + 짧은 변이 좁음**, 데스크톱이면 가로/큼으로 갈린다.

RDP `open()` 을 `isPhoneLikeRemoteScreen(threshold)` 로 게이트한다:

- `portrait = screen.height > screen.width`
- `shortEdge = min(width, height) <= threshold`
- 둘 다 참일 때만 폰으로 판정

임계값은 기존 설정 `remote.autoMobileModeMinWidth`(기본 720) 를 재사용 — 새 설정 안 만듦. 두 조건을 AND 로 묶어 **세로로 돌린 큰 모니터**(portrait지만 짧은 변 넓음)와 **작은 가로 화면**(좁지만 가로)까지 오탐 제거. 임계값 0 이면 auto-prompt 전체 비활성.

좁은 창(browser at phone size) 트리거는 그대로 유지.

## 변경 파일

- `ui/src/hooks/useAutoRemoteAccessPrompt.ts` — `isPhoneLikeRemoteScreen` 헬퍼 추가 + RDP 경로 게이트
- `ui/src/hooks/useAutoRemoteAccessPrompt.test.tsx` — 폰/데스크톱/회전 모니터/임계값 케이스 테스트 (17 pass)
- `src-tauri/src/remote_session.rs` — 모듈 doc 갱신(폰-vs-데스크톱 판정은 프론트에 있음 명시)
- `docs/architecture/api-contracts.md`, `ui/src/i18n/{ko,en}.json` — 설정 설명 갱신

## 검증

- vitest 17 pass, eslint/tsc/prettier clean, `cargo fmt --check` clean (rust 는 주석만 변경)

## ADR

**ADR 불필요** — 기존 remote 기능 내 auto-prompt 휴리스틱 버그 수정으로 포트/인증/CORS/외부 계약/SoT 결정을 새로 만들지 않음. living doc(api-contracts) + 코드 주석 + 테스트로 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)